### PR TITLE
keep asset url to detect compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 
 - Make `PluginContext.initContainer` checkered canvas background optional
+- Store URL of downloaded assets to detect zip/gzip based on extension
 
 ## [v3.23.0] - 2022-10-19
 

--- a/src/mol-util/assets.ts
+++ b/src/mol-util/assets.ts
@@ -100,7 +100,7 @@ class AssetManager {
                 }
 
                 const data = await ajaxGet({ ...asset, type: 'binary' }).runInContext(ctx);
-                const file = new File([data], 'raw-data');
+                const file = new File([data], asset.url);
                 this._assets.set(asset.id, { asset, file, refCount: 1 });
                 return Asset.Wrapper(await readFromFile(file, type).runInContext(ctx), asset, this);
             });


### PR DESCRIPTION
# Description
Tiny quality-of-life improvement that extends the handling of zip/gzip assets to URLs.
https://files.rcsb.org/download/4HHB.cif.gz
https://files.rcsb.org/download/4HHB.pdb.gz
https://models.rcsb.org/4HHB.bcif.gz

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`