### PR TITLE
Fix unit mapping in bondedAtomicPairs MolScript query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Check that model and coordinates have same element count when creating a trajectory
 - Fix aromatic rings assignment: do not mix flags and planarity test
 - Improve bonds assignment of coarse grained models: check for IndexPairBonds and exhaustive StructConn
+- Fix unit mapping in bondedAtomicPairs MolScript query
 
 ## [v3.5.0] - 2022-03-25
 

--- a/src/mol-model/structure/query/queries/generators.ts
+++ b/src/mol-model/structure/query/queries/generators.ts
@@ -353,7 +353,7 @@ export function bondedAtomicPairs(bondTest?: QueryPredicate): StructureQuery {
             atomicBond.a.unit = structure.unitMap.get(bond.unitA) as Unit.Atomic;
             atomicBond.a.element = atomicBond.a.unit.elements[bond.indexA];
             atomicBond.aIndex = bond.indexA;
-            atomicBond.b.unit = structure.unitMap.get(bond.unitA) as Unit.Atomic;
+            atomicBond.b.unit = structure.unitMap.get(bond.unitB) as Unit.Atomic;
             atomicBond.b.element = atomicBond.b.unit.elements[bond.indexB];
             atomicBond.bIndex = bond.indexB;
             atomicBond.order = bond.props.order;


### PR DESCRIPTION
The Disulfide Bridges selection includes wrong residues.

![disulfide](https://user-images.githubusercontent.com/9744615/160682444-1213bf48-3bb0-4686-9d60-6a6d9a66c5a8.png)