### PR TITLE
Add transform functionality to ModelServer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,6 +3607,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -6246,6 +6256,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -14217,6 +14234,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.3
+* optional transform parameter
+
 # 0.9.2
 * assemblyName in /residueInteraction
 * /ligand query

--- a/src/servers/model/server/api-web.ts
+++ b/src/servers/model/server/api-web.ts
@@ -64,7 +64,7 @@ function mapQuery(app: express.Express, queryName: string, queryDefinition: Quer
                 queryParams,
                 modelNums: commonParams.model_nums,
                 copyAllCategories: !!commonParams.copy_all_categories,
-                transformation: commonParams.transformation
+                transform: commonParams.transform
             })],
             writer: createResultWriter(res, commonParams.encoding!, entryId, queryName),
             options: { binary: commonParams.encoding === 'bcif', encoding: commonParams.encoding }

--- a/src/servers/model/server/api-web.ts
+++ b/src/servers/model/server/api-web.ts
@@ -63,7 +63,8 @@ function mapQuery(app: express.Express, queryName: string, queryDefinition: Quer
                 queryName: queryName as any,
                 queryParams,
                 modelNums: commonParams.model_nums,
-                copyAllCategories: !!commonParams.copy_all_categories
+                copyAllCategories: !!commonParams.copy_all_categories,
+                transformation: commonParams.transformation
             })],
             writer: createResultWriter(res, commonParams.encoding!, entryId, queryName),
             options: { binary: commonParams.encoding === 'bcif', encoding: commonParams.encoding }

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -46,7 +46,8 @@ export const CommonQueryParamsInfo: QueryParamInfo[] = [
     { name: 'model_nums', type: QueryParamType.String, description: `A comma-separated list of model ids (i.e. 1,2). If set, only include atoms with the corresponding '_atom_site.pdbx_PDB_model_num' field.` },
     { name: 'encoding', type: QueryParamType.String, defaultValue: 'cif', description: `Determines the output encoding (text based 'CIF' or binary 'BCIF'). Ligands can also be exported as 'SDF', 'MOL', or 'MOL2'.`, supportedValues: ['cif', 'bcif', 'sdf', 'mol', 'mol2'] },
     { name: 'copy_all_categories', type: QueryParamType.Boolean, defaultValue: false, description: 'If true, copy all categories from the input file.' },
-    { name: 'data_source', type: QueryParamType.String, defaultValue: '', description: 'Allows to control how the provided data source ID maps to input file (as specified by the server instance config).' }
+    { name: 'data_source', type: QueryParamType.String, defaultValue: '', description: 'Allows to control how the provided data source ID maps to input file (as specified by the server instance config).' },
+    { name: 'transformation', type: QueryParamType.JSON, defaultValue: void 0, description: `Transformation to apply to coordinates in '_atom_site'. Accepts a 4x4 transformation matrix, provided as array of 16 float values.` }
 ];
 
 export type Encoding = 'cif' | 'bcif' | 'sdf' | 'mol' | 'mol2';

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -8,6 +8,7 @@ import { Queries, Structure, StructureQuery, StructureSymmetry, StructurePropert
 import { getAtomsTests } from '../query/atoms';
 import { CifWriter } from '../../../mol-io/writer/cif';
 import { QuerySchemas } from '../query/schemas';
+import { Mat4 } from '../../../mol-math/linear-algebra';
 
 export enum QueryParamType {
     JSON,
@@ -55,7 +56,8 @@ export interface CommonQueryParamsInfo {
     model_nums?: number[],
     encoding?: Encoding,
     copy_all_categories?: boolean
-    data_source?: string
+    data_source?: string,
+    transformation?: Mat4
 }
 
 export const AtomSiteSchemaElement = {
@@ -289,7 +291,8 @@ export function normalizeRestCommonParams(params: any): CommonQueryParamsInfo {
         model_nums: params.model_nums ? ('' + params.model_nums).split(',').map(n => n.trim()).filter(n => !!n).map(n => +n) : void 0,
         data_source: params.data_source,
         copy_all_categories: Boolean(params.copy_all_categories),
-        encoding: mapEncoding(('' + params.encoding).toLocaleLowerCase())
+        encoding: mapEncoding(('' + params.encoding).toLocaleLowerCase()),
+        transformation: params.transformation ? createMat4(('' + params.transformation).split(',').map(n => n.trim()).map(n => +n)) : Mat4.identity()
     };
 }
 
@@ -306,4 +309,10 @@ function mapEncoding(value: string) {
         default:
             return 'cif';
     }
+}
+
+function createMat4(array: number[]): Mat4 {
+    const out = Mat4();
+    Mat4.fromArray(out, array, 0);
+    return out;
 }

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -57,7 +57,7 @@ export interface CommonQueryParamsInfo {
     encoding?: Encoding,
     copy_all_categories?: boolean
     data_source?: string,
-    transformation?: Mat4
+    transform?: Mat4
 }
 
 export const AtomSiteSchemaElement = {
@@ -292,7 +292,7 @@ export function normalizeRestCommonParams(params: any): CommonQueryParamsInfo {
         data_source: params.data_source,
         copy_all_categories: Boolean(params.copy_all_categories),
         encoding: mapEncoding(('' + params.encoding).toLocaleLowerCase()),
-        transformation: params.transformation ? createMat4(('' + params.transformation).split(',').map(n => n.trim()).map(n => +n)) : Mat4.identity()
+        transform: params.transform ? createMat4(('' + params.transform).split(',').map(n => n.trim()).map(n => +n)) : Mat4.identity()
     };
 }
 

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -48,7 +48,7 @@ export const CommonQueryParamsInfo: QueryParamInfo[] = [
     { name: 'encoding', type: QueryParamType.String, defaultValue: 'cif', description: `Determines the output encoding (text based 'CIF' or binary 'BCIF'). Ligands can also be exported as 'SDF', 'MOL', or 'MOL2'.`, supportedValues: ['cif', 'bcif', 'sdf', 'mol', 'mol2'] },
     { name: 'copy_all_categories', type: QueryParamType.Boolean, defaultValue: false, description: 'If true, copy all categories from the input file.' },
     { name: 'data_source', type: QueryParamType.String, defaultValue: '', description: 'Allows to control how the provided data source ID maps to input file (as specified by the server instance config).' },
-    { name: 'transformation', type: QueryParamType.JSON, defaultValue: void 0, description: `Transformation to apply to coordinates in '_atom_site'. Accepts a 4x4 transformation matrix, provided as array of 16 float values.` }
+    { name: 'transform', type: QueryParamType.JSON, defaultValue: void 0, description: `Transformation to apply to coordinates in '_atom_site'. Accepts a 4x4 transformation matrix, provided as array of 16 float values.` }
 ];
 
 export type Encoding = 'cif' | 'bcif' | 'sdf' | 'mol' | 'mol2';

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -292,7 +292,7 @@ export function normalizeRestCommonParams(params: any): CommonQueryParamsInfo {
         data_source: params.data_source,
         copy_all_categories: Boolean(params.copy_all_categories),
         encoding: mapEncoding(('' + params.encoding).toLocaleLowerCase()),
-        transform: params.transform ? createMat4(('' + params.transform).split(',').map(n => n.trim()).map(n => +n)) : Mat4.identity()
+        transform: params.transform ? ('' + params.transform).split(',').map(n => n.trim()).map(n => +n) as Mat4 : Mat4.identity()
     };
 }
 
@@ -309,10 +309,4 @@ function mapEncoding(value: string) {
         default:
             return 'cif';
     }
-}
-
-function createMat4(array: number[]): Mat4 {
-    const out = Mat4();
-    Mat4.fromArray(out, array, 0);
-    return out;
 }

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -48,7 +48,7 @@ export const CommonQueryParamsInfo: QueryParamInfo[] = [
     { name: 'encoding', type: QueryParamType.String, defaultValue: 'cif', description: `Determines the output encoding (text based 'CIF' or binary 'BCIF'). Ligands can also be exported as 'SDF', 'MOL', or 'MOL2'.`, supportedValues: ['cif', 'bcif', 'sdf', 'mol', 'mol2'] },
     { name: 'copy_all_categories', type: QueryParamType.Boolean, defaultValue: false, description: 'If true, copy all categories from the input file.' },
     { name: 'data_source', type: QueryParamType.String, defaultValue: '', description: 'Allows to control how the provided data source ID maps to input file (as specified by the server instance config).' },
-    { name: 'transform', type: QueryParamType.JSON, defaultValue: void 0, description: `Transformation to apply to coordinates in '_atom_site'. Accepts a 4x4 transformation matrix, provided as array of 16 float values.` }
+    { name: 'transform', type: QueryParamType.String, description: `Transformation to apply to coordinates in '_atom_site'. Accepts a 4x4 transformation matrix, provided as array of 16 float values.` }
 ];
 
 export type Encoding = 'cif' | 'bcif' | 'sdf' | 'mol' | 'mol2';

--- a/src/servers/model/server/jobs.ts
+++ b/src/servers/model/server/jobs.ts
@@ -8,6 +8,7 @@ import { UUID } from '../../../mol-util';
 import { getQueryByName, QueryDefinition, QueryName, QueryParams, Encoding } from './api';
 import { LinkedList } from '../../../mol-data/generic';
 import { ResultWriter } from '../utils/writer';
+import { Mat4 } from '../../../mol-math/linear-algebra';
 
 export interface ResponseFormat {
     tarball: boolean,
@@ -41,7 +42,8 @@ export interface JobEntry {
     queryDefinition: QueryDefinition,
     normalizedParams: any,
     modelNums?: number[],
-    copyAllCategories: boolean
+    copyAllCategories: boolean,
+    transformation?: Mat4
 }
 
 interface JobEntryDefinition<Name extends QueryName> {
@@ -50,7 +52,8 @@ interface JobEntryDefinition<Name extends QueryName> {
     queryName: Name,
     queryParams: QueryParams<Name>,
     modelNums?: number[],
-    copyAllCategories: boolean
+    copyAllCategories: boolean,
+    transformation?: Mat4
 }
 
 export function JobEntry<Name extends QueryName>(definition: JobEntryDefinition<Name>): JobEntry {
@@ -68,7 +71,8 @@ export function JobEntry<Name extends QueryName>(definition: JobEntryDefinition<
         queryDefinition,
         normalizedParams,
         modelNums: definition.modelNums,
-        copyAllCategories: !!definition.copyAllCategories
+        copyAllCategories: !!definition.copyAllCategories,
+        transformation: definition.transformation
     };
 }
 

--- a/src/servers/model/server/jobs.ts
+++ b/src/servers/model/server/jobs.ts
@@ -43,7 +43,7 @@ export interface JobEntry {
     normalizedParams: any,
     modelNums?: number[],
     copyAllCategories: boolean,
-    transformation?: Mat4
+    transform?: Mat4
 }
 
 interface JobEntryDefinition<Name extends QueryName> {
@@ -53,7 +53,7 @@ interface JobEntryDefinition<Name extends QueryName> {
     queryParams: QueryParams<Name>,
     modelNums?: number[],
     copyAllCategories: boolean,
-    transformation?: Mat4
+    transform?: Mat4
 }
 
 export function JobEntry<Name extends QueryName>(definition: JobEntryDefinition<Name>): JobEntry {
@@ -72,7 +72,7 @@ export function JobEntry<Name extends QueryName>(definition: JobEntryDefinition<
         normalizedParams,
         modelNums: definition.modelNums,
         copyAllCategories: !!definition.copyAllCategories,
-        transformation: definition.transformation
+        transform: definition.transform
     };
 }
 

--- a/src/servers/model/server/query.ts
+++ b/src/servers/model/server/query.ts
@@ -216,10 +216,10 @@ async function resolveJobEntry(entry: JobEntry, structure: StructureWrapper, enc
         for (let i = 0; i < structures.length; i++) {
             const s = StructureSelection.unionStructure(StructureQuery.run(queries[i], structures[i], { timeoutMs: Config.queryTimeoutMs }));
             if (s.elementCount > 0) {
-                if (!entry.transformation || Mat4.isIdentity(entry.transformation)) {
+                if (!entry.transform || Mat4.isIdentity(entry.transform)) {
                     result.push(s);
                 } else {
-                    result.push(Structure.transform(s, entry.transformation));
+                    result.push(Structure.transform(s, entry.transform));
                 }
             }
         }

--- a/src/servers/model/server/query.ts
+++ b/src/servers/model/server/query.ts
@@ -29,6 +29,7 @@ import { Mol2Writer } from '../../../mol-io/writer/mol2';
 import { MolEncoder } from '../../../mol-io/writer/mol/encoder';
 import { Mol2Encoder } from '../../../mol-io/writer/mol2/encoder';
 import { ComponentAtom } from '../../../mol-model-formats/structure/property/atoms/chem_comp';
+import { Mat4 } from '../../../mol-math/linear-algebra';
 
 export interface Stats {
     structure: StructureWrapper,
@@ -214,7 +215,13 @@ async function resolveJobEntry(entry: JobEntry, structure: StructureWrapper, enc
         const result: Structure[] = [];
         for (let i = 0; i < structures.length; i++) {
             const s = StructureSelection.unionStructure(StructureQuery.run(queries[i], structures[i], { timeoutMs: Config.queryTimeoutMs }));
-            if (s.elementCount > 0) result.push(s);
+            if (s.elementCount > 0) {
+                if (!entry.transformation || Mat4.isIdentity(entry.transformation)) {
+                    result.push(s);
+                } else {
+                    result.push(Structure.transform(s, entry.transformation));
+                }
+            }
         }
         perf.end('query');
 

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -4,4 +4,4 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export default '0.9.2';
+export default '0.9.3';


### PR DESCRIPTION
- adds `transform` parameter to (single) ModelServer queries that will be applied to coordinates in `_atom_site`
- honors rest of query normally
- e.g. useful to select a binding site and superimpose it onto a 2nd binding site if alignment was determined externally