### PR TITLE
Geometry export: use instancing in GLB

### DIFF
--- a/src/extensions/geo-export/glb-exporter.ts
+++ b/src/extensions/geo-export/glb-exporter.ts
@@ -8,6 +8,7 @@ import { BaseValues } from '../../mol-gl/renderable/schema';
 import { asciiWrite } from '../../mol-io/common/ascii';
 import { IsNativeEndianLittle, flipByteOrder } from '../../mol-io/common/binary';
 import { Vec3, Mat4 } from '../../mol-math/linear-algebra';
+import { PLUGIN_VERSION } from '../../mol-plugin/version';
 import { RuntimeContext } from '../../mol-task';
 import { Color } from '../../mol-util/color/color';
 import { arrayMinMax, fillSerial } from '../../mol-util/array';
@@ -322,7 +323,8 @@ export class GlbExporter extends MeshExporter<GlbData> {
 
         const gltf = {
             asset: {
-                version: '2.0'
+                version: '2.0',
+                generator: `Mol* ${PLUGIN_VERSION}`
             },
             scenes: [{
                 nodes: fillSerial(new Array(this.nodes.length) as number[])

--- a/src/extensions/geo-export/mesh-exporter.ts
+++ b/src/extensions/geo-export/mesh-exporter.ts
@@ -111,7 +111,34 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
         return interpolated.array;
     }
 
-    protected abstract addMeshWithColors(inpit: AddMeshInput): void;
+    protected static getInstance(input: AddMeshInput, instanceIndex: number) {
+        const { mesh, meshes } = input;
+        let vertices: Float32Array;
+        let normals: Float32Array;
+        let indices: Uint32Array | undefined;
+        let groups: Float32Array | Uint8Array;
+        let vertexCount: number;
+        let drawCount: number;
+        if (mesh !== undefined) {
+            vertices = mesh.vertices;
+            normals = mesh.normals;
+            indices = mesh.indices;
+            groups = mesh.groups;
+            vertexCount = mesh.vertexCount;
+            drawCount = mesh.drawCount;
+        } else {
+            const mesh = meshes![instanceIndex];
+            vertices = mesh.vertexBuffer.ref.value;
+            normals = mesh.normalBuffer.ref.value;
+            indices = mesh.indexBuffer.ref.value;
+            groups = mesh.groupBuffer.ref.value;
+            vertexCount = mesh.vertexCount;
+            drawCount = mesh.triangleCount * 3;
+        }
+        return { vertices, normals, indices, groups, vertexCount, drawCount };
+    }
+
+    protected abstract addMeshWithColors(input: AddMeshInput): void;
 
     private async addMesh(values: MeshValues, webgl: WebGLContext, ctx: RuntimeContext) {
         const aPosition = values.aPosition.ref.value;

--- a/src/extensions/geo-export/mesh-exporter.ts
+++ b/src/extensions/geo-export/mesh-exporter.ts
@@ -100,7 +100,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
         }
         const framebuffer = webgl.namedFramebuffers[GeoExportName];
 
-        const [ width, height ] = values.uColorTexDim.ref.value;
+        const [ width, height ] = colorTexDim;
         const colorGrid = new Uint8Array(width * height * 4);
 
         framebuffer.bind();
@@ -113,29 +113,19 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
 
     protected static getInstance(input: AddMeshInput, instanceIndex: number) {
         const { mesh, meshes } = input;
-        let vertices: Float32Array;
-        let normals: Float32Array;
-        let indices: Uint32Array | undefined;
-        let groups: Float32Array | Uint8Array;
-        let vertexCount: number;
-        let drawCount: number;
         if (mesh !== undefined) {
-            vertices = mesh.vertices;
-            normals = mesh.normals;
-            indices = mesh.indices;
-            groups = mesh.groups;
-            vertexCount = mesh.vertexCount;
-            drawCount = mesh.drawCount;
+            return mesh;
         } else {
             const mesh = meshes![instanceIndex];
-            vertices = mesh.vertexBuffer.ref.value;
-            normals = mesh.normalBuffer.ref.value;
-            indices = mesh.indexBuffer.ref.value;
-            groups = mesh.groupBuffer.ref.value;
-            vertexCount = mesh.vertexCount;
-            drawCount = mesh.triangleCount * 3;
+            return {
+                vertices: mesh.vertexBuffer.ref.value,
+                normals: mesh.normalBuffer.ref.value,
+                indices: mesh.indexBuffer.ref.value,
+                groups: mesh.groupBuffer.ref.value,
+                vertexCount: mesh.vertexCount,
+                drawCount: mesh.triangleCount * 3
+            };
         }
-        return { vertices, normals, indices, groups, vertexCount, drawCount };
     }
 
     protected abstract addMeshWithColors(input: AddMeshInput): void;

--- a/src/extensions/geo-export/obj-exporter.ts
+++ b/src/extensions/geo-export/obj-exporter.ts
@@ -132,7 +132,7 @@ export class ObjExporter extends MeshExporter<ObjData> {
     }
 
     protected async addMeshWithColors(input: AddMeshInput) {
-        const { mesh, meshes, values, isGeoTexture, webgl, ctx } = input;
+        const { mesh, values, isGeoTexture, webgl, ctx } = input;
 
         const obj = this.obj;
         const t = Mat4();
@@ -160,28 +160,7 @@ export class ObjExporter extends MeshExporter<ObjData> {
         for (let instanceIndex = 0; instanceIndex < instanceCount; ++instanceIndex) {
             if (ctx.shouldUpdate) await ctx.update({ current: instanceIndex + 1 });
 
-            let vertices: Float32Array;
-            let normals: Float32Array;
-            let indices: Uint32Array | undefined;
-            let groups: Float32Array | Uint8Array;
-            let vertexCount: number;
-            let drawCount: number;
-            if (mesh !== undefined) {
-                vertices = mesh.vertices;
-                normals = mesh.normals;
-                indices = mesh.indices;
-                groups = mesh.groups;
-                vertexCount = mesh.vertexCount;
-                drawCount = mesh.drawCount;
-            } else {
-                const mesh = meshes![instanceIndex];
-                vertices = mesh.vertexBuffer.ref.value;
-                normals = mesh.normalBuffer.ref.value;
-                indices = mesh.indexBuffer.ref.value;
-                groups = mesh.groupBuffer.ref.value;
-                vertexCount = mesh.vertexCount;
-                drawCount = mesh.triangleCount * 3;
-            }
+            const { vertices, normals, indices, groups, vertexCount, drawCount } = ObjExporter.getInstance(input, instanceIndex);
 
             Mat4.fromArray(t, aTransform, instanceIndex * 16);
             mat3directionTransform(n, t);
@@ -234,7 +213,7 @@ export class ObjExporter extends MeshExporter<ObjData> {
                         color = Color.fromArray(tColor, indices![i] * 3);
                         break;
                     case 'vertexInstance':
-                        color = Color.fromArray(tColor, (instanceIndex * drawCount + indices![i]) * 3);
+                        color = Color.fromArray(tColor, (instanceIndex * vertexCount + indices![i]) * 3);
                         break;
                     case 'volume':
                         color = Color.fromArray(interpolatedColors!, (isGeoTexture ? i : indices![i]) * 3);

--- a/src/extensions/geo-export/stl-exporter.ts
+++ b/src/extensions/geo-export/stl-exporter.ts
@@ -28,7 +28,7 @@ export class StlExporter extends MeshExporter<StlData> {
     private triangleCount = 0;
 
     protected async addMeshWithColors(input: AddMeshInput) {
-        const { mesh, meshes, values, isGeoTexture, ctx } = input;
+        const { values, isGeoTexture, ctx } = input;
 
         const t = Mat4();
         const tmpV = Vec3();
@@ -37,29 +37,14 @@ export class StlExporter extends MeshExporter<StlData> {
         const v3 = Vec3();
         const stride = isGeoTexture ? 4 : 3;
 
+        const aTransform = values.aTransform.ref.value;
         const instanceCount = values.uInstanceCount.ref.value;
 
         for (let instanceIndex = 0; instanceIndex < instanceCount; ++instanceIndex) {
             if (ctx.shouldUpdate) await ctx.update({ current: instanceIndex + 1 });
 
-            let vertices: Float32Array;
-            let indices: Uint32Array | undefined;
-            let vertexCount: number;
-            let drawCount: number;
-            if (mesh !== undefined) {
-                vertices = mesh.vertices;
-                indices = mesh.indices;
-                vertexCount = mesh.vertexCount;
-                drawCount = mesh.drawCount;
-            } else {
-                const mesh = meshes![instanceIndex];
-                vertices = mesh.vertexBuffer.ref.value;
-                indices = mesh.indexBuffer.ref.value;
-                vertexCount = mesh.vertexCount;
-                drawCount = mesh.triangleCount * 3;
-            }
+            const { vertices, indices, vertexCount, drawCount } = StlExporter.getInstance(input, instanceIndex);
 
-            const aTransform = values.aTransform.ref.value;
             Mat4.fromArray(t, aTransform, instanceIndex * 16);
 
             // position

--- a/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
@@ -96,7 +96,7 @@ async function createGaussianSurfaceMesh(ctx: VisualContext, unit: Unit, structu
     (surface.meta as GaussianSurfaceMeta) = { resolution };
 
     Mesh.transform(surface, transform);
-    if (ctx.webgl && !ctx.webgl.isWebGL2) Mesh.uniformTriangleGroup(surface);
+    if (ctx.webgl && !ctx.webgl.isWebGL2) Mesh.uniformTriangleGroup(surface, false);
 
     const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, props.radiusOffset + getUnitExtraRadius(unit));
     surface.setBoundingSphere(sphere);
@@ -157,7 +157,7 @@ async function createStructureGaussianSurfaceMesh(ctx: VisualContext, structure:
     (surface.meta as GaussianSurfaceMeta) = { resolution };
 
     Mesh.transform(surface, transform);
-    if (ctx.webgl && !ctx.webgl.isWebGL2) Mesh.uniformTriangleGroup(surface);
+    if (ctx.webgl && !ctx.webgl.isWebGL2) Mesh.uniformTriangleGroup(surface, false);
 
     const sphere = Sphere3D.expand(Sphere3D(), structure.boundary.sphere, props.radiusOffset + getStructureExtraRadius(structure));
     surface.setBoundingSphere(sphere);

--- a/src/mol-repr/structure/visual/molecular-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/molecular-surface-mesh.ts
@@ -48,7 +48,7 @@ async function createMolecularSurfaceMesh(ctx: VisualContext, unit: Unit, struct
     const surface = await computeMarchingCubesMesh(params, mesh).runAsChild(ctx.runtime);
 
     Mesh.transform(surface, transform);
-    if (ctx.webgl && !ctx.webgl.isWebGL2) Mesh.uniformTriangleGroup(surface);
+    if (ctx.webgl && !ctx.webgl.isWebGL2) Mesh.uniformTriangleGroup(surface, false);
 
     const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, props.probeRadius + getUnitExtraRadius(unit));
     surface.setBoundingSphere(sphere);


### PR DESCRIPTION
glTF/GLB supports [instancing](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#instantiation); The same mesh can be used by multiple nodes, which can have different transformations. The same vertex/normal/index/color buffers can also be used by multiple meshes. This PR tries to reuse meshes and buffers whenever possible.
- Use the same vertex/normal/index buffers for all instances if all instances have the same geometry. That is, the `GraphicsRenderObject`'s type is `mesh` or `texture-mesh`.
- Use the same color buffer for all instances if the color type is not one of the `*Instance` color types and per-group transparency is not used.
- If both conditions are true, use the same `mesh` object for all instances.

Exporting models with many instances such as 1RB8, 6CO8, 6B1T, etc. to GLB should now be very fast. The file size is also much smaller. Without instancing, 1RB8 uses ~900 MB. With instancing, it uses 15 MB. (However, if you change the color theme from "Chain Id" to "Chain Instance", it uses ~300 MB because we have to create a new color buffer for each instance.)

Other changes in this PR:
- Add "Mol* [version]" to the header.
- Remove `min` and `max` from normal/index/color accessors to save some space. They are only required for vertex accessors.
- Remove `indices` from TextureMesh primitives to save some space. They are arrays of serial numbers from 0 to n-1. The [glTF spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#primitiveindices) says "When [`primitive.indices`] is not defined, the primitives should be rendered without indices using `drawArrays()`."
- Refactor duplicate code.