### PR TITLE
Tweak measurement order labels

### DIFF
--- a/src/mol-geo/geometry/text/text.ts
+++ b/src/mol-geo/geometry/text/text.ts
@@ -245,7 +245,7 @@ export namespace Text {
             ...BaseGeometry.createValues(props, counts),
             uSizeFactor: ValueCell.create(props.sizeFactor),
 
-            uBorderWidth: ValueCell.create(clamp(props.borderWidth / 2, 0, 0.5)),
+            uBorderWidth: ValueCell.create(clamp(props.borderWidth, 0, 0.5)),
             uBorderColor: ValueCell.create(Color.toArrayNormalized(props.borderColor, Vec3.zero(), 0)),
             uOffsetX: ValueCell.create(props.offsetX),
             uOffsetY: ValueCell.create(props.offsetY),

--- a/src/mol-plugin-state/manager/structure/measurement.ts
+++ b/src/mol-plugin-state/manager/structure/measurement.ts
@@ -310,6 +310,7 @@ class StructureMeasurementManager extends StatefulPluginComponent<StructureMeasu
                     borderColor: Color.fromRgb(0, 0, 0),
                     textSize: 0.33,
                     borderWidth: 0.3,
+                    offsetZ: 0.75,
                     customText: `${order++}`
                 }, { tags: MeasurementOrderLabelTag });
         }

--- a/src/mol-plugin-state/manager/structure/measurement.ts
+++ b/src/mol-plugin-state/manager/structure/measurement.ts
@@ -308,8 +308,8 @@ class StructureMeasurementManager extends StatefulPluginComponent<StructureMeasu
                 .apply(StateTransforms.Representation.StructureSelectionsLabel3D, {
                     textColor: Color.fromRgb(255, 255, 255),
                     borderColor: Color.fromRgb(0, 0, 0),
-                    borderWidth: 0.5,
                     textSize: 0.33,
+                    borderWidth: 0.3,
                     customText: `${order++}`
                 }, { tags: MeasurementOrderLabelTag });
         }


### PR DESCRIPTION
Naturally, I discovered a few minor issues with the newly added measurement labels code. Sorry... :)

* Border width of 0.5 is too wide and may cause visual artifacts. It is reduced to 0.3.
* Default offsetZ value of 2 is most likely okay for ordinary labels but it seems too high for the order labels. If the user zooms in very closely, order labels get clipped off even though the structure itself is still clearly visible. Value of 0.75 seems to improve this a lot without causing the labels to sink into the structure.
* There was a minor glitch in the text rendering code where the border width was initially set at half of the intended value. With the fix in place it might make sense to check if the default border width (0.2?) is not too thick now.