### PR TITLE
ModelServer Ligand Export: Fix Alternate Locations & Mismatching Atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- ModelServer ligand queries: fixes for alternate locations, additional atoms & UNL ligand
 
 ## [v3.6.1] - 2022-04-03
 

--- a/src/mol-io/writer/ligand-encoder.ts
+++ b/src/mol-io/writer/ligand-encoder.ts
@@ -137,6 +137,10 @@ export abstract class LigandEncoder implements Encoder<string> {
         if (this.hydrogens) {
             return false;
         }
+        return this.isHydrogen(type_symbol);
+    }
+
+    protected isHydrogen(type_symbol: string & { '@type': 'element-symbol' }) {
         return isHydrogen(getElementIdx(type_symbol));
     }
 

--- a/src/mol-io/writer/ligand-encoder.ts
+++ b/src/mol-io/writer/ligand-encoder.ts
@@ -136,7 +136,7 @@ export abstract class LigandEncoder implements Encoder<string> {
         if (this.hydrogens) {
             return false;
         }
-        return type_symbol === 'H';
+        return type_symbol === 'H' || type_symbol === 'D';
     }
 
     private getSortedFields<Ctx>(instance: Category.Instance<Ctx>, names: string[]) {

--- a/src/mol-io/writer/ligand-encoder.ts
+++ b/src/mol-io/writer/ligand-encoder.ts
@@ -10,12 +10,13 @@ import { Encoder, Category, Field } from './cif/encoder';
 import { ComponentAtom } from '../../mol-model-formats/structure/property/atoms/chem_comp';
 import { ComponentBond } from '../../mol-model-formats/structure/property/bonds/chem_comp';
 import { getElementIdx, isHydrogen } from '../../mol-model/structure/structure/unit/bonds/common';
+import { ElementSymbol } from '../../mol-model/structure/model/types';
 
 interface Atom {
     Cartn_x: number,
     Cartn_y: number,
     Cartn_z: number,
-    type_symbol: string & { '@type': 'element-symbol' },
+    type_symbol: ElementSymbol,
     index: number
 }
 
@@ -113,7 +114,7 @@ export abstract class LigandEncoder implements Encoder<string> {
                 // ignore all alternate locations after the first
                 if (atoms.has(lai)) continue;
 
-                const ts = type_symbol.value(key, data, index) as string & { '@type': 'element-symbol' };
+                const ts = type_symbol.value(key, data, index) as ElementSymbol;
                 if (this.skipHydrogen(ts)) continue;
 
                 const a: { [k: string]: (string | number) } = {};
@@ -133,14 +134,14 @@ export abstract class LigandEncoder implements Encoder<string> {
         return atoms;
     }
 
-    protected skipHydrogen(type_symbol: string & { '@type': 'element-symbol' }) {
+    protected skipHydrogen(type_symbol: ElementSymbol) {
         if (this.hydrogens) {
             return false;
         }
         return this.isHydrogen(type_symbol);
     }
 
-    protected isHydrogen(type_symbol: string & { '@type': 'element-symbol' }) {
+    protected isHydrogen(type_symbol: ElementSymbol) {
         return isHydrogen(getElementIdx(type_symbol));
     }
 

--- a/src/mol-io/writer/ligand-encoder.ts
+++ b/src/mol-io/writer/ligand-encoder.ts
@@ -9,12 +9,13 @@ import { Writer } from './writer';
 import { Encoder, Category, Field } from './cif/encoder';
 import { ComponentAtom } from '../../mol-model-formats/structure/property/atoms/chem_comp';
 import { ComponentBond } from '../../mol-model-formats/structure/property/bonds/chem_comp';
+import { getElementIdx, isHydrogen } from '../../mol-model/structure/structure/unit/bonds/common';
 
 interface Atom {
     Cartn_x: number,
     Cartn_y: number,
     Cartn_z: number,
-    type_symbol: string,
+    type_symbol: string & { '@type': 'element-symbol' },
     index: number
 }
 
@@ -112,7 +113,7 @@ export abstract class LigandEncoder implements Encoder<string> {
                 // ignore all alternate locations after the first
                 if (atoms.has(lai)) continue;
 
-                const ts = type_symbol.value(key, data, index) as string;
+                const ts = type_symbol.value(key, data, index) as string & { '@type': 'element-symbol' };
                 if (this.skipHydrogen(ts)) continue;
 
                 const a: { [k: string]: (string | number) } = {};
@@ -132,11 +133,11 @@ export abstract class LigandEncoder implements Encoder<string> {
         return atoms;
     }
 
-    protected skipHydrogen(type_symbol: string) {
+    protected skipHydrogen(type_symbol: string & { '@type': 'element-symbol' }) {
         if (this.hydrogens) {
             return false;
         }
-        return type_symbol === 'H' || type_symbol === 'D';
+        return isHydrogen(getElementIdx(type_symbol));
     }
 
     private getSortedFields<Ctx>(instance: Category.Instance<Ctx>, names: string[]) {

--- a/src/mol-io/writer/ligand-encoder.ts
+++ b/src/mol-io/writer/ligand-encoder.ts
@@ -109,11 +109,12 @@ export abstract class LigandEncoder implements Encoder<string> {
                 const key = it.move();
 
                 const lai = label_atom_id.value(key, data, index) as string;
+                // ignore all alternate locations after the first
+                if (atoms.has(lai)) continue;
+
                 const ts = type_symbol.value(key, data, index) as string;
-                if (this.skipHydrogen(ts)) {
-                    index++;
-                    continue;
-                }
+                if (this.skipHydrogen(ts)) continue;
+
                 const a: { [k: string]: (string | number) } = {};
 
                 for (let _f = 0, _fl = fields.length; _f < _fl; _f++) {

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -26,6 +26,9 @@ export class MolEncoder extends LigandEncoder {
 
         const atomMap = this.componentAtomData.entries.get(name)!;
         const bondMap = this.componentBondData.entries.get(name)!;
+        // happens for unknown ligands like UNL
+        if (!atomMap) throw Error(`Component ${name} is not registered in the Chemical Component Dictionary`);
+
         let bondCount = 0;
         let chiral = false;
 

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -53,8 +53,8 @@ export class MolEncoder extends LigandEncoder {
                 const atom2 = atoms.get(label_atom_id2);
                 if (!atom2) return;
 
-                const { index: i2, type_symbol: type_symbol2 } = atom2;
-                if (i1 < i2 && !this.skipHydrogen(type_symbol2)) {
+                const { index: i2 } = atom2;
+                if (i1 < i2) {
                     const { order } = bond;
                     StringBuilder.writeIntegerPadLeft(bonds, i1 + 1, 3);
                     StringBuilder.writeIntegerPadLeft(bonds, i2 + 1, 3);

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -35,8 +35,18 @@ export class MolEncoder extends LigandEncoder {
         // traverse once to determine all actually present atoms
         const atoms = this.getAtoms(instance, source);
         atoms.forEach((atom1, label_atom_id1) => {
-            const { index: i1 } = atom1;
-            const { charge, stereo_config } = atomMap.map.get(label_atom_id1)!;
+            const { index: i1, type_symbol: type_symbol1 } = atom1;
+            const atomMapData1 = atomMap.map.get(label_atom_id1);
+
+            if (!atomMapData1) {
+                if (this.isHydrogen(type_symbol1)) {
+                    return;
+                } else {
+                    throw Error(`Unknown atom ${label_atom_id1} for component ${name}`);
+                }
+            }
+
+            const { charge, stereo_config } = atomMapData1;
             StringBuilder.writePadLeft(ctab, atom1.Cartn_x.toFixed(4), 10);
             StringBuilder.writePadLeft(ctab, atom1.Cartn_y.toFixed(4), 10);
             StringBuilder.writePadLeft(ctab, atom1.Cartn_z.toFixed(4), 10);

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -26,8 +26,8 @@ export class MolEncoder extends LigandEncoder {
 
         const atomMap = this.componentAtomData.entries.get(name)!;
         const bondMap = this.componentBondData.entries.get(name)!;
-        // happens for unknown ligands like UNL
-        if (!atomMap) throw Error(`Component ${name} is not registered in the Chemical Component Dictionary`);
+        // happens for the unknown ligands (UNL)
+        if (!atomMap) throw Error(`The Chemical Component Dictionary doesn't hold any atom data for ${name}`);
 
         let bondCount = 0;
         let chiral = false;

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -29,14 +29,27 @@ export class Mol2Encoder extends LigandEncoder {
         const name = this.getName(instance, source);
         StringBuilder.writeSafe(this.builder, `# Name: ${name}\n# Created by ${this.encoder}\n\n`);
 
+        const atomMap = this.componentAtomData.entries.get(name)!;
         const bondMap = this.componentBondData.entries.get(name)!;
+        // happens for the unknown ligands (UNL)
+        if (!atomMap) throw Error(`The Chemical Component Dictionary doesn't hold any atom data for ${name}`);
         let bondCount = 0;
 
         const atoms = this.getAtoms(instance, source);
         StringBuilder.writeSafe(a, '@<TRIPOS>ATOM\n');
         StringBuilder.writeSafe(b, '@<TRIPOS>BOND\n');
         atoms.forEach((atom1, label_atom_id1) => {
-            const { index: i1 } = atom1;
+            const { index: i1, type_symbol: type_symbol1 } = atom1;
+            const atomMapData1 = atomMap.map.get(label_atom_id1);
+
+            if (!atomMapData1) {
+                if (this.isHydrogen(type_symbol1)) {
+                    return;
+                } else {
+                    throw Error(`Unknown atom ${label_atom_id1} for component ${name}`);
+                }
+            }
+
             if (bondMap?.map) {
                 bondMap.map.get(label_atom_id1)!.forEach((bond, label_atom_id2) => {
                     const atom2 = atoms.get(label_atom_id2);
@@ -52,7 +65,7 @@ export class Mol2Encoder extends LigandEncoder {
                 });
             }
 
-            const sybyl = bondMap?.map ? this.mapToSybyl(label_atom_id1, atom1.type_symbol, bondMap) : atom1.type_symbol;
+            const sybyl = bondMap?.map ? this.mapToSybyl(label_atom_id1, type_symbol1, bondMap) : type_symbol1;
             StringBuilder.writeSafe(a, `${i1 + 1} ${label_atom_id1} ${atom1.Cartn_x.toFixed(3)} ${atom1.Cartn_y.toFixed(3)} ${atom1.Cartn_z.toFixed(3)} ${sybyl} 1 ${name} 0.000\n`);
         });
 

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -42,8 +42,8 @@ export class Mol2Encoder extends LigandEncoder {
                     const atom2 = atoms.get(label_atom_id2);
                     if (!atom2) return;
 
-                    const { index: i2, type_symbol: type_symbol2 } = atom2;
-                    if (i1 < i2 && !this.skipHydrogen(type_symbol2)) {
+                    const { index: i2 } = atom2;
+                    if (i1 < i2) {
                         const { order, flags } = bond;
                         const ar = BondType.is(BondType.Flag.Aromatic, flags);
                         StringBuilder.writeSafe(b, `${++bondCount} ${i1 + 1} ${i2 + 1} ${ar ? 'ar' : order}`);

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.9
+* /ligand queries: fix behavior for alternate locations
+* /ligand queries: handle additional atoms more gracefully
+* /ligand queries: better error message for UNL
+* /ligand queries: treat deuterium/tritium as hydrogen
+
 # 0.9.8
 * fix support for chem_comp_bond and struct_conn categories
 

--- a/src/servers/model/server/query.ts
+++ b/src/servers/model/server/query.ts
@@ -237,10 +237,8 @@ async function resolveJobEntry(entry: JobEntry, structure: StructureWrapper, enc
         encoder.writeCategory(_model_server_params, entry);
 
         if (entry.queryDefinition.niceName === 'Ligand') {
-            if (encoder instanceof MolEncoder) {
-                encoder.setComponentAtomData(ComponentAtom.Provider.get(structure.models[0])!);
-            }
             if (encoder instanceof MolEncoder || encoder instanceof Mol2Encoder) {
+                encoder.setComponentAtomData(ComponentAtom.Provider.get(structure.models[0])!);
                 encoder.setComponentBondData(ComponentBond.Provider.get(structure.models[0])!);
             }
         }

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -4,4 +4,4 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export const VERSION = '0.9.8';
+export const VERSION = '0.9.9';


### PR DESCRIPTION
1. [ligands with alternate locations](https://models.rcsb.org/v1/5sd0/ligand?auth_seq_id=202&label_asym_id=C&encoding=sdf) aren't handled properly
    - only the last atom was kept around, changed to the first occurrence
    - duplicated atoms were indexed incorrectly, causing out-of-bounds errors when reading
2. [ligands with atoms unknown to the CCD](https://models.rcsb.org/v1/6bho/ligand?auth_seq_id=800&encoding=mol&label_asym_id=B) are now handled more gracefully
    - discrepancies for hydrogen atoms get ignored
    - mismatching heavy atoms will throw an error
3. added special treatment for [UNL](https://models.rcsb.org/v1/1O5U/ligand?label_asym_id=C&encoding=sdf), which is registered in the CCD but doesn't have any atom or bond data - UNK and UNX are fine
4. now reuses `isHydrogen` check from bond/common

New behavior: [1](http://models-testing.rcsb.org/v1/5sd0/ligand?auth_seq_id=202&label_asym_id=C&encoding=sdf), [2](http://models-testing.rcsb.org/v1/6bho/ligand?auth_seq_id=800&encoding=mol&label_asym_id=B), [3](http://models-testing.rcsb.org/v1/1O5U/ligand?label_asym_id=C&encoding=sdf)