### PR TITLE
Fixing exit code for volume packer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Fix exit code of volume pack executable (pack.ts). Now exits with non-0 status when an error happens
+
 ## [v3.31.1] - 2023-02-05
 
 - Improve Component camera focus based on the PCA of the structure and the following rules:

--- a/src/servers/volume/pack/main.ts
+++ b/src/servers/volume/pack/main.ts
@@ -18,6 +18,7 @@ export async function pack(input: { name: string, filename: string }[], blockSiz
         await create(outputFilename, input, blockSizeInMB, isPeriodic, format);
     } catch (e) {
         console.error('[Error] ' + e);
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
The shell exit code was 0 when an error happened. Like this it will behave like any CLI program should

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`