### PR TITLE
ModelServer: filename parameter

### DIFF
--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -90,6 +90,7 @@ export class MolEncoder extends LigandEncoder {
         const { instance, source } = getCategoryInstanceData(category, context);
         const fields = instance.fields;
         const src = source[0];
+        if (!src) return;
         const data = src.data;
 
         const it = src.keys();

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -289,6 +289,7 @@ export class Mol2Encoder extends LigandEncoder {
         const { instance, source } = getCategoryInstanceData(category, context);
         const fields = instance.fields;
         const src = source[0];
+        if (!src) return;
         const data = src.data;
 
         const it = src.keys();

--- a/src/servers/model/server/api-web-multiple.ts
+++ b/src/servers/model/server/api-web-multiple.ts
@@ -19,7 +19,8 @@ export interface MultipleQuerySpec {
     queries: MultipleQueryEntry[],
     encoding?: Encoding,
     asTarGz?: boolean,
-    download?: boolean
+    download?: boolean,
+    filename?: string
 }
 
 export function getMultiQuerySpecFilename() {

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -291,7 +291,6 @@ export function normalizeRestQueryParams(query: QueryDefinition, params: any) {
 }
 
 export function normalizeRestCommonParams(params: any): CommonQueryParamsInfo {
-    console.log(`${params.download} ${isTrue(params.download)} ${!!params.filename} ${isTrue(params.download) || !!params.filename}}`);
     return {
         model_nums: params.model_nums ? ('' + params.model_nums).split(',').map(n => n.trim()).filter(n => !!n).map(n => +n) : void 0,
         data_source: params.data_source,

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -49,7 +49,8 @@ export const CommonQueryParamsInfo: QueryParamInfo[] = [
     { name: 'copy_all_categories', type: QueryParamType.Boolean, defaultValue: false, description: 'If true, copy all categories from the input file.' },
     { name: 'data_source', type: QueryParamType.String, defaultValue: '', description: 'Allows to control how the provided data source ID maps to input file (as specified by the server instance config).' },
     { name: 'transform', type: QueryParamType.String, description: `Transformation to apply to coordinates in '_atom_site'. Accepts a 4x4 transformation matrix, provided as array of 16 float values.` },
-    { name: 'download', type: QueryParamType.Boolean, defaultValue: false, description: 'If true, browser will download text files.' }
+    { name: 'download', type: QueryParamType.Boolean, defaultValue: false, description: 'If true, browser will download text files.' },
+    { name: 'filename', type: QueryParamType.String, defaultValue: '', description: `Controls the filename for downloaded files. Will force download if specified.` }
 ];
 
 export type Encoding = 'cif' | 'bcif' | 'sdf' | 'mol' | 'mol2';
@@ -59,7 +60,8 @@ export interface CommonQueryParamsInfo {
     copy_all_categories?: boolean
     data_source?: string,
     transform?: Mat4,
-    download?: boolean
+    download?: boolean,
+    filename?: string
 }
 
 export const AtomSiteSchemaElement = {
@@ -289,13 +291,15 @@ export function normalizeRestQueryParams(query: QueryDefinition, params: any) {
 }
 
 export function normalizeRestCommonParams(params: any): CommonQueryParamsInfo {
+    console.log(`${params.download} ${isTrue(params.download)} ${!!params.filename} ${isTrue(params.download) || !!params.filename}}`);
     return {
         model_nums: params.model_nums ? ('' + params.model_nums).split(',').map(n => n.trim()).filter(n => !!n).map(n => +n) : void 0,
         data_source: params.data_source,
         copy_all_categories: isTrue(params.copy_all_categories),
         encoding: mapEncoding(('' + params.encoding).toLocaleLowerCase()),
         transform: params.transform ? ('' + params.transform).split(',').map(n => n.trim()).map(n => +n) as Mat4 : Mat4.identity(),
-        download: isTrue(params.download)
+        download: isTrue(params.download) || !!params.filename,
+        filename: params.filename
     };
 }
 

--- a/src/servers/model/server/jobs.ts
+++ b/src/servers/model/server/jobs.ts
@@ -59,6 +59,7 @@ interface JobEntryDefinition<Name extends QueryName> {
 export interface ResultWriterParams {
     encoding: Encoding,
     download: boolean,
+    filename?: string,
     entryId?: string,
     queryName?: string
 }


### PR DESCRIPTION
- adds functionality to specify filenames for download via ModelServer
- as a drive-by (4676ad8): mol/mol2 writing would fail if `params` category is undefined (e.g. if no atom_site properties are specified at all for a query)

A use-case lies in exporting multiple ligands from a structure, currently all files will be generically named `1pdb_ligand.ext`.