### PR TITLE
DNATCO extension: Fix off-by-one error in element lookup

### DIFF
--- a/src/extensions/dnatco/confal-pyramids/property.ts
+++ b/src/extensions/dnatco/confal-pyramids/property.ts
@@ -123,10 +123,8 @@ function createPyramidsFromCif(model: Model,
 
     for (let i = 0; i < _rowCount; i++) {
         const model_num = PDB_model_number.value(i);
-        if (model_num !== model.modelNum) {
+        if (model_num !== model.modelNum)
             hasMultipleModels = true;
-            continue; // We are only interested in data for the current model
-        }
 
         const { _NtC, _confal_score } = getNtCAndConfalScore(id.value(i), i, stepsSummary);
 


### PR DESCRIPTION
This fixes some Confal pyramids failing to display in some peculiar structures such as [https://blackbox.ibt.biocev.org/devel_molstar/RCSB/cif_dnatco_updated/1jbs_v32C35A23.cif.gz](https://blackbox.ibt.biocev.org/devel_molstar/RCSB/cif_dnatco_updated/1jbs_v32C35A23.cif.gz).

(FYI, I have some more changes to the DNATCO extension lined up but this time I'll try to break them down to smaller MRs so things don't stall like last time)