### PR TITLE
Volume Streaming Error Message

### DIFF
--- a/src/mol-plugin-ui/structure/volume.tsx
+++ b/src/mol-plugin-ui/structure/volume.tsx
@@ -77,9 +77,9 @@ export class VolumeStreamingControls extends CollapsableControls<{}, VolumeStrea
         const rootCell = root && pivot.cell.parent.cells.get(root);
 
         const simpleApply = rootCell && rootCell.status === 'error'
-            ? { header: 'Error enabling', icon: ErrorSvg, title: rootCell.errorText }
+            ? { header: rootCell.errorText?.indexOf('404') === -1 ? 'Error Enabling' : 'No Density Data Available', icon: ErrorSvg, title: rootCell.errorText }
             : rootCell && rootCell.obj?.data.entries.length === 0
-                ? { header: 'Error enabling', icon: ErrorSvg, title: 'No entry for streaming found' }
+                ? { header: 'Error Enabling', icon: ErrorSvg, title: 'No Entry for Streaming Found' }
                 : { header: 'Enable', icon: CheckSvg, title: 'Enable' };
 
         return <ApplyActionControl state={pivot.cell.parent} action={InitVolumeStreaming} initiallyCollapsed={true} nodeRef={pivot.cell.transform.ref} simpleApply={simpleApply} />;

--- a/src/mol-plugin-ui/structure/volume.tsx
+++ b/src/mol-plugin-ui/structure/volume.tsx
@@ -77,7 +77,7 @@ export class VolumeStreamingControls extends CollapsableControls<{}, VolumeStrea
         const rootCell = root && pivot.cell.parent.cells.get(root);
 
         const simpleApply = rootCell && rootCell.status === 'error'
-            ? { header: rootCell.errorText?.indexOf('404') === -1 ? 'Error Enabling' : 'No Density Data Available', icon: ErrorSvg, title: rootCell.errorText }
+            ? { header: !!rootCell.errorText && rootCell.errorText?.includes('404') ? 'No Density Data Available' : 'Error Enabling', icon: ErrorSvg, title: rootCell.errorText }
             : rootCell && rootCell.obj?.data.entries.length === 0
                 ? { header: 'Error Enabling', icon: ErrorSvg, title: 'No Entry for Streaming Found' }
                 : { header: 'Enable', icon: CheckSvg, title: 'Enable' };


### PR DESCRIPTION
Folks on our end are interested in a more user-friendly error message when volume streaming can't be enabled. We would like a distinction between unexpected/parsing errors and the case where a structure just doesn't provide density data, indicated by a 404.

This would bring the error messages in alignment with the assembly symmetry component.