### PR TITLE
Prevent component controls collapsing when option is selected

### DIFF
--- a/src/mol-plugin-ui/structure/components.tsx
+++ b/src/mol-plugin-ui/structure/components.tsx
@@ -280,7 +280,6 @@ class StructureComponentGroup extends PurePluginUIComponent<{ group: StructureCo
 
     selectAction: ActionMenu.OnSelect = item => {
         if (!item) return;
-        this.setState({ action: void 0 });
         (item?.value as any)();
     };
 


### PR DESCRIPTION
Stops the component controls from automatically collapsing whenever an option is selected, see issue #582.