### PR TITLE
Add tubularHelices parameter to Cartoon representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Add `tubularHelices` parameter to Cartoon representation
 
 ## [v2.1.0] - 2021-07-05
 

--- a/src/mol-model-props/computed/helix-orientation.ts
+++ b/src/mol-model-props/computed/helix-orientation.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { ParamDefinition as PD } from '../../mol-util/param-definition';
+import { Model } from '../../mol-model/structure';
+import { CustomPropertyDescriptor } from '../../mol-model/custom-property';
+import { CustomModelProperty } from '../common/custom-model-property';
+import { calcHelixOrientation, HelixOrientation } from './helix-orientation/helix-orientation';
+
+export const HelixOrientationParams = { };
+export type HelixOrientationParams = typeof HelixOrientationParams
+export type HelixOrientationProps = PD.Values<HelixOrientationParams>
+
+export type HelixOrientationValue = HelixOrientation;
+
+export const HelixOrientationProvider: CustomModelProperty.Provider<HelixOrientationParams, HelixOrientationValue> = CustomModelProperty.createProvider({
+    label: 'Helix Orientation',
+    descriptor: CustomPropertyDescriptor({
+        name: 'molstar_helix_orientation'
+    }),
+    type: 'dynamic',
+    defaultParams: {},
+    getParams: () => ({}),
+    isApplicable: (data: Model) => true,
+    obtain: async (ctx, data) => {
+        return { value: calcHelixOrientation(data) };
+    }
+});

--- a/src/mol-model-props/computed/helix-orientation/helix-orientation.ts
+++ b/src/mol-model-props/computed/helix-orientation/helix-orientation.ts
@@ -15,7 +15,7 @@ export interface HelixOrientation {
     centers: ArrayLike<number>
 }
 
-/** Use same definition as GROMACS' helixorient */
+/** Usees same definition as GROMACS' helixorient */
 export function calcHelixOrientation(model: Model): HelixOrientation {
     const { x, y, z } = model.atomicConformation;
     const { polymerType, traceElementIndex } = model.atomicHierarchy.derived.residue;
@@ -27,10 +27,6 @@ export function calcHelixOrientation(model: Model): HelixOrientation {
 
     const centers = new Float32Array(n * 3);
     const axes = new Float32Array(n * 3);
-    // const twists = new Float32Array(n);
-    // const diffs = new Float32Array(n);
-    // const rises = new Float32Array(n);
-    // const radii = new Float32Array(n);
 
     let i = 0;
     let j = -1;
@@ -88,12 +84,7 @@ export function calcHelixOrientation(model: Model): HelixOrientation {
             Vec3.normalize(axis, axis);
             Vec3.toArray(axis, axes, j3);
 
-            // if (j > 0) {
-            //     diffs[j] = Vec3.angle(axis, prevAxis);
-            // }
-
             const tmp = Math.cos(Vec3.angle(diff13, diff24));
-            // twists[j] = 180.0 / Math.PI * Math.acos(tmp);
 
             const diff13Length = Vec3.magnitude(diff13);
             const diff24Length = Vec3.magnitude(diff24);
@@ -104,9 +95,6 @@ export function calcHelixOrientation(model: Model): HelixOrientation {
                 // angle between diff13 and diff24 is close to 0
                 Math.max(2.0, 2.0 * (1.0 - tmp))
             );
-            // radii[j] = r;
-
-            // rises[j] = Math.abs(Vec3.dot(r23, axis));
 
             Vec3.scale(v1, diff13, r / diff13Length);
             Vec3.sub(v1, a2, v1);
@@ -142,7 +130,6 @@ export function calcHelixOrientation(model: Model): HelixOrientation {
         Vec3.set(a1, x[eI], y[eI], z[eI]);Vec3.copy(vt, a1);
         Vec3.projectPointOnVector(vt, vt, axis, v1);
         Vec3.toArray(vt, centers, e3);
-
     }
 
     return {

--- a/src/mol-model-props/computed/helix-orientation/helix-orientation.ts
+++ b/src/mol-model-props/computed/helix-orientation/helix-orientation.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { ElementIndex } from '../../../mol-model/structure';
+import { Segmentation } from '../../../mol-data/int/segmentation';
+import { SortedRanges } from '../../../mol-data/int/sorted-ranges';
+import { OrderedSet } from '../../../mol-data/int';
+import { Model } from '../../../mol-model/structure/model';
+import { Vec3 } from '../../../mol-math/linear-algebra';
+
+export interface HelixOrientation {
+    centers: ArrayLike<number>
+}
+
+/** Use same definition as GROMACS' helixorient */
+export function calcHelixOrientation(model: Model): HelixOrientation {
+    const { x, y, z } = model.atomicConformation;
+    const { polymerType, traceElementIndex } = model.atomicHierarchy.derived.residue;
+    const n = polymerType.length;
+
+    const elements = OrderedSet.ofBounds(0, model.atomicConformation.atomId.rowCount) as OrderedSet<ElementIndex>;
+    const polymerIt = SortedRanges.transientSegments(model.atomicRanges.polymerRanges, elements);
+    const residueIt = Segmentation.transientSegments(model.atomicHierarchy.residueAtomSegments, elements);
+
+    const centers = new Float32Array(n * 3);
+    const axes = new Float32Array(n * 3);
+    // const twists = new Float32Array(n);
+    // const diffs = new Float32Array(n);
+    // const rises = new Float32Array(n);
+    // const radii = new Float32Array(n);
+
+    let i = 0;
+    let j = -1;
+    let s = -1;
+
+    const a1 = Vec3();
+    const a2 = Vec3();
+    const a3 = Vec3();
+    const a4 = Vec3();
+
+    const r12 = Vec3();
+    const r23 = Vec3();
+    const r34 = Vec3();
+
+    const v1 = Vec3();
+    const v2 = Vec3();
+    const vt = Vec3();
+
+    const diff13 = Vec3();
+    const diff24 = Vec3();
+
+    const axis = Vec3();
+    const prevAxis = Vec3();
+
+    while (polymerIt.hasNext) {
+        const ps = polymerIt.move();
+        residueIt.setSegment(ps);
+        i = -1;
+        s = -1;
+        while (residueIt.hasNext) {
+            i += 1;
+            const { index } = residueIt.move();
+            if (i === 0) s = index;
+
+            j = (index - 2);
+            const j3 = j * 3;
+
+            Vec3.copy(a1, a2);
+            Vec3.copy(a2, a3);
+            Vec3.copy(a3, a4);
+
+            const eI = traceElementIndex[index];
+            Vec3.set(a4, x[eI], y[eI], z[eI]);
+
+            if (i < 3) continue;
+
+            Vec3.sub(r12, a2, a1);
+            Vec3.sub(r23, a3, a2);
+            Vec3.sub(r34, a4, a3);
+
+            Vec3.sub(diff13, r12, r23);
+            Vec3.sub(diff24, r23, r34);
+
+            Vec3.cross(axis, diff13, diff24);
+            Vec3.normalize(axis, axis);
+            Vec3.toArray(axis, axes, j3);
+
+            // if (j > 0) {
+            //     diffs[j] = Vec3.angle(axis, prevAxis);
+            // }
+
+            const tmp = Math.cos(Vec3.angle(diff13, diff24));
+            // twists[j] = 180.0 / Math.PI * Math.acos(tmp);
+
+            const diff13Length = Vec3.magnitude(diff13);
+            const diff24Length = Vec3.magnitude(diff24);
+
+            const r = (
+                Math.sqrt(diff24Length * diff13Length) /
+                // clamp, to avoid numerical instabilities for when
+                // angle between diff13 and diff24 is close to 0
+                Math.max(2.0, 2.0 * (1.0 - tmp))
+            );
+            // radii[j] = r;
+
+            // rises[j] = Math.abs(Vec3.dot(r23, axis));
+
+            Vec3.scale(v1, diff13, r / diff13Length);
+            Vec3.sub(v1, a2, v1);
+            Vec3.toArray(v1, centers, j3);
+
+            Vec3.scale(v2, diff24, r / diff24Length);
+            Vec3.sub(v2, a3, v2);
+            Vec3.toArray(v2, centers, j3 + 3);
+
+            Vec3.copy(prevAxis, axis);
+        }
+
+        // calc axis as dir of second and third center pos
+        // project first trace atom onto axis to get first center pos
+        const s3 = s * 3;
+        Vec3.fromArray(v1, centers, s3 + 3);
+        Vec3.fromArray(v2, centers, s3 + 6);
+        Vec3.normalize(axis, Vec3.sub(axis, v1, v2));
+        const sI = traceElementIndex[s];
+        Vec3.set(a1, x[sI], y[sI], z[sI]);
+        Vec3.copy(vt, a1);
+        Vec3.projectPointOnVector(vt, vt, axis, v1);
+        Vec3.toArray(vt, centers, s3);
+
+        // calc axis as dir of n-1 and n-2 center pos
+        // project last traceAtom onto axis to get last center pos
+        const e = j + 2;
+        const e3 = e * 3;
+        Vec3.fromArray(v1, centers, e3 - 3);
+        Vec3.fromArray(v2, centers, e3 - 6);
+        Vec3.normalize(axis, Vec3.sub(axis, v1, v2));
+        const eI = traceElementIndex[e];
+        Vec3.set(a1, x[eI], y[eI], z[eI]);Vec3.copy(vt, a1);
+        Vec3.projectPointOnVector(vt, vt, axis, v1);
+        Vec3.toArray(vt, centers, e3);
+
+    }
+
+    return {
+        centers
+    };
+}

--- a/src/mol-repr/structure/representation/cartoon.ts
+++ b/src/mol-repr/structure/representation/cartoon.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -17,6 +17,7 @@ import { PolymerGapParams, PolymerGapVisual } from '../visual/polymer-gap-cylind
 import { PolymerTraceParams, PolymerTraceVisual } from '../visual/polymer-trace-mesh';
 import { SecondaryStructureProvider } from '../../../mol-model-props/computed/secondary-structure';
 import { CustomProperty } from '../../../mol-model-props/common/custom-property';
+import { HelixOrientationProvider } from '../../../mol-model-props/computed/helix-orientation';
 
 const CartoonVisuals = {
     'polymer-trace': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, PolymerTraceParams>) => UnitsRepresentation('Polymer trace mesh', ctx, getParams, PolymerTraceVisual),
@@ -67,7 +68,17 @@ export const CartoonRepresentationProvider = StructureRepresentationProvider({
     defaultSizeTheme: { name: 'uniform' },
     isApplicable: (structure: Structure) => structure.polymerResidueCount > 0,
     ensureCustomProperties: {
-        attach: (ctx: CustomProperty.Context, structure: Structure) => SecondaryStructureProvider.attach(ctx, structure, void 0, true),
-        detach: (data) => SecondaryStructureProvider.ref(data, false)
+        attach: async (ctx: CustomProperty.Context, structure: Structure) => {
+            await SecondaryStructureProvider.attach(ctx, structure, void 0, true);
+            for (const m of structure.models) {
+                await HelixOrientationProvider.attach(ctx, m, void 0, true);
+            }
+        },
+        detach: (data) => {
+            SecondaryStructureProvider.ref(data, false);
+            for (const m of data.models) {
+                HelixOrientationProvider.ref(m, false);
+            }
+        }
     }
 });

--- a/src/mol-repr/structure/visual/polymer-tube-mesh.ts
+++ b/src/mol-repr/structure/visual/polymer-tube-mesh.ts
@@ -46,7 +46,7 @@ function createPolymerTubeMesh(ctx: VisualContext, unit: Unit, structure: Struct
     const { curvePoints, normalVectors, binormalVectors, widthValues, heightValues } = state;
 
     let i = 0;
-    const polymerTraceIt = PolymerTraceIterator(unit, structure, true);
+    const polymerTraceIt = PolymerTraceIterator(unit, structure, { ignoreSecondaryStructure: true });
     while (polymerTraceIt.hasNext) {
         const v = polymerTraceIt.move();
         builderState.currentGroup = i;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/272250/125178037-c9fb5300-e195-11eb-882c-372b55860101.png)

Fixes #206.

At some point it might be worthwhile to precalculate the trace points...

There are some more things that could be done with the helix-orient data like in NGL but not sure if worthwhile
- http://nglviewer.org/ngl/?script=representation/helixorient (quite narrow use-case...)
- http://nglviewer.org/ngl/?script=representation/rocket (also allows splitting highly bend helices in more components)

--

Colored by hydrophobicity
![image](https://user-images.githubusercontent.com/272250/125178209-80ac0300-e197-11eb-8be7-84a134840ae8.png)
