### PR TITLE
Geometry export: support volume & volumeInstance color types

### DIFF
--- a/src/extensions/geo-export/glb-exporter.ts
+++ b/src/extensions/geo-export/glb-exporter.ts
@@ -94,7 +94,7 @@ export class GlbExporter extends MeshExporter<GlbData> {
                 indices = mesh.indexBuffer.ref.value;
                 groups = mesh.groupBuffer.ref.value;
                 vertexCount = mesh.vertexCount;
-                drawCount = indices.length;
+                drawCount = mesh.triangleCount * 3;
             }
 
             Mat4.fromArray(t, aTransform, instanceIndex * 16);

--- a/src/extensions/geo-export/glb-exporter.ts
+++ b/src/extensions/geo-export/glb-exporter.ts
@@ -160,6 +160,7 @@ export class GlbExporter extends MeshExporter<GlbData> {
                     alpha *= 1 - transparency;
                 }
 
+                color = Color.sRGBToLinear(color);
                 Color.toArrayNormalized(color, colorArray, i * 4);
                 colorArray[i * 4 + 3] = alpha;
             }

--- a/src/extensions/geo-export/glb-exporter.ts
+++ b/src/extensions/geo-export/glb-exporter.ts
@@ -4,7 +4,6 @@
  * @author Sukolsak Sakshuwong <sukolsak@stanford.edu>
  */
 
-import { BaseValues } from '../../mol-gl/renderable/schema';
 import { asciiWrite } from '../../mol-io/common/ascii';
 import { IsNativeEndianLittle, flipByteOrder } from '../../mol-io/common/binary';
 import { Vec3, Mat3, Mat4 } from '../../mol-math/linear-algebra';
@@ -12,7 +11,7 @@ import { RuntimeContext } from '../../mol-task';
 import { Color } from '../../mol-util/color/color';
 import { arrayMinMax, fillSerial } from '../../mol-util/array';
 import { NumberArray } from '../../mol-util/type-helpers';
-import { MeshExporter } from './mesh-exporter';
+import { MeshExporter, AddMeshInput } from './mesh-exporter';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3fromArray = Vec3.fromArray;
@@ -48,7 +47,9 @@ export class GlbExporter extends MeshExporter<GlbData> {
         return [ min, max ];
     }
 
-    protected async addMeshWithColors(vertices: Float32Array, normals: Float32Array, indices: Uint32Array | undefined, groups: Float32Array | Uint8Array, vertexCount: number, drawCount: number, values: BaseValues, instanceIndex: number, isGeoTexture: boolean, ctx: RuntimeContext) {
+    protected async addMeshWithColors(input: AddMeshInput) {
+        const { mesh, meshes, values, isGeoTexture, webgl, ctx } = input;
+
         const t = Mat4();
         const n = Mat3();
         const tmpV = Vec3();
@@ -61,185 +62,219 @@ export class GlbExporter extends MeshExporter<GlbData> {
         const dTransparency = values.dTransparency.ref.value;
         const tTransparency = values.tTransparency.ref.value;
         const aTransform = values.aTransform.ref.value;
+        const instanceCount = values.uInstanceCount.ref.value;
 
-        Mat4.fromArray(t, aTransform, instanceIndex * 16);
-        mat3directionTransform(n, t);
-
-        const currentProgress = (vertexCount * 3) * instanceIndex;
-        await ctx.update({ isIndeterminate: false, current: currentProgress, max: (vertexCount * 3) * values.uInstanceCount.ref.value });
-
-        const vertexArray = new Float32Array(vertexCount * 3);
-        const normalArray = new Float32Array(vertexCount * 3);
-        const colorArray = new Float32Array(vertexCount * 4);
-        let indexArray: Uint32Array;
-
-        // position
-        for (let i = 0; i < vertexCount; ++i) {
-            if (i % 1000 === 0 && ctx.shouldUpdate) await ctx.update({ current: currentProgress + i });
-            v3transformMat4(tmpV, v3fromArray(tmpV, vertices, i * stride), t);
-            v3toArray(tmpV, vertexArray, i * 3);
+        let interpolatedColors: Uint8Array;
+        if (colorType === 'volume' || colorType === 'volumeInstance') {
+            interpolatedColors = GlbExporter.getInterpolatedColors(mesh!.vertices, mesh!.vertexCount, values, stride, colorType, webgl!);
         }
 
-        // normal
-        for (let i = 0; i < vertexCount; ++i) {
-            if (i % 1000 === 0 && ctx.shouldUpdate) await ctx.update({ current: currentProgress + vertexCount + i });
-            v3fromArray(tmpV, normals, i * stride);
-            v3transformMat3(tmpV, v3normalize(tmpV, tmpV), n);
-            v3toArray(tmpV, normalArray, i * 3);
-        }
+        await ctx.update({ isIndeterminate: false, current: 0, max: instanceCount });
 
-        // color
-        for (let i = 0; i < vertexCount; ++i) {
-            if (i % 1000 === 0 && ctx.shouldUpdate) await ctx.update({ current: currentProgress + vertexCount * 2 + i });
+        for (let instanceIndex = 0; instanceIndex < instanceCount; ++instanceIndex) {
+            if (ctx.shouldUpdate) await ctx.update({ current: instanceIndex + 1 });
 
-            let color: Color;
-            switch (colorType) {
-                case 'uniform':
-                    color = Color.fromNormalizedArray(values.uColor.ref.value, 0);
-                    break;
-                case 'instance':
-                    color = Color.fromArray(tColor, instanceIndex * 3);
-                    break;
-                case 'group': {
-                    const group = isGeoTexture ? GlbExporter.getGroup(groups, i) : groups[i];
-                    color = Color.fromArray(tColor, group * 3);
-                    break;
-                }
-                case 'groupInstance': {
-                    const group = isGeoTexture ? GlbExporter.getGroup(groups, i) : groups[i];
-                    color = Color.fromArray(tColor, (instanceIndex * groupCount + group) * 3);
-                    break;
-                }
-                case 'vertex':
-                    color = Color.fromArray(tColor, i * 3);
-                    break;
-                case 'vertexInstance':
-                    color = Color.fromArray(tColor, (instanceIndex * drawCount + i) * 3);
-                    break;
-                default: throw new Error('Unsupported color type.');
+            let vertices: Float32Array;
+            let normals: Float32Array;
+            let indices: Uint32Array | undefined;
+            let groups: Float32Array | Uint8Array;
+            let vertexCount: number;
+            let drawCount: number;
+            if (mesh !== undefined) {
+                vertices = mesh.vertices;
+                normals = mesh.normals;
+                indices = mesh.indices;
+                groups = mesh.groups;
+                vertexCount = mesh.vertexCount;
+                drawCount = mesh.drawCount;
+            } else {
+                const mesh = meshes![instanceIndex];
+                vertices = mesh.vertexBuffer.ref.value;
+                normals = mesh.normalBuffer.ref.value;
+                indices = mesh.indexBuffer.ref.value;
+                groups = mesh.groupBuffer.ref.value;
+                vertexCount = mesh.vertexCount;
+                drawCount = indices.length;
             }
 
-            let alpha = uAlpha;
-            if (dTransparency) {
-                const group = isGeoTexture ? GlbExporter.getGroup(groups, i) : groups[i];
-                const transparency = tTransparency.array[instanceIndex * groupCount + group] / 255;
-                alpha *= 1 - transparency;
+            Mat4.fromArray(t, aTransform, instanceIndex * 16);
+            mat3directionTransform(n, t);
+
+            const vertexArray = new Float32Array(vertexCount * 3);
+            const normalArray = new Float32Array(vertexCount * 3);
+            const colorArray = new Float32Array(vertexCount * 4);
+            let indexArray: Uint32Array;
+
+            // position
+            for (let i = 0; i < vertexCount; ++i) {
+                v3transformMat4(tmpV, v3fromArray(tmpV, vertices, i * stride), t);
+                v3toArray(tmpV, vertexArray, i * 3);
             }
 
-            Color.toArrayNormalized(color, colorArray, i * 4);
-            colorArray[i * 4 + 3] = alpha;
+            // normal
+            for (let i = 0; i < vertexCount; ++i) {
+                v3fromArray(tmpV, normals, i * stride);
+                v3transformMat3(tmpV, v3normalize(tmpV, tmpV), n);
+                v3toArray(tmpV, normalArray, i * 3);
+            }
+
+            // color
+            for (let i = 0; i < vertexCount; ++i) {
+                let color: Color;
+                switch (colorType) {
+                    case 'uniform':
+                        color = Color.fromNormalizedArray(values.uColor.ref.value, 0);
+                        break;
+                    case 'instance':
+                        color = Color.fromArray(tColor, instanceIndex * 3);
+                        break;
+                    case 'group': {
+                        const group = isGeoTexture ? GlbExporter.getGroup(groups, i) : groups[i];
+                        color = Color.fromArray(tColor, group * 3);
+                        break;
+                    }
+                    case 'groupInstance': {
+                        const group = isGeoTexture ? GlbExporter.getGroup(groups, i) : groups[i];
+                        color = Color.fromArray(tColor, (instanceIndex * groupCount + group) * 3);
+                        break;
+                    }
+                    case 'vertex':
+                        color = Color.fromArray(tColor, i * 3);
+                        break;
+                    case 'vertexInstance':
+                        color = Color.fromArray(tColor, (instanceIndex * drawCount + i) * 3);
+                        break;
+                    case 'volume':
+                        color = Color.fromArray(interpolatedColors!, i * 3);
+                        break;
+                    case 'volumeInstance':
+                        color = Color.fromArray(interpolatedColors!, (instanceIndex * vertexCount + i) * 3);
+                        break;
+                    default: throw new Error('Unsupported color type.');
+                }
+
+                let alpha = uAlpha;
+                if (dTransparency) {
+                    const group = isGeoTexture ? GlbExporter.getGroup(groups, i) : groups[i];
+                    const transparency = tTransparency.array[instanceIndex * groupCount + group] / 255;
+                    alpha *= 1 - transparency;
+                }
+
+                Color.toArrayNormalized(color, colorArray, i * 4);
+                colorArray[i * 4 + 3] = alpha;
+            }
+
+            // face
+            if (isGeoTexture) {
+                indexArray = new Uint32Array(drawCount);
+                fillSerial(indexArray);
+            } else {
+                indexArray = indices!.slice(0, drawCount);
+            }
+
+            const [ vertexMin, vertexMax ] = GlbExporter.vecMinMax(vertexArray, 3);
+            const [ normalMin, normalMax ] = GlbExporter.vecMinMax(normalArray, 3);
+            const [ colorMin, colorMax ] = GlbExporter.vecMinMax(colorArray, 4);
+            const [ indexMin, indexMax ] = arrayMinMax(indexArray);
+
+            // binary buffer
+            let vertexBuffer = vertexArray.buffer;
+            let normalBuffer = normalArray.buffer;
+            let colorBuffer = colorArray.buffer;
+            let indexBuffer = indexArray.buffer;
+            if (!IsNativeEndianLittle) {
+                vertexBuffer = flipByteOrder(new Uint8Array(vertexBuffer), 4);
+                normalBuffer = flipByteOrder(new Uint8Array(normalBuffer), 4);
+                colorBuffer = flipByteOrder(new Uint8Array(colorBuffer), 4);
+                indexBuffer = flipByteOrder(new Uint8Array(indexBuffer), 4);
+            }
+            this.binaryBuffer.push(vertexBuffer, normalBuffer, colorBuffer, indexBuffer);
+
+            // buffer views
+            const bufferViewOffset = this.bufferViews.length;
+
+            this.bufferViews.push({
+                buffer: 0,
+                byteOffset: this.byteOffset,
+                byteLength: vertexBuffer.byteLength,
+                target: 34962 // ARRAY_BUFFER
+            });
+            this.byteOffset += vertexBuffer.byteLength;
+
+            this.bufferViews.push({
+                buffer: 0,
+                byteOffset: this.byteOffset,
+                byteLength: normalBuffer.byteLength,
+                target: 34962 // ARRAY_BUFFER
+            });
+            this.byteOffset += normalBuffer.byteLength;
+
+            this.bufferViews.push({
+                buffer: 0,
+                byteOffset: this.byteOffset,
+                byteLength: colorBuffer.byteLength,
+                target: 34962 // ARRAY_BUFFER
+            });
+            this.byteOffset += colorBuffer.byteLength;
+
+            this.bufferViews.push({
+                buffer: 0,
+                byteOffset: this.byteOffset,
+                byteLength: indexBuffer.byteLength,
+                target: 34963 // ELEMENT_ARRAY_BUFFER
+            });
+            this.byteOffset += indexBuffer.byteLength;
+
+            // accessors
+            const accessorOffset = this.accessors.length;
+            this.accessors.push({
+                bufferView: bufferViewOffset,
+                byteOffset: 0,
+                componentType: 5126, // FLOAT
+                count: vertexCount,
+                type: 'VEC3',
+                max: vertexMax,
+                min: vertexMin
+            });
+            this.accessors.push({
+                bufferView: bufferViewOffset + 1,
+                byteOffset: 0,
+                componentType: 5126, // FLOAT
+                count: vertexCount,
+                type: 'VEC3',
+                max: normalMax,
+                min: normalMin
+            });
+            this.accessors.push({
+                bufferView: bufferViewOffset + 2,
+                byteOffset: 0,
+                componentType: 5126, // FLOAT
+                count: vertexCount,
+                type: 'VEC4',
+                max: colorMax,
+                min: colorMin
+            });
+            this.accessors.push({
+                bufferView: bufferViewOffset + 3,
+                byteOffset: 0,
+                componentType: 5125, // UNSIGNED_INT
+                count: drawCount,
+                type: 'SCALAR',
+                max: [ indexMax ],
+                min: [ indexMin ]
+            });
+
+            // primitive
+            this.primitives.push({
+                attributes: {
+                    POSITION: accessorOffset,
+                    NORMAL: accessorOffset + 1,
+                    COLOR_0: accessorOffset + 2,
+                },
+                indices: accessorOffset + 3,
+                material: 0
+            });
         }
-
-        // face
-        if (isGeoTexture) {
-            indexArray = new Uint32Array(drawCount);
-            fillSerial(indexArray);
-        } else {
-            indexArray = indices!.slice(0, drawCount);
-        }
-
-        const [ vertexMin, vertexMax ] = GlbExporter.vecMinMax(vertexArray, 3);
-        const [ normalMin, normalMax ] = GlbExporter.vecMinMax(normalArray, 3);
-        const [ colorMin, colorMax ] = GlbExporter.vecMinMax(colorArray, 4);
-        const [ indexMin, indexMax ] = arrayMinMax(indexArray);
-
-        // binary buffer
-        let vertexBuffer = vertexArray.buffer;
-        let normalBuffer = normalArray.buffer;
-        let colorBuffer = colorArray.buffer;
-        let indexBuffer = indexArray.buffer;
-        if (!IsNativeEndianLittle) {
-            vertexBuffer = flipByteOrder(new Uint8Array(vertexBuffer), 4);
-            normalBuffer = flipByteOrder(new Uint8Array(normalBuffer), 4);
-            colorBuffer = flipByteOrder(new Uint8Array(colorBuffer), 4);
-            indexBuffer = flipByteOrder(new Uint8Array(indexBuffer), 4);
-        }
-        this.binaryBuffer.push(vertexBuffer, normalBuffer, colorBuffer, indexBuffer);
-
-        // buffer views
-        const bufferViewOffset = this.bufferViews.length;
-
-        this.bufferViews.push({
-            buffer: 0,
-            byteOffset: this.byteOffset,
-            byteLength: vertexBuffer.byteLength,
-            target: 34962 // ARRAY_BUFFER
-        });
-        this.byteOffset += vertexBuffer.byteLength;
-
-        this.bufferViews.push({
-            buffer: 0,
-            byteOffset: this.byteOffset,
-            byteLength: normalBuffer.byteLength,
-            target: 34962 // ARRAY_BUFFER
-        });
-        this.byteOffset += normalBuffer.byteLength;
-
-        this.bufferViews.push({
-            buffer: 0,
-            byteOffset: this.byteOffset,
-            byteLength: colorBuffer.byteLength,
-            target: 34962 // ARRAY_BUFFER
-        });
-        this.byteOffset += colorBuffer.byteLength;
-
-        this.bufferViews.push({
-            buffer: 0,
-            byteOffset: this.byteOffset,
-            byteLength: indexBuffer.byteLength,
-            target: 34963 // ELEMENT_ARRAY_BUFFER
-        });
-        this.byteOffset += indexBuffer.byteLength;
-
-        // accessors
-        const accessorOffset = this.accessors.length;
-        this.accessors.push({
-            bufferView: bufferViewOffset,
-            byteOffset: 0,
-            componentType: 5126, // FLOAT
-            count: vertexCount,
-            type: 'VEC3',
-            max: vertexMax,
-            min: vertexMin
-        });
-        this.accessors.push({
-            bufferView: bufferViewOffset + 1,
-            byteOffset: 0,
-            componentType: 5126, // FLOAT
-            count: vertexCount,
-            type: 'VEC3',
-            max: normalMax,
-            min: normalMin
-        });
-        this.accessors.push({
-            bufferView: bufferViewOffset + 2,
-            byteOffset: 0,
-            componentType: 5126, // FLOAT
-            count: vertexCount,
-            type: 'VEC4',
-            max: colorMax,
-            min: colorMin
-        });
-        this.accessors.push({
-            bufferView: bufferViewOffset + 3,
-            byteOffset: 0,
-            componentType: 5125, // UNSIGNED_INT
-            count: drawCount,
-            type: 'SCALAR',
-            max: [ indexMax ],
-            min: [ indexMin ]
-        });
-
-        // primitive
-        this.primitives.push({
-            attributes: {
-                POSITION: accessorOffset,
-                NORMAL: accessorOffset + 1,
-                COLOR_0: accessorOffset + 2,
-            },
-            indices: accessorOffset + 3,
-            material: 0
-        });
     }
 
     getData() {

--- a/src/extensions/geo-export/obj-exporter.ts
+++ b/src/extensions/geo-export/obj-exporter.ts
@@ -4,6 +4,7 @@
  * @author Sukolsak Sakshuwong <sukolsak@stanford.edu>
  */
 
+import { sort, arraySwap } from '../../mol-data/util';
 import { asciiWrite } from '../../mol-io/common/ascii';
 import { Vec3, Mat3, Mat4 } from '../../mol-math/linear-algebra';
 import { RuntimeContext } from '../../mol-task';
@@ -66,6 +67,70 @@ export class ObjExporter extends MeshExporter<ObjData> {
         }
     }
 
+    private static quantizeColors(colorArray: Uint8Array, vertexCount: number) {
+        if (vertexCount <= 1024) return;
+        const rgb = Vec3();
+        const min = Vec3();
+        const max = Vec3();
+        const sum = Vec3();
+        const colorMap = new Map<Color, Color>();
+        const colorComparers = [
+            (colors: Color[], i: number, j: number) => (Color.toVec3(rgb, colors[i])[0] - Color.toVec3(rgb, colors[j])[0]),
+            (colors: Color[], i: number, j: number) => (Color.toVec3(rgb, colors[i])[1] - Color.toVec3(rgb, colors[j])[1]),
+            (colors: Color[], i: number, j: number) => (Color.toVec3(rgb, colors[i])[2] - Color.toVec3(rgb, colors[j])[2]),
+        ];
+
+        const medianCut = (colors: Color[], l: number, r: number, depth: number) => {
+            if (l > r) return;
+            if (l === r || depth >= 10) {
+                // Find the average color.
+                Vec3.set(sum, 0, 0, 0);
+                for (let i = l; i <= r; ++i) {
+                    Color.toVec3(rgb, colors[i]);
+                    Vec3.add(sum, sum, rgb);
+                }
+                Vec3.round(rgb, Vec3.scale(rgb, sum, 1 / (r - l + 1)));
+                const averageColor = Color.fromArray(rgb, 0);
+                for (let i = l; i <= r; ++i) colorMap.set(colors[i], averageColor);
+                return;
+            }
+
+            // Find the color channel with the greatest range.
+            Vec3.set(min, 255, 255, 255);
+            Vec3.set(max, 0, 0, 0);
+            for (let i = l; i <= r; ++i) {
+                Color.toVec3(rgb, colors[i]);
+                for (let j = 0; j < 3; ++j) {
+                    Vec3.min(min, min, rgb);
+                    Vec3.max(max, max, rgb);
+                }
+            }
+            let k = 0;
+            if (max[1] - min[1] > max[k] - min[k]) k = 1;
+            if (max[2] - min[2] > max[k] - min[k]) k = 2;
+
+            sort(colors, l, r + 1, colorComparers[k], arraySwap);
+
+            const m = (l + r) >> 1;
+            medianCut(colors, l, m, depth + 1);
+            medianCut(colors, m + 1, r, depth + 1);
+        };
+
+        // Create an array of unique colors and use the median cut algorithm.
+        const colorSet = new Set<Color>();
+        for (let i = 0; i < vertexCount; ++i) {
+            colorSet.add(Color.fromArray(colorArray, i * 3));
+        }
+        const colors = Array.from(colorSet);
+        medianCut(colors, 0, colors.length - 1, 0);
+
+        // Map actual colors to quantized colors.
+        for (let i = 0; i < vertexCount; ++i) {
+            const color = colorMap.get(Color.fromArray(colorArray, i * 3));
+            Color.toArray(color!, colorArray, i * 3);
+        }
+    }
+
     protected async addMeshWithColors(input: AddMeshInput) {
         const { mesh, meshes, values, isGeoTexture, webgl, ctx } = input;
 
@@ -87,6 +152,7 @@ export class ObjExporter extends MeshExporter<ObjData> {
         let interpolatedColors: Uint8Array;
         if (colorType === 'volume' || colorType === 'volumeInstance') {
             interpolatedColors = ObjExporter.getInterpolatedColors(mesh!.vertices, mesh!.vertexCount, values, stride, colorType, webgl!);
+            ObjExporter.quantizeColors(interpolatedColors, mesh!.vertexCount);
         }
 
         await ctx.update({ isIndeterminate: false, current: 0, max: instanceCount });

--- a/src/extensions/geo-export/obj-exporter.ts
+++ b/src/extensions/geo-export/obj-exporter.ts
@@ -180,7 +180,7 @@ export class ObjExporter extends MeshExporter<ObjData> {
                 indices = mesh.indexBuffer.ref.value;
                 groups = mesh.groupBuffer.ref.value;
                 vertexCount = mesh.vertexCount;
-                drawCount = indices.length;
+                drawCount = mesh.triangleCount * 3;
             }
 
             Mat4.fromArray(t, aTransform, instanceIndex * 16);

--- a/src/extensions/geo-export/stl-exporter.ts
+++ b/src/extensions/geo-export/stl-exporter.ts
@@ -56,7 +56,7 @@ export class StlExporter extends MeshExporter<StlData> {
                 vertices = mesh.vertexBuffer.ref.value;
                 indices = mesh.indexBuffer.ref.value;
                 vertexCount = mesh.vertexCount;
-                drawCount = indices.length;
+                drawCount = mesh.triangleCount * 3;
             }
 
             const aTransform = values.aTransform.ref.value;

--- a/src/extensions/geo-export/stl-exporter.ts
+++ b/src/extensions/geo-export/stl-exporter.ts
@@ -4,12 +4,11 @@
  * @author Sukolsak Sakshuwong <sukolsak@stanford.edu>
  */
 
-import { BaseValues } from '../../mol-gl/renderable/schema';
 import { asciiWrite } from '../../mol-io/common/ascii';
 import { Vec3, Mat4 } from '../../mol-math/linear-algebra';
 import { PLUGIN_VERSION } from '../../mol-plugin/version';
 import { RuntimeContext } from '../../mol-task';
-import { MeshExporter } from './mesh-exporter';
+import { MeshExporter, AddMeshInput } from './mesh-exporter';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3fromArray = Vec3.fromArray;
@@ -28,7 +27,9 @@ export class StlExporter extends MeshExporter<StlData> {
     private triangleBuffers: ArrayBuffer[] = [];
     private triangleCount = 0;
 
-    protected async addMeshWithColors(vertices: Float32Array, normals: Float32Array, indices: Uint32Array | undefined, groups: Float32Array | Uint8Array, vertexCount: number, drawCount: number, values: BaseValues, instanceIndex: number, isGeoTexture: boolean, ctx: RuntimeContext) {
+    protected async addMeshWithColors(input: AddMeshInput) {
+        const { mesh, meshes, values, isGeoTexture, ctx } = input;
+
         const t = Mat4();
         const tmpV = Vec3();
         const v1 = Vec3();
@@ -36,51 +37,68 @@ export class StlExporter extends MeshExporter<StlData> {
         const v3 = Vec3();
         const stride = isGeoTexture ? 4 : 3;
 
-        const aTransform = values.aTransform.ref.value;
-        Mat4.fromArray(t, aTransform, instanceIndex * 16);
+        const instanceCount = values.uInstanceCount.ref.value;
 
-        const currentProgress = (vertexCount + drawCount) * instanceIndex;
-        await ctx.update({ isIndeterminate: false, current: currentProgress, max: (vertexCount + drawCount) * values.uInstanceCount.ref.value });
+        for (let instanceIndex = 0; instanceIndex < instanceCount; ++instanceIndex) {
+            if (ctx.shouldUpdate) await ctx.update({ current: instanceIndex + 1 });
 
-        // position
-        const vertexArray = new Float32Array(vertexCount * 3);
-        for (let i = 0; i < vertexCount; ++i) {
-            if (i % 1000 === 0 && ctx.shouldUpdate) await ctx.update({ current: currentProgress + i });
-            v3transformMat4(tmpV, v3fromArray(tmpV, vertices, i * stride), t);
-            v3toArray(tmpV, vertexArray, i * 3);
+            let vertices: Float32Array;
+            let indices: Uint32Array | undefined;
+            let vertexCount: number;
+            let drawCount: number;
+            if (mesh !== undefined) {
+                vertices = mesh.vertices;
+                indices = mesh.indices;
+                vertexCount = mesh.vertexCount;
+                drawCount = mesh.drawCount;
+            } else {
+                const mesh = meshes![instanceIndex];
+                vertices = mesh.vertexBuffer.ref.value;
+                indices = mesh.indexBuffer.ref.value;
+                vertexCount = mesh.vertexCount;
+                drawCount = indices.length;
+            }
+
+            const aTransform = values.aTransform.ref.value;
+            Mat4.fromArray(t, aTransform, instanceIndex * 16);
+
+            // position
+            const vertexArray = new Float32Array(vertexCount * 3);
+            for (let i = 0; i < vertexCount; ++i) {
+                v3transformMat4(tmpV, v3fromArray(tmpV, vertices, i * stride), t);
+                v3toArray(tmpV, vertexArray, i * 3);
+            }
+
+            // face
+            const triangleBuffer = new ArrayBuffer(50 * drawCount);
+            const dataView = new DataView(triangleBuffer);
+            for (let i = 0; i < drawCount; i += 3) {
+                v3fromArray(v1, vertexArray, (isGeoTexture ? i : indices![i]) * 3);
+                v3fromArray(v2, vertexArray, (isGeoTexture ? i + 1 : indices![i + 1]) * 3);
+                v3fromArray(v3, vertexArray, (isGeoTexture ? i + 2 : indices![i + 2]) * 3);
+                v3triangleNormal(tmpV, v1, v2, v3);
+
+                const byteOffset = 50 * i;
+                dataView.setFloat32(byteOffset, tmpV[0], true);
+                dataView.setFloat32(byteOffset + 4, tmpV[1], true);
+                dataView.setFloat32(byteOffset + 8, tmpV[2], true);
+
+                dataView.setFloat32(byteOffset + 12, v1[0], true);
+                dataView.setFloat32(byteOffset + 16, v1[1], true);
+                dataView.setFloat32(byteOffset + 20, v1[2], true);
+
+                dataView.setFloat32(byteOffset + 24, v2[0], true);
+                dataView.setFloat32(byteOffset + 28, v2[1], true);
+                dataView.setFloat32(byteOffset + 32, v2[2], true);
+
+                dataView.setFloat32(byteOffset + 36, v3[0], true);
+                dataView.setFloat32(byteOffset + 40, v3[1], true);
+                dataView.setFloat32(byteOffset + 44, v3[2], true);
+            }
+
+            this.triangleBuffers.push(triangleBuffer);
+            this.triangleCount += drawCount;
         }
-
-        // face
-        const triangleBuffer = new ArrayBuffer(50 * drawCount);
-        const dataView = new DataView(triangleBuffer);
-        for (let i = 0; i < drawCount; i += 3) {
-            if (i % 3000 === 0 && ctx.shouldUpdate) await ctx.update({ current: currentProgress + vertexCount + i });
-
-            v3fromArray(v1, vertexArray, (isGeoTexture ? i : indices![i]) * 3);
-            v3fromArray(v2, vertexArray, (isGeoTexture ? i + 1 : indices![i + 1]) * 3);
-            v3fromArray(v3, vertexArray, (isGeoTexture ? i + 2 : indices![i + 2]) * 3);
-            v3triangleNormal(tmpV, v1, v2, v3);
-
-            const byteOffset = 50 * i;
-            dataView.setFloat32(byteOffset, tmpV[0], true);
-            dataView.setFloat32(byteOffset + 4, tmpV[1], true);
-            dataView.setFloat32(byteOffset + 8, tmpV[2], true);
-
-            dataView.setFloat32(byteOffset + 12, v1[0], true);
-            dataView.setFloat32(byteOffset + 16, v1[1], true);
-            dataView.setFloat32(byteOffset + 20, v1[2], true);
-
-            dataView.setFloat32(byteOffset + 24, v2[0], true);
-            dataView.setFloat32(byteOffset + 28, v2[1], true);
-            dataView.setFloat32(byteOffset + 32, v2[2], true);
-
-            dataView.setFloat32(byteOffset + 36, v3[0], true);
-            dataView.setFloat32(byteOffset + 40, v3[1], true);
-            dataView.setFloat32(byteOffset + 44, v3[2], true);
-        }
-
-        this.triangleBuffers.push(triangleBuffer);
-        this.triangleCount += drawCount;
     }
 
     getData() {


### PR DESCRIPTION
#173 will add new `dColorType` values: "volume" | "volumeInstance". This PR adds support for them in the geometry exporters and resolves #184.

Most changes in this PR are moving the instance loop inside `addMeshWithColors` so that we can call `getTrilinearlyInterpolated` just once. This might also facilitate a potential plan to use the instancing feature in GLTF in the future.

Since vertex coloring [doesn't](https://gamedev.stackexchange.com/questions/21303/how-can-i-include-vertex-color-information-in-obj-files) [seem](https://blender.stackexchange.com/questions/90890/how-to-display-and-use-vertex-color-from-obj-model) to be officially supported in OBJ, exporting raw volume colors can create hundreds of thousands of colors in the MTL file and make some 3D software like Blender take forever to load. So I quantize the colors using the [median cut algorithm](https://en.wikipedia.org/wiki/Median_cut), as suggested by @arose, to limit the number of colors to at most 1024.

This PR also converts sRGB to linear when exporting to GLB.