### PR TITLE
[RFC] Do not assume that atom_site.auth_seq_id is an integer

### DIFF
--- a/src/extensions/dnatco/confal-pyramids/util.ts
+++ b/src/extensions/dnatco/confal-pyramids/util.ts
@@ -36,7 +36,7 @@ export namespace ConfalPyramidsUtil {
         asym_id: string,
         auth_asym_id: string,
         seq_id: number,
-        auth_seq_id: number,
+        auth_seq_id: string,
         comp_id: string,
         alt_id: string,
         ins_code: string,

--- a/src/extensions/rcsb/validation-report/prop.ts
+++ b/src/extensions/rcsb/validation-report/prop.ts
@@ -422,8 +422,8 @@ function parseValidationReportXml(xml: XMLDocument, model: Model): ValidationRep
                 const value = parseFloat(getItem(attributes, 'value'));
                 const auth_asym_id = getItem(attributes, 'chain');
                 const auth_comp_id = getItem(attributes, 'rescode');
-                const auth_seq_id = parseInt(getItem(attributes, 'resnum'));
-                const rI = index.findResidueAuth({ auth_asym_id, auth_comp_id, auth_seq_id });
+                const auth_seq_id = getItem(attributes, 'resnum');
+                const rI = index.findResidueAuth({ auth_asym_id, auth_comp_id, auth_seq_id }); // TODO: REVIEW!
                 if (rI !== -1) rci.set(rI, value);
             }
         }
@@ -439,7 +439,7 @@ function parseValidationReportXml(xml: XMLDocument, model: Model): ValidationRep
 
         const auth_asym_id = getItem(ga, 'chain');
         const auth_comp_id = getItem(ga, 'resname');
-        const auth_seq_id = parseInt(getItem(ga, 'resnum'));
+        const auth_seq_id = getItem(ga, 'resnum'); // TODO: REVIEW!
         const pdbx_PDB_ins_code = getItem(ga, 'icode').trim() || undefined;
         const label_alt_id = getItem(ga, 'altcode').trim() || undefined;
 

--- a/src/mol-io/reader/cif/schema/mmcif.ts
+++ b/src/mol-io/reader/cif/schema/mmcif.ts
@@ -69,7 +69,7 @@ export const mmCIF_Schema = {
          * scheme used here must match the scheme used in the publication
          * that describes the structure.
          */
-        auth_seq_id: int,
+        auth_seq_id: str,
         /**
          * Isotropic atomic displacement parameter, or equivalent isotropic
          * atomic displacement parameter, B~eq~, calculated from the
@@ -1192,7 +1192,7 @@ export const mmCIF_Schema = {
          * This data item is a pointer to _atom_site.auth_seq_id in the
          * ATOM_SITE category.
          */
-        ptnr1_auth_seq_id: int,
+        ptnr1_auth_seq_id: str,
         /**
          * Describes the symmetry operation that should be applied to the
          * atom set specified by _struct_conn.ptnr1_label* to generate the
@@ -1254,7 +1254,7 @@ export const mmCIF_Schema = {
          * This data item is a pointer to _atom_site.auth_seq_id in the
          * ATOM_SITE category.
          */
-        ptnr2_auth_seq_id: int,
+        ptnr2_auth_seq_id: str,
         /**
          * Describes the symmetry operation that should be applied to the
          * atom set specified by _struct_conn.ptnr2_label* to generate the

--- a/src/mol-model-formats/structure/cif-core.ts
+++ b/src/mol-model-formats/structure/cif-core.ts
@@ -53,6 +53,7 @@ async function getModels(db: CifCore_Database, format: CifCoreFormat, ctx: Runti
     const MOL = Column.ofConst('MOL', atomCount, Column.Schema.str);
     const A = Column.ofConst('A', atomCount, Column.Schema.str);
     const seq_id = Column.ofConst(1, atomCount, Column.Schema.int);
+    const auth_seq_id = Column.ofConst('1', atomCount, Column.Schema.str);
 
     const symmetry = getSymmetry(db);
     const m = symmetry.spacegroup.cell.fromFractional;
@@ -110,7 +111,7 @@ async function getModels(db: CifCore_Database, format: CifCoreFormat, ctx: Runti
         auth_asym_id: A,
         auth_atom_id: label,
         auth_comp_id: MOL,
-        auth_seq_id: seq_id,
+        auth_seq_id: auth_seq_id,
         Cartn_x: Column.ofFloatArray(x),
         Cartn_y: Column.ofFloatArray(y),
         Cartn_z: Column.ofFloatArray(z),

--- a/src/mol-model-formats/structure/cube.ts
+++ b/src/mol-model-formats/structure/cube.ts
@@ -22,12 +22,13 @@ async function getModels(cube: CubeFile, ctx: RuntimeContext) {
     const A = Column.ofConst('A', cube.atoms.count, Column.Schema.str);
     const type_symbol = Column.ofArray({ array: Column.mapToArray(atoms.number, n => getElementFromAtomicNumber(n)), schema: Column.Schema.Aliased<ElementSymbol>(Column.Schema.str) });
     const seq_id = Column.ofConst(1, atoms.count, Column.Schema.int);
+    const auth_seq_id = Column.ofConst('1', atoms.count, Column.Schema.str);
 
     const atom_site = Table.ofPartialColumns(BasicSchema.atom_site, {
         auth_asym_id: A,
         auth_atom_id: type_symbol,
         auth_comp_id: MOL,
-        auth_seq_id: seq_id,
+        auth_seq_id: auth_seq_id,
         Cartn_x: Column.asArrayColumn(atoms.x, Float32Array),
         Cartn_y: Column.asArrayColumn(atoms.y, Float32Array),
         Cartn_z: Column.asArrayColumn(atoms.z, Float32Array),

--- a/src/mol-model-formats/structure/gro.ts
+++ b/src/mol-model-formats/structure/gro.ts
@@ -27,6 +27,7 @@ function getBasic(atoms: GroAtoms, modelNum: number): BasicData {
     const asymIds = new Array<string>(atoms.count);
     const seqIds = new Uint32Array(atoms.count);
     const ids = new Uint32Array(atoms.count);
+    const authSeqIds = new Array<string>(atoms.count);
 
     const entityBuilder = new EntityBuilder();
     const componentBuilder = new ComponentBuilder(atoms.residueNumber, atoms.atomName);
@@ -66,6 +67,7 @@ function getBasic(atoms: GroAtoms, modelNum: number): BasicData {
         asymIds[i] = currentAsymId;
         seqIds[i] = currentSeqId;
         ids[i] = i;
+        authSeqIds[i] = residueNumber.toString();
     }
 
     const auth_asym_id = Column.ofStringArray(asymIds);
@@ -74,7 +76,7 @@ function getBasic(atoms: GroAtoms, modelNum: number): BasicData {
         auth_asym_id,
         auth_atom_id,
         auth_comp_id,
-        auth_seq_id: atoms.residueNumber,
+        auth_seq_id: Column.ofStringArray(authSeqIds),
         Cartn_x: Column.ofFloatArray(Column.mapToArray(atoms.x, x => x * 10, Float32Array)),
         Cartn_y: Column.ofFloatArray(Column.mapToArray(atoms.y, y => y * 10, Float32Array)),
         Cartn_z: Column.ofFloatArray(Column.mapToArray(atoms.z, z => z * 10, Float32Array)),

--- a/src/mol-model-formats/structure/mol.ts
+++ b/src/mol-model-formats/structure/mol.ts
@@ -24,12 +24,13 @@ async function getModels(mol: MolFile, ctx: RuntimeContext) {
     const A = Column.ofConst('A', mol.atoms.count, Column.Schema.str);
     const type_symbol = Column.asArrayColumn(atoms.type_symbol);
     const seq_id = Column.ofConst(1, atoms.count, Column.Schema.int);
+    const auth_seq_id = Column.ofConst('1', atoms.count, Column.Schema.str);
 
     const atom_site = Table.ofPartialColumns(BasicSchema.atom_site, {
         auth_asym_id: A,
         auth_atom_id: type_symbol,
         auth_comp_id: MOL,
-        auth_seq_id: seq_id,
+        auth_seq_id: auth_seq_id,
         Cartn_x: Column.asArrayColumn(atoms.x, Float32Array),
         Cartn_y: Column.asArrayColumn(atoms.y, Float32Array),
         Cartn_z: Column.asArrayColumn(atoms.z, Float32Array),

--- a/src/mol-model-formats/structure/mol2.ts
+++ b/src/mol-model-formats/structure/mol2.ts
@@ -36,7 +36,7 @@ async function getModels(mol2: Mol2File, ctx: RuntimeContext) {
             auth_asym_id: A,
             auth_atom_id: Column.asArrayColumn(atoms.atom_name),
             auth_comp_id: atoms.subst_name,
-            auth_seq_id: atoms.subst_id,
+            auth_seq_id: Column.ofStringArray(Column.mapToArray(atoms.subst_id, id => id.toString())),
             Cartn_x: Column.asArrayColumn(atoms.x, Float32Array),
             Cartn_y: Column.asArrayColumn(atoms.y, Float32Array),
             Cartn_z: Column.asArrayColumn(atoms.z, Float32Array),

--- a/src/mol-model-formats/structure/property/secondary-structure.ts
+++ b/src/mol-model-formats/structure/property/secondary-structure.ts
@@ -159,12 +159,12 @@ function addSheets(cat: StructSheetRange, map: SecondaryStructureMap, sheetCount
 }
 
 function assignSecondaryStructureEntry(hierarchy: AtomicHierarchy, entry: SecondaryStructureEntry, resStart: ResidueIndex, resEnd: ResidueIndex, data: SecondaryStructureData) {
-    const { auth_seq_id, pdbx_PDB_ins_code } = hierarchy.residues;
+    const { label_seq_id, pdbx_PDB_ins_code } = hierarchy.residues;
     const { endSeqNumber, endInsCode, key, type } = entry;
 
     let rI = resStart;
     while (rI < resEnd) {
-        const seqNumber = auth_seq_id.value(rI);
+        const seqNumber = label_seq_id.value(rI);
         data.type[rI] = type;
         data.key[rI] = key;
 
@@ -180,7 +180,7 @@ function assignSecondaryStructureEntry(hierarchy: AtomicHierarchy, entry: Second
 function assignSecondaryStructureRanges(hierarchy: AtomicHierarchy, map: SecondaryStructureMap, data: SecondaryStructureData) {
     const { count: chainCount } = hierarchy.chainAtomSegments;
     const { label_asym_id } = hierarchy.chains;
-    const { auth_seq_id, pdbx_PDB_ins_code } = hierarchy.residues;
+    const { label_seq_id, pdbx_PDB_ins_code } = hierarchy.residues;
 
     for (let cI = 0 as ChainIndex; cI < chainCount; cI++) {
         const resStart = AtomicHierarchy.chainStartResidueIndex(hierarchy, cI), resEnd = AtomicHierarchy.chainEndResidueIndexExcl(hierarchy, cI);
@@ -189,7 +189,7 @@ function assignSecondaryStructureRanges(hierarchy: AtomicHierarchy, map: Seconda
             const entries = map.get(asymId)!;
 
             for (let rI = resStart; rI < resEnd; rI++) {
-                const seqNumber = auth_seq_id.value(rI);
+                const seqNumber = label_seq_id.value(rI);
                 if (entries.has(seqNumber)) {
                     const entryList = entries.get(seqNumber)!;
                     for (const entry of entryList) {

--- a/src/mol-model-formats/structure/psf.ts
+++ b/src/mol-model-formats/structure/psf.ts
@@ -21,6 +21,7 @@ function getBasic(atoms: PsfFile['atoms']) {
     const asymIds = new Array<string>(atoms.count);
     const seqIds = new Uint32Array(atoms.count);
     const ids = new Uint32Array(atoms.count);
+    const authSeqIds = new Array<string>(atoms.count);
 
     const entityBuilder = new EntityBuilder();
     const componentBuilder = new ComponentBuilder(atoms.residueId, atoms.atomName);
@@ -68,13 +69,14 @@ function getBasic(atoms: PsfFile['atoms']) {
         asymIds[i] = currentAsymId;
         seqIds[i] = currentSeqId;
         ids[i] = i;
+        authSeqIds[i] = residueNumber.toString();
     }
 
     const atom_site = Table.ofPartialColumns(BasicSchema.atom_site, {
         auth_asym_id: atoms.segmentName,
         auth_atom_id: atoms.atomName,
         auth_comp_id: atoms.residueName,
-        auth_seq_id: atoms.residueId,
+        auth_seq_id: Column.ofStringArray(authSeqIds),
         id: Column.ofIntArray(ids),
 
         label_asym_id: Column.ofStringArray(asymIds),

--- a/src/mol-model-formats/structure/xyz.ts
+++ b/src/mol-model-formats/structure/xyz.ts
@@ -52,7 +52,7 @@ function getModels(mol: XyzFile, ctx: RuntimeContext) {
         auth_asym_id: A,
         auth_atom_id: type_symbol,
         auth_comp_id: MOL,
-        auth_seq_id: seq_id,
+        auth_seq_id: Column.ofStringArray(Column.mapToArray(seq_id, id => id.toString())),
         Cartn_x: Column.ofFloatArray(x),
         Cartn_y: Column.ofFloatArray(y),
         Cartn_z: Column.ofFloatArray(z),

--- a/src/mol-model-props/integrative/cross-link-restraint/format.ts
+++ b/src/mol-model-props/integrative/cross-link-restraint/format.ts
@@ -56,7 +56,7 @@ namespace ModelCrossLinkRestraint {
 
             if (table.model_granularity.value(row) === 'by-atom') {
                 const atomicElement = model.atomicHierarchy.index.findAtom({
-                    auth_seq_id: seqId,
+                    auth_seq_id: seqId.toString(),
                     label_asym_id: asymId,
                     label_atom_id: ps.atom_id.value(row),
                     label_entity_id: entityId,

--- a/src/mol-model/structure/export/categories/atom_site.ts
+++ b/src/mol-model/structure/export/categories/atom_site.ts
@@ -58,7 +58,7 @@ const atom_site_fields = () => CifWriter.fields<StructureElement.Location, Struc
 
     .str('auth_atom_id', P.atom.auth_atom_id)
     .str('auth_comp_id', P.atom.auth_comp_id)
-    .int('auth_seq_id', P.residue.auth_seq_id, { encoder: E.deltaRLE })
+    .str('auth_seq_id', P.residue.auth_seq_id, { encoder: E.deltaRLE })
     .str('auth_asym_id', atom_site_auth_asym_id)
 
     .int('pdbx_PDB_model_num', P.unit.model_num, { encoder: E.deltaRLE })
@@ -124,7 +124,7 @@ export function residueIdFields<K, D>(getLocation: (key: K, data: D) => Structur
         .str(prepostfixed(prefix, `label_entity_id`), mappedProp(getLocation, P.chain.label_entity_id))
 
         .str(prepostfixed(prefix, `auth_comp_id`), mappedProp(getLocation, P.atom.auth_comp_id))
-        .int(prepostfixed(prefix, `auth_seq_id`), mappedProp(getLocation, P.residue.auth_seq_id), { encoder: E.deltaRLE })
+        .str(prepostfixed(prefix, `auth_seq_id`), mappedProp(getLocation, P.residue.auth_seq_id), { encoder: E.deltaRLE })
         .str(prepostfixed(prefix, `auth_asym_id`), mappedProp(getLocation, P.chain.auth_asym_id));
 
     addModelNum(ret, getLocation, options);
@@ -172,7 +172,7 @@ export function atomIdFields<K, D>(getLocation: (key: K, data: D) => StructureEl
 
         .str(prepostfixed(prefix, `auth_atom_id`), mappedProp(getLocation, P.atom.auth_atom_id))
         .str(prepostfixed(prefix, `auth_comp_id`), mappedProp(getLocation, P.atom.auth_comp_id))
-        .int(prepostfixed(prefix, `auth_seq_id`), mappedProp(getLocation, P.residue.auth_seq_id), { encoder: E.deltaRLE })
+        .str(prepostfixed(prefix, `auth_seq_id`), mappedProp(getLocation, P.residue.auth_seq_id), { encoder: E.deltaRLE })
         .str(prepostfixed(prefix, `auth_asym_id`), mappedProp(getLocation, P.chain.auth_asym_id));
 
     addModelNum(ret, getLocation, options);

--- a/src/mol-model/structure/model/properties/atomic/hierarchy.ts
+++ b/src/mol-model/structure/model/properties/atomic/hierarchy.ts
@@ -164,7 +164,7 @@ export interface AtomicIndex {
      * @returns index or -1 if not present.
      */
     findResidue(key: AtomicIndex.ResidueKey): ResidueIndex,
-    findResidue(label_entity_id: string, label_asym_id: string, auth_seq_id: number, pdbx_PDB_ins_code?: string): ResidueIndex,
+    findResidue(label_entity_id: string, label_asym_id: string, auth_seq_id: string, pdbx_PDB_ins_code?: string): ResidueIndex,
 
     /**
      * Index of the 1st occurence of this residue.
@@ -211,12 +211,12 @@ export interface AtomicIndex {
 
 export namespace AtomicIndex {
     export interface ChainLabelKey { label_entity_id: string, label_asym_id: string }
-    export interface ChainAuthKey { auth_asym_id: string, auth_seq_id: number }
+    export interface ChainAuthKey { auth_asym_id: string, auth_seq_id: string }
 
-    export interface ResidueKey { label_entity_id: string, label_asym_id: string, auth_seq_id: number, pdbx_PDB_ins_code?: string }
-    export function EmptyResidueKey(): ResidueKey { return { label_entity_id: '', label_asym_id: '', auth_seq_id: 0, pdbx_PDB_ins_code: void 0 }; }
+    export interface ResidueKey { label_entity_id: string, label_asym_id: string, auth_seq_id: string, pdbx_PDB_ins_code?: string }
+    export function EmptyResidueKey(): ResidueKey { return { label_entity_id: '', label_asym_id: '', auth_seq_id: '', pdbx_PDB_ins_code: void 0 }; }
 
-    export interface ResidueAuthKey { auth_asym_id: string, auth_comp_id: string, auth_seq_id: number, pdbx_PDB_ins_code?: string }
+    export interface ResidueAuthKey { auth_asym_id: string, auth_comp_id: string, auth_seq_id: string, pdbx_PDB_ins_code?: string }
     export interface ResidueLabelKey { label_entity_id: string, label_asym_id: string, label_seq_id: number, pdbx_PDB_ins_code?: string }
 
     export interface AtomKey extends ResidueKey { label_atom_id: string, label_alt_id?: string }

--- a/src/mol-theme/label.ts
+++ b/src/mol-theme/label.ts
@@ -259,7 +259,7 @@ function _atomicElementLabel(location: StructureElement.Location<Unit.Atomic>, g
                 label.push(`<small>Conformation</small> <b>${alt_id}</b>`);
             }
         case 'residue':
-            const seq_id = label_seq_id === auth_seq_id || !has_label_seq_id ? auth_seq_id : label_seq_id;
+            const seq_id = label_seq_id.toString() === auth_seq_id || !has_label_seq_id ? auth_seq_id : label_seq_id;
             label.push(`<b>${compId} ${seq_id}</b>${seq_id !== auth_seq_id ? ` <small>[auth</small> <b>${auth_seq_id}</b><small>]</small>` : ''}<b>${ins_code ? ins_code : ''}</b>`);
         case 'chain':
             if (label_asym_id === auth_asym_id) {


### PR DESCRIPTION
According to multiple resources ([IURC](http://ww1.iucr.org/iucr-top/cif/cifdic_html/2/cif_mm.dic/Iatom_site.auth_seq_id.html), [WWPDB](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_atom_site.auth_seq_id.html), [Molstar code](https://github.com/molstar/molstar/blob/daa2bbd042b5541ba1e6dd23adfdc97c07ac8701/src/mol-io/reader/cif/schema/mmcif.ts#L52)) the value of `atom_site.auth_seq_id` field in mmCif is a string and no assumptions shall be made about its value. Molstar assumes that this field either directly mirrors `atom_site.label_seq_id` or at least contains a sensible integer.

This patch attempts to fix the issue. I'm submitting it as an RFC because the move from integral to string representation of `atom_cite.auth_seq_id` touches some quite low-level Molstar code and there is a pretty good chance that this change has some implications that I'm not seeing.