### PR TITLE
alignAndSuperposeWithSIFTSMapping includeResidueTest option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
-- [Fix] Clone ``Canvas3DParams`` when creating a ``Canvas3D`` instance to prevent shared state between multiple instances.
+- [Fix] Clone ``Canvas3DParams`` when creating a ``Canvas3D`` instance to prevent shared state between multiple instances
+- Add ``includeResidueTest`` option to ``alignAndSuperposeWithSIFTSMapping``
 
 ## [v3.16.0] - 2022-08-25
 


### PR DESCRIPTION
Example usage:

```ts
alignAndSuperposeWithSIFTSMapping(structures, {
    includeResidueTest: loc => StructureProperties.atom.B_iso_or_equiv(loc) < 90
})
```

More complicated usage (check all atoms in the residue):

```ts
alignAndSuperposeWithSIFTSMapping(structures, {
    includeResidueTest: (loc, _, start, end) => {
        for (let eI = start; eI < end; eI++) {
            loc.element = eI;
            if (StructureProperties.atom.B_iso_or_equiv(loc) > 90) return false;
        }
        return true;
    }
})
```