### PR TITLE
ANVIL: add TMDET amino acid classification and reference

### DIFF
--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -61,7 +61,7 @@ const TMDET_DEFINITION = new Set(['LEU', 'ILE', 'VAL', 'PHE', 'MET', 'GLY', 'TRP
  * Guillaume Postic, Yassine Ghouzam, Vincent Guiraud, and Jean-Christophe Gelly
  * Protein Engineering, Design & Selection, 2015, 1–5
  * doi: 10.1093/protein/gzv063
- * 
+ *
  * ANVIL is derived from TMDET, the corresponding classification of hydrophobic amino acids is provided as optional parameter:
  * Gabor E. Tusnady, Zsuzsanna Dosztanyi and Istvan Simon
  * Transmembrane proteins in the Protein Data Bank: identification and classification


### PR DESCRIPTION
- the ANVIL prediction depends on the set of amino acids that are considered 'membrane-favoring', this PR adds an alternative classification from TMDET, the TMDET definition shows better performance for porins & most beta-barrel structures and might be useful to some users as a fallback for flawed predictions
- adds a reference to TMDET which, in general, shows striking similarities to ANVIL, it's only fair to give them some credit as well
- fixes prediction for [6y1z](https://www.rcsb.org/3d-view/6Y1Z/1?preset=membrane) which contains amino acids that are not part of an entity

Thanks for having a look!