### PR TITLE
Fix cylinder orientation

### DIFF
--- a/src/mol-geo/geometry/mesh/builder/cylinder.ts
+++ b/src/mol-geo/geometry/mesh/builder/cylinder.ts
@@ -31,6 +31,7 @@ function setCylinderMat(m: Mat4, start: Vec3, dir: Vec3, length: number, matchDi
     // ensure the direction used to create the rotation is always pointing in the same
     // direction so the triangles of adjacent cylinder will line up
     if (matchDir) Vec3.matchDirection(tmpUp, up, tmpCylinderMatDir);
+    else Vec3.copy(tmpUp, up);
     Mat4.fromScaling(tmpCylinderMatScale, Vec3.set(tmpCylinderScale, 1, length, 1));
     Vec3.makeRotation(tmpCylinderMatRot, tmpUp, tmpCylinderMatDir);
     Mat4.mul(m, tmpCylinderMatRot, tmpCylinderMatScale);


### PR DESCRIPTION
If `Cylinder.setCylinderMat` is called for the first time with `matchDir` set to false, `tmpUp` will be a zero vector and the cylinder will have wrong orientation as shown below.
![1tqn](https://user-images.githubusercontent.com/226473/123559171-43835200-d74f-11eb-8ef5-07ec56f48b2d.png)

I discovered this bug while trying to update [molrender](https://github.com/molstar/molrender). It is a bit hard to reproduce this bug in the viewer without modifying the source code, because the axes are shown by default and the cylinders in the axes are created with `matchDir` set to true.

Another way to fix this is to simply change `var tmpUp = Vec3();` to `var tmpUp = Vec3.create(0, 1, 0);` But I think this fix is better because it eliminates side effects from `setCylinderMat`.