### PR TITLE
Handle resizing viewer element when window remains the same size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
+- Handle resizes of viewer element even when window remains the same size
 
 - Input/controls improvements
     - Move or fly around the scene using keys

--- a/src/mol-util/input/input-observer.ts
+++ b/src/mol-util/input/input-observer.ts
@@ -361,7 +361,11 @@ namespace InputObserver {
         let isInside = false;
         let hasMoved = false;
 
-        const resizeObserver: ResizeObserver = new window.ResizeObserver(onResize);
+        let resizeObserver: ResizeObserver | undefined;
+        if (typeof window.ResizeObserver !== 'undefined') {
+            resizeObserver = new window.ResizeObserver(onResize);
+        }
+
         const events = createEvents();
         const { drag, interactionEnd, wheel, pinch, gesture, click, move, leave, enter, resize, modifiers, key, keyUp, keyDown, lock } = events;
 
@@ -395,7 +399,11 @@ namespace InputObserver {
             document.addEventListener('pointerlockchange', onPointerLockChange, false);
             document.addEventListener('pointerlockerror', onPointerLockError, false);
 
-            resizeObserver.observe(element.parentElement!);
+            if (resizeObserver != null) {
+                resizeObserver.observe(element.parentElement!);
+            } else {
+                window.addEventListener('resize', onResize, false);
+            }
         }
 
         function dispose() {
@@ -427,8 +435,12 @@ namespace InputObserver {
 
             cross.remove();
 
-            resizeObserver.unobserve(element.parentElement!);
-            resizeObserver.disconnect();
+            if (resizeObserver != null) {
+                resizeObserver.unobserve(element.parentElement!);
+                resizeObserver.disconnect();
+            } else {
+                window.removeEventListener('resize', onResize, false);
+            }
         }
 
         function onPointerLockChange() {

--- a/src/mol-util/input/input-observer.ts
+++ b/src/mol-util/input/input-observer.ts
@@ -776,16 +776,6 @@ namespace InputObserver {
             gestureDelta(ev, true);
         }
 
-        function onMouseEnter(ev: Event) {
-            isInside = true;
-            enter.next(void 0);
-        }
-
-        function onMouseLeave(ev: Event) {
-            isInside = false;
-            leave.next(void 0);
-        }
-
         function onResize() {
             resize.next({});
         }

--- a/src/mol-util/input/input-observer.ts
+++ b/src/mol-util/input/input-observer.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Russell Parker <russell@benchling.com>
  */
 
 import { Subject, Observable } from 'rxjs';
@@ -360,6 +361,7 @@ namespace InputObserver {
         let isInside = false;
         let hasMoved = false;
 
+        const resizeObserver: ResizeObserver = new window.ResizeObserver(onResize);
         const events = createEvents();
         const { drag, interactionEnd, wheel, pinch, gesture, click, move, leave, enter, resize, modifiers, key, keyUp, keyDown, lock } = events;
 
@@ -393,7 +395,7 @@ namespace InputObserver {
             document.addEventListener('pointerlockchange', onPointerLockChange, false);
             document.addEventListener('pointerlockerror', onPointerLockError, false);
 
-            window.addEventListener('resize', onResize, false);
+            resizeObserver.observe(element.parentElement!);
         }
 
         function dispose() {
@@ -423,9 +425,10 @@ namespace InputObserver {
             document.removeEventListener('pointerlockchange', onPointerLockChange, false);
             document.removeEventListener('pointerlockerror', onPointerLockError, false);
 
-            window.removeEventListener('resize', onResize, false);
-
             cross.remove();
+
+            resizeObserver.unobserve(element.parentElement!);
+            resizeObserver.disconnect();
         }
 
         function onPointerLockChange() {
@@ -773,7 +776,17 @@ namespace InputObserver {
             gestureDelta(ev, true);
         }
 
-        function onResize(ev: Event) {
+        function onMouseEnter(ev: Event) {
+            isInside = true;
+            enter.next(void 0);
+        }
+
+        function onMouseLeave(ev: Event) {
+            isInside = false;
+            leave.next(void 0);
+        }
+
+        function onResize() {
             resize.next({});
         }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Use ResizeObserver to trigger `handleResize` when the canvas's parent element changes size. This handles changes that affect the viewer dimensions even if the window itself does not emit a resize event.

closes #749 

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`