### PR TITLE
update State Snapshots canApply when snapshots are added

### DIFF
--- a/src/extensions/mp4-export/controls.ts
+++ b/src/extensions/mp4-export/controls.ts
@@ -125,15 +125,18 @@ export class Mp4Controls extends PluginComponent {
         this.subscribe(this.plugin.canvas3d?.resized!, () => this.syncInfo());
         this.subscribe(this.plugin.helpers.viewportScreenshot?.events.previewed!, () => this.syncInfo());
 
-        this.subscribe(this.plugin.behaviors.state.isBusy, b => {
-            const anim = this.current;
-            if (!b && anim) {
-                this.behaviors.canApply.next(anim.anim.canApply?.(this.plugin) ?? { canApply: true });
-            }
-        });
+        this.subscribe(this.plugin.behaviors.state.isBusy, b => this.updateCanApply(b));
+        this.subscribe(this.plugin.managers.snapshot.events.changed, b => this.updateCanApply(b));
 
         this.sync();
         this.syncInfo();
+    }
+
+    private updateCanApply(b?: any) {
+        const anim = this.current;
+        if (!b && anim) {
+            this.behaviors.canApply.next(anim.anim.canApply?.(this.plugin) ?? { canApply: true });
+        }
     }
 
     constructor(private plugin: PluginContext) {


### PR DESCRIPTION
Under Export Animation, when exporting State Snapshots, the canApply values won't get updated when additional state snapshots are added (or removed). Will keep reporting 'At least 2 states required.' and requires e.g. switching temporarily to another animation type.

![state-snapshots](https://user-images.githubusercontent.com/9744615/146356209-17f1ead2-9b11-45e1-8e08-d85f2aa0b0cd.png)
