### PR TITLE
Fix "empty textures" error on empty canvas

### DIFF
--- a/src/mol-canvas3d/passes/passes.ts
+++ b/src/mol-canvas3d/passes/passes.ts
@@ -24,7 +24,10 @@ export class Passes {
 
     updateSize() {
         const { gl } = this.webgl;
-        this.draw.setSize(gl.drawingBufferWidth, gl.drawingBufferHeight);
+        // Avoid setting dimensions to 0x0 because it causes "empty textures are not allowed" error.
+        const width = Math.max(gl.drawingBufferWidth, 2);
+        const height = Math.max(gl.drawingBufferHeight, 2);
+        this.draw.setSize(width, height);
         this.pick.syncSize();
         this.multiSample.syncSize();
     }


### PR DESCRIPTION
Fixes an issue where hiding the canvas element would trigger an error. Used 2x2 as the minimum dimensions as discussed in the issue: https://github.com/molstar/molstar/issues/560