### PR TITLE
Fix normals in sheet arrows

### DIFF
--- a/src/mol-geo/geometry/mesh/builder/sheet.ts
+++ b/src/mol-geo/geometry/mesh/builder/sheet.ts
@@ -36,6 +36,7 @@ const v3magnitude = Vec3.magnitude;
 const v3negate = Vec3.negate;
 const v3copy = Vec3.copy;
 const v3cross = Vec3.cross;
+const v3set = Vec3.set;
 const caAdd3 = ChunkedArray.add3;
 const caAdd = ChunkedArray.add;
 
@@ -93,6 +94,8 @@ export function addSheet(state: MeshBuilder.State, controlPoints: ArrayLike<numb
         v3fromArray(tA, controlPoints, 0);
         v3fromArray(tB, controlPoints, linearSegments * 3);
         offsetLength = arrowHeight / v3magnitude(v3sub(tV, tB, tA));
+    } else {
+        v3set(normalOffset, 0, 0, 0);
     }
 
     for (let i = 0; i <= linearSegments; ++i) {
@@ -119,7 +122,7 @@ export function addSheet(state: MeshBuilder.State, controlPoints: ArrayLike<numb
         v3fromArray(torsionVector, binormalVectors, i3);
 
         v3add(tA, v3add(tA, positionVector, horizontalVector), verticalVector);
-        v3copy(tB, normalVector);
+        v3add(tB, normalVector, normalOffset);
         caAdd3(vertices, tA[0], tA[1], tA[2]);
         caAdd3(normals, tB[0], tB[1], tB[2]);
 
@@ -128,7 +131,7 @@ export function addSheet(state: MeshBuilder.State, controlPoints: ArrayLike<numb
         caAdd3(normals, tB[0], tB[1], tB[2]);
 
         // v3add(tA, v3sub(tA, positionVector, horizontalVector), verticalVector) // reuse tA
-        v3add(tB, v3negate(tB, torsionVector), normalOffset);
+        v3negate(tB, torsionVector)
         caAdd3(vertices, tA[0], tA[1], tA[2]);
         caAdd3(normals, tB[0], tB[1], tB[2]);
 
@@ -137,7 +140,7 @@ export function addSheet(state: MeshBuilder.State, controlPoints: ArrayLike<numb
         caAdd3(normals, tB[0], tB[1], tB[2]);
 
         // v3sub(tA, v3sub(tA, positionVector, horizontalVector), verticalVector) // reuse tA
-        v3negate(tB, normalVector);
+        v3add(tB, v3negate(tB, normalVector), normalOffset);
         caAdd3(vertices, tA[0], tA[1], tA[2]);
         caAdd3(normals, tB[0], tB[1], tB[2]);
 
@@ -146,7 +149,7 @@ export function addSheet(state: MeshBuilder.State, controlPoints: ArrayLike<numb
         caAdd3(normals, tB[0], tB[1], tB[2]);
 
         // v3sub(tA, v3add(tA, positionVector, horizontalVector), verticalVector) // reuse tA
-        v3add(tB, torsionVector, normalOffset);
+        v3copy(tB, torsionVector);
         caAdd3(vertices, tA[0], tA[1], tA[2]);
         caAdd3(normals, tB[0], tB[1], tB[2]);
 


### PR DESCRIPTION
When drawing an arrowhead, the current code applies `normalOffset` to the torsion vectors instead of the normal vectors. This results in incorrect lighting as shown below. Notice the sudden change in the lighting of the arrowheads.

![1TQN](https://user-images.githubusercontent.com/226473/117529502-c2001680-af8c-11eb-8fe2-07c488c7b1da.png)

This PR applies `normalOffset` to the normal vectors.
![1TQN-2](https://user-images.githubusercontent.com/226473/117529588-2cb15200-af8d-11eb-8b9a-4a322255ab79.png)

This PR also sets `normalOffset` to zero when drawing parts that are not an arrowhead.

Note that `normalOffset` causes some normal vectors to not be normalized (#175). This PR doesn't fix that. I don't know yet how to fix it without using `Vec3.normalize()`.