### PR TITLE
ANVIL fixes

### DIFF
--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -24,6 +24,7 @@ interface ANVILContext {
     minThickness: number,
     maxThickness: number,
     asaCutoff: number,
+    adjust: number,
 
     offsets: ArrayLike<number>,
     exposed: ArrayLike<boolean>,
@@ -32,11 +33,12 @@ interface ANVILContext {
 };
 
 export const ANVILParams = {
-    numberOfSpherePoints: PD.Numeric(120, { min: 35, max: 700, step: 1 }, { description: 'Number of spheres/directions to test for membrane placement. Original value is 350.' }),
+    numberOfSpherePoints: PD.Numeric(350, { min: 35, max: 700, step: 1 }, { description: 'Number of spheres/directions to test for membrane placement. Original value is 350.' }),
     stepSize: PD.Numeric(1, { min: 0.25, max: 4, step: 0.25 }, { description: 'Thickness of membrane slices that will be tested' }),
     minThickness: PD.Numeric(20, { min: 10, max: 30, step: 1}, { description: 'Minimum membrane thickness used during refinement' }),
     maxThickness: PD.Numeric(40, { min: 30, max: 50, step: 1}, { description: 'Maximum membrane thickness used during refinement' }),
-    asaCutoff: PD.Numeric(40, { min: 10, max: 100, step: 1 }, { description: 'Absolute ASA cutoff above which residues will be considered' })
+    asaCutoff: PD.Numeric(40, { min: 10, max: 100, step: 1 }, { description: 'Relative ASA cutoff above which residues will be considered' }),
+    adjust: PD.Numeric(14, { min: 0, max: 30, step: 1 }, { description: 'Minimum length of membrane-spanning regions (original values: 14 for alpha-helices and 5 for beta sheets). Set to 0 to not optimize membrane thickness.' })
 };
 export type ANVILParams = typeof ANVILParams
 export type ANVILProps = PD.Values<ANVILParams>
@@ -58,18 +60,20 @@ export function computeANVIL(structure: Structure, props: ANVILProps) {
 const centroidHelper = new CentroidHelper();
 function initialize(structure: Structure, props: ANVILProps): ANVILContext {
     const l = StructureElement.Location.create(structure);
-    const { label_atom_id, x, y, z } = StructureProperties.atom;
+    const { label_atom_id, label_comp_id, x, y, z } = StructureProperties.atom;
     const elementCount = structure.polymerResidueCount;
     centroidHelper.reset();
 
-    let offsets = new Int32Array(elementCount);
+    let offsets = new Array<number>(elementCount);
     let exposed = new Array<boolean>(elementCount);
 
     const accessibleSurfaceArea = structure && AccessibleSurfaceAreaProvider.get(structure);
     const asa = accessibleSurfaceArea.value!;
+    const asaCutoff = props.asaCutoff / 100;
 
     const vec = Vec3();
     let m = 0;
+    let e = 0, b = 0;
     for (let i = 0, il = structure.units.length; i < il; ++i) {
         const unit = structure.units[i];
         const { elements } = unit;
@@ -95,13 +99,19 @@ function initialize(structure: Structure, props: ANVILProps): ANVILContext {
 
             // keep track of offsets and exposed state to reuse
             offsets[m] = structure.serialMapping.getSerialIndex(l.unit, l.element);
-            exposed[m] = AccessibleSurfaceArea.getValue(l, asa) > props.asaCutoff;
-
+            exposed[m] = AccessibleSurfaceArea.getValue(l, asa) / MaxAsa[label_comp_id(l)] > asaCutoff;
+            if (AccessibleSurfaceArea.getValue(l, asa) / MaxAsa[label_comp_id(l)] > asaCutoff) {
+                e++;
+            } else {
+                b++;
+            }
             m++;
         }
     }
+    console.log('CAs = ' + m);
+    console.log('exposed ' + e + ' - buried ' + b);
 
-    // omit potentially empty tail1
+    // omit potentially empty tail
     offsets = offsets.slice(0, m);
     exposed = exposed.slice(0, m);
 
@@ -114,28 +124,52 @@ function initialize(structure: Structure, props: ANVILProps): ANVILContext {
         centroidHelper.radiusStep(vec);
     }
     const extent = 1.2 * Math.sqrt(centroidHelper.radiusSq);
+    console.log(`center: ${centroid}, radius: ${Math.sqrt(centroidHelper.radiusSq)}`);
 
     return {
         ...props,
-        structure: structure,
+        structure,
 
-        offsets: offsets,
-        exposed: exposed,
-        centroid: centroid,
-        extent: extent
+        offsets,
+        exposed,
+        centroid,
+        extent
     };
 }
 
 export async function calculate(runtime: RuntimeContext, structure: Structure, params: ANVILProps): Promise<MembraneOrientation> {
-    const { label_comp_id } = StructureProperties.atom;
-
     const ctx = initialize(structure, params);
-    const initialHphobHphil = HphobHphil.filtered(ctx, label_comp_id);
+    const initialHphobHphil = HphobHphil.filtered(ctx);
+    console.log(`init: ${initialHphobHphil.hphob} - ${initialHphobHphil.hphil}`);
 
-    const initialMembrane = findMembrane(ctx, generateSpherePoints(ctx, ctx.numberOfSpherePoints), initialHphobHphil, label_comp_id);
-    const alternativeMembrane = findMembrane(ctx, findProximateAxes(ctx, initialMembrane), initialHphobHphil, label_comp_id);
+    if (runtime.shouldUpdate) {
+        await runtime.update({ message: 'Placing initial membrane...' });
+    }
+    console.time('ini-membrane');
+    const initialMembrane = findMembrane(ctx, generateSpherePoints(ctx, ctx.numberOfSpherePoints), initialHphobHphil)!;
+    console.timeEnd('ini-membrane');
+    console.log(`initial: ${initialMembrane.qmax}`);
 
-    const membrane = initialMembrane.qmax! > alternativeMembrane.qmax! ? initialMembrane : alternativeMembrane;
+    if (runtime.shouldUpdate) {
+        await runtime.update({ message: 'Refining membrane placement...' });
+    }
+    console.time('ref-membrane');
+    const refinedMembrane = findMembrane(ctx, findProximateAxes(ctx, initialMembrane), initialHphobHphil)!;
+    console.timeEnd('ref-membrane');
+    console.log(`refined: ${refinedMembrane.qmax}`);
+    let membrane = initialMembrane.qmax! > refinedMembrane.qmax! ? initialMembrane : refinedMembrane;
+
+    if (ctx.adjust) {
+        if (runtime.shouldUpdate) {
+            await runtime.update({ message: 'Adjusting membrane thickness...' });
+        }
+        console.time('adj-thickness');
+        membrane = adjustThickness(ctx, membrane, initialHphobHphil);
+        console.timeEnd('adj-thickness');
+        console.log('Membrane width: ' + Vec3.distance(membrane.planePoint1, membrane.planePoint2));
+    }
+
+
 
     return {
         planePoint1: membrane.planePoint1,
@@ -166,7 +200,7 @@ namespace MembraneCandidate {
 
     export function scored(spherePoint: Vec3, c1: Vec3, c2: Vec3, stats: HphobHphil, qmax: number, centroid: Vec3): MembraneCandidate {
         const diam_vect = Vec3();
-        Vec3.sub(diam_vect, centroid, spherePoint);
+        Vec3.sub(diam_vect, spherePoint, centroid);
         return {
             planePoint1: c1,
             planePoint2: c2,
@@ -178,36 +212,40 @@ namespace MembraneCandidate {
     }
 }
 
-function findMembrane(ctx: ANVILContext, spherePoints: Vec3[], initialStats: HphobHphil, label_comp_id: StructureElement.Property<string>): MembraneCandidate {
+function findMembrane(ctx: ANVILContext, spherePoints: Vec3[], initialStats: HphobHphil): MembraneCandidate | undefined {
     const { centroid, stepSize, minThickness, maxThickness } = ctx;
     // best performing membrane
-    let membrane: MembraneCandidate;
+    let membrane: MembraneCandidate | undefined;
     // score of the best performing membrane
     let qmax = 0;
 
     // construct slices of thickness 1.0 along the axis connecting the centroid and the spherePoint
     const diam = Vec3();
-    for (let i = 0, il = spherePoints.length; i < il; i++) {
-        const spherePoint = spherePoints[i];
+    for (let n = 0, nl = spherePoints.length; n < nl; n++) {
+        const spherePoint = spherePoints[n];
         Vec3.sub(diam, centroid, spherePoint);
         Vec3.scale(diam, diam, 2);
         const diamNorm = Vec3.magnitude(diam);
-        const qvartemp = [];
+        const qvartemp = []; // TODO use fixed length array
 
         for (let i = 0, il = diamNorm - stepSize; i < il; i += stepSize) {
             const c1 = Vec3();
             const c2 = Vec3();
             Vec3.scaleAndAdd(c1, spherePoint, diam, i / diamNorm);
             Vec3.scaleAndAdd(c2, spherePoint, diam, (i + stepSize) / diamNorm);
+            const d1 = -Vec3.dot(diam, c1);
+            const d2 = -Vec3.dot(diam, c2);
+            const dMin = Math.min(d1, d2);
+            const dMax = Math.max(d1, d2);
 
             // evaluate how well this membrane slice embeddeds the peculiar residues
-            const stats = HphobHphil.filtered(ctx, label_comp_id, (testPoint: Vec3) => isInMembranePlane(testPoint, diam, c1, c2));
+            const stats = HphobHphil.filtered(ctx, (testPoint: Vec3) => _isInMembranePlane(testPoint, diam, dMin, dMax));
             qvartemp.push(MembraneCandidate.initial(c1, c2, stats));
         }
 
-        let jmax = (minThickness / stepSize) - 1;
+        let jmax = Math.floor((minThickness / stepSize) - 1);
 
-        for (let width = 0, widthl = maxThickness; width < widthl;) {
+        for (let width = 0, widthl = maxThickness; width <= widthl;) {
             const imax = qvartemp.length - 1 - jmax;
 
             for (let i = 0, il = imax; i < il; i++) {
@@ -220,7 +258,7 @@ function findMembrane(ctx: ANVILContext, spherePoints: Vec3[], initialStats: Hph
                 for (let j = 0; j < jmax; j++) {
                     const ij = qvartemp[i + j];
                     if (j === 0 || j === jmax - 1) {
-                        hphob += 0.5 * ij.stats.hphob;
+                        hphob += Math.floor(0.5 * ij.stats.hphob);
                         hphil += 0.5 * ij.stats.hphil;
                     } else {
                         hphob += ij.stats.hphob;
@@ -229,11 +267,10 @@ function findMembrane(ctx: ANVILContext, spherePoints: Vec3[], initialStats: Hph
                     total += ij.stats.total;
                 }
 
-                const stats = HphobHphil.of(hphob, hphil, total);
-
                 if (hphob !== 0) {
+                    const stats = HphobHphil.of(hphob, hphil, total);
                     const qvaltest = qValue(stats, initialStats);
-                    if (qvaltest > qmax) {
+                    if (qvaltest >= qmax) {
                         qmax = qvaltest;
                         membrane = MembraneCandidate.scored(spherePoint, c1, c2, HphobHphil.of(hphob, hphil, total), qmax, centroid);
                     }
@@ -244,7 +281,141 @@ function findMembrane(ctx: ANVILContext, spherePoints: Vec3[], initialStats: Hph
         }
     }
 
-    return membrane!;
+    return membrane;
+}
+
+function adjustThickness(ctx: ANVILContext, membrane: MembraneCandidate, initialHphobHphil: HphobHphil): MembraneCandidate {
+    const { minThickness } = ctx;
+    const step = 0.3;
+    let maxThickness = Vec3.distance(membrane.planePoint1, membrane.planePoint2);
+
+    let maxNos = membraneSegments(ctx, membrane).length;
+    let optimalThickness = membrane;
+
+    while (maxThickness > minThickness) {
+        const p = {
+            ...ctx,
+            maxThickness,
+            stepSize: step
+        };
+        const temp = findMembrane(p, [membrane.spherePoint!], initialHphobHphil);
+        if (temp) {
+            const nos = membraneSegments(ctx, temp).length;
+            if (nos > maxNos) {
+                maxNos = nos;
+                optimalThickness = temp;
+            }
+        }
+        maxThickness -= step;
+    }
+
+    console.log('Number of TM segments: ' + maxNos);
+    return optimalThickness;
+}
+
+const testPoint = Vec3();
+function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): ArrayLike<{ start: number, end: number }> {
+    const { offsets, structure, adjust } = ctx;
+    const { normalVector, planePoint1, planePoint2 } = membrane;
+    const l = StructureElement.Location.create(structure);
+    const { auth_asym_id } = StructureProperties.chain;
+    const { auth_seq_id } = StructureProperties.residue;
+    const { x, y, z } = StructureProperties.atom;
+
+    const d1 = -Vec3.dot(normalVector!, planePoint1);
+    const d2 = -Vec3.dot(normalVector!, planePoint2);
+    const dMin = Math.min(d1, d2);
+    const dMax = Math.max(d1, d2);
+
+    const inMembrane: { [k: string]: Set<number> } = Object.create(null);
+    const outMembrane: { [k: string]: Set<number> } = Object.create(null);
+    const segments: Array<{ start: number, end: number }> = [];
+    setLocation(l, structure, offsets[0]);
+    let authAsymId;
+    let lastAuthAsymId = null;
+    let authSeqId;
+    let lastAuthSeqId = auth_seq_id(l) - 1;
+    let startOffset = 0;
+    let endOffset = 0;
+
+    // collect all residues in membrane layer
+    for (let k = 0, kl = offsets.length; k < kl; k++) {
+        setLocation(l, structure, offsets[k]);
+        authAsymId = auth_asym_id(l);
+        if (authAsymId !== lastAuthAsymId) {
+            if (!inMembrane[authAsymId]) inMembrane[authAsymId] = new Set<number>();
+            if (!outMembrane[authAsymId]) outMembrane[authAsymId] = new Set<number>();
+            lastAuthAsymId = authAsymId;
+        }
+
+        authSeqId = auth_seq_id(l);
+        Vec3.set(testPoint, x(l), y(l), z(l));
+        if (_isInMembranePlane(testPoint, normalVector!, dMin, dMax)) {
+            inMembrane[authAsymId].add(authSeqId);
+        } else {
+            outMembrane[authAsymId].add(authSeqId);
+        }
+    }
+
+    for (let k = 0, kl = offsets.length; k < kl; k++) {
+        setLocation(l, structure, offsets[k]);
+        authAsymId = auth_asym_id(l);
+        authSeqId = auth_seq_id(l);
+        if (inMembrane[authAsymId].has(authSeqId)) {
+            // chain change
+            if (authAsymId !== lastAuthAsymId) {
+                segments.push({ start: startOffset, end: endOffset });
+                lastAuthAsymId = authAsymId;
+                startOffset = k;
+                endOffset = k;
+            }
+
+            // sequence gaps
+            if (authSeqId !== lastAuthSeqId + 1) {
+                if (outMembrane[authAsymId].has(lastAuthSeqId + 1)) {
+                    segments.push({ start: startOffset, end: endOffset });
+                    startOffset = k;
+                }
+                lastAuthSeqId = authSeqId;
+                endOffset = k;
+            } else  {
+                lastAuthSeqId++;
+                endOffset++;
+            }
+        }
+    }
+    segments.push({ start: startOffset, end: endOffset });
+
+    let startAuth;
+    let endAuth;
+    const refinedSegments: Array<{ start: number, end: number }> = [];
+    for (let k = 0, kl = segments.length; k < kl; k++) {
+        const { start, end } = segments[k];
+        if (start === 0 || end === offsets.length - 1) continue;
+
+        // evaluate residues 1 pos outside of membrane
+        setLocation(l, structure, offsets[start - 1]);
+        Vec3.set(testPoint, x(l), y(l), z(l));
+        const d3 = -Vec3.dot(normalVector!, testPoint);
+
+        setLocation(l, structure, offsets[end + 1]);
+        Vec3.set(testPoint, x(l), y(l), z(l));
+        const d4 = -Vec3.dot(normalVector!, testPoint);
+
+        if (Math.min(d3, d4) < dMin && Math.max(d3, d4) > dMax) {
+            // reject this refinement
+            setLocation(l, structure, offsets[start]);
+            startAuth = auth_seq_id(l);
+            setLocation(l, structure, offsets[end]);
+            endAuth = auth_seq_id(l);
+            if (Math.abs(startAuth - endAuth) + 1 < adjust) {
+                return [];
+            }
+            refinedSegments.push(segments[k]);
+        }
+    }
+
+    return refinedSegments;
 }
 
 function qValue(currentStats: HphobHphil, initialStats: HphobHphil): number {
@@ -264,8 +435,12 @@ function qValue(currentStats: HphobHphil, initialStats: HphobHphil): number {
 export function isInMembranePlane(testPoint: Vec3, normalVector: Vec3, planePoint1: Vec3, planePoint2: Vec3): boolean {
     const d1 = -Vec3.dot(normalVector, planePoint1);
     const d2 = -Vec3.dot(normalVector, planePoint2);
+    return _isInMembranePlane(testPoint, normalVector, Math.min(d1, d2), Math.max(d1, d2));
+}
+
+function _isInMembranePlane(testPoint: Vec3, normalVector: Vec3, min: number, max: number): boolean {
     const d = -Vec3.dot(normalVector, testPoint);
-    return d > Math.min(d1, d2) && d < Math.max(d1, d2);
+    return d > min && d < max;
 }
 
 // generates a defined number of points on a sphere with radius = extent around the specified centroid
@@ -296,9 +471,9 @@ function findProximateAxes(ctx: ANVILContext, membrane: MembraneCandidate): Vec3
     const points = generateSpherePoints(ctx, 30000);
     let j = 4;
     let sphere_pts2: Vec3[] = [];
+    const s = 2 * extent / numberOfSpherePoints;
     while (sphere_pts2.length < numberOfSpherePoints) {
-        const d = 2 * extent / numberOfSpherePoints + j;
-        const dsq = d * d;
+        const dsq = (s + j) * (s + j);
         sphere_pts2 = [];
         for (let i = 0, il = points.length; i < il; i++) {
             if (Vec3.squaredDistance(points[i], membrane.spherePoint!) < dsq) {
@@ -326,8 +501,9 @@ namespace HphobHphil {
     }
 
     const testPoint = Vec3();
-    export function filtered(ctx: ANVILContext, label_comp_id: StructureElement.Property<string>, filter?: (test: Vec3) => boolean): HphobHphil {
+    export function filtered(ctx: ANVILContext, filter?: (test: Vec3) => boolean): HphobHphil {
         const { offsets, exposed, structure } = ctx;
+        const { label_comp_id } = StructureProperties.atom;
         const l = StructureElement.Location.create(structure);
         const { x, y, z } = StructureProperties.atom;
         let hphob = 0;
@@ -339,11 +515,13 @@ namespace HphobHphil {
             }
 
             setLocation(l, structure, offsets[k]);
-            Vec3.set(testPoint, x(l), y(l), z(l));
 
             // testPoints have to be in putative membrane layer
-            if (filter && !filter(testPoint)) {
-                continue;
+            if (filter) {
+                Vec3.set(testPoint, x(l), y(l), z(l));
+                if (!filter(testPoint)) {
+                    continue;
+                }
             }
 
             if (isHydrophobic(label_comp_id(l))) {
@@ -357,10 +535,34 @@ namespace HphobHphil {
 }
 
 // ANVIL-specific (not general) definition of membrane-favoring amino acids
-const HYDROPHOBIC_AMINO_ACIDS = new Set(['ALA', 'CYS', 'GLY', 'HIS', 'ILE', 'LEU', 'MET', 'PHE', 'SER', 'THR', 'VAL']);
+const HYDROPHOBIC_AMINO_ACIDS = new Set(['ALA', 'CYS', 'GLY', 'HIS', 'ILE', 'LEU', 'MET', 'PHE', 'SER', 'TRP', 'VAL']);
 export function isHydrophobic(label_comp_id: string): boolean {
     return HYDROPHOBIC_AMINO_ACIDS.has(label_comp_id);
 }
+
+/** Accessible surface area used for normalization. ANVIL uses 'Total-Side REL' values from NACCESS, from: Hubbard, S. J., & Thornton, J. M. (1993). naccess. Computer Program, Department of Biochemistry and Molecular Biology, University College London, 2(1). */
+export const MaxAsa: { [k: string]: number } = {
+    'ALA': 69.41,
+    'ARG': 201.25,
+    'ASN': 106.24,
+    'ASP': 102.69,
+    'CYS': 96.75,
+    'GLU': 134.74,
+    'GLN': 140.99,
+    'GLY': 32.33,
+    'HIS': 147.08,
+    'ILE': 137.96,
+    'LEU': 141.12,
+    'LYS': 163.30,
+    'MET': 156.64,
+    'PHE': 164.11,
+    'PRO': 119.90,
+    'SER': 78.11,
+    'THR': 101.70,
+    'TRP': 211.26,
+    'TYR': 177.38,
+    'VAL': 114.28
+};
 
 function setLocation(l: StructureElement.Location, structure: Structure, serialIndex: number) {
     l.structure = structure;

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -216,8 +216,8 @@ async function findMembrane(runtime: RuntimeContext, message: string | undefined
     // construct slices of thickness 1.0 along the axis connecting the centroid and the spherePoint
     const diam = Vec3();
     for (let n = 0, nl = spherePoints.length; n < nl; n++) {
-        if (runtime?.shouldUpdate && message && n % UPDATE_INTERVAL === 0) {
-            await runtime.update({ message, current: n + 1, max: nl + 1 });
+        if (runtime?.shouldUpdate && message && (n + 1) % UPDATE_INTERVAL === 0) {
+            await runtime.update({ message, current: (n + 1), max: nl });
         }
 
         const spherePoint = spherePoints[n];
@@ -319,7 +319,6 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
     const testPoint = Vec3();
     const { auth_asym_id } = StructureProperties.chain;
     const { auth_seq_id } = StructureProperties.residue;
-    const { x, y, z } = StructureProperties.atom;
 
     const d1 = -Vec3.dot(normalVector!, planePoint1);
     const d2 = -Vec3.dot(normalVector!, planePoint2);
@@ -348,7 +347,7 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
         }
 
         authSeqId = auth_seq_id(l);
-        Vec3.set(testPoint, x(l), y(l), z(l));
+        Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
         if (_isInMembranePlane(testPoint, normalVector!, dMin, dMax)) {
             inMembrane[authAsymId].add(authSeqId);
         } else {
@@ -394,11 +393,11 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
 
         // evaluate residues 1 pos outside of membrane
         setLocation(l, structure, offsets[start - 1]);
-        Vec3.set(testPoint, x(l), y(l), z(l));
+        Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
         const d3 = -Vec3.dot(normalVector!, testPoint);
 
         setLocation(l, structure, offsets[end + 1]);
-        Vec3.set(testPoint, x(l), y(l), z(l));
+        Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
         const d4 = -Vec3.dot(normalVector!, testPoint);
 
         if (Math.min(d3, d4) < dMin && Math.max(d3, d4) > dMax) {
@@ -528,7 +527,6 @@ namespace HphobHphil {
         const { exposed, structure } = ctx;
         const { label_comp_id } = StructureProperties.atom;
         const l = StructureElement.Location.create(structure);
-        const { x, y, z } = StructureProperties.atom;
         let hphob = 0;
         let hphil = 0;
         for (let k = 0, kl = exposed.length; k < kl; k++) {
@@ -536,7 +534,7 @@ namespace HphobHphil {
 
             // testPoints have to be in putative membrane layer
             if (filter) {
-                Vec3.set(testPoint, x(l), y(l), z(l));
+                Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
                 if (!_isInMembranePlane(testPoint, filter.normalVector, filter.dMin, filter.dMax)) {
                     continue;
                 }

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -79,17 +79,14 @@ const centroidHelper = new CentroidHelper();
 async function initialize(structure: Structure, props: ANVILProps, accessibleSurfaceArea: AccessibleSurfaceArea): Promise<ANVILContext> {
     const l = StructureElement.Location.create(structure);
     const { label_atom_id, label_comp_id, x, y, z } = StructureProperties.atom;
-    const elementCount = structure.polymerResidueCount;
     const asaCutoff = props.asaCutoff / 100;
     centroidHelper.reset();
 
-    let offsets = new Array<number>(elementCount);
-    let exposed = new Array<number>(elementCount);
-    let hydrophobic = new Array<boolean>(elementCount);
+    let offsets = new Array<number>();
+    let exposed = new Array<number>();
+    let hydrophobic = new Array<boolean>();
 
     const vec = v3zero();
-    let m = 0;
-    let n = 0;
     for (let i = 0, il = structure.units.length; i < il; ++i) {
         const unit = structure.units[i];
         const { elements } = unit;
@@ -119,19 +116,13 @@ async function initialize(structure: Structure, props: ANVILProps, accessibleSur
             centroidHelper.includeStep(vec);
 
             // keep track of offsets and exposed state to reuse
-            offsets[m++] = structure.serialMapping.getSerialIndex(l.unit, l.element);
+            offsets.push(structure.serialMapping.getSerialIndex(l.unit, l.element));
             if (AccessibleSurfaceArea.getValue(l, accessibleSurfaceArea) / MaxAsa[label_comp_id(l)] > asaCutoff) {
-                exposed[n] = structure.serialMapping.getSerialIndex(l.unit, l.element);
-                hydrophobic[n] = isHydrophobic(label_comp_id(l));
-                n++;
+                exposed.push(structure.serialMapping.getSerialIndex(l.unit, l.element));
+                hydrophobic.push(isHydrophobic(label_comp_id(l)));
             }
         }
     }
-
-    // omit potentially empty tail
-    offsets = offsets.slice(0, m);
-    exposed = exposed.slice(0, n);
-    hydrophobic = hydrophobic.splice(0, n);
 
     // calculate centroid and extent
     centroidHelper.finishedIncludeStep();

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -151,18 +151,11 @@ export async function calculate(runtime: RuntimeContext, structure: Structure, p
 
     const normalVector = Vec3.zero();
     const center =  Vec3.zero();
-    const jitter = [0.001, 0.001, 0.001] as Vec3;
     Vec3.sub(normalVector, membrane.planePoint1, membrane.planePoint2);
     Vec3.normalize(normalVector, normalVector);
 
-    // prevent degenerate matrices (e.g., 5cbg - assembly 1 which is oriented along the y-axis)
-    if (Math.abs(normalVector[0]) === 1 || Math.abs(normalVector[1]) === 1 || Math.abs(normalVector[2]) === 1) {
-        Vec3.add(normalVector, normalVector, jitter);
-    }
-
     Vec3.add(center, membrane.planePoint1, membrane.planePoint2);
     Vec3.scale(center, center, 0.5);
-    Vec3.add(center, center, jitter);
     const extent = adjustExtent(ctx, membrane, center);
 
     return {

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -82,9 +82,9 @@ async function initialize(structure: Structure, props: ANVILProps, accessibleSur
     const asaCutoff = props.asaCutoff / 100;
     centroidHelper.reset();
 
-    let offsets = new Array<number>();
-    let exposed = new Array<number>();
-    let hydrophobic = new Array<boolean>();
+    const offsets = new Array<number>();
+    const exposed = new Array<number>();
+    const hydrophobic = new Array<boolean>();
 
     const vec = v3zero();
     for (let i = 0, il = structure.units.length; i < il; ++i) {

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -225,7 +225,7 @@ async function findMembrane(runtime: RuntimeContext, message: string | undefined
     const diam = v3zero();
     const testPoint = v3zero();
     for (let n = 0, nl = spherePoints.length; n < nl; n++) {
-        if (runtime?.shouldUpdate && message && (n + 1) % UPDATE_INTERVAL === 0) {
+        if (runtime.shouldUpdate && message && (n + 1) % UPDATE_INTERVAL === 0) {
             await runtime.update({ message, current: (n + 1), max: nl });
         }
 
@@ -306,7 +306,7 @@ async function adjustThickness(runtime: RuntimeContext, message: string | undefi
     const nl = Math.ceil((maxThickness - minThickness) / step);
     while (maxThickness > minThickness) {
         n++;
-        if (runtime?.shouldUpdate && message && n % UPDATE_INTERVAL === 0) {
+        if (runtime.shouldUpdate && message && n % UPDATE_INTERVAL === 0) {
             await runtime.update({ message, current: n, max: nl });
         }
 

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -345,7 +345,6 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
     const { units } = structure;
     const { elementIndices, unitIndices } = structure.serialMapping;
     const testPoint = v3zero();
-    const { auth_asym_id } = StructureProperties.chain;
     const { auth_seq_id } = StructureProperties.residue;
 
     const d1 = -v3dot(normalVector!, planePoint1);
@@ -418,7 +417,6 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
     segments.push({ start: startOffset, end: endOffset });
 
     const l = StructureElement.Location.create(structure);
-    setLocation(l, structure, offsets[0]);
     let startAuth;
     let endAuth;
     const refinedSegments: Array<{ start: number, end: number }> = [];

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -59,6 +59,21 @@ export function computeANVIL(structure: Structure, props: ANVILProps) {
     });
 }
 
+// avoiding namespace lookup improved performance in Chrome (Aug 2020)
+const v3add = Vec3.add;
+const v3clone = Vec3.clone;
+const v3create = Vec3.create;
+const v3distance = Vec3.distance;
+const v3dot = Vec3.dot;
+const v3magnitude = Vec3.magnitude;
+const v3normalize = Vec3.normalize;
+const v3scale = Vec3.scale;
+const v3scaleAndAdd = Vec3.scaleAndAdd;
+const v3set = Vec3.set;
+const v3squaredDistance = Vec3.squaredDistance;
+const v3sub = Vec3.sub;
+const v3zero = Vec3.zero;
+
 const centroidHelper = new CentroidHelper();
 async function initialize(runtime: RuntimeContext, structure: Structure, props: ANVILProps): Promise<ANVILContext> {
     const l = StructureElement.Location.create(structure);
@@ -74,7 +89,7 @@ async function initialize(runtime: RuntimeContext, structure: Structure, props: 
     const accessibleSurfaceArea = await AccessibleSurfaceArea.compute(structure, p).runInContext(runtime);
     const asaCutoff = props.asaCutoff / 100;
 
-    const vec = Vec3();
+    const vec = v3zero();
     let m = 0;
     let n = 0;
     for (let i = 0, il = structure.units.length; i < il; ++i) {
@@ -102,7 +117,7 @@ async function initialize(runtime: RuntimeContext, structure: Structure, props: 
             }
 
             // while iterating use first pass to compute centroid
-            Vec3.set(vec, x(l), y(l), z(l));
+            v3set(vec, x(l), y(l), z(l));
             centroidHelper.includeStep(vec);
 
             // keep track of offsets and exposed state to reuse
@@ -119,10 +134,10 @@ async function initialize(runtime: RuntimeContext, structure: Structure, props: 
 
     // calculate centroid and extent
     centroidHelper.finishedIncludeStep();
-    const centroid = Vec3.clone(centroidHelper.center);
+    const centroid = v3clone(centroidHelper.center);
     for (let k = 0, kl = offsets.length; k < kl; k++) {
         setLocation(l, structure, offsets[k]);
-        Vec3.set(vec, x(l), y(l), z(l));
+        v3set(vec, x(l), y(l), z(l));
         centroidHelper.radiusStep(vec);
     }
     const extent = 1.2 * Math.sqrt(centroidHelper.radiusSq);
@@ -150,13 +165,13 @@ export async function calculate(runtime: RuntimeContext, structure: Structure, p
         membrane = await adjustThickness(runtime, 'Adjusting membrane thickness...', ctx, membrane, initialHphobHphil);
     }
 
-    const normalVector = Vec3.zero();
-    const center =  Vec3.zero();
-    Vec3.sub(normalVector, membrane.planePoint1, membrane.planePoint2);
-    Vec3.normalize(normalVector, normalVector);
+    const normalVector = v3zero();
+    const center =  v3zero();
+    v3sub(normalVector, membrane.planePoint1, membrane.planePoint2);
+    v3normalize(normalVector, normalVector);
 
-    Vec3.add(center, membrane.planePoint1, membrane.planePoint2);
-    Vec3.scale(center, center, 0.5);
+    v3add(center, membrane.planePoint1, membrane.planePoint2);
+    v3scale(center, center, 0.5);
     const extent = adjustExtent(ctx, membrane, center);
 
     return {
@@ -187,8 +202,8 @@ namespace MembraneCandidate {
     }
 
     export function scored(spherePoint: Vec3, planePoint1: Vec3, planePoint2: Vec3, stats: HphobHphil, qmax: number, centroid: Vec3): MembraneCandidate {
-        const normalVector = Vec3();
-        Vec3.sub(normalVector, centroid, spherePoint);
+        const normalVector = v3zero();
+        v3sub(normalVector, centroid, spherePoint);
         return {
             planePoint1,
             planePoint2,
@@ -208,25 +223,25 @@ async function findMembrane(runtime: RuntimeContext, message: string | undefined
     let qmax = 0;
 
     // construct slices of thickness 1.0 along the axis connecting the centroid and the spherePoint
-    const diam = Vec3();
+    const diam = v3zero();
     for (let n = 0, nl = spherePoints.length; n < nl; n++) {
         if (runtime?.shouldUpdate && message && (n + 1) % UPDATE_INTERVAL === 0) {
             await runtime.update({ message, current: (n + 1), max: nl });
         }
 
         const spherePoint = spherePoints[n];
-        Vec3.sub(diam, centroid, spherePoint);
-        Vec3.scale(diam, diam, 2);
-        const diamNorm = Vec3.magnitude(diam);
+        v3sub(diam, centroid, spherePoint);
+        v3scale(diam, diam, 2);
+        const diamNorm = v3magnitude(diam);
         const qvartemp = [];
 
         for (let i = 0, il = diamNorm - stepSize; i < il; i += stepSize) {
-            const c1 = Vec3();
-            const c2 = Vec3();
-            Vec3.scaleAndAdd(c1, spherePoint, diam, i / diamNorm);
-            Vec3.scaleAndAdd(c2, spherePoint, diam, (i + stepSize) / diamNorm);
-            const d1 = -Vec3.dot(diam, c1);
-            const d2 = -Vec3.dot(diam, c2);
+            const c1 = v3zero();
+            const c2 = v3zero();
+            v3scaleAndAdd(c1, spherePoint, diam, i / diamNorm);
+            v3scaleAndAdd(c2, spherePoint, diam, (i + stepSize) / diamNorm);
+            const d1 = -v3dot(diam, c1);
+            const d2 = -v3dot(diam, c2);
             const dMin = Math.min(d1, d2);
             const dMax = Math.max(d1, d2);
 
@@ -273,7 +288,7 @@ async function findMembrane(runtime: RuntimeContext, message: string | undefined
 async function adjustThickness(runtime: RuntimeContext, message: string | undefined, ctx: ANVILContext, membrane: MembraneCandidate, initialHphobHphil: HphobHphil): Promise<MembraneCandidate> {
     const { minThickness } = ctx;
     const step = 0.3;
-    let maxThickness = Vec3.distance(membrane.planePoint1, membrane.planePoint2);
+    let maxThickness = v3distance(membrane.planePoint1, membrane.planePoint2);
 
     let maxNos = membraneSegments(ctx, membrane).length;
     let optimalThickness = membrane;
@@ -310,12 +325,12 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
     const { offsets, structure, adjust } = ctx;
     const { normalVector, planePoint1, planePoint2 } = membrane;
     const l = StructureElement.Location.create(structure);
-    const testPoint = Vec3();
+    const testPoint = v3zero();
     const { auth_asym_id } = StructureProperties.chain;
     const { auth_seq_id } = StructureProperties.residue;
 
-    const d1 = -Vec3.dot(normalVector!, planePoint1);
-    const d2 = -Vec3.dot(normalVector!, planePoint2);
+    const d1 = -v3dot(normalVector!, planePoint1);
+    const d2 = -v3dot(normalVector!, planePoint2);
     const dMin = Math.min(d1, d2);
     const dMax = Math.max(d1, d2);
 
@@ -341,7 +356,7 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
         }
 
         authSeqId = auth_seq_id(l);
-        Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
+        v3set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
         if (_isInMembranePlane(testPoint, normalVector!, dMin, dMax)) {
             inMembrane[authAsymId].add(authSeqId);
         } else {
@@ -387,12 +402,12 @@ function membraneSegments(ctx: ANVILContext, membrane: MembraneCandidate): Array
 
         // evaluate residues 1 pos outside of membrane
         setLocation(l, structure, offsets[start - 1]);
-        Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
-        const d3 = -Vec3.dot(normalVector!, testPoint);
+        v3set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
+        const d3 = -v3dot(normalVector!, testPoint);
 
         setLocation(l, structure, offsets[end + 1]);
-        Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
-        const d4 = -Vec3.dot(normalVector!, testPoint);
+        v3set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
+        const d4 = -v3dot(normalVector!, testPoint);
 
         if (Math.min(d3, d4) < dMin && Math.max(d3, d4) > dMax) {
             // reject this refinement
@@ -415,20 +430,20 @@ function adjustExtent(ctx: ANVILContext, membrane: MembraneCandidate, centroid: 
     const { offsets, structure } = ctx;
     const { normalVector, planePoint1, planePoint2 } = membrane;
     const l = StructureElement.Location.create(structure);
-    const testPoint = Vec3();
+    const testPoint = v3zero();
     const { x, y, z } = StructureProperties.atom;
 
-    const d1 = -Vec3.dot(normalVector!, planePoint1);
-    const d2 = -Vec3.dot(normalVector!, planePoint2);
+    const d1 = -v3dot(normalVector!, planePoint1);
+    const d2 = -v3dot(normalVector!, planePoint2);
     const dMin = Math.min(d1, d2);
     const dMax = Math.max(d1, d2);
     let extent = 0;
 
     for (let k = 0, kl = offsets.length; k < kl; k++) {
         setLocation(l, structure, offsets[k]);
-        Vec3.set(testPoint, x(l), y(l), z(l));
+        v3set(testPoint, x(l), y(l), z(l));
         if (_isInMembranePlane(testPoint, normalVector!, dMin, dMax)) {
-            const dsq = Vec3.squaredDistance(testPoint, centroid);
+            const dsq = v3squaredDistance(testPoint, centroid);
             if (dsq > extent) extent = dsq;
         }
     }
@@ -451,13 +466,13 @@ function qValue(currentStats: HphobHphil, initialStats: HphobHphil): number {
 }
 
 export function isInMembranePlane(testPoint: Vec3, normalVector: Vec3, planePoint1: Vec3, planePoint2: Vec3): boolean {
-    const d1 = -Vec3.dot(normalVector, planePoint1);
-    const d2 = -Vec3.dot(normalVector, planePoint2);
+    const d1 = -v3dot(normalVector, planePoint1);
+    const d2 = -v3dot(normalVector, planePoint2);
     return _isInMembranePlane(testPoint, normalVector, Math.min(d1, d2), Math.max(d1, d2));
 }
 
 function _isInMembranePlane(testPoint: Vec3, normalVector: Vec3, min: number, max: number): boolean {
-    const d = -Vec3.dot(normalVector, testPoint);
+    const d = -v3dot(normalVector, testPoint);
     return d > min && d < max;
 }
 
@@ -471,7 +486,7 @@ function generateSpherePoints(ctx: ANVILContext, numberOfSpherePoints: number): 
         theta = Math.acos(h);
         phi = (k === 1 || k === numberOfSpherePoints) ? 0 : (oldPhi + 3.6 / Math.sqrt(numberOfSpherePoints * (1 - h * h))) % (2 * Math.PI);
 
-        const point = Vec3.create(
+        const point = v3create(
             extent * Math.sin(phi) * Math.sin(theta) + centroid[0],
             extent * Math.cos(theta) + centroid[1],
             extent * Math.cos(phi) * Math.sin(theta) + centroid[2]
@@ -494,7 +509,7 @@ function findProximateAxes(ctx: ANVILContext, membrane: MembraneCandidate): Vec3
         const dsq = (s + j) * (s + j);
         sphere_pts2 = [];
         for (let i = 0, il = points.length; i < il; i++) {
-            if (Vec3.squaredDistance(points[i], membrane.spherePoint!) < dsq) {
+            if (v3squaredDistance(points[i], membrane.spherePoint!) < dsq) {
                 sphere_pts2.push(points[i]);
             }
         }
@@ -516,7 +531,7 @@ namespace HphobHphil {
         };
     }
 
-    const testPoint = Vec3();
+    const testPoint = v3zero();
     export function filtered(ctx: ANVILContext, filter?: { normalVector: Vec3, dMin: number, dMax: number }): HphobHphil {
         const { exposed, structure } = ctx;
         const { label_comp_id } = StructureProperties.atom;
@@ -528,7 +543,7 @@ namespace HphobHphil {
 
             // testPoints have to be in putative membrane layer
             if (filter) {
-                Vec3.set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
+                v3set(testPoint, l.unit.conformation.x(l.element), l.unit.conformation.y(l.element), l.unit.conformation.z(l.element));
                 if (!_isInMembranePlane(testPoint, filter.normalVector, filter.dMin, filter.dMax)) {
                     continue;
                 }

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -123,7 +123,7 @@ function initialize(structure: Structure, props: ANVILProps): ANVILContext {
         Vec3.set(vec, x(l), y(l), z(l));
         centroidHelper.radiusStep(vec);
     }
-    const extent = Math.sqrt(centroidHelper.radiusSq);
+    const extent = 1.2 * Math.sqrt(centroidHelper.radiusSq);
 
     return {
         ...props,

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -485,9 +485,9 @@ function generateSpherePoints(ctx: ANVILContext, numberOfSpherePoints: number): 
     const points = [];
     let oldPhi = 0, h, theta, phi;
     for(let k = 1, kl = numberOfSpherePoints + 1; k < kl; k++) {
-        h = -1 + 2 * (k - 1) / (numberOfSpherePoints - 1);
+        h = -1 + 2 * (k - 1) / (2 * numberOfSpherePoints - 1);
         theta = Math.acos(h);
-        phi = (k === 1 || k === numberOfSpherePoints) ? 0 : (oldPhi + 3.6 / Math.sqrt(numberOfSpherePoints * (1 - h * h))) % (2 * Math.PI);
+        phi = (k === 1 || k === numberOfSpherePoints) ? 0 : (oldPhi + 3.6 / Math.sqrt(2 * numberOfSpherePoints * (1 - h * h))) % (2 * Math.PI);
 
         const point = v3create(
             extent * Math.sin(phi) * Math.sin(theta) + centroid[0],

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -77,7 +77,7 @@ export const MembraneOrientationProvider: CustomStructureProperty.Provider<Membr
 
 async function computeAnvil(ctx: CustomProperty.Context, data: Structure, props: Partial<ANVILProps>): Promise<MembraneOrientation> {
     // can't get away with the default 92 points here
-    await AccessibleSurfaceAreaProvider.attach(ctx, data, { probeSize: 4.0, alphaOnly: true, numberOfSpherePoints: 184 });
+    await AccessibleSurfaceAreaProvider.attach(ctx, data, { probeSize: 4.0, traceOnly: true, numberOfSpherePoints: 184 });
     const p = { ...PD.getDefaultValues(ANVILParams), ...props };
     return await computeANVIL(data, p).runInContext(ctx.runtime);
 }

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -76,7 +76,8 @@ export const MembraneOrientationProvider: CustomStructureProperty.Provider<Membr
 });
 
 async function computeAnvil(ctx: CustomProperty.Context, data: Structure, props: Partial<ANVILProps>): Promise<MembraneOrientation> {
-    await AccessibleSurfaceAreaProvider.attach(ctx, data);
+    // can't get away with the default 92 points here
+    await AccessibleSurfaceAreaProvider.attach(ctx, data, { probeSize: 4.0, alphaOnly: true, numberOfSpherePoints: 184 });
     const p = { ...PD.getDefaultValues(ANVILParams), ...props };
     return await computeANVIL(data, p).runInContext(ctx.runtime);
 }

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -11,7 +11,6 @@ import { CustomPropertyDescriptor } from '../../mol-model/custom-property';
 import { ANVILParams, ANVILProps, computeANVIL, isInMembranePlane } from './algorithm';
 import { CustomStructureProperty } from '../../mol-model-props/common/custom-structure-property';
 import { CustomProperty } from '../../mol-model-props/common/custom-property';
-import { AccessibleSurfaceAreaProvider } from '../../mol-model-props/computed/accessible-surface-area';
 import { Vec3 } from '../../mol-math/linear-algebra';
 import { QuerySymbolRuntime } from '../../mol-script/runtime/query/base';
 import { CustomPropSymbol } from '../../mol-script/language/symbol';
@@ -76,8 +75,6 @@ export const MembraneOrientationProvider: CustomStructureProperty.Provider<Membr
 });
 
 async function computeAnvil(ctx: CustomProperty.Context, data: Structure, props: Partial<ANVILProps>): Promise<MembraneOrientation> {
-    // can't get away with the default 92 points here
-    await AccessibleSurfaceAreaProvider.attach(ctx, data, { probeSize: 4.0, traceOnly: true, numberOfSpherePoints: 184 });
     const p = { ...PD.getDefaultValues(ANVILParams), ...props };
     return await computeANVIL(data, p).runInContext(ctx.runtime);
 }

--- a/src/extensions/anvil/representation.ts
+++ b/src/extensions/anvil/representation.ts
@@ -29,7 +29,7 @@ import { CustomProperty } from '../../mol-model-props/common/custom-property';
 
 const SharedParams = {
     color: PD.Color(ColorNames.lightgrey),
-    radiusFactor: PD.Numeric(1.0, { min: 0.1, max: 3.0, step: 0.01 }, { description: 'Scale the radius of the membrane layer' })
+    radiusFactor: PD.Numeric(1.2, { min: 0.1, max: 3.0, step: 0.01 }, { description: 'Scale the radius of the membrane layer' })
 };
 
 const BilayerPlanesParams = {

--- a/src/extensions/anvil/representation.ts
+++ b/src/extensions/anvil/representation.ts
@@ -119,8 +119,11 @@ function getLayerCircle(builder: LinesBuilder, p: Vec3, centroid: Vec3, normal: 
 }
 
 const tmpMat = Mat4();
+const tmpV = Vec3();
+const jitter = Vec3.create(0.001, 0.001, 0.001);
 function getCircle(p: Vec3, centroid: Vec3, normal: Vec3, radius: number) {
-    Mat4.targetTo(tmpMat, p, centroid, normal);
+    Vec3.add(tmpV, centroid, jitter);
+    Mat4.targetTo(tmpMat, p, tmpV, normal);
     Mat4.setTranslation(tmpMat, p);
     Mat4.mul(tmpMat, tmpMat, Mat4.rotX90);
 

--- a/src/extensions/anvil/representation.ts
+++ b/src/extensions/anvil/representation.ts
@@ -9,7 +9,6 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import { Vec3, Mat4 } from '../../mol-math/linear-algebra';
 import { Representation, RepresentationContext, RepresentationParamsGetter } from '../../mol-repr/representation';
 import { Structure } from '../../mol-model/structure';
-import { Spheres } from '../../mol-geo/geometry/spheres/spheres';
 import { StructureRepresentationProvider, StructureRepresentation, StructureRepresentationStateBuilder } from '../../mol-repr/structure/representation';
 import { MembraneOrientation } from './prop';
 import { ThemeRegistryContext } from '../../mol-theme/theme';
@@ -30,17 +29,8 @@ import { CustomProperty } from '../../mol-model-props/common/custom-property';
 
 const SharedParams = {
     color: PD.Color(ColorNames.lightgrey),
-    radiusFactor: PD.Numeric(0.8333, { min: 0.1, max: 3.0, step: 0.01 }, { description: 'Scale the radius of the membrane layer' })
+    radiusFactor: PD.Numeric(1.0, { min: 0.1, max: 3.0, step: 0.01 }, { description: 'Scale the radius of the membrane layer' })
 };
-
-const BilayerSpheresParams = {
-    ...Spheres.Params,
-    ...SharedParams,
-    sphereSize: PD.Numeric(1, { min: 0.1, max: 10, step: 0.1 }, { description: 'Size of spheres that represent membrane planes' }),
-    density: PD.Numeric(1, { min: 0.25, max: 10, step: 0.25 }, { description: 'Distance between spheres'})
-};
-export type BilayerSpheresParams = typeof BilayerSpheresParams
-export type BilayerSpheresProps = PD.Values<BilayerSpheresParams>
 
 const BilayerPlanesParams = {
     ...Mesh.Params,
@@ -66,7 +56,6 @@ const MembraneOrientationVisuals = {
 };
 
 export const MembraneOrientationParams = {
-    ...BilayerSpheresParams,
     ...BilayerPlanesParams,
     ...BilayerRimsParams,
     visuals: PD.MultiSelect(['bilayer-planes', 'bilayer-rims'], PD.objectToOptions(MembraneOrientationVisuals)),

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -107,9 +107,22 @@ namespace AccessibleSurfaceArea {
         return area[rSI];
     }
 
-    function indexOf<T>(a: ArrayLike<T>, e: T): number {
-        for (let i = 0, il = a.length; i < il; i++) {
-            if (a[i] === e) return i;
+    function indexOf(a: ArrayLike<number>, e: number): number {
+        let min = 0, max = a.length - 1;
+
+        while (min <= max) {
+            if (min + 11 > max) {
+                for (let i = min; i <= max; i++) {
+                    if (e === a[i]) return i;
+                }
+                return -1;
+            }
+
+            const mid = (min + max) >> 1;
+            const v = a[mid];
+            if (e < v) max = mid - 1;
+            else if (e > v) min = mid + 1;
+            else return mid;
         }
         return -1;
     }

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -102,9 +102,16 @@ namespace AccessibleSurfaceArea {
 
     export function getValue(location: StructureElement.Location, accessibleSurfaceArea: AccessibleSurfaceArea) {
         const { area, serialResidueIndex } = accessibleSurfaceArea;
-        const rSI = serialResidueIndex[location.element];
+        const rSI = serialResidueIndex[indexOf(location.structure.root.serialMapping.elementIndices, location.element)];
         if (rSI === -1) return -1;
         return area[rSI];
+    }
+
+    function indexOf<T>(a: ArrayLike<T>, e: T): number {
+        for (let i = 0, il = a.length; i < il; i++) {
+            if (a[i] === e) return i;
+        }
+        return -1;
     }
 
     export function getNormalizedValue(location: StructureElement.Location, accessibleSurfaceArea: AccessibleSurfaceArea) {

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -101,9 +101,8 @@ namespace AccessibleSurfaceArea {
     }
 
     export function getValue(location: StructureElement.Location, accessibleSurfaceArea: AccessibleSurfaceArea) {
-        const { getSerialIndex } = location.structure.root.serialMapping;
         const { area, serialResidueIndex } = accessibleSurfaceArea;
-        const rSI = serialResidueIndex[getSerialIndex(location.unit, location.element)];
+        const rSI = serialResidueIndex[location.element];
         if (rSI === -1) return -1;
         return area[rSI];
     }

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -18,7 +18,8 @@ export const ShrakeRupleyComputationParams = {
     numberOfSpherePoints: PD.Numeric(92, { min: 12, max: 360, step: 1 }, { description: 'Number of sphere points to sample per atom: 92 (original paper), 960 (BioJava), 3000 (EPPIC) - see Shrake A, Rupley JA: Environment and exposure to solvent of protein atoms. Lysozyme and insulin. J Mol Biol 1973.' }),
     probeSize: PD.Numeric(1.4, { min: 0.1, max: 4, step: 0.01 }, { description: 'Corresponds to the size of a water molecule: 1.4 (original paper), 1.5 (occassionally used)' }),
     // buriedRasaThreshold: PD.Numeric(0.16, { min: 0.0, max: 1.0 }, { description: 'below this cutoff of relative accessible surface area a residue will be considered buried - see: Rost B, Sander C: Conservation and prediction of solvent accessibility in protein families. Proteins 1994.' }),
-    nonPolymer: PD.Boolean(false, { description: 'Include non-polymer atoms as occluders.' })
+    nonPolymer: PD.Boolean(false, { description: 'Include non-polymer atoms as occluders.' }),
+    alphaOnly: PD.Boolean(false, { description: 'Compute only using alpha-carbons, if true increase probeSize accordingly (e.g., 4 A).' })
 };
 export type ShrakeRupleyComputationParams = typeof ShrakeRupleyComputationParams
 export type ShrakeRupleyComputationProps = PD.Values<ShrakeRupleyComputationParams>
@@ -57,12 +58,13 @@ namespace AccessibleSurfaceArea {
 
     function initialize(structure: Structure, props: ShrakeRupleyComputationProps): ShrakeRupleyContext {
         const { elementCount, atomicResidueCount } = structure;
-        const { probeSize, nonPolymer, numberOfSpherePoints } = props;
+        const { probeSize, nonPolymer, alphaOnly, numberOfSpherePoints } = props;
 
         return {
             structure,
             probeSize,
             nonPolymer,
+            alphaOnly,
             spherePoints: generateSpherePoints(numberOfSpherePoints),
             scalingConstant: 4.0 * Math.PI / numberOfSpherePoints,
             maxLookupRadius: 2 * props.probeSize + 2 * VdWLookup[2], // 2x probe size + 2x largest VdW

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -103,7 +103,7 @@ namespace AccessibleSurfaceArea {
 
     export function getValue(location: StructureElement.Location, accessibleSurfaceArea: AccessibleSurfaceArea) {
         const { area, serialResidueIndex } = accessibleSurfaceArea;
-        const rSI = serialResidueIndex[SortedArray.indexOf(location.structure.root.serialMapping.elementIndices as unknown as SortedArray, location.element)];
+        const rSI = serialResidueIndex[SortedArray.indexOf(SortedArray.ofSortedArray(location.structure.root.serialMapping.elementIndices), location.element)];
         if (rSI === -1) return -1;
         return area[rSI];
     }

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -19,7 +19,7 @@ export const ShrakeRupleyComputationParams = {
     probeSize: PD.Numeric(1.4, { min: 0.1, max: 4, step: 0.01 }, { description: 'Corresponds to the size of a water molecule: 1.4 (original paper), 1.5 (occassionally used)' }),
     // buriedRasaThreshold: PD.Numeric(0.16, { min: 0.0, max: 1.0 }, { description: 'below this cutoff of relative accessible surface area a residue will be considered buried - see: Rost B, Sander C: Conservation and prediction of solvent accessibility in protein families. Proteins 1994.' }),
     nonPolymer: PD.Boolean(false, { description: 'Include non-polymer atoms as occluders.' }),
-    traceOnly: PD.Boolean(false, { description: 'Compute only using alpha-carbons, if true increase probeSize accordingly (e.g., 4 A).' })
+    traceOnly: PD.Boolean(false, { description: 'Compute only using alpha-carbons, if true increase probeSize accordingly (e.g., 4 A). Considers only canonical amino acids.' })
 };
 export type ShrakeRupleyComputationParams = typeof ShrakeRupleyComputationParams
 export type ShrakeRupleyComputationProps = PD.Values<ShrakeRupleyComputationParams>

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -19,7 +19,7 @@ export const ShrakeRupleyComputationParams = {
     probeSize: PD.Numeric(1.4, { min: 0.1, max: 4, step: 0.01 }, { description: 'Corresponds to the size of a water molecule: 1.4 (original paper), 1.5 (occassionally used)' }),
     // buriedRasaThreshold: PD.Numeric(0.16, { min: 0.0, max: 1.0 }, { description: 'below this cutoff of relative accessible surface area a residue will be considered buried - see: Rost B, Sander C: Conservation and prediction of solvent accessibility in protein families. Proteins 1994.' }),
     nonPolymer: PD.Boolean(false, { description: 'Include non-polymer atoms as occluders.' }),
-    alphaOnly: PD.Boolean(false, { description: 'Compute only using alpha-carbons, if true increase probeSize accordingly (e.g., 4 A).' })
+    traceOnly: PD.Boolean(false, { description: 'Compute only using alpha-carbons, if true increase probeSize accordingly (e.g., 4 A).' })
 };
 export type ShrakeRupleyComputationParams = typeof ShrakeRupleyComputationParams
 export type ShrakeRupleyComputationProps = PD.Values<ShrakeRupleyComputationParams>
@@ -58,13 +58,13 @@ namespace AccessibleSurfaceArea {
 
     function initialize(structure: Structure, props: ShrakeRupleyComputationProps): ShrakeRupleyContext {
         const { elementCount, atomicResidueCount } = structure;
-        const { probeSize, nonPolymer, alphaOnly, numberOfSpherePoints } = props;
+        const { probeSize, nonPolymer, traceOnly, numberOfSpherePoints } = props;
 
         return {
             structure,
             probeSize,
             nonPolymer,
-            alphaOnly,
+            traceOnly,
             spherePoints: generateSpherePoints(numberOfSpherePoints),
             scalingConstant: 4.0 * Math.PI / numberOfSpherePoints,
             maxLookupRadius: 2 * props.probeSize + 2 * VdWLookup[2], // 2x probe size + 2x largest VdW

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley.ts
@@ -13,6 +13,7 @@ import { Structure, StructureElement, StructureProperties } from '../../../mol-m
 import { assignRadiusForHeavyAtoms } from './shrake-rupley/radii';
 import { ShrakeRupleyContext, VdWLookup, MaxAsa, DefaultMaxAsa } from './shrake-rupley/common';
 import { computeArea } from './shrake-rupley/area';
+import { SortedArray } from '../../../mol-data/int';
 
 export const ShrakeRupleyComputationParams = {
     numberOfSpherePoints: PD.Numeric(92, { min: 12, max: 360, step: 1 }, { description: 'Number of sphere points to sample per atom: 92 (original paper), 960 (BioJava), 3000 (EPPIC) - see Shrake A, Rupley JA: Environment and exposure to solvent of protein atoms. Lysozyme and insulin. J Mol Biol 1973.' }),
@@ -102,29 +103,9 @@ namespace AccessibleSurfaceArea {
 
     export function getValue(location: StructureElement.Location, accessibleSurfaceArea: AccessibleSurfaceArea) {
         const { area, serialResidueIndex } = accessibleSurfaceArea;
-        const rSI = serialResidueIndex[indexOf(location.structure.root.serialMapping.elementIndices, location.element)];
+        const rSI = serialResidueIndex[SortedArray.indexOf(location.structure.root.serialMapping.elementIndices as unknown as SortedArray, location.element)];
         if (rSI === -1) return -1;
         return area[rSI];
-    }
-
-    function indexOf(a: ArrayLike<number>, e: number): number {
-        let min = 0, max = a.length - 1;
-
-        while (min <= max) {
-            if (min + 11 > max) {
-                for (let i = min; i <= max; i++) {
-                    if (e === a[i]) return i;
-                }
-                return -1;
-            }
-
-            const mid = (min + max) >> 1;
-            const v = a[mid];
-            if (e < v) max = mid - 1;
-            else if (e > v) min = mid + 1;
-            else return mid;
-        }
-        return -1;
     }
 
     export function getNormalizedValue(location: StructureElement.Location, accessibleSurfaceArea: AccessibleSurfaceArea) {

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
@@ -6,7 +6,6 @@
  */
 
 import { ShrakeRupleyContext, VdWLookup } from './common';
-import { Vec3 } from '../../../../mol-math/linear-algebra';
 import { RuntimeContext } from '../../../../mol-task';
 
 // TODO
@@ -27,9 +26,6 @@ export async function computeArea(runtime: RuntimeContext, ctx: ShrakeRupleyCont
     }
 }
 
-const v3set = Vec3.set;
-const aPos = Vec3();
-
 function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
     const { structure, atomRadiusType, serialResidueIndex, area, spherePoints, scalingConstant, maxLookupRadius, probeSize } = ctx;
     const { lookup3d, serialMapping, unitIndexMap, units } = structure;
@@ -44,7 +40,6 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
         const aX = aUnit.conformation.x(aElementIndex);
         const aY = aUnit.conformation.y(aElementIndex);
         const aZ = aUnit.conformation.z(aElementIndex);
-        v3set(aPos, aX, aY, aZ);
 
         // pre-filter by lookup3d (provides >10x speed-up compared to naive evaluation)
         const { count, units: lUnits, indices, squaredDistances } = lookup3d.find(aX, aY, aZ, maxLookupRadius);
@@ -68,9 +63,9 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
                 // while here: compute values for later lookup
                 neighbors[neighbors.length] = [squaredDistances[iI],
                     (squaredDistances[iI] + radius1 * radius1 - radius2 * radius2) / (2 * radius1),
-                    bUnit.conformation.x(bElementIndex) - aPos[0],
-                    bUnit.conformation.y(bElementIndex) - aPos[1],
-                    bUnit.conformation.z(bElementIndex) - aPos[2]];
+                    bUnit.conformation.x(bElementIndex) - aX,
+                    bUnit.conformation.y(bElementIndex) - aY,
+                    bUnit.conformation.z(bElementIndex) - aZ];
             }
         }
 

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
@@ -53,7 +53,7 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
         // collect neighbors for each atom
         const radius1 = probeSize + vdw1;
         const cutoff1 = probeSize + radius1;
-        let neighbors = []; // TODO reuse
+        const neighbors = []; // TODO reuse
         for (let iI = 0; iI < count; ++iI) {
             const bUnit = lUnits[iI];
             const bI = cumulativeUnitElementCount[unitIndexMap.get(bUnit.id)] + indices[iI];
@@ -75,7 +75,7 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
         }
 
         // sort ascendingly by distance for improved downstream performance
-        neighbors = neighbors.sort((a, b) => a[0] - b[0]);
+        neighbors.sort((a, b) => a[0] - b[0]);
 
         let accessiblePointCount = 0;
         sl: for (let sI = 0; sI < spherePoints.length; ++sI) {

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
@@ -62,19 +62,15 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
             const vdw2 = VdWLookup[atomRadiusType[bI]];
             if ((aUnit === bUnit && aElementIndex === bElementIndex) || vdw2 === VdWLookup[0]) continue;
 
-            const cutoff2 = (cutoff1 + vdw2) * (cutoff1 + vdw2);
             const radius2 = probeSize + vdw2;
-            if (squaredDistances[iI] < cutoff2) {
+            if (squaredDistances[iI] < (cutoff1 + vdw2) * (cutoff1 + vdw2)) {
                 const bElementIndex = elementIndices[bI];
-                const bX = bUnit.conformation.x(bElementIndex);
-                const bY = bUnit.conformation.y(bElementIndex);
-                const bZ = bUnit.conformation.z(bElementIndex);
                 // while here: compute values for later lookup
                 neighbors[neighbors.length] = [squaredDistances[iI],
                     (squaredDistances[iI] + radius1 * radius1 - radius2 * radius2) / (2 * radius1),
-                    bX - aPos[0],
-                    bY - aPos[1],
-                    bZ - aPos[2]];
+                    bUnit.conformation.x(bElementIndex) - aPos[0],
+                    bUnit.conformation.y(bElementIndex) - aPos[1],
+                    bUnit.conformation.z(bElementIndex) - aPos[2]];
             }
         }
 

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/common.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/common.ts
@@ -12,6 +12,7 @@ export interface ShrakeRupleyContext {
     spherePoints: Vec3[],
     probeSize: number,
     nonPolymer: boolean,
+    alphaOnly: boolean,
     scalingConstant: number,
     maxLookupRadius: number,
     atomRadiusType: Int8Array,

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/common.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/common.ts
@@ -12,7 +12,7 @@ export interface ShrakeRupleyContext {
     spherePoints: Vec3[],
     probeSize: number,
     nonPolymer: boolean,
-    alphaOnly: boolean,
+    traceOnly: boolean,
     scalingConstant: number,
     maxLookupRadius: number,
     atomRadiusType: Int8Array,

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
@@ -53,7 +53,7 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
             const atomId = label_atom_id(l);
             const moleculeType = getElementMoleculeType(unit, eI);
             // skip water and optionally non-polymer groups
-            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.traceOnly && (atomId !== 'CA' || !MaxAsa[label_comp_id(l)]))) {
+            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.traceOnly && ((atomId !== 'CA' && atomId !== 'BB') || !MaxAsa[label_comp_id(l)]))) {
                 atomRadiusType[mj] = VdWLookup[0];
                 serialResidueIndex[mj] = -1;
                 continue;

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
@@ -45,7 +45,7 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
 
             // skip hydrogen atoms
             if (isHydrogen(elementIdx)) {
-                atomRadiusType[mj] = VdWLookup[0];
+                atomRadiusType[mj] = 0;
                 serialResidueIndex[mj] = -1;
                 continue;
             }
@@ -53,13 +53,18 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
             const atomId = label_atom_id(l);
             const moleculeType = getElementMoleculeType(unit, eI);
             // skip water and optionally non-polymer groups
-            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.traceOnly && ((atomId !== 'CA' && atomId !== 'BB') || !MaxAsa[label_comp_id(l)]))) {
-                atomRadiusType[mj] = VdWLookup[0];
+            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType))) {
+                atomRadiusType[mj] = 0;
                 serialResidueIndex[mj] = -1;
                 continue;
             }
 
             const compId = label_comp_id(l);
+            if (ctx.traceOnly && ((atomId !== 'CA' && atomId !== 'BB') || !MaxAsa[compId])) {
+                atomRadiusType[mj] = 0;
+                serialResidueIndex[mj] = serialResidueIdx;
+                continue;
+            }
 
             if (isNucleic(moleculeType)) {
                 atomRadiusType[mj] = determineRadiusNucl(atomId, element, compId);

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
@@ -50,15 +50,15 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
                 continue;
             }
 
+            const atomId = label_atom_id(l);
             const moleculeType = getElementMoleculeType(unit, eI);
             // skip water and optionally non-polymer groups
-            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType))) {
+            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.alphaOnly && atomId !== 'CA')) {
                 atomRadiusType[mj] = VdWLookup[0];
                 serialResidueIndex[mj] = -1;
                 continue;
             }
 
-            const atomId = label_atom_id(l);
             const compId = label_comp_id(l);
 
             if (isNucleic(moleculeType)) {

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
@@ -53,7 +53,7 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
             const atomId = label_atom_id(l);
             const moleculeType = getElementMoleculeType(unit, eI);
             // skip water and optionally non-polymer groups
-            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.alphaOnly && (atomId !== 'CA' || !MaxAsa[label_comp_id(l)]))) {
+            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.traceOnly && (atomId !== 'CA' || !MaxAsa[label_comp_id(l)]))) {
                 atomRadiusType[mj] = VdWLookup[0];
                 serialResidueIndex[mj] = -1;
                 continue;

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
@@ -5,7 +5,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { ShrakeRupleyContext, VdWLookup } from './common';
+import { MaxAsa, ShrakeRupleyContext, VdWLookup } from './common';
 import { getElementIdx, isHydrogen } from '../../../../mol-model/structure/structure/unit/bonds/common';
 import { isPolymer, isNucleic, MoleculeType, ElementSymbol } from '../../../../mol-model/structure/model/types';
 import { VdwRadius } from '../../../../mol-model/structure/model/properties/atomic';
@@ -53,7 +53,7 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
             const atomId = label_atom_id(l);
             const moleculeType = getElementMoleculeType(unit, eI);
             // skip water and optionally non-polymer groups
-            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.alphaOnly && atomId !== 'CA')) {
+            if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType)) || (ctx.alphaOnly && (atomId !== 'CA' || !MaxAsa[label_comp_id(l)]))) {
                 atomRadiusType[mj] = VdWLookup[0];
                 serialResidueIndex[mj] = -1;
                 continue;


### PR DESCRIPTION
Provides a number of fixes for issues with the ANVIL implementation, which predicts the location of the membrane layer.

- new alpha-only parameter for ASA calculation which is faster and provides values closer to the NACCESS configuration used in the original ANVIL code
- fixes a typo which confused threonine and tryptophan, leading to egregiously bad predictions in some cases
- implements routine to adjust the thickness of the membrane layer
- better way to determine the radius of membrane layer
- add some status updates
- removes remnants of the deleted sphere visuals
- fix for ASA calculation/visual issues - #132 

**Question**
`Mat3.directionTransform` might fail to invert if a structure is oriented exactly along an axis (happens e.g. for 5CBG). Given that, I've changed the code to use the two plane points to construct center and normal vector and always add some 'jitter' to avoid linear dependency.
Is there a cleaner way to create membrane visuals?

Thanks for having a look!