### PR TITLE
fix volume streaming for entries with multiple contour lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Improve bonds assignment of coarse grained models: check for IndexPairBonds and exhaustive StructConn
 - Fix unit mapping in bondedAtomicPairs MolScript query
 - Improve pdb parsing: handle non unique atom and chain names (fixes #156)
+- Fix volume streaming for entries with multiple contour lists
 
 ## [v3.5.0] - 2022-03-25
 

--- a/src/mol-plugin/behavior/dynamic/volume-streaming/util.ts
+++ b/src/mol-plugin/behavior/dynamic/volume-streaming/util.ts
@@ -69,7 +69,8 @@ export async function getContourLevel(provider: 'emdb' | 'pdbe', plugin: PluginC
 export async function getContourLevelEmdb(plugin: PluginContext, taskCtx: RuntimeContext, emdbId: string) {
     const emdbHeaderServer = plugin.config.get(PluginConfig.VolumeStreaming.EmdbHeaderServer);
     const header = await plugin.fetch({ url: `${emdbHeaderServer}/${emdbId.toUpperCase()}/header/${emdbId.toLowerCase()}.xml`, type: 'xml' }).runInContext(taskCtx);
-    const contours = header.getElementsByTagName('contour');
+    const map = header.getElementsByTagName('map')[0];
+    const contours = map.getElementsByTagName('contour');
 
     let primaryContour = contours[0];
     for (let i = 1; i < contours.length; i++) {


### PR DESCRIPTION
Fixes an issue introduced by me in https://github.com/molstar/molstar/pull/377: It's imperative to select the `map` tag before looking for the contour list.

Happens e.g. for 6Z0S. 