### PR TITLE
Added an option to disable the drag overlay

### DIFF
--- a/src/mol-plugin-ui/plugin.tsx
+++ b/src/mol-plugin-ui/plugin.tsx
@@ -159,7 +159,7 @@ class Layout extends PluginUIComponent {
                     {layout.showControls && controls.bottom !== 'none' && this.region('bottom', controls.bottom || Log)}
                 </div>
                 {!this.plugin.spec.components?.hideTaskOverlay && <OverlayTaskProgress />}
-                <DragOverlay plugin={this.plugin} showDragOverlay={this.showDragOverlay} />
+                {!this.plugin.spec.components?.disableDragOverlay && <DragOverlay plugin={this.plugin} showDragOverlay={this.showDragOverlay} />}
             </div>
         </div>;
     }

--- a/src/mol-plugin-ui/spec.ts
+++ b/src/mol-plugin-ui/spec.ts
@@ -24,7 +24,8 @@ interface PluginUISpec extends PluginSpec {
             view?: React.ComponentClass,
             controls?: React.ComponentClass
         },
-        hideTaskOverlay?: boolean
+        hideTaskOverlay?: boolean,
+        disableDragOverlay?: boolean,
     },
 }
 


### PR DESCRIPTION
Added an option to the components spec to allow disabling of the drag-and-drop overlay for Molstar that loads files into the viewer. By default the drag overlay is enabled, just as it was before.