### PR TITLE
Marking depth avoid alpha 0 rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
+  - Avoid rendering of fully transparent renderables (on renderMarkingDepth)
 
 ## [v3.33.0] - 2023-04-02
 

--- a/src/mol-gl/renderer.ts
+++ b/src/mol-gl/renderer.ts
@@ -463,7 +463,8 @@ namespace Renderer {
             for (let i = 0, il = renderables.length; i < il; ++i) {
                 const r = renderables[i];
 
-                if (r.values.markerAverage.ref.value !== 1) {
+                const alpha = clamp(r.values.alpha.ref.value * r.state.alphaFactor, 0, 1);
+                if (alpha !== 0 && r.values.markerAverage.ref.value !== 1) {
                     renderObject(renderables[i], 'marking', Flag.None);
                 }
             }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Avoid rendering of fully transparent renderables (on renderMarkingDepth)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`