### PR TITLE
Change nodejs-shim conditional to avoid checking `document` object existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix issue with outlines and orthographic camera
 - Reduce over-blurring occlusion at larger view distances
 - Fix occlusion artefact with non-canvas viewport and pixel-ratio > 1
+- Update nodejs-shims conditionals to handle polyfilled document object in NodeJS environment.
 
 ## [v3.31.4] - 2023-02-24
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "Ke Ma <mark.ma@rcsb.org>",
     "Jason Pattle <jpattle@exscientia.co.uk>",
     "David Williams <dwilliams@nobiastx.com>",
-    "Zhenyu Zhang <jump2cn@gmail.com>"
+    "Zhenyu Zhang <jump2cn@gmail.com>",
+    "Russell Parker <russell@benchling.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-util/nodejs-shims.ts
+++ b/src/mol-util/nodejs-shims.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author Russell Parker <russell@benchling.com>
  *
  * Implements some browser-only global variables for Node.js environment.
  * These workarounds will also work in browsers as usual.
@@ -19,7 +20,7 @@ export const File_ = getFile();
 
 
 function getXMLHttpRequest(): typeof XMLHttpRequest {
-    if (typeof document === 'undefined') {
+    if (typeof XMLHttpRequest === 'undefined' || RUNNING_IN_NODEJS) {
         return require('xhr2');
     } else {
         return XMLHttpRequest;
@@ -27,7 +28,7 @@ function getXMLHttpRequest(): typeof XMLHttpRequest {
 }
 
 function getFile(): typeof File {
-    if (typeof document === 'undefined') {
+    if (typeof File === 'undefined' || RUNNING_IN_NODEJS) {
         class File_NodeJs implements File {
             private readonly blob: Blob;
             // Blob fields


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

On updating molstar I noticed some runtime errors were being thrown because we have `document` polyfilled in a NodeJS env. This change updates the conditionals in nodejs-shims.ts to avoid checking `typeof document === 'undefined'`.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`