### PR TITLE
Feature/formal charge labels

### DIFF
--- a/src/mol-io/reader/sdf/parser.ts
+++ b/src/mol-io/reader/sdf/parser.ts
@@ -29,12 +29,18 @@ export interface SdfFile {
 
 
 const delimiter = '$$$$';
+const formalChargePrefix = 'M  CHG';
+
 function handleDataItems(tokenizer: Tokenizer): { dataHeader: Column<string>, data: Column<string> } {
     const dataHeader = TokenBuilder.create(tokenizer.data, 32);
     const data = TokenBuilder.create(tokenizer.data, 32);
 
     while (tokenizer.position < tokenizer.length) {
         const line = Tokenizer.readLine(tokenizer);
+        if (line.startsWith(formalChargePrefix)) {
+            console.log('charge found');
+            console.log(line);
+        }
         if (line.startsWith(delimiter)) break;
         if (!line) continue;
 

--- a/src/mol-model-formats/structure/mol.ts
+++ b/src/mol-model-formats/structure/mol.ts
@@ -45,6 +45,7 @@ export async function getMolModels(mol: MolFile, format: ModelFormat<any> | unde
         type_symbol,
 
         pdbx_PDB_model_num: Column.ofConst(1, atoms.count, Column.Schema.int),
+        pdbx_formal_charge: Column.range(-1, 1)
     }, atoms.count);
 
     const entityBuilder = new EntityBuilder();


### PR DESCRIPTION
@dsehnal this is the (very) first step to implementing the feature. My question is: given that we find the line which contains the atom id and the charge, where should we pass it next?

I understand that when
`export async function getMolModels(mol: MolFile, format: ModelFormat<any> | undefined, ctx: RuntimeContext) {
`
is called, the necessary info should already be in the `mol: MolFile`, right?