### PR TITLE
Impostor cylinders interior

### DIFF
--- a/src/mol-gl/shader/cylinders.frag.ts
+++ b/src/mol-gl/shader/cylinders.frag.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 export const cylinders_frag = `

--- a/src/mol-gl/shader/cylinders.frag.ts
+++ b/src/mol-gl/shader/cylinders.frag.ts
@@ -104,7 +104,10 @@ bool CylinderImpostor(
             modelPosition = rayOrigin + t * rayDir;
             viewPosition = (uView * vec4(modelPosition, 1.0)).xyz;
             fragmentDepth = calcDepth(viewPosition);
-            return true;
+            if (fragmentDepth > 0.0) {
+              if (topCap && bottomCap) fragmentDepth = 0.0 + (0.0000001 / vSize);
+              return true;
+            }
         }
 
         if (topCap && y < 0.0) {
@@ -116,7 +119,10 @@ bool CylinderImpostor(
                 modelPosition = rayOrigin + t * rayDir;
                 viewPosition = (uView * vec4(modelPosition, 1.0)).xyz;
                 fragmentDepth = calcDepth(viewPosition);
-                if (fragmentDepth > 0.0) return true;
+                if (fragmentDepth > 0.0) {
+                  if (bottomCap) fragmentDepth = 0.0 + (0.0000001 / vSize);
+                  return true;
+                }
             }
         } else if(bottomCap && y >= 0.0) {
             // bottom cap
@@ -127,7 +133,10 @@ bool CylinderImpostor(
                 modelPosition = rayOrigin + t * rayDir;
                 viewPosition = (uView * vec4(modelPosition, 1.0)).xyz;
                 fragmentDepth = calcDepth(viewPosition);
-                if (fragmentDepth > 0.0) return true;
+                if (fragmentDepth > 0.0) {
+                  if (topCap) fragmentDepth = 0.0 + (0.0000001 / vSize);
+                  return true;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Improving impostor cylinder interior when clipping to address #635
It is working well with my custom visual. Using default ball and sticks representation seems that there is no way to enable both caps to test..

![image](https://user-images.githubusercontent.com/20627977/207355990-24431207-b4bc-4e7b-a2c4-249566e75c0e.png)
