### PR TITLE
Make cleanup script work with older vesions of Node.js

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -7,6 +7,23 @@
 const fs = require('fs');
 const path = require('path');
 
+function removeDir(dirPath) {
+    for (const ent of fs.readdirSync(dirPath)) {
+        const entryPath = path.join(dirPath, ent);
+        remove(entryPath);
+    }
+
+    fs.rmdirSync(dirPath);
+}
+
+function remove(entryPath) {
+    const st = fs.statSync(entryPath);
+    if (st.isDirectory())
+        removeDir(entryPath);
+    else
+        fs.unlinkSync(entryPath);
+}
+
 const toClean = [
     path.resolve(__dirname, '../build'),
     path.resolve(__dirname, '../lib'),
@@ -14,6 +31,11 @@ const toClean = [
 ];
 
 toClean.forEach(ph => {
-    if (fs.existsSync(ph))
-        fs.rm(ph, { recursive: true }, err => { if (err) console.warn(`Failed to delete ${ph}: ${err}`); });
+    if (fs.existsSync(ph)) {
+        try {
+            remove(ph);
+        } catch (err) {
+            console.warn(`Cleanup failed: ${err}`);
+        }
+    }
 });


### PR DESCRIPTION
The original cleanup script required at least Node v14.14 . The updated version should work with any version of Node that can be expected to build Molstar.