### PR TITLE
handle metal ions correctly for ModelServer ligand export

### DIFF
--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -44,6 +44,8 @@ export class MolEncoder extends LigandEncoder {
             StringBuilder.writeSafe(ctab, '  0  0  0  0  0  0  0  0  0  0\n');
             if (stereo_config !== 'N') chiral = true;
 
+            // no data for metal ions
+            if (!bondMap?.map) return;
             bondMap.map.get(label_atom_id1)!.forEach((bond, label_atom_id2) => {
                 const atom2 = atoms.get(label_atom_id2);
                 if (!atom2) return;

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -52,7 +52,7 @@ export class Mol2Encoder extends LigandEncoder {
                 });
             }
 
-            const sybyl = bondMap ? this.mapToSybyl(label_atom_id1, atom1.type_symbol, bondMap) : atom1.type_symbol;
+            const sybyl = bondMap?.map ? this.mapToSybyl(label_atom_id1, atom1.type_symbol, bondMap) : atom1.type_symbol;
             StringBuilder.writeSafe(a, `${i1 + 1} ${label_atom_id1} ${atom1.Cartn_x.toFixed(3)} ${atom1.Cartn_y.toFixed(3)} ${atom1.Cartn_z.toFixed(3)} ${sybyl} 1 ${name} 0.000\n`);
         });
 

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -37,20 +37,22 @@ export class Mol2Encoder extends LigandEncoder {
         StringBuilder.writeSafe(b, '@<TRIPOS>BOND\n');
         atoms.forEach((atom1, label_atom_id1) => {
             const { index: i1 } = atom1;
-            bondMap.map.get(label_atom_id1)!.forEach((bond, label_atom_id2) => {
-                const atom2 = atoms.get(label_atom_id2);
-                if (!atom2) return;
+            if (bondMap?.map) {
+                bondMap.map.get(label_atom_id1)!.forEach((bond, label_atom_id2) => {
+                    const atom2 = atoms.get(label_atom_id2);
+                    if (!atom2) return;
 
-                const { index: i2, type_symbol: type_symbol2 } = atom2;
-                if (i1 < i2 && !this.skipHydrogen(type_symbol2)) {
-                    const { order, flags } = bond;
-                    const ar = BondType.is(BondType.Flag.Aromatic, flags);
-                    StringBuilder.writeSafe(b, `${++bondCount} ${i1 + 1} ${i2 + 1} ${ar ? 'ar' : order}`);
-                    StringBuilder.newline(b);
-                }
-            });
+                    const { index: i2, type_symbol: type_symbol2 } = atom2;
+                    if (i1 < i2 && !this.skipHydrogen(type_symbol2)) {
+                        const { order, flags } = bond;
+                        const ar = BondType.is(BondType.Flag.Aromatic, flags);
+                        StringBuilder.writeSafe(b, `${++bondCount} ${i1 + 1} ${i2 + 1} ${ar ? 'ar' : order}`);
+                        StringBuilder.newline(b);
+                    }
+                });
+            }
 
-            const sybyl = this.mapToSybyl(label_atom_id1, atom1.type_symbol, bondMap);
+            const sybyl = bondMap ? this.mapToSybyl(label_atom_id1, atom1.type_symbol, bondMap) : atom1.type_symbol;
             StringBuilder.writeSafe(a, `${i1 + 1} ${label_atom_id1} ${atom1.Cartn_x.toFixed(3)} ${atom1.Cartn_y.toFixed(3)} ${atom1.Cartn_z.toFixed(3)} ${sybyl} 1 ${name} 0.000\n`);
         });
 

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.4
+* bug fix for /ligand queries on metal ions
+
 # 0.9.3
 * optional transform parameter
 

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -4,4 +4,4 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export default '0.9.3';
+export default '0.9.4';


### PR DESCRIPTION
- `bondMap` is undefined if metal ions are requested
- this PR ensures that those cases are handled gracefully and SDF/MOL/MOL2 files without bond information are returned