### PR TITLE
Do not cache LevelTexturesFramebuffers as they may become invalid

### DIFF
--- a/src/mol-gl/compute/histogram-pyramid/reduction.ts
+++ b/src/mol-gl/compute/histogram-pyramid/reduction.ts
@@ -64,20 +64,15 @@ function createHistopyramidReductionRenderable(ctx: WebGLContext, inputLevel: Te
 }
 
 type TextureFramebuffer = { texture: Texture, framebuffer: Framebuffer }
-const LevelTexturesFramebuffers: TextureFramebuffer[] = [];
 function getLevelTextureFramebuffer(ctx: WebGLContext, level: number) {
-    let textureFramebuffer = LevelTexturesFramebuffers[level];
     const size = Math.pow(2, level);
-    if (textureFramebuffer === undefined) {
-        const texture = ctx.isWebGL2
-            ? getTexture(`level${level}`, ctx, 'image-int32', 'alpha', 'int', 'nearest')
-            : getTexture(`level${level}`, ctx, 'image-uint8', 'rgba', 'ubyte', 'nearest');
-        texture.define(size, size);
-        const framebuffer = getFramebuffer(`level${level}`, ctx);
-        texture.attachFramebuffer(framebuffer, 0);
-        textureFramebuffer = { texture, framebuffer };
-        LevelTexturesFramebuffers[level] = textureFramebuffer;
-    }
+    const texture = ctx.isWebGL2
+        ? getTexture(`level${level}`, ctx, 'image-int32', 'alpha', 'int', 'nearest')
+        : getTexture(`level${level}`, ctx, 'image-uint8', 'rgba', 'ubyte', 'nearest');
+    texture.define(size, size);
+    const framebuffer = getFramebuffer(`level${level}`, ctx);
+    texture.attachFramebuffer(framebuffer, 0);
+    const textureFramebuffer = { texture, framebuffer };
     return textureFramebuffer;
 }
 

--- a/src/mol-gl/compute/histogram-pyramid/reduction.ts
+++ b/src/mol-gl/compute/histogram-pyramid/reduction.ts
@@ -66,14 +66,17 @@ function createHistopyramidReductionRenderable(ctx: WebGLContext, inputLevel: Te
 type TextureFramebuffer = { texture: Texture, framebuffer: Framebuffer }
 function getLevelTextureFramebuffer(ctx: WebGLContext, level: number) {
     const size = Math.pow(2, level);
+    const name = `level${level}`;
     const texture = ctx.isWebGL2
-        ? getTexture(`level${level}`, ctx, 'image-int32', 'alpha', 'int', 'nearest')
-        : getTexture(`level${level}`, ctx, 'image-uint8', 'rgba', 'ubyte', 'nearest');
+        ? getTexture(name, ctx, 'image-int32', 'alpha', 'int', 'nearest')
+        : getTexture(name, ctx, 'image-uint8', 'rgba', 'ubyte', 'nearest');
     texture.define(size, size);
-    const framebuffer = getFramebuffer(`level${level}`, ctx);
-    texture.attachFramebuffer(framebuffer, 0);
-    const textureFramebuffer = { texture, framebuffer };
-    return textureFramebuffer;
+    let framebuffer = tryGetFramebuffer(name, ctx);
+    if (!framebuffer) {
+        framebuffer = getFramebuffer(name, ctx);
+        texture.attachFramebuffer(framebuffer, 0);
+    }
+    return { texture, framebuffer };
 }
 
 function setRenderingDefaults(ctx: WebGLContext) {
@@ -101,6 +104,11 @@ function getTexture(name: string, webgl: WebGLContext, kind: TextureKind, format
         webgl.namedTextures[_name] = webgl.resources.texture(kind, format, type, filter);
     }
     return webgl.namedTextures[_name];
+}
+
+function tryGetFramebuffer(name: string, webgl: WebGLContext): Framebuffer | undefined {
+    const _name = `${HistogramPyramidName}-${name}`;
+    return webgl.namedFramebuffers[_name];
 }
 
 export interface HistogramPyramid {


### PR DESCRIPTION
Texture framebuffers use in histogram pyramid calculation are cached in a global variable that exists throughout the entire lifetime of the application. These cached objects may become invalid under some circumstances. One example could be a JS application that creates and destroys a Molstar plugin on demand. Framebuffer objects created by the plugin will not be valid when the plugin's instance gets destroyed and recreated at a later time. Density maps will then fail to display as a result and the only way out is to reload the entire page in the browser.

This could possibly be improved by flushing the cache only when it's actually necessary but I couldn't find a place in the code where doing so wouldn't feel really hacky.