### PR TITLE
Update selection history when Loci is removed from selection

### DIFF
--- a/src/mol-plugin-state/manager/structure/selection.ts
+++ b/src/mol-plugin-state/manager/structure/selection.ts
@@ -113,7 +113,10 @@ export class StructureSelectionManager extends StatefulPluginComponent<Structure
 
         const sel = entry.selection;
         entry.selection = StructureElement.Loci.subtract(entry.selection, loci);
-        // this.addHistory(loci);
+
+        const historyEntry = this.additionsHistory.find(he => Loci.areEqual(he.loci, loci));
+        if (historyEntry)
+            this.modifyHistory(historyEntry, 'remove');
         this.referenceLoci = loci;
         this.events.loci.remove.next(loci);
         return !StructureElement.Loci.areEqual(sel, entry.selection);


### PR DESCRIPTION
When a Loci is removed from selection, additionsHistory does not seem to get updated properly. This causes a bit of bad user experience with the Measurements functionality because the user cannot change their mind about what to measure unless they deselect everything and start over.

(This looks like way too easy a fix, what am I missing here?)