### PR TITLE
proposed fix for headless-gl issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 
 - Fix issues with marking camera/handle helper (#433)
+- Fix issues with array uniforms when running with headless-gl
 
 ## [v3.8.0] - 2022-04-30
 

--- a/src/mol-gl/webgl/program.ts
+++ b/src/mol-gl/webgl/program.ts
@@ -7,7 +7,7 @@
 import { ShaderCode, DefineValues, addShaderDefines } from '../shader-code';
 import { WebGLState } from './state';
 import { WebGLExtensions } from './extensions';
-import { getUniformSetters, UniformsList, getUniformType, UniformSetters } from './uniform';
+import { getUniformSetters, UniformsList, getUniformType, UniformSetters, isArrayUniform } from './uniform';
 import { AttributeBuffers, getAttribType } from './buffer';
 import { TextureId, Textures } from './texture';
 import { idFactory } from '../../mol-util/id-factory';
@@ -41,7 +41,14 @@ function getLocations(gl: GLRenderingContext, program: WebGLProgram, schema: Ren
             // unused attributes will result in a `-1` location which is usually fine
             // if (loc === -1) console.info(`Could not get attribute location for '${k}'`);
             locations[k] = loc;
-        } else if (spec.type === 'uniform' || spec.type === 'texture') {
+        } else if (spec.type === 'uniform') {
+            let loc = gl.getUniformLocation(program, k);
+            // headless-gl requires a '[0]' suffix for array uniforms (https://github.com/stackgl/headless-gl/issues/170)
+            if (loc === null && isArrayUniform(spec.kind)) loc = gl.getUniformLocation(program, k + '[0]');
+            // unused uniforms will result in a `null` location which is usually fine
+            // if (loc === null) console.info(`Could not get uniform location for '${k}'`);
+            locations[k] = loc as number;
+        } else if (spec.type === 'texture') {
             const loc = gl.getUniformLocation(program, k);
             // unused uniforms will result in a `null` location which is usually fine
             // if (loc === null) console.info(`Could not get uniform location for '${k}'`);

--- a/src/mol-gl/webgl/uniform.ts
+++ b/src/mol-gl/webgl/uniform.ts
@@ -43,11 +43,7 @@ export function getUniformType(gl: GLRenderingContext, kind: UniformKind) {
 }
 
 export function isArrayUniform(kind: UniformKind) {
-    switch (kind) {
-        case 'b[]': case 'f[]': case 'i[]': case 'v2[]': case 'v3[]': case 'v4[]': case 'm3[]': case 'm4[]': return true;
-        case 'b': case 'f': case 'i': case 'v2': case 'v3': case 'v4': case 'm3': case 'm4': return false;
-        default: console.error(`unknown uniform kind '${kind}'`);
-    }
+    return kind.endsWith('[]');
 }
 
 export type UniformSetter = (gl: GLRenderingContext, location: number, value: any) => void

--- a/src/mol-gl/webgl/uniform.ts
+++ b/src/mol-gl/webgl/uniform.ts
@@ -42,6 +42,14 @@ export function getUniformType(gl: GLRenderingContext, kind: UniformKind) {
     }
 }
 
+export function isArrayUniform(kind: UniformKind) {
+    switch (kind) {
+        case 'b[]': case 'f[]': case 'i[]': case 'v2[]': case 'v3[]': case 'v4[]': case 'm3[]': case 'm4[]': return true;
+        case 'b': case 'f': case 'i': case 'v2': case 'v3': case 'v4': case 'm3': case 'm4': return false;
+        default: console.error(`unknown uniform kind '${kind}'`);
+    }
+}
+
 export type UniformSetter = (gl: GLRenderingContext, location: number, value: any) => void
 export type UniformSetters = { [k: string]: UniformSetter }
 


### PR DESCRIPTION
Headless-gl requires a `[0]` suffix when getting the location of array uniforms (https://github.com/stackgl/headless-gl/issues/170). Without neither `uLightDirection` nor `uLightColor` get set.

See https://github.com/molstar/molrender/issues/3#issuecomment-1117615459.