### PR TITLE
Allow download of Gzipped files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Improve naming of some internal types in Confal pyramids extension coordinate
 - Add example mmCIF file with categories necessary to display Confal pyramids
 - Change the lookup logic of NtC steps from residues
+- Add support for download of gzipped files
 
 ## [v3.13.0] - 2022-07-24
 


### PR DESCRIPTION
As far as I can tell, Molstar Viewer will automatically decompress assets only when come from a local file. There is support for remote Zip archives but getting Gzipped files from a remote source does not seem possible. This little patch adds the option to download Gzipped files.

Is there a reason why there is no direct support for download of compressed structure files etc? I might be missing something obvious...