### PR TITLE
Fix Handling of Gzipped Assets by Reverting #615

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Fix handling of gzipped assets (reverts #615)
+
 ## [v3.24.0] - 2022-11-13
 
 - Make `PluginContext.initContainer` checkered canvas background optional
-- Store URL of downloaded assets to detect zip/gzip based on extension
+- Store URL of downloaded assets to detect zip/gzip based on extension (#615)
 - Add optional `operator.key`; can be referenced in `IndexPairBonds`
 - Add overpaint/transparency/substance theme strength to representations
 - Fix viewport color for transparent background

--- a/src/mol-util/assets.ts
+++ b/src/mol-util/assets.ts
@@ -100,7 +100,7 @@ class AssetManager {
                 }
 
                 const data = await ajaxGet({ ...asset, type: 'binary' }).runInContext(ctx);
-                const file = new File([data], asset.url);
+                const file = new File([data], 'raw-data');
                 this._assets.set(asset.id, { asset, file, refCount: 1 });
                 return Asset.Wrapper(await readFromFile(file, type).runInContext(ctx), asset, this);
             });


### PR DESCRIPTION
# Description
My apologies for the hassle. Validation reports are working again.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`