### PR TITLE
Fix inverted hydrophobicity color model

### DIFF
--- a/src/mol-theme/color/hydrophobicity.ts
+++ b/src/mol-theme/color/hydrophobicity.ts
@@ -58,7 +58,7 @@ export function HydrophobicityColorTheme(ctx: ThemeDataContext, props: PD.Values
 
     const scale = ColorScale.create({
         listOrName: props.list.colors,
-        domain: [max, min],
+        domain: [min, max],
         minLabel: 'Hydrophobic',
         maxLabel: 'Hydrophilic'
     });


### PR DESCRIPTION
I think the hydrophobicity colormap is inverted.

This PR fixes the assigned colours but you could eventually prefer fixing the label "Hydrophobic" and "Hydrophilic" instead. I think the current fix is more intuitive (green for hydrophilic and red for hydrophobic) but let me know what you prefer.

**Before**
![before](https://user-images.githubusercontent.com/528003/156944620-6fd5b884-9e92-41fb-baa5-2b98bb3aec31.png)

**After**
![after](https://user-images.githubusercontent.com/528003/156944623-54937798-4eb4-4af9-bc6a-a83647b9272c.png)


