### PR TITLE
Add chromosome and region query for g3d format

### DIFF
--- a/src/extensions/g3d/model.ts
+++ b/src/extensions/g3d/model.ts
@@ -153,7 +153,8 @@ async function getTraj(ctx: RuntimeContext, data: G3dDataBlock) {
         haplotypes: Object.keys(data.data),
         haplotype: normalized.haplotype,
         resolution: data.resolution,
-        start: normalized.start
+        start: normalized.start,
+        chroms: normalized.chromosome,
     });
 
     return models;
@@ -224,7 +225,8 @@ export interface G3dInfoData {
     haplotypes: string[],
     haplotype: string[],
     start: Int32Array,
-    resolution: number
+    resolution: number,
+    chroms: string[]
 };
 
 export const G3dLabelProvider: LociLabelProvider = {

--- a/src/extensions/g3d/model.ts
+++ b/src/extensions/g3d/model.ts
@@ -178,7 +178,7 @@ export const G3dSymbols = {
     chromosome: QuerySymbolRuntime.Dynamic(CustomPropSymbol('g3d', 'chromosome', Type.Str),
         ctx => {
             if (Unit.isAtomic(ctx.element.unit)) return '';
-            const {  asym_id } = ctx.element.unit.model.coarseHierarchy.spheres;
+            const { asym_id } = ctx.element.unit.model.coarseHierarchy.spheres;
             return asym_id.value(ctx.element.element) || '';
         }
     ),
@@ -202,15 +202,21 @@ export function g3dHaplotypeQuery(haplotype: string) {
     });
 }
 
-export function g3dChromosomeQuery(chromosome: string) {
+export function g3dChromosomeQuery(chr: string) {
     return MS.struct.generator.atomGroups({
-        'chain-test': MS.core.rel.eq([G3dSymbols.chromosome.symbol(), chromosome]),
+        'chain-test': MS.core.logic.and([
+            MS.core.rel.eq([MS.ammp('objectPrimitive'), 'sphere']),
+            MS.core.rel.eq([G3dSymbols.chromosome.symbol(), chr])
+        ])
     });
 }
 
 export function g3dRegionQuery(chr: string, start: number, end: number) {
     return MS.struct.generator.atomGroups({
-        'chain-test': MS.core.rel.eq([G3dSymbols.chromosome.symbol(), chr]),
+        'chain-test': MS.core.logic.and([
+            MS.core.rel.eq([MS.ammp('objectPrimitive'), 'sphere']),
+            MS.core.rel.eq([G3dSymbols.chromosome.symbol(), chr])
+        ]),
         'residue-test': MS.core.rel.inRange([G3dSymbols.region.symbol(), start, end])
     });
 }

--- a/src/extensions/g3d/model.ts
+++ b/src/extensions/g3d/model.ts
@@ -208,13 +208,9 @@ export function g3dChromosomeQuery(chromosome: string) {
     });
 }
 
-export function g3dRegionQuery(region: string) {
-    // region looks like chr7:2000000-7000000, make sure input data looks like this format
-    const regionArr = region.split(/[:-]/);
-    const start = Number.parseInt(regionArr[1], 10);
-    const end = Number.parseInt(regionArr[2], 10);
+export function g3dRegionQuery(chr: string, start: number, end: number) {
     return MS.struct.generator.atomGroups({
-        'chain-test': MS.core.rel.eq([G3dSymbols.chromosome.symbol(), regionArr[0]]),
+        'chain-test': MS.core.rel.eq([G3dSymbols.chromosome.symbol(), chr]),
         'residue-test': MS.core.rel.inRange([G3dSymbols.region.symbol(), start, end])
     });
 }

--- a/src/extensions/g3d/model.ts
+++ b/src/extensions/g3d/model.ts
@@ -182,14 +182,13 @@ export const G3dSymbols = {
             return asym_id.value(ctx.element.element) || '';
         }
     ),
-    region: QuerySymbolRuntime.Dynamic(CustomPropSymbol('g3d', 'region', Type.Str),
+    region: QuerySymbolRuntime.Dynamic(CustomPropSymbol('g3d', 'region', Type.Num),
         ctx => {
             if (Unit.isAtomic(ctx.element.unit)) return '';
             const info = (G3dInfoDataProperty as any).get(ctx.element.unit.model);
-            if (!info) return '';
+            if (!info) return 0;
             const seqId = ctx.element.unit.model.coarseHierarchy.spheres.seq_id_begin.value(ctx.element.element);
-            const s = info.start[seqId];
-            return s || 0;
+            return info.start[seqId] || 0;
         }
     )
 };


### PR DESCRIPTION
add chromosome and region query for g3d format with examples below.

show struct from chr7:
```js
components.apply(StateTransforms.Model.StructureSelectionFromExpression, { expression: g3dChromosomeQuery('chr7'), label: 'chr7' })
        .apply(StateTransforms.Representation.StructureRepresentation3D, reprChrom);
```
show struct from chr7:2000000-7000000:
```js
    components.apply(StateTransforms.Model.StructureSelectionFromExpression, { expression: g3dRegionQuery('chr7', 2000000, 7000000), label: 'chr7:2000000-7000000' })
        .apply(StateTransforms.Representation.StructureRepresentation3D, reprRegion);
```
