### PR TITLE
ANVIL: improve prediction for 3pqr

### DIFF
--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -39,7 +39,7 @@ interface ANVILContext {
 };
 
 export const ANVILParams = {
-    numberOfSpherePoints: PD.Numeric(140, { min: 35, max: 700, step: 1 }, { description: 'Number of spheres/directions to test for membrane placement. Original value is 350.' }),
+    numberOfSpherePoints: PD.Numeric(175, { min: 35, max: 700, step: 1 }, { description: 'Number of spheres/directions to test for membrane placement. Original value is 350.' }),
     stepSize: PD.Numeric(1, { min: 0.25, max: 4, step: 0.25 }, { description: 'Thickness of membrane slices that will be tested' }),
     minThickness: PD.Numeric(20, { min: 10, max: 30, step: 1}, { description: 'Minimum membrane thickness used during refinement' }),
     maxThickness: PD.Numeric(40, { min: 30, max: 50, step: 1}, { description: 'Maximum membrane thickness used during refinement' }),


### PR DESCRIPTION
I've had a look at the dubious ANVIL prediction for 3pqr that Alex reported. Seems like lowering the number of sphere points to 140 was a bit too greedy.

175, half of the original value, results in a better prediction in this case while not affecting performance greatly. Calculations for extreme cases like 7cgo or 6nk5 still finish similarly fast.

Left: 140 points, right: 175
![3pqr](https://user-images.githubusercontent.com/9744615/130287948-c372e26c-f4fc-43c3-b24a-e00f7962be95.png)