### PR TITLE
Disable ts config that leads to sourceMappingURL comment

### DIFF
--- a/tsconfig.commonjs.json
+++ b/tsconfig.commonjs.json
@@ -5,7 +5,7 @@
         "alwaysStrict": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "sourceMap": true,
+        "sourceMap": false,
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "alwaysStrict": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "sourceMap": true,
+        "sourceMap": false,
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,


### PR DESCRIPTION
As a follow-up to https://github.com/molstar/molstar/issues/296 I noticed that the NPM package JS files all have a comment like `//# sourceMappingURL=context.js.map` at the bottom of the file that references a now non-existent source map file. This also caused a flood of Webpack errors when trying out locally. I was able to get rid of the comments in the output JS by disabling one of the TypeScript configs