### PR TITLE
Fix incorrect deflate progress

### DIFF
--- a/src/mol-util/zip/deflate.ts
+++ b/src/mol-util/zip/deflate.ts
@@ -139,7 +139,7 @@ export async function _deflateRaw(runtime: RuntimeContext, data: Uint8Array, out
 
     while (ctx.i < dlen) {
         if (runtime.shouldUpdate) {
-            await runtime.update({ message: 'Deflating...', current: ctx.pos, max: data.length });
+            await runtime.update({ message: 'Deflating...', current: ctx.i, max: dlen });
         }
         deflateChunk(ctx, 1024 * 1024);
     }


### PR DESCRIPTION
The `deflate` function sometimes reports partial progress where the current value is larger than the max value, such as "Deflating... [417630611/252028364]". This usually happens when exporting a large mesh such as 1RB8. This PR fixes the issue by using the correct current value.