### PR TITLE
FIX issue #147 CSS transform:scale cause molstar canvas to have incorrect size

### DIFF
--- a/src/mol-canvas3d/util.ts
+++ b/src/mol-canvas3d/util.ts
@@ -12,13 +12,13 @@ export function setCanvasSize(canvas: HTMLCanvasElement, width: number, height: 
 }
 
 /** Resize canvas to container element taking `devicePixelRatio` into account */
-export function resizeCanvas (canvas: HTMLCanvasElement, container: Element, scale = 1) {
+export function resizeCanvas (canvas: HTMLCanvasElement, container: HTMLElement, scale = 1) {
     let width = window.innerWidth;
     let height = window.innerHeight;
     if (container !== document.body) {
-        let bounds = container.getBoundingClientRect();
-        width = bounds.right - bounds.left;
-        height = bounds.bottom - bounds.top;
+        // fixes issue #molstar/molstar#147, offsetWidth/offsetHeight is correct size when css transform:scale is used
+        width = container.offsetWidth;
+        height = container.offsetHeight;
     }
     setCanvasSize(canvas, width, height, scale);
 }


### PR DESCRIPTION
FIX issue #147 CSS transform:scale cause molstar canvas to have incorrect size
When CSS transform is used e.g.: scale(0.5);transform-origin:top left;width:200% molstar canvas is broken. 

The introduced fix uses HTMLElement offsetWidth/offsetHeight properties containing correct size of element when css transform:scale is used.