### PR TITLE
Geometry export: center exported models

### DIFF
--- a/src/extensions/geo-export/controls.ts
+++ b/src/extensions/geo-export/controls.ts
@@ -5,6 +5,7 @@
  */
 
 import { getStyle } from '../../mol-gl/renderer';
+import { Box3D } from '../../mol-math/geometry';
 import { PluginComponent } from '../../mol-plugin-state/component';
 import { PluginContext } from '../../mol-plugin/context';
 import { Task } from '../../mol-task';
@@ -43,17 +44,18 @@ export class GeometryControls extends PluginComponent {
                 const renderObjects = this.plugin.canvas3d?.getRenderObjects()!;
                 const filename = this.getFilename();
 
-                let renderObjectExporter: ObjExporter | GlbExporter | StlExporter;
+                const boundingBox = Box3D.fromSphere3D(Box3D(), this.plugin.canvas3d?.boundingSphereVisible!);
+                let renderObjectExporter: GlbExporter | ObjExporter | StlExporter;
                 switch (this.behaviors.params.value.format) {
-                    case 'obj':
-                        renderObjectExporter = new ObjExporter(filename);
-                        break;
                     case 'glb':
                         const style = getStyle(this.plugin.canvas3d?.props.renderer.style!);
-                        renderObjectExporter = new GlbExporter(style);
+                        renderObjectExporter = new GlbExporter(style, boundingBox);
+                        break;
+                    case 'obj':
+                        renderObjectExporter = new ObjExporter(filename, boundingBox);
                         break;
                     case 'stl':
-                        renderObjectExporter = new StlExporter();
+                        renderObjectExporter = new StlExporter(boundingBox);
                         break;
                     default: throw new Error('Unsupported format.');
                 }

--- a/src/mol-canvas3d/canvas3d.ts
+++ b/src/mol-canvas3d/canvas3d.ts
@@ -242,6 +242,7 @@ interface Canvas3D {
     requestCameraReset(options?: { durationMs?: number, snapshot?: Camera.SnapshotProvider }): void
     readonly camera: Camera
     readonly boundingSphere: Readonly<Sphere3D>
+    readonly boundingSphereVisible: Readonly<Sphere3D>
     setProps(props: PartialCanvas3DProps | ((old: Canvas3DProps) => Partial<Canvas3DProps> | void), doNotRequestDraw?: boolean /* = false */): void
     getImagePass(props: Partial<ImageProps>): ImagePass
     getRenderObjects(): GraphicsRenderObject[]
@@ -717,6 +718,7 @@ namespace Canvas3D {
             },
             camera,
             boundingSphere: scene.boundingSphere,
+            boundingSphereVisible: scene.boundingSphereVisible,
             get notifyDidDraw() { return notifyDidDraw; },
             set notifyDidDraw(v: boolean) { notifyDidDraw = v; },
             didDraw,


### PR DESCRIPTION
When importing some models such as 7NCK to Blender using the geometry exporter, the models are very off the center and make it look like nothing is imported. This PR centers exported models.

This will also be useful when we implement the USDZ format for AR. Apple says that "Base of object should sit on the ground plane (y = 0)" (slide 30 in https://devstreaming-cdn.apple.com/videos/wwdc/2018/603augiuv41xoowslk8/603/603_integrating_apps_and_content_with_ar_quick_look.pdf). iOS AR doesn't automatically center the object. I'm not sure about Android.

Note: I don't factor out the translation matrix calculation because it will be a bit different for USDZ. 