### PR TITLE
Fixed degenerate case (1-point) in PCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 
 Fix impostor bond visuals not correctly updating on `sizeFactor` changes
+Fix degenerate case in PCA
 
 ## [v3.31.2] - 2023-02-12
 

--- a/src/mol-math/linear-algebra/matrix/principal-axes.ts
+++ b/src/mol-math/linear-algebra/matrix/principal-axes.ts
@@ -27,7 +27,7 @@ namespace PrincipalAxes {
 
     export function calculateMomentsAxes(positions: NumberArray): Axes3D {
         if (positions.length === 3) {
-            return Axes3D.create(Vec3.fromArray(Vec3(), positions, 0), Vec3.create(1, 0, 0), Vec3.create(0, 1, 0), Vec3.create(0, 1, 0));
+            return Axes3D.create(Vec3.fromArray(Vec3(), positions, 0), Vec3.create(1, 0, 0), Vec3.create(0, 1, 0), Vec3.create(0, 0, 1));
         }
 
         const points = Matrix.fromArray(positions, 3, positions.length / 3);


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
I fixed the small bug in PCA, mentioned here #722 .
When the number of points is 1, PCA axes should be an identity matrix.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`