### PR TITLE
Refactor away from namespaces for several files

### DIFF
--- a/src/examples/proteopedia-wrapper/helpers.ts
+++ b/src/examples/proteopedia-wrapper/helpers.ts
@@ -16,8 +16,8 @@ export interface ModelInfo {
     preferredAssemblyId: string | undefined
 }
 
-export namespace ModelInfo {
-    async function getPreferredAssembly(ctx: PluginContext, model: Model) {
+export const ModelInfo = {
+    async getPreferredAssembly(ctx: PluginContext, model: Model) {
         if (model.entryId.length <= 3) return void 0;
         try {
             const id = model.entryId.toLowerCase();
@@ -37,16 +37,15 @@ export namespace ModelInfo {
         } catch (e) {
             console.warn('getPreferredAssembly', e);
         }
-    }
-
-    export async function get(ctx: PluginContext, model: Model, checkPreferred: boolean): Promise<ModelInfo> {
+    },
+    async get(ctx: PluginContext, model: Model, checkPreferred: boolean): Promise<ModelInfo> {
         const { _rowCount: residueCount } = model.atomicHierarchy.residues;
         const { offsets: residueOffsets } = model.atomicHierarchy.residueAtomSegments;
         const chainIndex = model.atomicHierarchy.chainAtomSegments.index;
         // const resn = SP.residue.label_comp_id, entType = SP.entity.type;
 
         const pref = checkPreferred
-            ? getPreferredAssembly(ctx, model)
+            ? this.getPreferredAssembly(ctx, model)
             : void 0;
 
         const hetResidues: ModelInfo['hetResidues'] = [];
@@ -78,7 +77,7 @@ export namespace ModelInfo {
             preferredAssemblyId
         };
     }
-}
+};
 
 export type SupportedFormats = 'cif' | 'pdb'
 export interface LoadParams {
@@ -89,15 +88,17 @@ export interface LoadParams {
     representationStyle?: RepresentationStyle
 }
 
-export interface RepresentationStyle {
-    sequence?: RepresentationStyle.Entry,
-    hetGroups?: RepresentationStyle.Entry,
-    snfg3d?: { hide?: boolean },
-    water?: RepresentationStyle.Entry
-}
+type RepresentationStyleEntry = {
+    hide?: boolean,
+    kind?: StructureRepresentationRegistry.BuiltIn,
+    coloring?: ColorTheme.BuiltIn
+};
 
-export namespace RepresentationStyle {
-    export type Entry = { hide?: boolean, kind?: StructureRepresentationRegistry.BuiltIn, coloring?: ColorTheme.BuiltIn }
+export interface RepresentationStyle {
+    sequence?: RepresentationStyleEntry,
+    hetGroups?: RepresentationStyleEntry,
+    snfg3d?: { hide?: boolean },
+    water?: RepresentationStyleEntry
 }
 
 export enum StateElements {

--- a/src/extensions/anvil/algorithm.ts
+++ b/src/extensions/anvil/algorithm.ts
@@ -209,16 +209,15 @@ interface MembraneCandidate {
     qmax?: number
 }
 
-namespace MembraneCandidate {
-    export function initial(c1: Vec3, c2: Vec3, stats: HphobHphil): MembraneCandidate {
+const MembraneCandidate = {
+    initial(c1: Vec3, c2: Vec3, stats: HphobHphil): MembraneCandidate {
         return {
             planePoint1: c1,
             planePoint2: c2,
             stats
         };
-    }
-
-    export function scored(spherePoint: Vec3, planePoint1: Vec3, planePoint2: Vec3, stats: HphobHphil, qmax: number, centroid: Vec3): MembraneCandidate {
+    },
+    scored(spherePoint: Vec3, planePoint1: Vec3, planePoint2: Vec3, stats: HphobHphil, qmax: number, centroid: Vec3): MembraneCandidate {
         const normalVector = v3zero();
         v3sub(normalVector, centroid, spherePoint);
         return {
@@ -230,7 +229,7 @@ namespace MembraneCandidate {
             qmax
         };
     }
-}
+};
 
 async function findMembrane(runtime: RuntimeContext, message: string | undefined, ctx: ANVILContext, spherePoints: Vec3[], initialStats: HphobHphil): Promise<MembraneCandidate | undefined> {
     const { centroid, stepSize, minThickness, maxThickness, large } = ctx;
@@ -547,8 +546,8 @@ interface HphobHphil {
     hphil: number
 }
 
-namespace HphobHphil {
-    export function initial(ctx: ANVILContext): HphobHphil {
+const HphobHphil = {
+    initial(ctx: ANVILContext): HphobHphil {
         const { exposed, hydrophobic } = ctx;
         let hphob = 0;
         let hphil = 0;
@@ -560,10 +559,9 @@ namespace HphobHphil {
             }
         }
         return { hphob, hphil };
-    }
-
-    const testPoint = v3zero();
-    export function sliced(ctx: ANVILContext, stepSize: number, spherePoint: Vec3, diam: Vec3, diamNorm: number): HphobHphil[] {
+    },
+    testPoint: v3zero(),
+    sliced(ctx: ANVILContext, stepSize: number, spherePoint: Vec3, diam: Vec3, diamNorm: number): HphobHphil[] {
         const { exposed, hydrophobic, structure } = ctx;
         const { units, serialMapping } = structure;
         const { unitIndices, elementIndices } = serialMapping;
@@ -575,17 +573,17 @@ namespace HphobHphil {
         for (let i = 0, il = exposed.length; i < il; i++) {
             const unit = units[unitIndices[exposed[i]]];
             const elementIndex = elementIndices[exposed[i]];
-            v3set(testPoint, unit.conformation.x(elementIndex), unit.conformation.y(elementIndex), unit.conformation.z(elementIndex));
-            v3sub(testPoint, testPoint, spherePoint);
+            v3set(this.testPoint, unit.conformation.x(elementIndex), unit.conformation.y(elementIndex), unit.conformation.z(elementIndex));
+            v3sub(this.testPoint, this.testPoint, spherePoint);
             if (hydrophobic[i]) {
-                sliceStats[Math.floor(v3dot(testPoint, diam) / diamNorm / stepSize)].hphob++;
+                sliceStats[Math.floor(v3dot(this.testPoint, diam) / diamNorm / stepSize)].hphob++;
             } else {
-                sliceStats[Math.floor(v3dot(testPoint, diam) / diamNorm / stepSize)].hphil++;
+                sliceStats[Math.floor(v3dot(this.testPoint, diam) / diamNorm / stepSize)].hphil++;
             }
         }
         return sliceStats;
     }
-}
+};
 
 /** Returns true if the definition considers this as membrane-favoring amino acid */
 export function isHydrophobic(definition: Set<string>, label_comp_id: string): boolean {

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -22,9 +22,7 @@ export const MembraneOrientationParams = {
 export type MembraneOrientationParams = typeof MembraneOrientationParams
 export type MembraneOrientationProps = PD.Values<MembraneOrientationParams>
 
-export { MembraneOrientation };
-
-interface MembraneOrientation {
+export interface MembraneOrientation {
     // point in membrane boundary
     readonly planePoint1: Vec3,
     // point in opposite side of membrane boundary
@@ -36,13 +34,11 @@ interface MembraneOrientation {
     readonly centroid: Vec3
 }
 
-namespace MembraneOrientation {
-    export enum Tag {
-        Representation = 'membrane-orientation-3d'
-    }
-
-    const pos = Vec3();
-    export const symbols = {
+export const MembraneOrientation = {
+    Tag: {
+        Representation: 'membrane-orientation-3d'
+    },
+    symbols: {
         isTransmembrane: QuerySymbolRuntime.Dynamic(CustomPropSymbol('computed', 'membrane-orientation.is-transmembrane', Type.Bool),
             ctx => {
                 const { unit, structure } = ctx.element;
@@ -50,12 +46,12 @@ namespace MembraneOrientation {
                 if (!Unit.isAtomic(unit)) return 0;
                 const membraneOrientation = MembraneOrientationProvider.get(structure).value;
                 if (!membraneOrientation) return 0;
-                Vec3.set(pos, x(ctx.element), y(ctx.element), z(ctx.element));
+                Vec3.set(Vec3(), x(ctx.element), y(ctx.element), z(ctx.element));
                 const { normalVector, planePoint1, planePoint2 } = membraneOrientation!;
-                return isInMembranePlane(pos, normalVector, planePoint1, planePoint2);
+                return isInMembranePlane(Vec3(), normalVector, planePoint1, planePoint2);
             })
-    };
-}
+    }
+};
 
 export const MembraneOrientationProvider: CustomStructureProperty.Provider<MembraneOrientationParams, MembraneOrientation> = CustomStructureProperty.createProvider({
     label: 'Membrane Orientation',

--- a/src/extensions/model-archive/quality-assessment/prop.ts
+++ b/src/extensions/model-archive/quality-assessment/prop.ts
@@ -15,22 +15,20 @@ import { Type } from '../../../mol-script/language/type';
 import { CustomPropertyDescriptor } from '../../../mol-model/custom-property';
 import { MmcifFormat } from '../../../mol-model-formats/structure/mmcif';
 
-export { QualityAssessment };
-
 interface QualityAssessment {
     localMetrics: Map<string, Map<ResidueIndex, number>>
     pLDDT?: Map<ResidueIndex, number>
     qmean?: Map<ResidueIndex, number>
 }
 
-namespace QualityAssessment {
-    const Empty = {
+export const QualityAssessment = {
+    Empty: {
         value: {
             localMetrics: new Map()
         }
-    };
+    },
 
-    export function isApplicable(model?: Model, localMetricName?: 'pLDDT' | 'qmean'): boolean {
+    isApplicable(model?: Model, localMetricName?: 'pLDDT' | 'qmean'): boolean {
         if (!model || !MmcifFormat.is(model.sourceData)) return false;
         const { db } = model.sourceData.data;
         const hasLocalMetric = (
@@ -46,10 +44,10 @@ namespace QualityAssessment {
         } else {
             return hasLocalMetric;
         }
-    }
+    },
 
-    export async function obtain(ctx: CustomProperty.Context, model: Model, props: QualityAssessmentProps): Promise<CustomProperty.Data<QualityAssessment>> {
-        if (!model || !MmcifFormat.is(model.sourceData)) return Empty;
+    async obtain(ctx: CustomProperty.Context, model: Model, props: QualityAssessmentProps): Promise<CustomProperty.Data<QualityAssessment>> {
+        if (!model || !MmcifFormat.is(model.sourceData)) return this.Empty;
         const { ma_qa_metric, ma_qa_metric_local } = model.sourceData.data.db;
         const { model_id, label_asym_id, label_seq_id, metric_id, metric_value } = ma_qa_metric_local;
         const { index } = model.atomicHierarchy;
@@ -88,9 +86,9 @@ namespace QualityAssessment {
                 qmean: localMetrics.get('qmean'),
             }
         };
-    }
+    },
 
-    export const symbols = {
+    symbols: {
         pLDDT: QuerySymbolRuntime.Dynamic(CustomPropSymbol('ma', 'quality-assessment.pLDDT', Type.Num),
             ctx => {
                 const { unit, element } = ctx.element;
@@ -107,8 +105,8 @@ namespace QualityAssessment {
                 return qualityAssessment?.qmean?.get(unit.model.atomicHierarchy.residueAtomSegments.index[element]) ?? -1;
             }
         ),
-    };
-}
+    }
+};
 
 export const QualityAssessmentParams = { };
 export type QualityAssessmentParams = typeof QualityAssessmentParams

--- a/src/mol-util/image.ts
+++ b/src/mol-util/image.ts
@@ -4,45 +4,47 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-export { PixelData };
-
-interface PixelData {
+export interface PixelData {
     readonly array: Uint8Array | Float32Array
     readonly width: number
     readonly height: number
 }
 
-namespace PixelData {
-    export function create(array: Uint8Array | Float32Array, width: number, height: number): PixelData {
-        return { array, width, height };
-    }
-
-    /** horizontally flips the pixel data in-place */
-    export function flipY(pixelData: PixelData): PixelData {
-        const { array, width, height } = pixelData;
-        const width4 = width * 4;
-        for (let i = 0, maxI = height / 2; i < maxI; ++i) {
-            for (let j = 0, maxJ = width4; j < maxJ; ++j) {
-                const index1 = i * width4 + j;
-                const index2 = (height - i - 1) * width4 + j;
-                const tmp = array[index1];
-                array[index1] = array[index2];
-                array[index2] = tmp;
-            }
-        }
-        return pixelData;
-    }
-
-    /** to undo pre-multiplied alpha */
-    export function divideByAlpha(pixelData: PixelData): PixelData {
-        const { array } = pixelData;
-        const factor = (array instanceof Uint8Array) ? 255 : 1;
-        for (let i = 0, il = array.length; i < il; i += 4) {
-            const a = array[i + 3] / factor;
-            array[i] /= a;
-            array[i + 1] /= a;
-            array[i + 2] /= a;
-        }
-        return pixelData;
-    }
+function create(array: Uint8Array | Float32Array, width: number, height: number): PixelData {
+    return { array, width, height };
 }
+
+/** horizontally flips the pixel data in-place */
+function flipY(pixelData: PixelData): PixelData {
+    const { array, width, height } = pixelData;
+    const width4 = width * 4;
+    for (let i = 0, maxI = height / 2; i < maxI; ++i) {
+        for (let j = 0, maxJ = width4; j < maxJ; ++j) {
+            const index1 = i * width4 + j;
+            const index2 = (height - i - 1) * width4 + j;
+            const tmp = array[index1];
+            array[index1] = array[index2];
+            array[index2] = tmp;
+        }
+    }
+    return pixelData;
+}
+
+/** to undo pre-multiplied alpha */
+function divideByAlpha(pixelData: PixelData): PixelData {
+    const { array } = pixelData;
+    const factor = (array instanceof Uint8Array) ? 255 : 1;
+    for (let i = 0, il = array.length; i < il; i += 4) {
+        const a = array[i + 3] / factor;
+        array[i] /= a;
+        array[i + 1] /= a;
+        array[i + 2] /= a;
+    }
+    return pixelData;
+}
+
+export const PixelData = {
+    create,
+    flipY,
+    divideByAlpha
+};

--- a/src/servers/model/properties/providers/pdbe.ts
+++ b/src/servers/model/properties/providers/pdbe.ts
@@ -34,23 +34,23 @@ export const PDBe_structRefDomain: AttachModelProperty = ({ model, params, cache
     return PDBeStructRefDomain.attachFromCifOrApi(model, { PDBe_apiSourceJson });
 };
 
-namespace residuewise_outlier_summary {
-    const json = new Map<string, any>();
-    export function getDataFromAggregateFile(pathPrefix: string) {
+const residuewise_outlier_summary = {
+    json: new Map<string, any>(),
+    getDataFromAggregateFile(pathPrefix: string) {
         // This is for "testing" purposes and should probably only read
         // a single file with the appropriate prop in the "production" version.
         return async (model: Model) => {
             const key = `${model.entryId[1]}${model.entryId[2]}`;
-            if (!json.has(key)) {
+            if (!this.json.has(key)) {
                 const fn = path.join(pathPrefix, `${key}.json`);
-                if (!fs.existsSync(fn)) json.set(key, { });
+                if (!fs.existsSync(fn)) this.json.set(key, { });
                 // TODO: use async readFile?
-                else json.set(key, JSON.parse(fs.readFileSync(fn, 'utf8')));
+                else this.json.set(key, JSON.parse(fs.readFileSync(fn, 'utf8')));
             }
-            return json.get(key)![model.entryId.toLowerCase()] || { };
+            return this.json.get(key)![model.entryId.toLowerCase()] || { };
         };
     }
-}
+};
 
 function getApiUrl(params: any, name: string, fallback: string) {
     const url = getParam<string>(params, 'PDBe', 'API', name);

--- a/src/servers/volume/server/algebra/coordinate.ts
+++ b/src/servers/volume/server/algebra/coordinate.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2016 - now, David Sehnal, licensed under Apache 2.0, See LICENSE file for more info.
  */
 
-import { Mat4, Vec3 } from '../../../../mol-math/linear-algebra';
 import { SpacegroupCell } from '../../../../mol-math/geometry';
+import * as Helpers from './helpers';
 
 /** Information about a region sampled in fractional coordinates */
 export interface GridInfo {
@@ -141,20 +141,4 @@ export function sampleCounts(dimensions: Fractional, delta: Fractional) {
     ];
 }
 
-// to prevent floating point rounding errors
-export function round(v: number) {
-    return Math.round(10000000 * v) / 10000000;
-}
-
-namespace Helpers {
-    export function transform(x: { [index: number]: number }, matrix: Mat4) {
-        return Vec3.transformMat4(Vec3.zero(), x as Vec3, matrix);
-    }
-
-    export function snap(v: number, to: 'bottom' | 'top') {
-        switch (to) {
-            case 'bottom': return Math.floor(round(v)) | 0;
-            case 'top': return Math.ceil(round(v)) | 0;
-        }
-    }
-}
+export const { round } = Helpers;

--- a/src/servers/volume/server/algebra/helpers.ts
+++ b/src/servers/volume/server/algebra/helpers.ts
@@ -1,0 +1,17 @@
+import { Mat4, Vec3 } from '../../../../mol-math/linear-algebra';
+
+// to prevent floating point rounding errors
+export function round(v: number) {
+    return Math.round(10000000 * v) / 10000000;
+}
+
+export function transform(x: { [index: number]: number }, matrix: Mat4) {
+    return Vec3.transformMat4(Vec3.zero(), x as Vec3, matrix);
+}
+
+export function snap(v: number, to: 'bottom' | 'top') {
+    switch (to) {
+        case 'bottom': return Math.floor(round(v)) | 0;
+        case 'top': return Math.ceil(round(v)) | 0;
+    }
+}


### PR DESCRIPTION
First step to the ultimate goal of being able to compile molstar using the `isolatedModules` flag. See https://github.com/molstar/molstar/issues/361#issuecomment-1166641617 for context.

This PR is just a refactoring for several files to move them away from using namespaces.

Ran `npm test`, and `npm run rebuild`, which completed successfully. Did not check whether the compiled code works.