### PR TITLE
parse contour-level from emdb v3 header files

### DIFF
--- a/src/mol-plugin/behavior/dynamic/volume-streaming/util.ts
+++ b/src/mol-plugin/behavior/dynamic/volume-streaming/util.ts
@@ -75,6 +75,7 @@ export async function getContourLevelEmdb(plugin: PluginContext, taskCtx: Runtim
     for (let i = 1; i < contours.length; i++) {
         if (contours[i].getAttribute('primary') === 'true') {
             primaryContour = contours[i];
+            break;
         }
     }
     const contourLevel = parseFloat(primaryContour.getElementsByTagName('level')[0].textContent!);

--- a/src/mol-plugin/behavior/dynamic/volume-streaming/util.ts
+++ b/src/mol-plugin/behavior/dynamic/volume-streaming/util.ts
@@ -69,8 +69,15 @@ export async function getContourLevel(provider: 'emdb' | 'pdbe', plugin: PluginC
 export async function getContourLevelEmdb(plugin: PluginContext, taskCtx: RuntimeContext, emdbId: string) {
     const emdbHeaderServer = plugin.config.get(PluginConfig.VolumeStreaming.EmdbHeaderServer);
     const header = await plugin.fetch({ url: `${emdbHeaderServer}/${emdbId.toUpperCase()}/header/${emdbId.toLowerCase()}.xml`, type: 'xml' }).runInContext(taskCtx);
-    const map = header.getElementsByTagName('map')[0];
-    const contourLevel = parseFloat(map.getElementsByTagName('contourLevel')[0].textContent!);
+    const contours = header.getElementsByTagName('contour');
+
+    let primaryContour = contours[0];
+    for (let i = 1; i < contours.length; i++) {
+        if (contours[i].getAttribute('primary') === 'true') {
+            primaryContour = contours[i];
+        }
+    }
+    const contourLevel = parseFloat(primaryContour.getElementsByTagName('level')[0].textContent!);
 
     return contourLevel;
 }


### PR DESCRIPTION
There was a breaking change wrt the format of EMDB XML header files (https://www.wwpdb.org/news/news?year=2021#610ad31fef055f03d1f222bb). This causes all loading of EM maps on rcsb.org & molstar.org to fail.