### PR TITLE
Add TraceOnly option for Structure Superposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Rename "best database mapping" to "SIFTS Mapping"
 - Add schema and export support for ``atom_site.pdbx_sifts_xref_*`` fields
 - Add schema export support for ``atom_site.pdbx_label_index`` field
+- Add `traceOnly` parameter to chain/UniProt-based structure alignment
 
 ## [v3.1.0] - 2022-02-06
 

--- a/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
+++ b/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
@@ -98,7 +98,6 @@ function getPositionTables(index: IndexEntry[], pivot: number, other: number, N:
 }
 
 function traceAtom(unit: Unit.Atomic, eI: ElementIndex): boolean {
-    // TODO could check based on traceElementIndex too
     const l = unit.model.atomicHierarchy.atoms.label_atom_id.value(eI);
     return l === 'CA' || l === 'BB' || l === `C4'`;
 }

--- a/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
+++ b/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
 
 import { Segmentation } from '../../../../mol-data/int';

--- a/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
+++ b/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
@@ -163,7 +163,7 @@ function buildIndex(structure: Structure, index: Map<string, IndexEntry>, sI: nu
 
                 let start, end;
                 if (traceOnly) {
-                    start = traceElementIndex[rI] as ElementIndex;
+                    start = traceElementIndex[rI];
                     if (start === -1) continue;
                     end = start + 1 as ElementIndex;
                 } else {

--- a/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
+++ b/src/mol-model/structure/structure/util/superposition-sifts-mapping.ts
@@ -24,7 +24,7 @@ export interface AlignmentResult {
     failedPairs: [number, number][]
 }
 
-export function alignAndSuperposeWithSIFTSMapping(structures: Structure[], traceOnly: boolean = true): AlignmentResult {
+export function alignAndSuperposeWithSIFTSMapping(structures: Structure[], options?: { traceOnly?: boolean }): AlignmentResult {
     const indexMap = new Map<string, IndexEntry>();
 
     for (let i = 0; i < structures.length; i++) {
@@ -45,7 +45,7 @@ export function alignAndSuperposeWithSIFTSMapping(structures: Structure[], trace
         if (p.count === 0) {
             zeroOverlapPairs.push([p.i, p.j]);
         } else {
-            const [a, b] = getPositionTables(index, p.i, p.j, p.count, traceOnly);
+            const [a, b] = getPositionTables(index, p.i, p.j, p.count, options?.traceOnly ?? true);
             const transform = MinimizeRmsd.compute({ a, b });
             if (Number.isNaN(transform.rmsd)) {
                 failedPairs.push([p.i, p.j]);

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -49,6 +49,7 @@ export class StructureSuperpositionControls extends CollapsableControls {
 
 export const StructureSuperpositionParams = {
     alignSequences: PD.Boolean(true, { isEssential: true, description: 'For Chain-based 3D superposition, perform a sequence alignment and use the aligned residue pairs to guide the 3D superposition.' }),
+    traceOnly: PD.Boolean(true, { description: 'For Chain- and Uniprot-based 3D superposition, base superposition only on CA (and equivalent) atoms.' })
 };
 const DefaultStructureSuperpositionOptions = PD.getDefaultValues(StructureSuperpositionParams);
 export type StructureSuperpositionOptions = PD.ValuesFor<typeof StructureSuperpositionParams>

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -177,9 +177,10 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
 
     superposeDb = async () => {
         const input = this.plugin.managers.structure.hierarchy.behaviors.selection.value.structures;
+        const traceOnly = this.state.options.traceOnly;
 
         const structures = input.map(s => s.cell.obj?.data!);
-        const { entries, failedPairs, zeroOverlapPairs } = alignAndSuperposeWithSIFTSMapping(structures, this.state.options.traceOnly);
+        const { entries, failedPairs, zeroOverlapPairs } = alignAndSuperposeWithSIFTSMapping(structures, { traceOnly });
 
         let rmsd = 0;
 

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -124,10 +124,10 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
     }
 
     superposeChains = async () => {
-        const { query } = StructureSelectionQueries.trace;
+        const { query } = this.state.options.traceOnly ? StructureSelectionQueries.trace : StructureSelectionQueries.all;
         const entries = this.chainEntries;
 
-        const traceLocis = entries.map((e, i) => {
+        const locis = entries.map((e, i) => {
             const s = StructureElement.Loci.toStructure(e.loci);
             const loci = StructureSelection.toLociWithSourceUnits(query(new QueryContext(s)));
             return StructureElement.Loci.remap(loci, i === 0
@@ -137,11 +137,11 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
         });
 
         const transforms = this.state.options.alignSequences
-            ? alignAndSuperpose(traceLocis)
-            : superpose(traceLocis);
+            ? alignAndSuperpose(locis)
+            : superpose(locis);
 
         const eA = entries[0];
-        for (let i = 1, il = traceLocis.length; i < il; ++i) {
+        for (let i = 1, il = locis.length; i < il; ++i) {
             const eB = entries[i];
             const { bTransform, rmsd } = transforms[i - 1];
             await this.transform(eB.cell, bTransform);
@@ -178,7 +178,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
         const input = this.plugin.managers.structure.hierarchy.behaviors.selection.value.structures;
 
         const structures = input.map(s => s.cell.obj?.data!);
-        const { entries, failedPairs, zeroOverlapPairs } = alignAndSuperposeWithSIFTSMapping(structures);
+        const { entries, failedPairs, zeroOverlapPairs } = alignAndSuperposeWithSIFTSMapping(structures, this.state.options.traceOnly);
 
         let rmsd = 0;
 

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
 
 import { CollapsableControls, PurePluginUIComponent } from '../base';

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -150,6 +150,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
             const labelB = stripTags(eB.label);
             this.plugin.log.info(`Superposed [${labelA}] and [${labelB}] with RMSD ${rmsd.toFixed(2)}.`);
         }
+        await this.cameraReset();
     };
 
     superposeAtoms = async () => {
@@ -173,6 +174,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
             const count = entries[i].atoms.length;
             this.plugin.log.info(`Superposed ${count} ${count === 1 ? 'atom' : 'atoms'} of [${labelA}] and [${labelB}] with RMSD ${rmsd.toFixed(2)}.`);
         }
+        await this.cameraReset();
     };
 
     superposeDb = async () => {
@@ -205,10 +207,14 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
 
         if (entries.length) {
             this.plugin.log.info(`Superposed ${entries.length + 1} structures with avg. RMSD ${rmsd.toFixed(2)} Å.`);
-            await new Promise(res => requestAnimationFrame(res));
-            PluginCommands.Camera.Reset(this.plugin);
+            await this.cameraReset();
         }
     };
+
+    async cameraReset() {
+        await new Promise(res => requestAnimationFrame(res));
+        PluginCommands.Camera.Reset(this.plugin);
+    }
 
     toggleByChains = () => this.setState({ action: this.state.action === 'byChains' ? void 0 : 'byChains' });
     toggleByAtoms = () => this.setState({ action: this.state.action === 'byAtoms' ? void 0 : 'byAtoms' });

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -124,7 +124,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
     }
 
     superposeChains = async () => {
-        const { query } = this.state.options.traceOnly ? StructureSelectionQueries.trace : StructureSelectionQueries.all;
+        const { query } = this.state.options.traceOnly ? StructureSelectionQueries.trace : StructureSelectionQueries.polymer;
         const entries = this.chainEntries;
 
         const locis = entries.map((e, i) => {


### PR DESCRIPTION
This addresses #371.

Is it intentional that the camera only resets for the UniProt alignment but not for the ones based on chains/atoms?