### PR TITLE
Fix NtC tube and Confal pyramids mesh when there are discontinuous chains

### DIFF
--- a/src/extensions/dnatco/behavior.ts
+++ b/src/extensions/dnatco/behavior.ts
@@ -39,11 +39,15 @@ export const DnatcoNtCs = PluginBehavior.create<{ autoAttach: boolean, showToolT
         }
 
         unregister() {
+            this.ctx.customModelProperties.unregister(ConfalPyramidsProvider.descriptor.name);
             this.ctx.customModelProperties.unregister(NtCTubeProvider.descriptor.name);
 
+            this.ctx.representation.structure.registry.remove(ConfalPyramidsRepresentationProvider);
+            this.ctx.representation.structure.themes.colorThemeRegistry.remove(ConfalPyramidsColorThemeProvider);
             this.ctx.representation.structure.registry.remove(NtCTubeRepresentationProvider);
             this.ctx.representation.structure.themes.colorThemeRegistry.remove(NtCTubeColorThemeProvider);
 
+            this.ctx.builders.structure.representation.unregisterPreset(ConfalPyramidsPreset);
             this.ctx.builders.structure.representation.unregisterPreset(NtCTubePreset);
         }
     },

--- a/src/extensions/dnatco/confal-pyramids/representation.ts
+++ b/src/extensions/dnatco/confal-pyramids/representation.ts
@@ -88,6 +88,8 @@ function createConfalPyramidsMesh(ctx: VisualContext, unit: Unit, structure: Str
     const it = new ConfalPyramidsIterator(structure, unit);
     while (it.hasNext) {
         const allPoints = it.move();
+        if (!allPoints)
+            continue;
 
         for (const points of allPoints) {
             const { O3, P, OP1, OP2, O5, confalScore } = points;

--- a/src/extensions/dnatco/confal-pyramids/util.ts
+++ b/src/extensions/dnatco/confal-pyramids/util.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Michal Malý <michal.maly@ibt.cas.cz>
  * @author Jiří Černý <jiri.cerny@ibt.cas.cz>
@@ -47,6 +47,10 @@ export class ConfalPyramidsIterator {
     private moveStep() {
         this.residueOne = DnatcoUtil.copyResidue(this.residueTwo);
         this.residueTwo = DnatcoUtil.copyResidue(this.residueIt.move())!;
+
+        // Check for discontinuity
+        if (this.residueTwo.index !== (this.residueOne!.index + 1))
+            return void 0;
 
         return this.toPyramids(this.residueOne!, this.residueTwo);
     }


### PR DESCRIPTION
I just realized that when there are discontinuities in chains the mesh building logic won't detect them and draw things wrong. See the example below:

Wrong:
![bad](https://user-images.githubusercontent.com/1009657/212861641-d9b24324-8077-4f61-b155-093349336f93.png)

Fixed:
![fixed](https://user-images.githubusercontent.com/1009657/212861903-9aacb34e-aff2-4505-b7af-ed496cc323b0.png)

This can probably only happen if the user applies a selection on the structure. I used the following input to create the testing example:

- Structure: https://dnatco.datmos.org/v4.1/RCSB/cif_dnatco_updated/1bna_v41C35A23.cif.gz
- Selection script:
```
(sel.atom.res
    (or
        (in-range atom.resno 1 2)
        (or
            (in-range atom.resno 5 9)
            (or
                (in-range atom.resno 11 12)
                (or
                    (in-range atom.resno 13 14)
                    (in-range atom.resno 16 21)
                )
            )
        )
    )
)
```

I'm sorry for not catching this sooner.