### PR TITLE
iterate over `structure.unitSymmetryGroups`, fixes #364

### DIFF
--- a/src/mol-model/structure/export/categories/secondary-structure.ts
+++ b/src/mol-model/structure/export/categories/secondary-structure.ts
@@ -78,12 +78,12 @@ function findElements<T extends SecondaryStructure.Element>(ctx: CifExportContex
     const ssElements: SSElement<any>[] = [];
 
     const structure = ctx.structures[0];
-    for (const unit of structure.units) {
-        // currently can only support this for "identity" operators.
-        if (!Unit.isAtomic(unit) || !unit.conformation.operator.isIdentity) continue;
+    for (const unit of structure.unitSymmetryGroups) {
+        const u = unit.units[0];
+        if (!Unit.isAtomic(u)) continue;
 
-        const segs = unit.model.atomicHierarchy.residueAtomSegments;
-        const residues = Segmentation.transientSegments(segs, unit.elements);
+        const segs = u.model.atomicHierarchy.residueAtomSegments;
+        const residues = Segmentation.transientSegments(segs, u.elements);
 
         let current: Segmentation.Segment, move = true;
         while (residues.hasNext) {
@@ -104,8 +104,8 @@ function findElements<T extends SecondaryStructure.Element>(ctx: CifExportContex
                 if (startIdx !== key[current.index]) {
                     move = false;
                     ssElements[ssElements.length] = {
-                        start: StructureElement.Location.create(structure, unit, segs.offsets[start]),
-                        end: StructureElement.Location.create(structure, unit, segs.offsets[prev]),
+                        start: StructureElement.Location.create(structure, u, segs.offsets[start]),
+                        end: StructureElement.Location.create(structure, u, segs.offsets[prev]),
                         length: prev - start + 1,
                         element
                     };


### PR DESCRIPTION
This ensures that SSE information is exported for transformed structures.
`const u = unit.units[0];` is used in other places, I assume this is also the way to go here.