### PR TITLE
DownloadScreenshotControls: componentWillUnmount

### DIFF
--- a/src/mol-plugin-ui/viewport/screenshot.tsx
+++ b/src/mol-plugin-ui/viewport/screenshot.tsx
@@ -58,6 +58,7 @@ export class DownloadScreenshotControls extends PluginUIComponent<{ close: () =>
     }
 
     componentWillUnmount() {
+        super.componentWillUnmount();
         this.setState({ imageData: void 0 });
     }
 


### PR DESCRIPTION
This should solve the error:

Warning: Can't perform a React state update on an unmounted component.
This is a no-op, but it indicates a memory leak in your application.
To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.