### PR TITLE
cleaner default representation style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
-- Fix ``xrayShader`` & ``ignoreLight`` params not working at the same time
+- Fix ``xrayShaded`` & ``ignoreLight`` params not working at the same time
 - Add ``ignoreLight`` to component params
+- Tweaks for cleaner default representation style
+    - Cartoon: use ``nucleotide-ring`` instead of ``nucleotide-block``
+    - Focus: use ``xrayShaded`` instead of opacity; adjust target size; don't show non-covalent interactions twice
 
 ## [v3.0.2] - 2022-01-30
 

--- a/src/mol-plugin/behavior/dynamic/selection/structure-focus-representation.ts
+++ b/src/mol-plugin/behavior/dynamic/selection/structure-focus-representation.ts
@@ -27,11 +27,19 @@ const StructureFocusRepresentationParams = (plugin: PluginContext) => {
         expandRadius: PD.Numeric(5, { min: 1, max: 10, step: 1 }),
         targetParams: PD.Group(reprParams, {
             label: 'Target',
-            customDefault: createStructureRepresentationParams(plugin, void 0, { type: 'ball-and-stick', size: 'physical', typeParams: { sizeFactor: 0.26, alpha: 0.51, adjustCylinderLength: true } })
+            customDefault: createStructureRepresentationParams(plugin, void 0, {
+                type: 'ball-and-stick',
+                size: 'physical',
+                typeParams: { sizeFactor: 0.22, sizeAspectRatio: 0.73, adjustCylinderLength: true, xrayShaded: true, aromaticBonds: false, multipleBonds: 'off', excludeTypes: ['hydrogen-bond', 'metal-coordination'] },
+            })
         }),
         surroundingsParams: PD.Group(reprParams, {
             label: 'Surroundings',
-            customDefault: createStructureRepresentationParams(plugin, void 0, { type: 'ball-and-stick', size: 'physical', typeParams: { sizeFactor: 0.16 } })
+            customDefault: createStructureRepresentationParams(plugin, void 0, {
+                type: 'ball-and-stick',
+                size: 'physical',
+                typeParams: { sizeFactor: 0.16, excludeTypes: ['hydrogen-bond', 'metal-coordination'] }
+            })
         }),
         nciParams: PD.Group(reprParams, {
             label: 'Non-covalent Int.',

--- a/src/mol-repr/structure/representation/cartoon.ts
+++ b/src/mol-repr/structure/representation/cartoon.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -35,7 +35,7 @@ export const CartoonParams = {
     ...NucleotideRingParams,
     ...PolymerDirectionParams,
     sizeFactor: PD.Numeric(0.2, { min: 0, max: 10, step: 0.01 }),
-    visuals: PD.MultiSelect(['polymer-trace', 'polymer-gap', 'nucleotide-block'], PD.objectToOptions(CartoonVisuals)),
+    visuals: PD.MultiSelect(['polymer-trace', 'polymer-gap', 'nucleotide-ring'], PD.objectToOptions(CartoonVisuals)),
     bumpFrequency: PD.Numeric(2, { min: 0, max: 10, step: 0.1 }, BaseGeometry.ShadingCategory),
 };
 
@@ -49,7 +49,7 @@ export function getCartoonParams(ctx: ThemeRegistryContext, structure: Structure
         if (!hasGaps && u.gapElements.length) hasGaps = true;
     });
     params.visuals.defaultValue = ['polymer-trace'];
-    if (hasNucleotides) params.visuals.defaultValue.push('nucleotide-block');
+    if (hasNucleotides) params.visuals.defaultValue.push('nucleotide-ring');
     if (hasGaps) params.visuals.defaultValue.push('polymer-gap');
     return params;
 }


### PR DESCRIPTION
I am proposing some tweaks to the cartoon and focus representation defaults

- Cartoon: use ``nucleotide-ring`` instead of ``nucleotide-block``
- Focus: use ``xrayShaded`` instead of opacity; adjust target size; don't show non-covalent interactions twice

New
![image](https://user-images.githubusercontent.com/272250/152658935-c0f54e2a-6008-4a26-a23a-f424d2fa71ba.png)

Old
![image](https://user-images.githubusercontent.com/272250/152658943-4c69fbb7-308f-4fad-ab5f-deafb8a4a7d3.png)
