### PR TITLE
Fix USDZ and OBJ export

### DIFF
--- a/src/extensions/geo-export/obj-exporter.ts
+++ b/src/extensions/geo-export/obj-exporter.ts
@@ -145,7 +145,7 @@ export class ObjExporter extends MeshExporter<ObjData> {
                 const color = ObjExporter.getColor(v, geoData, interpolatedColors, interpolatedOverpaint);
                 Color.toArray(color, quantizedColors, i);
             }
-            ObjExporter.quantizeColors(quantizedColors, mesh!.vertexCount);
+            ObjExporter.quantizeColors(quantizedColors, vertexCount);
 
             // face
             for (let i = 0; i < drawCount; i += 3) {

--- a/src/extensions/geo-export/usdz-exporter.ts
+++ b/src/extensions/geo-export/usdz-exporter.ts
@@ -149,7 +149,7 @@ def Material "material${materialKey}"
                 const color = UsdzExporter.getColor(v, geoData, interpolatedColors, interpolatedOverpaint);
                 Color.toArray(color, quantizedColors, i);
             }
-            UsdzExporter.quantizeColors(quantizedColors, mesh!.vertexCount);
+            UsdzExporter.quantizeColors(quantizedColors, vertexCount);
 
             // material
             const faceIndicesByMaterial = new Map<number, number[]>();


### PR DESCRIPTION
The current code throws an error when exporting the default 1TQN as USDZ or OBJ. ("Cannot read properties of undefined (reading 'vertexCount')".) This is because it tries to read the `vertexCount` property of `input.mesh`, which is only defined for GraphicsRenderObjects that share the same vertex and normal arrays for every instance, such as Mesh or TextureMesh. For other kinds of GraphicsRenderObjects, `input.meshes` is defined. The proper way to read `vertexCount` of an instance is to use `MeshExporter.getInstance(input, instanceIndex).vertexCount`, which takes care of `input.mesh` and `input.meshes`.