### PR TITLE
Model index updates & carbon color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- [Breaking] Renamed the ``model-index`` color theme to ``trajectory-index``
+- Added a new ``model-index`` color theme that uses the `Model.Index` property
+- Added the new ``model-index`` color theme as an option for the carbon color in the ``element-symbol`` and ``ilustrative`` color themes
+
 ## [v3.19.0] - 2022-10-01
 
 - Fix "empty textures" error on empty canvas
@@ -13,9 +17,6 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix dual depth peeling when post-processing is off or when rendering direct-volumes
 - Add ``cameraClipping.minNear`` parameter
 - Fix black artifacts on specular highlights with transparent background
-- [Breaking] Renamed the ``model-index`` color theme to ``trajectory-index``
-- Added a new ``model-index`` color theme that uses the `Model.Index` property
-- Added the new ``model-index`` color theme as an option for the carbon color in the ``element-symbol`` color theme
 
 ## [v3.18.0] - 2022-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix dual depth peeling when post-processing is off or when rendering direct-volumes
 - Add ``cameraClipping.minNear`` parameter
 - Fix black artifacts on specular highlights with transparent background
+- [Breaking] Renamed the ``model-index`` color theme to ``trajectory-index``
+- Added a new ``model-index`` color theme that uses the `Model.Index` property
+- Added the new ``model-index`` color theme as an option for the carbon color in the ``element-symbol`` color theme
 
 ## [v3.18.0] - 2022-09-17
 

--- a/src/mol-model-props/common/custom-model-property.ts
+++ b/src/mol-model-props/common/custom-model-property.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -71,12 +71,12 @@ namespace CustomModelProperty {
             },
             ref: (data: Model, add: boolean) => data.customProperties.reference(builder.descriptor, add),
             get: (data: Model) => get(data)?.data,
-            set: (data: Model, props: Partial<PD.Values<Params>> = {}) => {
+            set: (data: Model, props: Partial<PD.Values<Params>> = {}, value?: Value) => {
                 const property = get(data);
                 const p = PD.merge(builder.defaultParams, property.props, props);
                 if (!PD.areEqual(builder.defaultParams, property.props, p)) {
                     // this invalidates property.value
-                    set(data, p, undefined);
+                    set(data, p, value);
                     // dispose of assets
                     data.customProperties.assets(builder.descriptor);
                 }
@@ -96,7 +96,7 @@ namespace CustomModelProperty {
             getParams: () => ({ value: PD.Value(defaultValue, { isHidden: true }) }),
             isApplicable: () => true,
             obtain: async (ctx: CustomProperty.Context, data: Model, props: Partial<PD.Values<typeof defaultParams>>) => {
-                return { value: props.value ?? defaultValue };
+                return { ...PD.getDefaultValues(defaultParams), ...props };
             }
         });
     }

--- a/src/mol-model/structure/model/model.ts
+++ b/src/mol-model/structure/model/model.ts
@@ -213,6 +213,9 @@ export namespace Model {
     export type Index = number;
     export const Index = CustomModelProperty.createSimple<Index>('index', 'static');
 
+    export type MaxIndex = number;
+    export const MaxIndex = CustomModelProperty.createSimple<MaxIndex>('max_index', 'static');
+
     export function getRoot(model: Model) {
         return model.parent || model;
     }

--- a/src/mol-plugin-state/builder/structure/hierarchy-preset.ts
+++ b/src/mol-plugin-state/builder/structure/hierarchy-preset.ts
@@ -86,7 +86,7 @@ const allModels = TrajectoryHierarchyPresetProvider({
     id: 'preset-trajectory-all-models',
     display: {
         name: 'All Models', group: 'Preset',
-        description: 'Shows all models; colored by model-index.'
+        description: 'Shows all models; colored by trajectory-index.'
     },
     isApplicable: o => {
         return o.data.frameCount > 1;
@@ -115,7 +115,7 @@ const allModels = TrajectoryHierarchyPresetProvider({
 
             const quality = structure.obj ? getStructureQuality(structure.obj.data, { elementCountFactor: tr.frameCount }) : 'medium';
             const representationPreset = params.representationPreset || plugin.config.get(PluginConfig.Structure.DefaultRepresentationPreset) || PresetStructureRepresentations.auto.id;
-            await builder.representation.applyPreset(structureProperties, representationPreset, { theme: { globalName: 'model-index' }, quality });
+            await builder.representation.applyPreset(structureProperties, representationPreset, { theme: { globalName: 'trajectory-index' }, quality });
         }
 
         return { models, structures };

--- a/src/mol-plugin/behavior/dynamic/custom-props/structure-info.ts
+++ b/src/mol-plugin/behavior/dynamic/custom-props/structure-info.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -52,17 +52,28 @@ export const StructureInfo = PluginBehavior.create({
             return { auth, label };
         }
 
+        private setModelMaxIndex() {
+            const maxIndex = this.maxModelIndex;
+            const cells = this.ctx.state.data.select(StateSelection.Generators.rootsOfType(PluginStateObject.Molecule.Model));
+            for (const c of cells) {
+                const m = c.obj?.data;
+                if (m) {
+                    Model.MaxIndex.set(m, { value: maxIndex }, maxIndex);
+                }
+            }
+        }
+
         private handleModel(model: Model, oldModel?: Model) {
             if (Model.Index.get(model).value === undefined) {
                 const oldIndex = oldModel && Model.Index.get(oldModel).value;
                 const value = oldIndex ?? (this.maxModelIndex + 1);
-                Model.Index.set(model, { value });
+                Model.Index.set(model, { value }, value);
             }
 
             if (Model.AsymIdOffset.get(model).value === undefined) {
                 const oldOffset = oldModel && Model.AsymIdOffset.get(oldModel).value;
                 const value = oldOffset ?? { ...this.asymIdOffset };
-                Model.AsymIdOffset.set(model, { value });
+                Model.AsymIdOffset.set(model, { value }, value);
             }
         }
 
@@ -72,7 +83,7 @@ export const StructureInfo = PluginBehavior.create({
 
             const oldIndex = oldStructure && Structure.Index.get(oldStructure).value;
             const value = oldIndex ?? (this.maxStructureIndex + 1);
-            Structure.Index.set(structure, { value });
+            Structure.Index.set(structure, { value }, value);
         }
 
         private handle(ref: string, obj: StateObject<any, StateObject.Type<any>>, oldObj?: StateObject<any, StateObject.Type<any>>) {
@@ -92,10 +103,12 @@ export const StructureInfo = PluginBehavior.create({
         register(): void {
             this.ctx.customModelProperties.register(Model.AsymIdOffset, true);
             this.ctx.customModelProperties.register(Model.Index, true);
+            this.ctx.customModelProperties.register(Model.MaxIndex, true);
             this.ctx.customStructureProperties.register(Structure.Index, true);
 
             this.subscribeObservable(this.ctx.state.data.events.object.created, o => {
                 this.handle(o.ref, o.obj);
+                this.setModelMaxIndex();
             });
 
             this.subscribeObservable(this.ctx.state.data.events.object.updated, o => {
@@ -106,6 +119,7 @@ export const StructureInfo = PluginBehavior.create({
         unregister() {
             this.ctx.customModelProperties.unregister(Model.AsymIdOffset.descriptor.name);
             this.ctx.customModelProperties.unregister(Model.Index.descriptor.name);
+            this.ctx.customModelProperties.unregister(Model.MaxIndex.descriptor.name);
             this.ctx.customStructureProperties.unregister(Structure.Index.descriptor.name);
         }
     }

--- a/src/mol-plugin/behavior/dynamic/custom-props/structure-info.ts
+++ b/src/mol-plugin/behavior/dynamic/custom-props/structure-info.ts
@@ -53,12 +53,14 @@ export const StructureInfo = PluginBehavior.create({
         }
 
         private setModelMaxIndex() {
-            const maxIndex = this.maxModelIndex;
+            const value = this.maxModelIndex;
             const cells = this.ctx.state.data.select(StateSelection.Generators.rootsOfType(PluginStateObject.Molecule.Model));
             for (const c of cells) {
                 const m = c.obj?.data;
                 if (m) {
-                    Model.MaxIndex.set(m, { value: maxIndex }, maxIndex);
+                    if (Model.MaxIndex.get(m).value !== value) {
+                        Model.MaxIndex.set(m, { value }, value);
+                    }
                 }
             }
         }

--- a/src/mol-theme/color.ts
+++ b/src/mol-theme/color.ts
@@ -28,7 +28,7 @@ import { UncertaintyColorThemeProvider } from './color/uncertainty';
 import { EntitySourceColorThemeProvider } from './color/entity-source';
 import { IllustrativeColorThemeProvider } from './color/illustrative';
 import { HydrophobicityColorThemeProvider } from './color/hydrophobicity';
-import { ModelIndexColorThemeProvider } from './color/model-index';
+import { TrajectoryIndexColorThemeProvider } from './color/model-index';
 import { OccupancyColorThemeProvider } from './color/occupancy';
 import { OperatorNameColorThemeProvider } from './color/operator-name';
 import { OperatorHklColorThemeProvider } from './color/operator-hkl';
@@ -132,7 +132,7 @@ namespace ColorTheme {
         'entity-source': EntitySourceColorThemeProvider,
         'hydrophobicity': HydrophobicityColorThemeProvider,
         'illustrative': IllustrativeColorThemeProvider,
-        'model-index': ModelIndexColorThemeProvider,
+        'trajectory-index': TrajectoryIndexColorThemeProvider,
         'molecule-type': MoleculeTypeColorThemeProvider,
         'occupancy': OccupancyColorThemeProvider,
         'operator-hkl': OperatorHklColorThemeProvider,

--- a/src/mol-theme/color.ts
+++ b/src/mol-theme/color.ts
@@ -38,6 +38,7 @@ import { EntityIdColorThemeProvider } from './color/entity-id';
 import { Texture, TextureFilter } from '../mol-gl/webgl/texture';
 import { VolumeValueColorThemeProvider } from './color/volume-value';
 import { Vec3, Vec4 } from '../mol-math/linear-algebra';
+import { ModelIndexColorThemeProvider } from './color/model-index';
 
 export type LocationColor = (location: Location, isSecondary: boolean) => Color
 
@@ -132,7 +133,7 @@ namespace ColorTheme {
         'entity-source': EntitySourceColorThemeProvider,
         'hydrophobicity': HydrophobicityColorThemeProvider,
         'illustrative': IllustrativeColorThemeProvider,
-        'trajectory-index': TrajectoryIndexColorThemeProvider,
+        'model-index': ModelIndexColorThemeProvider,
         'molecule-type': MoleculeTypeColorThemeProvider,
         'occupancy': OccupancyColorThemeProvider,
         'operator-hkl': OperatorHklColorThemeProvider,
@@ -144,6 +145,7 @@ namespace ColorTheme {
         'secondary-structure': SecondaryStructureColorThemeProvider,
         'sequence-id': SequenceIdColorThemeProvider,
         'shape-group': ShapeGroupColorThemeProvider,
+        'trajectory-index': TrajectoryIndexColorThemeProvider,
         'uncertainty': UncertaintyColorThemeProvider,
         'unit-index': UnitIndexColorThemeProvider,
         'uniform': UniformColorThemeProvider,

--- a/src/mol-theme/color.ts
+++ b/src/mol-theme/color.ts
@@ -28,7 +28,7 @@ import { UncertaintyColorThemeProvider } from './color/uncertainty';
 import { EntitySourceColorThemeProvider } from './color/entity-source';
 import { IllustrativeColorThemeProvider } from './color/illustrative';
 import { HydrophobicityColorThemeProvider } from './color/hydrophobicity';
-import { TrajectoryIndexColorThemeProvider } from './color/model-index';
+import { TrajectoryIndexColorThemeProvider } from './color/trajectory-index';
 import { OccupancyColorThemeProvider } from './color/occupancy';
 import { OperatorNameColorThemeProvider } from './color/operator-name';
 import { OperatorHklColorThemeProvider } from './color/operator-hkl';

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -19,6 +19,7 @@ import { OperatorNameColorThemeParams, OperatorNameColorTheme } from './operator
 import { EntityIdColorTheme, EntityIdColorThemeParams } from './entity-id';
 import { assertUnreachable } from '../../mol-util/type-helpers';
 import { EntitySourceColorTheme, EntitySourceColorThemeParams } from './entity-source';
+import { ModelIndexColorTheme, ModelIndexColorThemeParams } from './model-index';
 
 // from Jmol http://jmol.sourceforge.net/jscolors/ (or 0xFFFFFF)
 export const ElementSymbolColors = ColorMap({
@@ -35,6 +36,7 @@ export const ElementSymbolColorThemeParams = {
         'entity-id': PD.Group(EntityIdColorThemeParams),
         'entity-source': PD.Group(EntitySourceColorThemeParams),
         'operator-name': PD.Group(OperatorNameColorThemeParams),
+        'model-index': PD.Group(ModelIndexColorThemeParams),
         'element-symbol': PD.EmptyGroup()
     }, { description: 'Use chain-id coloring for carbon atoms.' }),
     saturation: PD.Numeric(0, { min: -6, max: 6, step: 0.1 }),
@@ -63,8 +65,9 @@ export function ElementSymbolColorTheme(ctx: ThemeDataContext, props: PD.Values<
             pcc.name === 'entity-id' ? EntityIdColorTheme(ctx, pcc.params).color :
                 pcc.name === 'entity-source' ? EntitySourceColorTheme(ctx, pcc.params).color :
                     pcc.name === 'operator-name' ? OperatorNameColorTheme(ctx, pcc.params).color :
-                        pcc.name === 'element-symbol' ? undefined :
-                            assertUnreachable(pcc);
+                        pcc.name === 'model-index' ? ModelIndexColorTheme(ctx, pcc.params).color :
+                            pcc.name === 'element-symbol' ? undefined :
+                                assertUnreachable(pcc);
 
     function elementColor(element: ElementSymbol, location: Location) {
         return (carbonColor && element === 'C')

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -41,6 +41,7 @@ export const ElementSymbolColorThemeParams = {
     }, { description: 'Use chain-id coloring for carbon atoms.' }),
     saturation: PD.Numeric(0, { min: -6, max: 6, step: 0.1 }),
     lightness: PD.Numeric(0.2, { min: -6, max: 6, step: 0.1 }),
+    adjustCarbonColor: PD.Boolean(false, { description: 'apply the saturation and lightness adjustments to the carbon color' }),
     colors: PD.MappedStatic('default', {
         'default': PD.EmptyGroup(),
         'custom': PD.Group(getColorMapParams(ElementSymbolColors))
@@ -69,9 +70,11 @@ export function ElementSymbolColorTheme(ctx: ThemeDataContext, props: PD.Values<
                             pcc.name === 'element-symbol' ? undefined :
                                 assertUnreachable(pcc);
 
+    const getFinalCarbonColor = props.adjustCarbonColor ? getAdjustedColor : (color: Color) => color;
+
     function elementColor(element: ElementSymbol, location: Location) {
         return (carbonColor && element === 'C')
-            ? getAdjustedColor(carbonColor(location, false), props.saturation, props.lightness)
+            ? getFinalCarbonColor(carbonColor(location, false), props.saturation, props.lightness)
             : elementSymbolColor(colorMap, element);
     }
 

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -12,7 +12,7 @@ import { ColorTheme } from '../color';
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import { ThemeDataContext } from '../theme';
 import { TableLegend } from '../../mol-util/legend';
-import { getAdjustedColorMap } from '../../mol-util/color/color';
+import { getAdjustedColor, getAdjustedColorMap } from '../../mol-util/color/color';
 import { getColorMapParams } from '../../mol-util/color/params';
 import { ChainIdColorTheme, ChainIdColorThemeParams } from './chain-id';
 import { OperatorNameColorThemeParams, OperatorNameColorTheme } from './operator-name';
@@ -68,7 +68,7 @@ export function ElementSymbolColorTheme(ctx: ThemeDataContext, props: PD.Values<
 
     function elementColor(element: ElementSymbol, location: Location) {
         return (carbonColor && element === 'C')
-            ? carbonColor(location, false)
+            ? getAdjustedColor(carbonColor(location, false), props.saturation, props.lightness)
             : elementSymbolColor(colorMap, element);
     }
 

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -46,7 +46,7 @@ export const ElementSymbolColorThemeParams = {
 };
 export type ElementSymbolColorThemeParams = typeof ElementSymbolColorThemeParams
 export function getElementSymbolColorThemeParams(ctx: ThemeDataContext) {
-    return PD.clone(ElementSymbolColorThemeParams)
+    return PD.clone(ElementSymbolColorThemeParams);
 }
 
 export function elementSymbolColor(colorMap: ElementSymbolColors, element: ElementSymbol): Color {

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -46,7 +46,7 @@ export const ElementSymbolColorThemeParams = {
 };
 export type ElementSymbolColorThemeParams = typeof ElementSymbolColorThemeParams
 export function getElementSymbolColorThemeParams(ctx: ThemeDataContext) {
-    return ElementSymbolColorThemeParams; // TODO return copy
+    return PD.clone(ElementSymbolColorThemeParams)
 }
 
 export function elementSymbolColor(colorMap: ElementSymbolColors, element: ElementSymbol): Color {

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -12,7 +12,7 @@ import { ColorTheme } from '../color';
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import { ThemeDataContext } from '../theme';
 import { TableLegend } from '../../mol-util/legend';
-import { getAdjustedColor, getAdjustedColorMap } from '../../mol-util/color/color';
+import { getAdjustedColorMap } from '../../mol-util/color/color';
 import { getColorMapParams } from '../../mol-util/color/params';
 import { ChainIdColorTheme, ChainIdColorThemeParams } from './chain-id';
 import { OperatorNameColorThemeParams, OperatorNameColorTheme } from './operator-name';
@@ -41,7 +41,6 @@ export const ElementSymbolColorThemeParams = {
     }, { description: 'Use chain-id coloring for carbon atoms.' }),
     saturation: PD.Numeric(0, { min: -6, max: 6, step: 0.1 }),
     lightness: PD.Numeric(0.2, { min: -6, max: 6, step: 0.1 }),
-    adjustCarbonColor: PD.Boolean(false, { description: 'apply the saturation and lightness adjustments to the carbon color' }),
     colors: PD.MappedStatic('default', {
         'default': PD.EmptyGroup(),
         'custom': PD.Group(getColorMapParams(ElementSymbolColors))
@@ -70,11 +69,9 @@ export function ElementSymbolColorTheme(ctx: ThemeDataContext, props: PD.Values<
                             pcc.name === 'element-symbol' ? undefined :
                                 assertUnreachable(pcc);
 
-    const getFinalCarbonColor = props.adjustCarbonColor ? getAdjustedColor : (color: Color) => color;
-
     function elementColor(element: ElementSymbol, location: Location) {
         return (carbonColor && element === 'C')
-            ? getFinalCarbonColor(carbonColor(location, false), props.saturation, props.lightness)
+            ? carbonColor(location, false)
             : elementSymbolColor(colorMap, element);
     }
 

--- a/src/mol-theme/color/illustrative.ts
+++ b/src/mol-theme/color/illustrative.ts
@@ -17,9 +17,10 @@ import { assertUnreachable } from '../../mol-util/type-helpers';
 import { EntityIdColorTheme, EntityIdColorThemeParams } from './entity-id';
 import { MoleculeTypeColorTheme, MoleculeTypeColorThemeParams } from './molecule-type';
 import { EntitySourceColorTheme, EntitySourceColorThemeParams } from './entity-source';
+import { ModelIndexColorTheme, ModelIndexColorThemeParams } from './model-index';
 
 const DefaultIllustrativeColor = Color(0xEEEEEE);
-const Description = `Assigns an illustrative color that gives every chain a color based on the choosen style but with lighter carbons (inspired by David Goodsell's Molecule of the Month style).`;
+const Description = `Assigns an illustrative color that gives every chain a color based on the chosen style but with lighter carbons (inspired by David Goodsell's Molecule of the Month style).`;
 
 export const IllustrativeColorThemeParams = {
     style: PD.MappedStatic('entity-id', {
@@ -28,6 +29,7 @@ export const IllustrativeColorThemeParams = {
         'entity-id': PD.Group(EntityIdColorThemeParams),
         'entity-source': PD.Group(EntitySourceColorThemeParams),
         'molecule-type': PD.Group(MoleculeTypeColorThemeParams),
+        'model-index': PD.Group(ModelIndexColorThemeParams),
     }),
     carbonLightness: PD.Numeric(0.8, { min: -6, max: 6, step: 0.1 })
 };
@@ -44,7 +46,8 @@ export function IllustrativeColorTheme(ctx: ThemeDataContext, props: PD.Values<I
                 props.style.name === 'entity-id' ? EntityIdColorTheme(ctx, props.style.params) :
                     props.style.name === 'entity-source' ? EntitySourceColorTheme(ctx, props.style.params) :
                         props.style.name === 'molecule-type' ? MoleculeTypeColorTheme(ctx, props.style.params) :
-                            assertUnreachable(props.style);
+                            props.style.name === 'model-index' ? ModelIndexColorTheme(ctx, props.style.params) :
+                                assertUnreachable(props.style);
 
     function illustrativeColor(location: Location, typeSymbol: ElementSymbol) {
         const baseColor = styleColor(location, false);

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { Color } from '../../mol-util/color';
+import { Location } from '../../mol-model/location';
+import { StructureElement, Bond, Model } from '../../mol-model/structure';
+import { ColorTheme, LocationColor } from '../color';
+import { ParamDefinition as PD } from '../../mol-util/param-definition';
+import { ThemeDataContext } from '../../mol-theme/theme';
+import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
+import { TableLegend, ScaleLegend } from '../../mol-util/legend';
+
+const DefaultColor = Color(0xCCCCCC);
+const Description = 'Gives every model a unique color based on the position (index) of the model in the list of models in the structure.';
+
+export const ModelIndexColorThemeParams = {
+    ...getPaletteParams({ type: 'colors', colorList: 'purples' }),
+};
+export type ModelIndexColorThemeParams = typeof ModelIndexColorThemeParams
+export function getModelIndexColorThemeParams(ctx: ThemeDataContext) {
+    return ModelIndexColorThemeParams; // TODO return copy
+}
+
+export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<ModelIndexColorThemeParams>): ColorTheme<ModelIndexColorThemeParams> {
+    let color: LocationColor;
+    let legend: ScaleLegend | TableLegend | undefined;
+
+    if (ctx.structure) {
+        const { models } = ctx.structure.root;
+
+        const size = Math.max(...models.map(m => Model.Index.get(m)?.value || 0));
+
+        const palette = getPalette(size, props);
+        legend = palette.legend;
+        const modelColor = new Map<number, Color>();
+        for (let i = 0, il = models.length; i < il; ++i) {
+            const idx = Model.Index.get(models[i])?.value || 0;
+            modelColor.set(idx, palette.color(idx));
+        }
+
+        color = (location: Location): Color => {
+            if (StructureElement.Location.is(location)) {
+                return modelColor.get(Model.Index.get(location.unit.model).value || 0)!;
+            } else if (Bond.isLocation(location)) {
+                return modelColor.get(Model.Index.get(location.aUnit.model).value || 0)!;
+            }
+            return DefaultColor;
+        };
+    } else {
+        color = () => DefaultColor;
+    }
+
+    return {
+        factory: ModelIndexColorTheme,
+        granularity: 'instance',
+        color,
+        props,
+        description: Description,
+        legend
+    };
+}
+
+export const ModelIndexColorThemeProvider: ColorTheme.Provider<ModelIndexColorThemeParams, 'model-index'> = {
+    name: 'model-index',
+    label: 'Model Index',
+    category: ColorTheme.Category.Chain,
+    factory: ModelIndexColorTheme,
+    getParams: getModelIndexColorThemeParams,
+    defaultValues: PD.getDefaultValues(ModelIndexColorThemeParams),
+    isApplicable: (ctx: ThemeDataContext) => !!ctx.structure && ctx.structure.elementCount > 0
+};

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -14,7 +14,7 @@ import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
 import { TableLegend, ScaleLegend } from '../../mol-util/legend';
 
 const DefaultColor = Color(0xCCCCCC);
-const Description = 'Gives every model a unique color based on the position (index) of the model in the list of models in the structure.';
+const Description = 'Gives every model a unique color based on its index.';
 
 export const ModelIndexColorThemeParams = {
     ...getPaletteParams({ type: 'colors', colorList: 'many-distinct' }),

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Jason Pattle <jpattle@exscientia.co.uk>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import { Color } from '../../mol-util/color';
@@ -29,9 +30,8 @@ export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<Mod
     let legend: ScaleLegend | TableLegend | undefined;
 
     if (ctx.structure) {
-        const { models } = ctx.structure.root;
-
-        const size = Math.max(...models.map(m => Model.Index.get(m)?.value || 0));
+        // max-index is the same for all models
+        const size = (Model.MaxIndex.get(ctx.structure.models[0])?.value || -1) + 1;
 
         const palette = getPalette(size, props);
         legend = palette.legend;

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Jason Pattle <jpattle@exscientia.co.uk>
  */
 
 import { Color } from '../../mol-util/color';
@@ -21,7 +21,7 @@ export const ModelIndexColorThemeParams = {
 };
 export type ModelIndexColorThemeParams = typeof ModelIndexColorThemeParams
 export function getModelIndexColorThemeParams(ctx: ThemeDataContext) {
-    return ModelIndexColorThemeParams; // TODO return copy
+    return PD.clone(ModelIndexColorThemeParams);
 }
 
 export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<ModelIndexColorThemeParams>): ColorTheme<ModelIndexColorThemeParams> {

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -31,7 +31,7 @@ export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<Mod
 
     if (ctx.structure) {
         // max-index is the same for all models
-        const size = (Model.MaxIndex.get(ctx.structure.models[0])?.value || -1) + 1;
+        const size = (Model.MaxIndex.get(ctx.structure.models[0]).value ?? -1) + 1;
 
         const palette = getPalette(size, props);
         legend = palette.legend;

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -14,17 +14,17 @@ import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
 import { TableLegend, ScaleLegend } from '../../mol-util/legend';
 
 const DefaultColor = Color(0xCCCCCC);
-const Description = 'Gives every model a unique color based on the position (index) of the model in the list of models in the structure.';
+const Description = 'Gives every model a unique color based on the position (index) of the trajectory in the list of trajectories in the structure.';
 
-export const ModelIndexColorThemeParams = {
+export const TrajectoryIndexColorThemeParams = {
     ...getPaletteParams({ type: 'colors', colorList: 'purples' }),
 };
-export type ModelIndexColorThemeParams = typeof ModelIndexColorThemeParams
-export function getModelIndexColorThemeParams(ctx: ThemeDataContext) {
-    return ModelIndexColorThemeParams; // TODO return copy
+export type TrajectoryIndexColorThemeParams = typeof TrajectoryIndexColorThemeParams
+export function getTrajectoryIndexColorThemeParams(ctx: ThemeDataContext) {
+    return TrajectoryIndexColorThemeParams; // TODO return copy
 }
 
-export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<ModelIndexColorThemeParams>): ColorTheme<ModelIndexColorThemeParams> {
+export function TrajectoryIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<TrajectoryIndexColorThemeParams>): ColorTheme<TrajectoryIndexColorThemeParams> {
     let color: LocationColor;
     let legend: ScaleLegend | TableLegend | undefined;
 
@@ -55,7 +55,7 @@ export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<Mod
     }
 
     return {
-        factory: ModelIndexColorTheme,
+        factory: TrajectoryIndexColorTheme,
         granularity: 'instance',
         color,
         props,
@@ -64,12 +64,12 @@ export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<Mod
     };
 }
 
-export const ModelIndexColorThemeProvider: ColorTheme.Provider<ModelIndexColorThemeParams, 'model-index'> = {
-    name: 'model-index',
-    label: 'Model Index',
+export const TrajectoryIndexColorThemeProvider: ColorTheme.Provider<TrajectoryIndexColorThemeParams, 'trajectory-index'> = {
+    name: 'trajectory-index',
+    label: 'Trajectory Index',
     category: ColorTheme.Category.Chain,
-    factory: ModelIndexColorTheme,
-    getParams: getModelIndexColorThemeParams,
-    defaultValues: PD.getDefaultValues(ModelIndexColorThemeParams),
+    factory: TrajectoryIndexColorTheme,
+    getParams: getTrajectoryIndexColorThemeParams,
+    defaultValues: PD.getDefaultValues(TrajectoryIndexColorThemeParams),
     isApplicable: (ctx: ThemeDataContext) => !!ctx.structure && ctx.structure.elementCount > 0 && Model.TrajectoryInfo.get(ctx.structure.models[0]).size > 1
 };

--- a/src/mol-theme/color/model-index.ts
+++ b/src/mol-theme/color/model-index.ts
@@ -17,7 +17,7 @@ const DefaultColor = Color(0xCCCCCC);
 const Description = 'Gives every model a unique color based on the position (index) of the model in the list of models in the structure.';
 
 export const ModelIndexColorThemeParams = {
-    ...getPaletteParams({ type: 'colors', colorList: 'purples' }),
+    ...getPaletteParams({ type: 'colors', colorList: 'many-distinct' }),
 };
 export type ModelIndexColorThemeParams = typeof ModelIndexColorThemeParams
 export function getModelIndexColorThemeParams(ctx: ThemeDataContext) {
@@ -35,17 +35,12 @@ export function ModelIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<Mod
 
         const palette = getPalette(size, props);
         legend = palette.legend;
-        const modelColor = new Map<number, Color>();
-        for (let i = 0, il = models.length; i < il; ++i) {
-            const idx = Model.Index.get(models[i])?.value || 0;
-            modelColor.set(idx, palette.color(idx));
-        }
 
         color = (location: Location): Color => {
             if (StructureElement.Location.is(location)) {
-                return modelColor.get(Model.Index.get(location.unit.model).value || 0)!;
+                return palette.color(Model.Index.get(location.unit.model).value || 0)!;
             } else if (Bond.isLocation(location)) {
-                return modelColor.get(Model.Index.get(location.aUnit.model).value || 0)!;
+                return palette.color(Model.Index.get(location.aUnit.model).value || 0)!;
             }
             return DefaultColor;
         };

--- a/src/mol-theme/color/trajectory-index.ts
+++ b/src/mol-theme/color/trajectory-index.ts
@@ -21,7 +21,7 @@ export const TrajectoryIndexColorThemeParams = {
 };
 export type TrajectoryIndexColorThemeParams = typeof TrajectoryIndexColorThemeParams
 export function getTrajectoryIndexColorThemeParams(ctx: ThemeDataContext) {
-    return TrajectoryIndexColorThemeParams; // TODO return copy
+    return PD.clone(TrajectoryIndexColorThemeParams);
 }
 
 export function TrajectoryIndexColorTheme(ctx: ThemeDataContext, props: PD.Values<TrajectoryIndexColorThemeParams>): ColorTheme<TrajectoryIndexColorThemeParams> {

--- a/src/mol-theme/color/trajectory-index.ts
+++ b/src/mol-theme/color/trajectory-index.ts
@@ -14,7 +14,7 @@ import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
 import { TableLegend, ScaleLegend } from '../../mol-util/legend';
 
 const DefaultColor = Color(0xCCCCCC);
-const Description = 'Gives every model a unique color based on the position (index) of the trajectory in the list of trajectories in the structure.';
+const Description = 'Gives every model (frame) a unique color based on the index in its trajectory.';
 
 export const TrajectoryIndexColorThemeParams = {
     ...getPaletteParams({ type: 'colors', colorList: 'purples' }),

--- a/src/mol-theme/color/trajectory-index.ts
+++ b/src/mol-theme/color/trajectory-index.ts
@@ -9,7 +9,7 @@ import { Location } from '../../mol-model/location';
 import { StructureElement, Bond, Model } from '../../mol-model/structure';
 import { ColorTheme, LocationColor } from '../color';
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
-import { ThemeDataContext } from '../../mol-theme/theme';
+import { ThemeDataContext } from '../theme';
 import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
 import { TableLegend, ScaleLegend } from '../../mol-util/legend';
 

--- a/src/mol-util/color/color.ts
+++ b/src/mol-util/color/color.ts
@@ -166,12 +166,15 @@ export function ColorMap<T extends { [k: string]: number }>(o: T) { return o as 
 export function getAdjustedColorMap<T extends { [k: string]: number }>(map: ColorMap<T>, saturation: number, lightness: number) {
     const adjustedMap: { [k: string]: Color } = {};
     for (const e in map) {
-        let c = map[e];
-        c = Color.saturate(c, saturation);
-        c = Color.darken(c, -lightness);
-        adjustedMap[e] = c;
+        adjustedMap[e] = getAdjustedColor(map[e], saturation, lightness);
     }
     return adjustedMap as ColorMap<T>;
+}
+export function getAdjustedColor(color: Color, saturation: number, lightness: number) {
+    let c = color;
+    c = Color.saturate(c, saturation);
+    c = Color.darken(c, -lightness);
+    return c
 }
 
 export type ColorSwatch = [string, Color][]

--- a/src/mol-util/color/color.ts
+++ b/src/mol-util/color/color.ts
@@ -166,15 +166,12 @@ export function ColorMap<T extends { [k: string]: number }>(o: T) { return o as 
 export function getAdjustedColorMap<T extends { [k: string]: number }>(map: ColorMap<T>, saturation: number, lightness: number) {
     const adjustedMap: { [k: string]: Color } = {};
     for (const e in map) {
-        adjustedMap[e] = getAdjustedColor(map[e], saturation, lightness);
+        let c = map[e];
+        c = Color.saturate(c, saturation);
+        c = Color.darken(c, -lightness);
+        adjustedMap[e] = c;
     }
     return adjustedMap as ColorMap<T>;
-}
-export function getAdjustedColor(color: Color, saturation: number, lightness: number) {
-    let c = color;
-    c = Color.saturate(c, saturation);
-    c = Color.darken(c, -lightness);
-    return c;
 }
 
 export type ColorSwatch = [string, Color][]

--- a/src/mol-util/color/color.ts
+++ b/src/mol-util/color/color.ts
@@ -174,7 +174,7 @@ export function getAdjustedColor(color: Color, saturation: number, lightness: nu
     let c = color;
     c = Color.saturate(c, saturation);
     c = Color.darken(c, -lightness);
-    return c
+    return c;
 }
 
 export type ColorSwatch = [string, Color][]

--- a/src/mol-util/color/distinct.ts
+++ b/src/mol-util/color/distinct.ts
@@ -13,6 +13,7 @@ import { deepClone } from '../../mol-util/object';
 import { deepEqual } from '../../mol-util';
 import { arraySum } from '../../mol-util/array';
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
+import { ColorNames } from './names';
 
 export const DistinctColorsParams = {
     hue: PD.Interval([1, 360], { min: 0, max: 360, step: 1 }),
@@ -105,7 +106,8 @@ export function distinctColors(count: number, props: Partial<DistinctColorsProps
 
     const samples = getSamples(Math.max(p.minSampleCount, count * 5), p);
     if (samples.length < count) {
-        throw new Error('Not enough samples to generate distinct colors, increase sample count.');
+        console.warn('Not enough samples to generate distinct colors, increase sample count.');
+        return (new Array(count)).fill(ColorNames.lightgrey);
     }
 
     const colors: Lab[] = [];


### PR DESCRIPTION
Based off discussion for [molstar-577](https://github.com/molstar/molstar/issues/577)

* Renamed the existing model-index color theme to trajectory-index
* Created a new model-index color theme that uses `Model.Index` to determine color
* Added the new model-index color theme as an option in the element-symbol color theme for carbon color
* Added the option to alter the element-symbol's carbon color by the saturation/lightness parameters
    * If we feel this change is not needed then I can remove it

Contains a 'breaking' change in that the model-index theme no longer works at all like it used to.