### PR TITLE
Added "Zoom All", "Orient Axes", "Reset Axes" buttons

### DIFF
--- a/1og2.cif
+++ b/1og2.cif
@@ -1,0 +1,10440 @@
+data_1OG2
+# 
+_entry.id   1OG2 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.279 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   1OG2         
+PDBE  EBI-12633    
+WWPDB D_1290012633 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        1OG2 
+_pdbx_database_status.deposit_site                    PDBE 
+_pdbx_database_status.process_site                    PDBE 
+_pdbx_database_status.SG_entry                        . 
+_pdbx_database_status.recvd_initial_deposition_date   2003-04-23 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_sf                  ? 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.methods_development_category    ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Williams, P.A.'     1 
+'Cosme, J.'          2 
+'Ward, A.'           3 
+'Angove, H.C.'       4 
+'Matak Vinkovic, D.' 5 
+'Jhoti, H.'          6 
+# 
+_citation.id                        primary 
+_citation.title                     'Crystal Structure of Human Cytochrome P450 2C9 with Bound Warfarin' 
+_citation.journal_abbrev            Nature 
+_citation.journal_volume            424 
+_citation.page_first                464 
+_citation.page_last                 ? 
+_citation.year                      2003 
+_citation.journal_id_ASTM           NATUAS 
+_citation.country                   UK 
+_citation.journal_id_ISSN           0028-0836 
+_citation.journal_id_CSD            0006 
+_citation.book_publisher            ? 
+_citation.pdbx_database_id_PubMed   12861225 
+_citation.pdbx_database_id_DOI      10.1038/NATURE01862 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Williams, P.A.'     1 
+primary 'Cosme, J.'          2 
+primary 'Ward, A.'           3 
+primary 'Angove, H.C.'       4 
+primary 'Matak Vinkovic, D.' 5 
+primary 'Jhoti, H.'          6 
+# 
+_cell.entry_id           1OG2 
+_cell.length_a           164.870 
+_cell.length_b           164.870 
+_cell.length_c           111.105 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        120.00 
+_cell.Z_PDB              12 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         1OG2 
+_symmetry.space_group_name_H-M             'P 3 2 1' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                150 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     man 'CYTOCHROME P450 2C9' 54168.590 2   '1.14.13.80, 1.14.13.48, 1.14.13.49' YES 'SOLUBLE DOMAIN, RESIDUES 30-490' ? 
+2 non-polymer syn 'HEME C'              618.503   2   ?                                    ?   ?                                 ? 
+3 water       nat water                 18.015    147 ?                                    ?   ?                                 ? 
+# 
+_entity_name_com.entity_id   1 
+_entity_name_com.name        
+;(R)-LIMONENE 6-MONOOXYGENASE, (S)-LIMONENE 6-MONOOXYGENASE, (S)-LIMONENE 7-MONOOXYGENASE, CYPIIC9, CYTOCHROME P-450MP, CYTOCHROME P450 MP-4, CYTOCHROME P450 MP-8, CYTOCHROME P450 PB-1, S-MEPHENYTOIN 4-HYDROXYLASE
+;
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;MAKKTSSKGRPPGPTPLPVIGNILQIGIKDISKSLTNLSKVYGPVFTLYFGLKPIVVLHGYEAVKEALIDLGEEFSGRGI
+FPLAERANRGFGIVFSNGKKWKEIRRFSLMTLRNFGMGKRSIEDRVQEEARCLVEELRKTKASPCDPTFILGCAPCNVIC
+SIIFHKRFDYKDQQFLNLMEKLNENIEILSSPWIQVYNNFPALLDYFPGTHNKLLKNVAFMKSYILEKVKEHQESMDMNN
+PQDFIDCFLMKMEKEKHNQPSEFTIESLENTAVDLFGAGTETTSTTLRYALLLLLKHPEVTAKVQEEIERVIGRNRSPCM
+QDRSHMPYTDAVVHEVQRYIDLLPTSLPHAVTCDIKFRNYLIPKGTTILISLTSVLHDNKEFPNPEMFDPHHFLDEGGNF
+KKSKYFMPFSAGKRICVGEALAGMELFLFLTSILQNFNLKSLVDPKNLDTTPVVNGFASVPPFYQLCFIPVHHHH
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;MAKKTSSKGRPPGPTPLPVIGNILQIGIKDISKSLTNLSKVYGPVFTLYFGLKPIVVLHGYEAVKEALIDLGEEFSGRGI
+FPLAERANRGFGIVFSNGKKWKEIRRFSLMTLRNFGMGKRSIEDRVQEEARCLVEELRKTKASPCDPTFILGCAPCNVIC
+SIIFHKRFDYKDQQFLNLMEKLNENIEILSSPWIQVYNNFPALLDYFPGTHNKLLKNVAFMKSYILEKVKEHQESMDMNN
+PQDFIDCFLMKMEKEKHNQPSEFTIESLENTAVDLFGAGTETTSTTLRYALLLLLKHPEVTAKVQEEIERVIGRNRSPCM
+QDRSHMPYTDAVVHEVQRYIDLLPTSLPHAVTCDIKFRNYLIPKGTTILISLTSVLHDNKEFPNPEMFDPHHFLDEGGNF
+KKSKYFMPFSAGKRICVGEALAGMELFLFLTSILQNFNLKSLVDPKNLDTTPVVNGFASVPPFYQLCFIPVHHHH
+;
+_entity_poly.pdbx_strand_id                 A,B 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   MET n 
+1 2   ALA n 
+1 3   LYS n 
+1 4   LYS n 
+1 5   THR n 
+1 6   SER n 
+1 7   SER n 
+1 8   LYS n 
+1 9   GLY n 
+1 10  ARG n 
+1 11  PRO n 
+1 12  PRO n 
+1 13  GLY n 
+1 14  PRO n 
+1 15  THR n 
+1 16  PRO n 
+1 17  LEU n 
+1 18  PRO n 
+1 19  VAL n 
+1 20  ILE n 
+1 21  GLY n 
+1 22  ASN n 
+1 23  ILE n 
+1 24  LEU n 
+1 25  GLN n 
+1 26  ILE n 
+1 27  GLY n 
+1 28  ILE n 
+1 29  LYS n 
+1 30  ASP n 
+1 31  ILE n 
+1 32  SER n 
+1 33  LYS n 
+1 34  SER n 
+1 35  LEU n 
+1 36  THR n 
+1 37  ASN n 
+1 38  LEU n 
+1 39  SER n 
+1 40  LYS n 
+1 41  VAL n 
+1 42  TYR n 
+1 43  GLY n 
+1 44  PRO n 
+1 45  VAL n 
+1 46  PHE n 
+1 47  THR n 
+1 48  LEU n 
+1 49  TYR n 
+1 50  PHE n 
+1 51  GLY n 
+1 52  LEU n 
+1 53  LYS n 
+1 54  PRO n 
+1 55  ILE n 
+1 56  VAL n 
+1 57  VAL n 
+1 58  LEU n 
+1 59  HIS n 
+1 60  GLY n 
+1 61  TYR n 
+1 62  GLU n 
+1 63  ALA n 
+1 64  VAL n 
+1 65  LYS n 
+1 66  GLU n 
+1 67  ALA n 
+1 68  LEU n 
+1 69  ILE n 
+1 70  ASP n 
+1 71  LEU n 
+1 72  GLY n 
+1 73  GLU n 
+1 74  GLU n 
+1 75  PHE n 
+1 76  SER n 
+1 77  GLY n 
+1 78  ARG n 
+1 79  GLY n 
+1 80  ILE n 
+1 81  PHE n 
+1 82  PRO n 
+1 83  LEU n 
+1 84  ALA n 
+1 85  GLU n 
+1 86  ARG n 
+1 87  ALA n 
+1 88  ASN n 
+1 89  ARG n 
+1 90  GLY n 
+1 91  PHE n 
+1 92  GLY n 
+1 93  ILE n 
+1 94  VAL n 
+1 95  PHE n 
+1 96  SER n 
+1 97  ASN n 
+1 98  GLY n 
+1 99  LYS n 
+1 100 LYS n 
+1 101 TRP n 
+1 102 LYS n 
+1 103 GLU n 
+1 104 ILE n 
+1 105 ARG n 
+1 106 ARG n 
+1 107 PHE n 
+1 108 SER n 
+1 109 LEU n 
+1 110 MET n 
+1 111 THR n 
+1 112 LEU n 
+1 113 ARG n 
+1 114 ASN n 
+1 115 PHE n 
+1 116 GLY n 
+1 117 MET n 
+1 118 GLY n 
+1 119 LYS n 
+1 120 ARG n 
+1 121 SER n 
+1 122 ILE n 
+1 123 GLU n 
+1 124 ASP n 
+1 125 ARG n 
+1 126 VAL n 
+1 127 GLN n 
+1 128 GLU n 
+1 129 GLU n 
+1 130 ALA n 
+1 131 ARG n 
+1 132 CYS n 
+1 133 LEU n 
+1 134 VAL n 
+1 135 GLU n 
+1 136 GLU n 
+1 137 LEU n 
+1 138 ARG n 
+1 139 LYS n 
+1 140 THR n 
+1 141 LYS n 
+1 142 ALA n 
+1 143 SER n 
+1 144 PRO n 
+1 145 CYS n 
+1 146 ASP n 
+1 147 PRO n 
+1 148 THR n 
+1 149 PHE n 
+1 150 ILE n 
+1 151 LEU n 
+1 152 GLY n 
+1 153 CYS n 
+1 154 ALA n 
+1 155 PRO n 
+1 156 CYS n 
+1 157 ASN n 
+1 158 VAL n 
+1 159 ILE n 
+1 160 CYS n 
+1 161 SER n 
+1 162 ILE n 
+1 163 ILE n 
+1 164 PHE n 
+1 165 HIS n 
+1 166 LYS n 
+1 167 ARG n 
+1 168 PHE n 
+1 169 ASP n 
+1 170 TYR n 
+1 171 LYS n 
+1 172 ASP n 
+1 173 GLN n 
+1 174 GLN n 
+1 175 PHE n 
+1 176 LEU n 
+1 177 ASN n 
+1 178 LEU n 
+1 179 MET n 
+1 180 GLU n 
+1 181 LYS n 
+1 182 LEU n 
+1 183 ASN n 
+1 184 GLU n 
+1 185 ASN n 
+1 186 ILE n 
+1 187 GLU n 
+1 188 ILE n 
+1 189 LEU n 
+1 190 SER n 
+1 191 SER n 
+1 192 PRO n 
+1 193 TRP n 
+1 194 ILE n 
+1 195 GLN n 
+1 196 VAL n 
+1 197 TYR n 
+1 198 ASN n 
+1 199 ASN n 
+1 200 PHE n 
+1 201 PRO n 
+1 202 ALA n 
+1 203 LEU n 
+1 204 LEU n 
+1 205 ASP n 
+1 206 TYR n 
+1 207 PHE n 
+1 208 PRO n 
+1 209 GLY n 
+1 210 THR n 
+1 211 HIS n 
+1 212 ASN n 
+1 213 LYS n 
+1 214 LEU n 
+1 215 LEU n 
+1 216 LYS n 
+1 217 ASN n 
+1 218 VAL n 
+1 219 ALA n 
+1 220 PHE n 
+1 221 MET n 
+1 222 LYS n 
+1 223 SER n 
+1 224 TYR n 
+1 225 ILE n 
+1 226 LEU n 
+1 227 GLU n 
+1 228 LYS n 
+1 229 VAL n 
+1 230 LYS n 
+1 231 GLU n 
+1 232 HIS n 
+1 233 GLN n 
+1 234 GLU n 
+1 235 SER n 
+1 236 MET n 
+1 237 ASP n 
+1 238 MET n 
+1 239 ASN n 
+1 240 ASN n 
+1 241 PRO n 
+1 242 GLN n 
+1 243 ASP n 
+1 244 PHE n 
+1 245 ILE n 
+1 246 ASP n 
+1 247 CYS n 
+1 248 PHE n 
+1 249 LEU n 
+1 250 MET n 
+1 251 LYS n 
+1 252 MET n 
+1 253 GLU n 
+1 254 LYS n 
+1 255 GLU n 
+1 256 LYS n 
+1 257 HIS n 
+1 258 ASN n 
+1 259 GLN n 
+1 260 PRO n 
+1 261 SER n 
+1 262 GLU n 
+1 263 PHE n 
+1 264 THR n 
+1 265 ILE n 
+1 266 GLU n 
+1 267 SER n 
+1 268 LEU n 
+1 269 GLU n 
+1 270 ASN n 
+1 271 THR n 
+1 272 ALA n 
+1 273 VAL n 
+1 274 ASP n 
+1 275 LEU n 
+1 276 PHE n 
+1 277 GLY n 
+1 278 ALA n 
+1 279 GLY n 
+1 280 THR n 
+1 281 GLU n 
+1 282 THR n 
+1 283 THR n 
+1 284 SER n 
+1 285 THR n 
+1 286 THR n 
+1 287 LEU n 
+1 288 ARG n 
+1 289 TYR n 
+1 290 ALA n 
+1 291 LEU n 
+1 292 LEU n 
+1 293 LEU n 
+1 294 LEU n 
+1 295 LEU n 
+1 296 LYS n 
+1 297 HIS n 
+1 298 PRO n 
+1 299 GLU n 
+1 300 VAL n 
+1 301 THR n 
+1 302 ALA n 
+1 303 LYS n 
+1 304 VAL n 
+1 305 GLN n 
+1 306 GLU n 
+1 307 GLU n 
+1 308 ILE n 
+1 309 GLU n 
+1 310 ARG n 
+1 311 VAL n 
+1 312 ILE n 
+1 313 GLY n 
+1 314 ARG n 
+1 315 ASN n 
+1 316 ARG n 
+1 317 SER n 
+1 318 PRO n 
+1 319 CYS n 
+1 320 MET n 
+1 321 GLN n 
+1 322 ASP n 
+1 323 ARG n 
+1 324 SER n 
+1 325 HIS n 
+1 326 MET n 
+1 327 PRO n 
+1 328 TYR n 
+1 329 THR n 
+1 330 ASP n 
+1 331 ALA n 
+1 332 VAL n 
+1 333 VAL n 
+1 334 HIS n 
+1 335 GLU n 
+1 336 VAL n 
+1 337 GLN n 
+1 338 ARG n 
+1 339 TYR n 
+1 340 ILE n 
+1 341 ASP n 
+1 342 LEU n 
+1 343 LEU n 
+1 344 PRO n 
+1 345 THR n 
+1 346 SER n 
+1 347 LEU n 
+1 348 PRO n 
+1 349 HIS n 
+1 350 ALA n 
+1 351 VAL n 
+1 352 THR n 
+1 353 CYS n 
+1 354 ASP n 
+1 355 ILE n 
+1 356 LYS n 
+1 357 PHE n 
+1 358 ARG n 
+1 359 ASN n 
+1 360 TYR n 
+1 361 LEU n 
+1 362 ILE n 
+1 363 PRO n 
+1 364 LYS n 
+1 365 GLY n 
+1 366 THR n 
+1 367 THR n 
+1 368 ILE n 
+1 369 LEU n 
+1 370 ILE n 
+1 371 SER n 
+1 372 LEU n 
+1 373 THR n 
+1 374 SER n 
+1 375 VAL n 
+1 376 LEU n 
+1 377 HIS n 
+1 378 ASP n 
+1 379 ASN n 
+1 380 LYS n 
+1 381 GLU n 
+1 382 PHE n 
+1 383 PRO n 
+1 384 ASN n 
+1 385 PRO n 
+1 386 GLU n 
+1 387 MET n 
+1 388 PHE n 
+1 389 ASP n 
+1 390 PRO n 
+1 391 HIS n 
+1 392 HIS n 
+1 393 PHE n 
+1 394 LEU n 
+1 395 ASP n 
+1 396 GLU n 
+1 397 GLY n 
+1 398 GLY n 
+1 399 ASN n 
+1 400 PHE n 
+1 401 LYS n 
+1 402 LYS n 
+1 403 SER n 
+1 404 LYS n 
+1 405 TYR n 
+1 406 PHE n 
+1 407 MET n 
+1 408 PRO n 
+1 409 PHE n 
+1 410 SER n 
+1 411 ALA n 
+1 412 GLY n 
+1 413 LYS n 
+1 414 ARG n 
+1 415 ILE n 
+1 416 CYS n 
+1 417 VAL n 
+1 418 GLY n 
+1 419 GLU n 
+1 420 ALA n 
+1 421 LEU n 
+1 422 ALA n 
+1 423 GLY n 
+1 424 MET n 
+1 425 GLU n 
+1 426 LEU n 
+1 427 PHE n 
+1 428 LEU n 
+1 429 PHE n 
+1 430 LEU n 
+1 431 THR n 
+1 432 SER n 
+1 433 ILE n 
+1 434 LEU n 
+1 435 GLN n 
+1 436 ASN n 
+1 437 PHE n 
+1 438 ASN n 
+1 439 LEU n 
+1 440 LYS n 
+1 441 SER n 
+1 442 LEU n 
+1 443 VAL n 
+1 444 ASP n 
+1 445 PRO n 
+1 446 LYS n 
+1 447 ASN n 
+1 448 LEU n 
+1 449 ASP n 
+1 450 THR n 
+1 451 THR n 
+1 452 PRO n 
+1 453 VAL n 
+1 454 VAL n 
+1 455 ASN n 
+1 456 GLY n 
+1 457 PHE n 
+1 458 ALA n 
+1 459 SER n 
+1 460 VAL n 
+1 461 PRO n 
+1 462 PRO n 
+1 463 PHE n 
+1 464 TYR n 
+1 465 GLN n 
+1 466 LEU n 
+1 467 CYS n 
+1 468 PHE n 
+1 469 ILE n 
+1 470 PRO n 
+1 471 VAL n 
+1 472 HIS n 
+1 473 HIS n 
+1 474 HIS n 
+1 475 HIS n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               HUMAN 
+_entity_src_gen.gene_src_genus                     ? 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'HOMO SAPIENS' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     9606 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'ESCHERICHIA COLI' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     562 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               'XL1 BLUE' 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               PCWORI+ 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+loop_
+_struct_ref.id 
+_struct_ref.db_name 
+_struct_ref.db_code 
+_struct_ref.entity_id 
+_struct_ref.pdbx_seq_one_letter_code 
+_struct_ref.pdbx_align_begin 
+_struct_ref.pdbx_db_accession 
+_struct_ref.pdbx_db_isoform 
+1 PDB 1OG2       1 ? ? 1OG2   ? 
+2 UNP CPC9_HUMAN 1 ? ? P11712 ? 
+# 
+loop_
+_struct_ref_seq.align_id 
+_struct_ref_seq.ref_id 
+_struct_ref_seq.pdbx_PDB_id_code 
+_struct_ref_seq.pdbx_strand_id 
+_struct_ref_seq.seq_align_beg 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code 
+_struct_ref_seq.seq_align_end 
+_struct_ref_seq.pdbx_seq_align_end_ins_code 
+_struct_ref_seq.pdbx_db_accession 
+_struct_ref_seq.db_align_beg 
+_struct_ref_seq.pdbx_db_align_beg_ins_code 
+_struct_ref_seq.db_align_end 
+_struct_ref_seq.pdbx_db_align_end_ins_code 
+_struct_ref_seq.pdbx_auth_seq_align_beg 
+_struct_ref_seq.pdbx_auth_seq_align_end 
+1 1 1OG2 A 1   ? 10  ? 1OG2   20  ? 29  ? 20  29  
+2 2 1OG2 A 11  ? 471 ? P11712 30  ? 490 ? 30  490 
+3 1 1OG2 A 472 ? 475 ? 1OG2   491 ? 494 ? 491 494 
+4 1 1OG2 B 1   ? 10  ? 1OG2   20  ? 29  ? 20  29  
+5 2 1OG2 B 11  ? 471 ? P11712 30  ? 490 ? 30  490 
+6 1 1OG2 B 472 ? 475 ? 1OG2   491 ? 494 ? 491 494 
+# 
+loop_
+_struct_ref_seq_dif.align_id 
+_struct_ref_seq_dif.pdbx_pdb_id_code 
+_struct_ref_seq_dif.mon_id 
+_struct_ref_seq_dif.pdbx_pdb_strand_id 
+_struct_ref_seq_dif.seq_num 
+_struct_ref_seq_dif.pdbx_pdb_ins_code 
+_struct_ref_seq_dif.pdbx_seq_db_name 
+_struct_ref_seq_dif.pdbx_seq_db_accession_code 
+_struct_ref_seq_dif.db_mon_id 
+_struct_ref_seq_dif.pdbx_seq_db_seq_num 
+_struct_ref_seq_dif.details 
+_struct_ref_seq_dif.pdbx_auth_seq_num 
+_struct_ref_seq_dif.pdbx_ordinal 
+1 1OG2 GLU A 187 ? UNP P11712 LYS 206 'engineered mutation' 206 1  
+1 1OG2 VAL A 196 ? UNP P11712 ILE 215 'engineered mutation' 215 2  
+1 1OG2 TYR A 197 ? UNP P11712 CYS 216 'engineered mutation' 216 3  
+1 1OG2 PRO A 201 ? UNP P11712 SER 220 'engineered mutation' 220 4  
+1 1OG2 ALA A 202 ? UNP P11712 PRO 221 'engineered mutation' 221 5  
+1 1OG2 LEU A 203 ? UNP P11712 ILE 222 'engineered mutation' 222 6  
+1 1OG2 LEU A 204 ? UNP P11712 ILE 223 'engineered mutation' 223 7  
+4 1OG2 GLU B 187 ? UNP P11712 LYS 206 'engineered mutation' 206 8  
+4 1OG2 VAL B 196 ? UNP P11712 ILE 215 'engineered mutation' 215 9  
+4 1OG2 TYR B 197 ? UNP P11712 CYS 216 'engineered mutation' 216 10 
+4 1OG2 PRO B 201 ? UNP P11712 SER 220 'engineered mutation' 220 11 
+4 1OG2 ALA B 202 ? UNP P11712 PRO 221 'engineered mutation' 221 12 
+4 1OG2 LEU B 203 ? UNP P11712 ILE 222 'engineered mutation' 222 13 
+4 1OG2 LEU B 204 ? UNP P11712 ILE 223 'engineered mutation' 223 14 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE         ? 'C3 H7 N O2'       89.093  
+ARG 'L-peptide linking' y ARGININE        ? 'C6 H15 N4 O2 1'   175.209 
+ASN 'L-peptide linking' y ASPARAGINE      ? 'C4 H8 N2 O3'      132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID' ? 'C4 H7 N O4'       133.103 
+CYS 'L-peptide linking' y CYSTEINE        ? 'C3 H7 N O2 S'     121.158 
+GLN 'L-peptide linking' y GLUTAMINE       ? 'C5 H10 N2 O3'     146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID' ? 'C5 H9 N O4'       147.129 
+GLY 'peptide linking'   y GLYCINE         ? 'C2 H5 N O2'       75.067  
+HEC non-polymer         . 'HEME C'        ? 'C34 H34 Fe N4 O4' 618.503 
+HIS 'L-peptide linking' y HISTIDINE       ? 'C6 H10 N3 O2 1'   156.162 
+HOH non-polymer         . WATER           ? 'H2 O'             18.015  
+ILE 'L-peptide linking' y ISOLEUCINE      ? 'C6 H13 N O2'      131.173 
+LEU 'L-peptide linking' y LEUCINE         ? 'C6 H13 N O2'      131.173 
+LYS 'L-peptide linking' y LYSINE          ? 'C6 H15 N2 O2 1'   147.195 
+MET 'L-peptide linking' y METHIONINE      ? 'C5 H11 N O2 S'    149.211 
+PHE 'L-peptide linking' y PHENYLALANINE   ? 'C9 H11 N O2'      165.189 
+PRO 'L-peptide linking' y PROLINE         ? 'C5 H9 N O2'       115.130 
+SER 'L-peptide linking' y SERINE          ? 'C3 H7 N O3'       105.093 
+THR 'L-peptide linking' y THREONINE       ? 'C4 H9 N O3'       119.119 
+TRP 'L-peptide linking' y TRYPTOPHAN      ? 'C11 H12 N2 O2'    204.225 
+TYR 'L-peptide linking' y TYROSINE        ? 'C9 H11 N O3'      181.189 
+VAL 'L-peptide linking' y VALINE          ? 'C5 H11 N O2'      117.146 
+# 
+_exptl.entry_id          1OG2 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   1 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      4.02 
+_exptl_crystal.density_percent_sol   70 
+_exptl_crystal.description           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          ? 
+_exptl_crystal_grow.temp            ? 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              8.40 
+_exptl_crystal_grow.pdbx_pH_range   ? 
+_exptl_crystal_grow.pdbx_details    'pH 8.40' 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           100.0 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               CCD 
+_diffrn_detector.type                   'ADSC CCD' 
+_diffrn_detector.pdbx_collection_date   ? 
+_diffrn_detector.details                ? 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   0.9 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.type                        'ESRF BEAMLINE ID14-2' 
+_diffrn_source.pdbx_synchrotron_site       ESRF 
+_diffrn_source.pdbx_synchrotron_beamline   ID14-2 
+_diffrn_source.pdbx_wavelength             0.9 
+_diffrn_source.pdbx_wavelength_list        ? 
+# 
+_reflns.pdbx_diffrn_id               1 
+_reflns.pdbx_ordinal                 1 
+_reflns.entry_id                     1OG2 
+_reflns.observed_criterion_sigma_I   ? 
+_reflns.observed_criterion_sigma_F   ? 
+_reflns.d_resolution_low             50.000 
+_reflns.d_resolution_high            2.600 
+_reflns.number_obs                   51912 
+_reflns.number_all                   ? 
+_reflns.percent_possible_obs         96.5 
+_reflns.pdbx_Rmerge_I_obs            0.08700 
+_reflns.pdbx_Rsym_value              ? 
+_reflns.pdbx_netI_over_sigmaI        6.8000 
+_reflns.B_iso_Wilson_estimate        ? 
+_reflns.pdbx_redundancy              2.600 
+# 
+_reflns_shell.pdbx_diffrn_id         1 
+_reflns_shell.pdbx_ordinal           1 
+_reflns_shell.d_res_high             2.60 
+_reflns_shell.d_res_low              2.74 
+_reflns_shell.percent_possible_all   96.5 
+_reflns_shell.Rmerge_I_obs           0.57000 
+_reflns_shell.pdbx_Rsym_value        ? 
+_reflns_shell.meanI_over_sigI_obs    1.210 
+_reflns_shell.pdbx_redundancy        2.00 
+# 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.entry_id                                 1OG2 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.ls_number_reflns_obs                     49246 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             55.90 
+_refine.ls_d_res_high                            2.60 
+_refine.ls_percent_reflns_obs                    96.4 
+_refine.ls_R_factor_obs                          0.210 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       0.208 
+_refine.ls_R_factor_R_free                       0.259 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 5.100 
+_refine.ls_number_reflns_R_free                  2628 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.correlation_coeff_Fo_to_Fc               0.936 
+_refine.correlation_coeff_Fo_to_Fc_free          0.909 
+_refine.B_iso_mean                               47.75 
+_refine.aniso_B[1][1]                            0.01000 
+_refine.aniso_B[2][2]                            0.01000 
+_refine.aniso_B[3][3]                            -0.02000 
+_refine.aniso_B[1][2]                            0.01000 
+_refine.aniso_B[1][3]                            0.00000 
+_refine.aniso_B[2][3]                            0.00000 
+_refine.solvent_model_details                    'BABINET MODEL WITH MASK' 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_solvent_vdw_probe_radii             1.40 
+_refine.pdbx_solvent_ion_probe_radii             0.80 
+_refine.pdbx_solvent_shrinkage_radii             0.80 
+_refine.pdbx_ls_cross_valid_method               THROUGHOUT 
+_refine.details                                  'HYDROGENS HAVE BEEN ADDED IN THE RIDING POSITIONS' 
+_refine.pdbx_starting_model                      'PDB ENTRY 1DT6' 
+_refine.pdbx_method_to_determine_struct          'MOLECULAR REPLACEMENT' 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       'MAXIMUM LIKELIHOOD' 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            RANDOM 
+_refine.pdbx_overall_ESU_R                       0.354 
+_refine.pdbx_overall_ESU_R_Free                  0.273 
+_refine.overall_SU_ML                            0.217 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.overall_SU_B                             10.960 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        7386 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         86 
+_refine_hist.number_atoms_solvent             147 
+_refine_hist.number_atoms_total               7619 
+_refine_hist.d_res_high                       2.60 
+_refine_hist.d_res_low                        55.90 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+r_bond_refined_d             0.014 0.022 ? 7662  'X-RAY DIFFRACTION' ? 
+r_bond_other_d               0.004 0.020 ? 6948  'X-RAY DIFFRACTION' ? 
+r_angle_refined_deg          1.756 1.981 ? 10380 'X-RAY DIFFRACTION' ? 
+r_angle_other_deg            0.891 3.000 ? 16256 'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_1_deg       6.572 5.000 ? 920   'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_2_deg       ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_3_deg       ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_4_deg       ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_chiral_restr               0.085 0.200 ? 1136  'X-RAY DIFFRACTION' ? 
+r_gen_planes_refined         0.007 0.020 ? 8356  'X-RAY DIFFRACTION' ? 
+r_gen_planes_other           0.009 0.020 ? 1526  'X-RAY DIFFRACTION' ? 
+r_nbd_refined                0.215 0.200 ? 1939  'X-RAY DIFFRACTION' ? 
+r_nbd_other                  0.228 0.200 ? 8055  'X-RAY DIFFRACTION' ? 
+r_nbtor_refined              ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_nbtor_other                0.088 0.200 ? 4574  'X-RAY DIFFRACTION' ? 
+r_xyhbond_nbd_refined        0.153 0.200 ? 161   'X-RAY DIFFRACTION' ? 
+r_xyhbond_nbd_other          ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_metal_ion_refined          ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_metal_ion_other            ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_symmetry_vdw_refined       0.126 0.200 ? 1     'X-RAY DIFFRACTION' ? 
+r_symmetry_vdw_other         0.186 0.200 ? 13    'X-RAY DIFFRACTION' ? 
+r_symmetry_hbond_refined     0.148 0.200 ? 2     'X-RAY DIFFRACTION' ? 
+r_symmetry_hbond_other       ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_symmetry_metal_ion_refined ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_symmetry_metal_ion_other   ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_mcbond_it                  2.641 5.000 ? 4620  'X-RAY DIFFRACTION' ? 
+r_mcbond_other               ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_mcangle_it                 4.236 6.000 ? 7528  'X-RAY DIFFRACTION' ? 
+r_mcangle_other              ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_scbond_it                  3.377 6.000 ? 3042  'X-RAY DIFFRACTION' ? 
+r_scbond_other               ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_scangle_it                 5.348 7.500 ? 2852  'X-RAY DIFFRACTION' ? 
+r_scangle_other              ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_long_range_B_refined       ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_long_range_B_other         ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_rigid_bond_restr           ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_sphericity_free            ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+r_sphericity_bonded          ?     ?     ? ?     'X-RAY DIFFRACTION' ? 
+# 
+_refine_ls_shell.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_ls_shell.pdbx_total_number_of_bins_used   20 
+_refine_ls_shell.d_res_high                       2.60 
+_refine_ls_shell.d_res_low                        2.67 
+_refine_ls_shell.number_reflns_R_work             2950 
+_refine_ls_shell.R_factor_R_work                  0.3640 
+_refine_ls_shell.percent_reflns_obs               ? 
+_refine_ls_shell.R_factor_R_free                  0.4070 
+_refine_ls_shell.R_factor_R_free_error            ? 
+_refine_ls_shell.percent_reflns_R_free            ? 
+_refine_ls_shell.number_reflns_R_free             186 
+_refine_ls_shell.number_reflns_all                ? 
+_refine_ls_shell.R_factor_all                     ? 
+# 
+_struct_ncs_oper.id             1 
+_struct_ncs_oper.code           given 
+_struct_ncs_oper.details        ? 
+_struct_ncs_oper.matrix[1][1]   -0.819100 
+_struct_ncs_oper.matrix[1][2]   0.573600 
+_struct_ncs_oper.matrix[1][3]   0.003300 
+_struct_ncs_oper.matrix[2][1]   -0.573600 
+_struct_ncs_oper.matrix[2][2]   -0.819000 
+_struct_ncs_oper.matrix[2][3]   -0.016600 
+_struct_ncs_oper.matrix[3][1]   -0.006800 
+_struct_ncs_oper.matrix[3][2]   -0.015500 
+_struct_ncs_oper.matrix[3][3]   0.999900 
+_struct_ncs_oper.vector[1]      27.58400 
+_struct_ncs_oper.vector[2]      125.64900 
+_struct_ncs_oper.vector[3]      10.79400 
+# 
+_struct.entry_id                  1OG2 
+_struct.title                     'Structure of human cytochrome P450 CYP2C9' 
+_struct.pdbx_descriptor           'CYTOCHROME P450 2C9 (E.C.1.14.13.80, 1.14.13.48, 1.14.13.49)' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1OG2 
+_struct_keywords.pdbx_keywords   'ELECTRON TRANSPORT' 
+_struct_keywords.text            'DRUG METABOLISM, ELECTRON TRANSPORT, OXIDOREDUCTASE, HEME, MONOOXYGENASE' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 1 ? 
+C N N 2 ? 
+D N N 2 ? 
+E N N 3 ? 
+F N N 3 ? 
+# 
+_struct_biol.id   1 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1  1  ASN A 22  ? GLY A 27  ? ASN A 41  GLY A 46  1 ? 6  
+HELX_P HELX_P2  2  ASP A 30  ? GLY A 43  ? ASP A 49  GLY A 62  1 ? 14 
+HELX_P HELX_P3  3  GLY A 60  ? ILE A 69  ? GLY A 79  ILE A 88  1 ? 10 
+HELX_P HELX_P4  4  PHE A 81  ? ASN A 88  ? PHE A 100 ASN A 107 1 ? 8  
+HELX_P HELX_P5  5  ASN A 97  ? ARG A 113 ? ASN A 116 ARG A 132 1 ? 17 
+HELX_P HELX_P6  6  SER A 121 ? THR A 140 ? SER A 140 THR A 159 1 ? 20 
+HELX_P HELX_P7  7  PRO A 147 ? HIS A 165 ? PRO A 166 HIS A 184 1 ? 19 
+HELX_P HELX_P8  8  ASP A 172 ? SER A 190 ? ASP A 191 SER A 209 1 ? 19 
+HELX_P HELX_P9  9  SER A 191 ? TRP A 193 ? SER A 210 TRP A 212 5 ? 3  
+HELX_P HELX_P10 10 ILE A 194 ? PHE A 200 ? ILE A 213 PHE A 219 1 ? 7  
+HELX_P HELX_P11 11 ALA A 202 ? PHE A 207 ? ALA A 221 PHE A 226 1 ? 6  
+HELX_P HELX_P12 12 PRO A 208 ? MET A 236 ? PRO A 227 MET A 255 1 ? 29 
+HELX_P HELX_P13 13 ASP A 243 ? LYS A 256 ? ASP A 262 LYS A 275 1 ? 14 
+HELX_P HELX_P14 14 THR A 264 ? ILE A 312 ? THR A 283 ILE A 331 1 ? 49 
+HELX_P HELX_P15 15 CYS A 319 ? ARG A 323 ? CYS A 338 ARG A 342 5 ? 5  
+HELX_P HELX_P16 16 MET A 326 ? ASP A 341 ? MET A 345 ASP A 360 1 ? 16 
+HELX_P HELX_P17 17 SER A 371 ? HIS A 377 ? SER A 390 HIS A 396 1 ? 7  
+HELX_P HELX_P18 18 ASP A 389 ? PHE A 393 ? ASP A 408 PHE A 412 5 ? 5  
+HELX_P HELX_P19 19 ALA A 411 ? ILE A 415 ? ALA A 430 ILE A 434 5 ? 5  
+HELX_P HELX_P20 20 GLY A 418 ? ASN A 436 ? GLY A 437 ASN A 455 1 ? 19 
+HELX_P HELX_P21 21 ASN B 22  ? GLY B 27  ? ASN B 41  GLY B 46  1 ? 6  
+HELX_P HELX_P22 22 ASP B 30  ? GLY B 43  ? ASP B 49  GLY B 62  1 ? 14 
+HELX_P HELX_P23 23 GLY B 60  ? ILE B 69  ? GLY B 79  ILE B 88  1 ? 10 
+HELX_P HELX_P24 24 PHE B 81  ? ASN B 88  ? PHE B 100 ASN B 107 1 ? 8  
+HELX_P HELX_P25 25 ASN B 97  ? LEU B 112 ? ASN B 116 LEU B 131 1 ? 16 
+HELX_P HELX_P26 26 SER B 121 ? LYS B 139 ? SER B 140 LYS B 158 1 ? 19 
+HELX_P HELX_P27 27 PHE B 149 ? HIS B 165 ? PHE B 168 HIS B 184 1 ? 17 
+HELX_P HELX_P28 28 ASP B 172 ? SER B 190 ? ASP B 191 SER B 209 1 ? 19 
+HELX_P HELX_P29 29 PRO B 192 ? PHE B 200 ? PRO B 211 PHE B 219 1 ? 9  
+HELX_P HELX_P30 30 ALA B 202 ? PHE B 207 ? ALA B 221 PHE B 226 1 ? 6  
+HELX_P HELX_P31 31 PRO B 208 ? MET B 236 ? PRO B 227 MET B 255 1 ? 29 
+HELX_P HELX_P32 32 ASP B 243 ? MET B 252 ? ASP B 262 MET B 271 1 ? 10 
+HELX_P HELX_P33 33 THR B 264 ? ILE B 312 ? THR B 283 ILE B 331 1 ? 49 
+HELX_P HELX_P34 34 CYS B 319 ? SER B 324 ? CYS B 338 SER B 343 5 ? 6  
+HELX_P HELX_P35 35 MET B 326 ? ASP B 341 ? MET B 345 ASP B 360 1 ? 16 
+HELX_P HELX_P36 36 SER B 371 ? HIS B 377 ? SER B 390 HIS B 396 1 ? 7  
+HELX_P HELX_P37 37 ASP B 389 ? PHE B 393 ? ASP B 408 PHE B 412 5 ? 5  
+HELX_P HELX_P38 38 ALA B 411 ? ILE B 415 ? ALA B 430 ILE B 434 5 ? 5  
+HELX_P HELX_P39 39 GLY B 418 ? ASN B 436 ? GLY B 437 ASN B 455 1 ? 19 
+HELX_P HELX_P40 40 ASP B 444 ? LEU B 448 ? ASP B 463 LEU B 467 5 ? 5  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+metalc1 metalc ? ? C HEC . FE ? ? ? 1_555 E HOH .   O  ? ? A HEC 501 A HOH 2031 1_555 ? ? ? ? ? ? ? 2.899 ? 
+metalc2 metalc ? ? C HEC . FE ? ? ? 1_555 A CYS 416 SG ? ? A HEC 501 A CYS 435  1_555 ? ? ? ? ? ? ? 2.294 ? 
+metalc3 metalc ? ? D HEC . FE ? ? ? 1_555 B CYS 416 SG ? ? B HEC 501 B CYS 435  1_555 ? ? ? ? ? ? ? 2.523 ? 
+# 
+_struct_conn_type.id          metalc 
+_struct_conn_type.criteria    ? 
+_struct_conn_type.reference   ? 
+# 
+loop_
+_struct_sheet.id 
+_struct_sheet.type 
+_struct_sheet.number_strands 
+_struct_sheet.details 
+AA ? 5 ? 
+AB ? 2 ? 
+AC ? 2 ? 
+BA ? 5 ? 
+BB ? 2 ? 
+BC ? 2 ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+AA 1 2 ? anti-parallel 
+AA 2 3 ? parallel      
+AA 3 4 ? anti-parallel 
+AA 4 5 ? anti-parallel 
+AB 1 2 ? anti-parallel 
+AC 1 2 ? anti-parallel 
+BA 1 2 ? anti-parallel 
+BA 2 3 ? parallel      
+BA 3 4 ? anti-parallel 
+BA 4 5 ? anti-parallel 
+BB 1 2 ? anti-parallel 
+BC 1 2 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+AA 1 VAL A 45  ? PHE A 50  ? VAL A 64  PHE A 69  
+AA 2 LYS A 53  ? LEU A 58  ? LYS A 72  LEU A 77  
+AA 3 THR A 367 ? ILE A 370 ? THR A 386 ILE A 389 
+AA 4 HIS A 349 ? ALA A 350 ? HIS A 368 ALA A 369 
+AA 5 GLY A 77  ? ARG A 78  ? GLY A 96  ARG A 97  
+AB 1 PHE A 437 ? SER A 441 ? PHE A 456 SER A 460 
+AB 2 LEU A 466 ? PRO A 470 ? LEU A 485 PRO A 489 
+AC 1 VAL A 453 ? VAL A 454 ? VAL A 472 VAL A 473 
+AC 2 SER A 459 ? VAL A 460 ? SER A 478 VAL A 479 
+BA 1 VAL B 45  ? PHE B 50  ? VAL B 64  PHE B 69  
+BA 2 LYS B 53  ? LEU B 58  ? LYS B 72  LEU B 77  
+BA 3 THR B 367 ? ILE B 370 ? THR B 386 ILE B 389 
+BA 4 HIS B 349 ? ALA B 350 ? HIS B 368 ALA B 369 
+BA 5 GLY B 77  ? ARG B 78  ? GLY B 96  ARG B 97  
+BB 1 PHE B 437 ? SER B 441 ? PHE B 456 SER B 460 
+BB 2 LEU B 466 ? PRO B 470 ? LEU B 485 PRO B 489 
+BC 1 VAL B 453 ? ASN B 455 ? VAL B 472 ASN B 474 
+BC 2 ALA B 458 ? VAL B 460 ? ALA B 477 VAL B 479 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+AA 1 2 N PHE A 50  ? N PHE A 69  O LYS A 53  ? O LYS A 72  
+AA 2 3 N VAL A 56  ? N VAL A 75  O THR A 367 ? O THR A 386 
+AA 3 4 N ILE A 368 ? N ILE A 387 O HIS A 349 ? O HIS A 368 
+AA 4 5 N ALA A 350 ? N ALA A 369 O GLY A 77  ? O GLY A 96  
+AB 1 2 N LYS A 440 ? N LYS A 459 O CYS A 467 ? O CYS A 486 
+AC 1 2 N VAL A 453 ? N VAL A 472 O VAL A 460 ? O VAL A 479 
+BA 1 2 N PHE B 50  ? N PHE B 69  O LYS B 53  ? O LYS B 72  
+BA 2 3 N VAL B 56  ? N VAL B 75  O THR B 367 ? O THR B 386 
+BA 3 4 N ILE B 368 ? N ILE B 387 O HIS B 349 ? O HIS B 368 
+BA 4 5 N ALA B 350 ? N ALA B 369 O GLY B 77  ? O GLY B 96  
+BB 1 2 N LYS B 440 ? N LYS B 459 O CYS B 467 ? O CYS B 486 
+BC 1 2 N ASN B 455 ? N ASN B 474 O ALA B 458 ? O ALA B 477 
+# 
+loop_
+_struct_site.id 
+_struct_site.pdbx_evidence_code 
+_struct_site.pdbx_auth_asym_id 
+_struct_site.pdbx_auth_comp_id 
+_struct_site.pdbx_auth_seq_id 
+_struct_site.pdbx_auth_ins_code 
+_struct_site.pdbx_num_residues 
+_struct_site.details 
+AC1 Software ? ? ? ? 22 'BINDING SITE FOR RESIDUE HEC A 501' 
+AC2 Software ? ? ? ? 18 'BINDING SITE FOR RESIDUE HEC B 501' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1  AC1 22 ARG A 78  ? ARG A 97   . ? 1_555 ? 
+2  AC1 22 ILE A 93  ? ILE A 112  . ? 1_555 ? 
+3  AC1 22 VAL A 94  ? VAL A 113  . ? 1_555 ? 
+4  AC1 22 TRP A 101 ? TRP A 120  . ? 1_555 ? 
+5  AC1 22 ARG A 105 ? ARG A 124  . ? 1_555 ? 
+6  AC1 22 ALA A 278 ? ALA A 297  . ? 1_555 ? 
+7  AC1 22 GLY A 279 ? GLY A 298  . ? 1_555 ? 
+8  AC1 22 THR A 282 ? THR A 301  . ? 1_555 ? 
+9  AC1 22 THR A 283 ? THR A 302  . ? 1_555 ? 
+10 AC1 22 THR A 286 ? THR A 305  . ? 1_555 ? 
+11 AC1 22 GLN A 337 ? GLN A 356  . ? 1_555 ? 
+12 AC1 22 LEU A 343 ? LEU A 362  . ? 1_555 ? 
+13 AC1 22 SER A 346 ? SER A 365  . ? 1_555 ? 
+14 AC1 22 HIS A 349 ? HIS A 368  . ? 1_555 ? 
+15 AC1 22 PRO A 408 ? PRO A 427  . ? 1_555 ? 
+16 AC1 22 PHE A 409 ? PHE A 428  . ? 1_555 ? 
+17 AC1 22 SER A 410 ? SER A 429  . ? 1_555 ? 
+18 AC1 22 ARG A 414 ? ARG A 433  . ? 1_555 ? 
+19 AC1 22 CYS A 416 ? CYS A 435  . ? 1_555 ? 
+20 AC1 22 VAL A 417 ? VAL A 436  . ? 1_555 ? 
+21 AC1 22 GLU A 425 ? GLU A 444  . ? 1_555 ? 
+22 AC1 22 HOH E .   ? HOH A 2031 . ? 1_555 ? 
+23 AC2 18 ARG B 78  ? ARG B 97   . ? 1_555 ? 
+24 AC2 18 TRP B 101 ? TRP B 120  . ? 1_555 ? 
+25 AC2 18 ARG B 105 ? ARG B 124  . ? 1_555 ? 
+26 AC2 18 LEU B 275 ? LEU B 294  . ? 1_555 ? 
+27 AC2 18 ALA B 278 ? ALA B 297  . ? 1_555 ? 
+28 AC2 18 GLY B 279 ? GLY B 298  . ? 1_555 ? 
+29 AC2 18 THR B 282 ? THR B 301  . ? 1_555 ? 
+30 AC2 18 THR B 283 ? THR B 302  . ? 1_555 ? 
+31 AC2 18 THR B 286 ? THR B 305  . ? 1_555 ? 
+32 AC2 18 GLN B 337 ? GLN B 356  . ? 1_555 ? 
+33 AC2 18 LEU B 343 ? LEU B 362  . ? 1_555 ? 
+34 AC2 18 SER B 346 ? SER B 365  . ? 1_555 ? 
+35 AC2 18 HIS B 349 ? HIS B 368  . ? 1_555 ? 
+36 AC2 18 PRO B 408 ? PRO B 427  . ? 1_555 ? 
+37 AC2 18 PHE B 409 ? PHE B 428  . ? 1_555 ? 
+38 AC2 18 SER B 410 ? SER B 429  . ? 1_555 ? 
+39 AC2 18 ARG B 414 ? ARG B 433  . ? 1_555 ? 
+40 AC2 18 CYS B 416 ? CYS B 435  . ? 1_555 ? 
+# 
+_database_PDB_matrix.entry_id          1OG2 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    1OG2 
+_atom_sites.fract_transf_matrix[1][1]   0.006065 
+_atom_sites.fract_transf_matrix[1][2]   0.003502 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.007004 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.009000 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C  
+FE 
+N  
+O  
+S  
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N  N   . PRO A 1 11  ? 6.878   61.335 49.245 1.00 61.00  ? 30   PRO A N   1 
+ATOM   2    C  CA  . PRO A 1 11  ? 8.014   61.919 48.416 1.00 61.43  ? 30   PRO A CA  1 
+ATOM   3    C  C   . PRO A 1 11  ? 8.336   63.307 48.907 1.00 58.16  ? 30   PRO A C   1 
+ATOM   4    O  O   . PRO A 1 11  ? 7.494   64.150 48.681 1.00 61.01  ? 30   PRO A O   1 
+ATOM   5    C  CB  . PRO A 1 11  ? 7.464   61.966 46.979 1.00 61.58  ? 30   PRO A CB  1 
+ATOM   6    C  CG  . PRO A 1 11  ? 6.154   61.199 47.016 1.00 63.73  ? 30   PRO A CG  1 
+ATOM   7    C  CD  . PRO A 1 11  ? 5.664   61.064 48.459 1.00 62.97  ? 30   PRO A CD  1 
+ATOM   8    N  N   . PRO A 1 12  ? 9.496   63.542 49.529 1.00 55.37  ? 31   PRO A N   1 
+ATOM   9    C  CA  . PRO A 1 12  ? 9.698   64.685 50.431 1.00 53.40  ? 31   PRO A CA  1 
+ATOM   10   C  C   . PRO A 1 12  ? 9.722   65.984 49.683 1.00 53.45  ? 31   PRO A C   1 
+ATOM   11   O  O   . PRO A 1 12  ? 9.553   65.933 48.486 1.00 58.59  ? 31   PRO A O   1 
+ATOM   12   C  CB  . PRO A 1 12  ? 11.078  64.414 51.056 1.00 52.92  ? 31   PRO A CB  1 
+ATOM   13   C  CG  . PRO A 1 12  ? 11.798  63.562 50.074 1.00 53.95  ? 31   PRO A CG  1 
+ATOM   14   C  CD  . PRO A 1 12  ? 10.733  62.755 49.377 1.00 56.47  ? 31   PRO A CD  1 
+ATOM   15   N  N   . GLY A 1 13  ? 9.945   67.100 50.368 1.00 53.10  ? 32   GLY A N   1 
+ATOM   16   C  CA  . GLY A 1 13  ? 10.008  68.411 49.742 1.00 52.79  ? 32   GLY A CA  1 
+ATOM   17   C  C   . GLY A 1 13  ? 9.588   69.477 50.736 1.00 54.93  ? 32   GLY A C   1 
+ATOM   18   O  O   . GLY A 1 13  ? 8.930   69.157 51.728 1.00 56.94  ? 32   GLY A O   1 
+ATOM   19   N  N   . PRO A 1 14  ? 9.906   70.742 50.474 1.00 54.97  ? 33   PRO A N   1 
+ATOM   20   C  CA  . PRO A 1 14  ? 9.568   71.805 51.421 1.00 56.07  ? 33   PRO A CA  1 
+ATOM   21   C  C   . PRO A 1 14  ? 8.067   71.886 51.550 1.00 56.18  ? 33   PRO A C   1 
+ATOM   22   O  O   . PRO A 1 14  ? 7.380   71.707 50.543 1.00 55.49  ? 33   PRO A O   1 
+ATOM   23   C  CB  . PRO A 1 14  ? 10.115  73.090 50.767 1.00 55.27  ? 33   PRO A CB  1 
+ATOM   24   C  CG  . PRO A 1 14  ? 10.286  72.764 49.341 1.00 56.42  ? 33   PRO A CG  1 
+ATOM   25   C  CD  . PRO A 1 14  ? 10.501  71.274 49.241 1.00 56.05  ? 33   PRO A CD  1 
+ATOM   26   N  N   . THR A 1 15  ? 7.599   72.100 52.779 1.00 58.13  ? 34   THR A N   1 
+ATOM   27   C  CA  . THR A 1 15  ? 6.201   72.390 53.080 1.00 59.19  ? 34   THR A CA  1 
+ATOM   28   C  C   . THR A 1 15  ? 5.791   73.729 52.439 1.00 55.16  ? 34   THR A C   1 
+ATOM   29   O  O   . THR A 1 15  ? 6.429   74.773 52.658 1.00 49.57  ? 34   THR A O   1 
+ATOM   30   C  CB  . THR A 1 15  ? 5.926   72.433 54.640 1.00 62.47  ? 34   THR A CB  1 
+ATOM   31   O  OG1 . THR A 1 15  ? 7.144   72.686 55.359 1.00 67.08  ? 34   THR A OG1 1 
+ATOM   32   C  CG2 . THR A 1 15  ? 5.437   71.068 55.183 1.00 63.35  ? 34   THR A CG2 1 
+ATOM   33   N  N   . PRO A 1 16  ? 4.727   73.688 51.647 1.00 52.53  ? 35   PRO A N   1 
+ATOM   34   C  CA  . PRO A 1 16  ? 4.228   74.872 50.942 1.00 57.60  ? 35   PRO A CA  1 
+ATOM   35   C  C   . PRO A 1 16  ? 3.282   75.743 51.773 1.00 62.91  ? 35   PRO A C   1 
+ATOM   36   O  O   . PRO A 1 16  ? 2.536   75.227 52.604 1.00 66.03  ? 35   PRO A O   1 
+ATOM   37   C  CB  . PRO A 1 16  ? 3.455   74.258 49.792 1.00 58.33  ? 35   PRO A CB  1 
+ATOM   38   C  CG  . PRO A 1 16  ? 2.904   72.968 50.404 1.00 57.16  ? 35   PRO A CG  1 
+ATOM   39   C  CD  . PRO A 1 16  ? 3.938   72.483 51.341 1.00 51.06  ? 35   PRO A CD  1 
+ATOM   40   N  N   . LEU A 1 17  ? 3.305   77.048 51.521 1.00 66.79  ? 36   LEU A N   1 
+ATOM   41   C  CA  . LEU A 1 17  ? 2.446   78.003 52.213 1.00 67.88  ? 36   LEU A CA  1 
+ATOM   42   C  C   . LEU A 1 17  ? 1.030   77.983 51.620 1.00 72.00  ? 36   LEU A C   1 
+ATOM   43   O  O   . LEU A 1 17  ? 0.858   77.570 50.462 1.00 71.33  ? 36   LEU A O   1 
+ATOM   44   C  CB  . LEU A 1 17  ? 3.057   79.408 52.135 1.00 65.49  ? 36   LEU A CB  1 
+ATOM   45   C  CG  . LEU A 1 17  ? 4.111   79.725 53.197 1.00 64.24  ? 36   LEU A CG  1 
+ATOM   46   C  CD1 . LEU A 1 17  ? 4.514   81.209 53.112 1.00 63.99  ? 36   LEU A CD1 1 
+ATOM   47   C  CD2 . LEU A 1 17  ? 3.662   79.351 54.623 1.00 63.01  ? 36   LEU A CD2 1 
+ATOM   48   N  N   . PRO A 1 18  ? 0.035   78.432 52.407 1.00 74.53  ? 37   PRO A N   1 
+ATOM   49   C  CA  . PRO A 1 18  ? -1.382  78.218 52.092 1.00 74.69  ? 37   PRO A CA  1 
+ATOM   50   C  C   . PRO A 1 18  ? -1.764  78.338 50.611 1.00 73.79  ? 37   PRO A C   1 
+ATOM   51   O  O   . PRO A 1 18  ? -2.268  77.360 50.048 1.00 77.01  ? 37   PRO A O   1 
+ATOM   52   C  CB  . PRO A 1 18  ? -2.088  79.290 52.938 1.00 76.28  ? 37   PRO A CB  1 
+ATOM   53   C  CG  . PRO A 1 18  ? -1.215  79.481 54.139 1.00 76.86  ? 37   PRO A CG  1 
+ATOM   54   C  CD  . PRO A 1 18  ? 0.187   79.182 53.674 1.00 75.76  ? 37   PRO A CD  1 
+ATOM   55   N  N   . VAL A 1 19  ? -1.543  79.487 49.985 1.00 70.46  ? 38   VAL A N   1 
+ATOM   56   C  CA  . VAL A 1 19  ? -1.994  79.671 48.593 1.00 71.17  ? 38   VAL A CA  1 
+ATOM   57   C  C   . VAL A 1 19  ? -0.831  79.878 47.593 1.00 70.86  ? 38   VAL A C   1 
+ATOM   58   O  O   . VAL A 1 19  ? -0.965  79.565 46.396 1.00 71.52  ? 38   VAL A O   1 
+ATOM   59   C  CB  . VAL A 1 19  ? -3.048  80.830 48.485 1.00 72.09  ? 38   VAL A CB  1 
+ATOM   60   C  CG1 . VAL A 1 19  ? -2.494  82.160 49.039 1.00 72.48  ? 38   VAL A CG1 1 
+ATOM   61   C  CG2 . VAL A 1 19  ? -3.559  80.997 47.039 1.00 72.34  ? 38   VAL A CG2 1 
+ATOM   62   N  N   . ILE A 1 20  ? 0.301   80.381 48.096 1.00 68.60  ? 39   ILE A N   1 
+ATOM   63   C  CA  . ILE A 1 20  ? 1.465   80.736 47.272 1.00 65.17  ? 39   ILE A CA  1 
+ATOM   64   C  C   . ILE A 1 20  ? 2.407   79.552 46.976 1.00 64.64  ? 39   ILE A C   1 
+ATOM   65   O  O   . ILE A 1 20  ? 3.514   79.747 46.452 1.00 61.51  ? 39   ILE A O   1 
+ATOM   66   C  CB  . ILE A 1 20  ? 2.272   81.901 47.914 1.00 65.20  ? 39   ILE A CB  1 
+ATOM   67   C  CG1 . ILE A 1 20  ? 2.423   81.696 49.430 1.00 67.49  ? 39   ILE A CG1 1 
+ATOM   68   C  CG2 . ILE A 1 20  ? 1.632   83.243 47.590 1.00 61.63  ? 39   ILE A CG2 1 
+ATOM   69   C  CD1 . ILE A 1 20  ? 3.548   82.502 50.052 1.00 68.54  ? 39   ILE A CD1 1 
+ATOM   70   N  N   . GLY A 1 21  ? 1.966   78.333 47.292 1.00 61.40  ? 40   GLY A N   1 
+ATOM   71   C  CA  . GLY A 1 21  ? 2.721   77.146 46.949 1.00 57.61  ? 40   GLY A CA  1 
+ATOM   72   C  C   . GLY A 1 21  ? 4.116   77.243 47.522 1.00 55.40  ? 40   GLY A C   1 
+ATOM   73   O  O   . GLY A 1 21  ? 4.275   77.687 48.659 1.00 53.09  ? 40   GLY A O   1 
+ATOM   74   N  N   . ASN A 1 22  ? 5.121   76.863 46.728 1.00 52.11  ? 41   ASN A N   1 
+ATOM   75   C  CA  . ASN A 1 22  ? 6.507   76.838 47.182 1.00 46.90  ? 41   ASN A CA  1 
+ATOM   76   C  C   . ASN A 1 22  ? 7.304   78.004 46.624 1.00 48.76  ? 41   ASN A C   1 
+ATOM   77   O  O   . ASN A 1 22  ? 8.516   77.991 46.685 1.00 51.72  ? 41   ASN A O   1 
+ATOM   78   C  CB  . ASN A 1 22  ? 7.155   75.507 46.801 1.00 44.37  ? 41   ASN A CB  1 
+ATOM   79   C  CG  . ASN A 1 22  ? 6.996   74.450 47.869 1.00 45.32  ? 41   ASN A CG  1 
+ATOM   80   O  OD1 . ASN A 1 22  ? 7.345   74.669 49.022 1.00 51.73  ? 41   ASN A OD1 1 
+ATOM   81   N  ND2 . ASN A 1 22  ? 6.492   73.289 47.493 1.00 46.81  ? 41   ASN A ND2 1 
+ATOM   82   N  N   . ILE A 1 23  ? 6.621   79.034 46.128 1.00 51.11  ? 42   ILE A N   1 
+ATOM   83   C  CA  . ILE A 1 23  ? 7.251   80.137 45.395 1.00 54.36  ? 42   ILE A CA  1 
+ATOM   84   C  C   . ILE A 1 23  ? 8.306   80.922 46.158 1.00 56.53  ? 42   ILE A C   1 
+ATOM   85   O  O   . ILE A 1 23  ? 9.143   81.564 45.547 1.00 63.07  ? 42   ILE A O   1 
+ATOM   86   C  CB  . ILE A 1 23  ? 6.162   81.148 44.855 1.00 57.29  ? 42   ILE A CB  1 
+ATOM   87   C  CG1 . ILE A 1 23  ? 6.600   81.775 43.525 1.00 57.47  ? 42   ILE A CG1 1 
+ATOM   88   C  CG2 . ILE A 1 23  ? 5.853   82.270 45.876 1.00 57.93  ? 42   ILE A CG2 1 
+ATOM   89   C  CD1 . ILE A 1 23  ? 5.581   82.752 42.926 1.00 56.59  ? 42   ILE A CD1 1 
+ATOM   90   N  N   . LEU A 1 24  ? 8.248   80.956 47.481 1.00 60.90  ? 43   LEU A N   1 
+ATOM   91   C  CA  . LEU A 1 24  ? 9.274   81.697 48.228 1.00 61.26  ? 43   LEU A CA  1 
+ATOM   92   C  C   . LEU A 1 24  ? 10.605  80.962 48.079 1.00 61.13  ? 43   LEU A C   1 
+ATOM   93   O  O   . LEU A 1 24  ? 11.626  81.576 47.847 1.00 63.68  ? 43   LEU A O   1 
+ATOM   94   C  CB  . LEU A 1 24  ? 8.884   81.871 49.705 1.00 60.92  ? 43   LEU A CB  1 
+ATOM   95   C  CG  . LEU A 1 24  ? 8.148   83.156 50.143 1.00 58.93  ? 43   LEU A CG  1 
+ATOM   96   C  CD1 . LEU A 1 24  ? 7.493   83.955 49.002 1.00 58.38  ? 43   LEU A CD1 1 
+ATOM   97   C  CD2 . LEU A 1 24  ? 7.126   82.814 51.210 1.00 58.58  ? 43   LEU A CD2 1 
+ATOM   98   N  N   . GLN A 1 25  ? 10.550  79.640 48.146 1.00 62.00  ? 44   GLN A N   1 
+ATOM   99   C  CA  . GLN A 1 25  ? 11.721  78.770 48.050 1.00 66.10  ? 44   GLN A CA  1 
+ATOM   100  C  C   . GLN A 1 25  ? 12.385  78.705 46.662 1.00 65.31  ? 44   GLN A C   1 
+ATOM   101  O  O   . GLN A 1 25  ? 13.589  78.448 46.582 1.00 68.54  ? 44   GLN A O   1 
+ATOM   102  C  CB  . GLN A 1 25  ? 11.345  77.323 48.449 1.00 69.58  ? 44   GLN A CB  1 
+ATOM   103  C  CG  . GLN A 1 25  ? 10.551  77.155 49.756 1.00 73.34  ? 44   GLN A CG  1 
+ATOM   104  C  CD  . GLN A 1 25  ? 11.451  77.222 50.977 1.00 76.75  ? 44   GLN A CD  1 
+ATOM   105  O  OE1 . GLN A 1 25  ? 11.565  76.239 51.717 1.00 77.94  ? 44   GLN A OE1 1 
+ATOM   106  N  NE2 . GLN A 1 25  ? 12.069  78.389 51.198 1.00 78.11  ? 44   GLN A NE2 1 
+ATOM   107  N  N   . ILE A 1 26  ? 11.611  78.890 45.586 1.00 62.74  ? 45   ILE A N   1 
+ATOM   108  C  CA  . ILE A 1 26  ? 12.108  78.709 44.210 1.00 59.94  ? 45   ILE A CA  1 
+ATOM   109  C  C   . ILE A 1 26  ? 12.182  80.003 43.416 1.00 58.66  ? 45   ILE A C   1 
+ATOM   110  O  O   . ILE A 1 26  ? 13.067  80.205 42.579 1.00 55.39  ? 45   ILE A O   1 
+ATOM   111  C  CB  . ILE A 1 26  ? 11.257  77.650 43.458 1.00 59.17  ? 45   ILE A CB  1 
+ATOM   112  C  CG1 . ILE A 1 26  ? 10.042  78.262 42.778 1.00 59.74  ? 45   ILE A CG1 1 
+ATOM   113  C  CG2 . ILE A 1 26  ? 10.807  76.565 44.411 1.00 58.29  ? 45   ILE A CG2 1 
+ATOM   114  C  CD1 . ILE A 1 26  ? 9.101   77.212 42.194 1.00 64.66  ? 45   ILE A CD1 1 
+ATOM   115  N  N   . GLY A 1 27  ? 11.216  80.866 43.669 1.00 61.29  ? 46   GLY A N   1 
+ATOM   116  C  CA  . GLY A 1 27  ? 11.189  82.188 43.096 1.00 61.99  ? 46   GLY A CA  1 
+ATOM   117  C  C   . GLY A 1 27  ? 10.771  82.129 41.655 1.00 62.28  ? 46   GLY A C   1 
+ATOM   118  O  O   . GLY A 1 27  ? 10.257  81.138 41.155 1.00 62.06  ? 46   GLY A O   1 
+ATOM   119  N  N   . ILE A 1 28  ? 11.045  83.218 40.981 1.00 66.16  ? 47   ILE A N   1 
+ATOM   120  C  CA  . ILE A 1 28  ? 10.602  83.431 39.626 1.00 70.11  ? 47   ILE A CA  1 
+ATOM   121  C  C   . ILE A 1 28  ? 11.786  83.646 38.655 1.00 71.63  ? 47   ILE A C   1 
+ATOM   122  O  O   . ILE A 1 28  ? 11.589  83.681 37.435 1.00 71.09  ? 47   ILE A O   1 
+ATOM   123  C  CB  . ILE A 1 28  ? 9.706   84.652 39.697 1.00 72.59  ? 47   ILE A CB  1 
+ATOM   124  C  CG1 . ILE A 1 28  ? 8.668   84.626 38.596 1.00 77.25  ? 47   ILE A CG1 1 
+ATOM   125  C  CG2 . ILE A 1 28  ? 10.539  85.958 39.718 1.00 72.25  ? 47   ILE A CG2 1 
+ATOM   126  C  CD1 . ILE A 1 28  ? 7.527   85.548 38.915 1.00 79.30  ? 47   ILE A CD1 1 
+ATOM   127  N  N   . LYS A 1 29  ? 12.998  83.739 39.230 1.00 72.11  ? 48   LYS A N   1 
+ATOM   128  C  CA  . LYS A 1 29  ? 14.245  84.111 38.551 1.00 71.74  ? 48   LYS A CA  1 
+ATOM   129  C  C   . LYS A 1 29  ? 14.827  82.859 37.852 1.00 70.54  ? 48   LYS A C   1 
+ATOM   130  O  O   . LYS A 1 29  ? 14.159  82.275 36.991 1.00 69.74  ? 48   LYS A O   1 
+ATOM   131  C  CB  . LYS A 1 29  ? 15.256  84.732 39.565 1.00 74.19  ? 48   LYS A CB  1 
+ATOM   132  C  CG  . LYS A 1 29  ? 14.664  85.544 40.784 1.00 77.74  ? 48   LYS A CG  1 
+ATOM   133  C  CD  . LYS A 1 29  ? 14.879  84.830 42.170 1.00 75.87  ? 48   LYS A CD  1 
+ATOM   134  C  CE  . LYS A 1 29  ? 13.932  85.358 43.272 1.00 74.40  ? 48   LYS A CE  1 
+ATOM   135  N  NZ  . LYS A 1 29  ? 14.043  86.833 43.495 1.00 69.34  ? 48   LYS A NZ  1 
+ATOM   136  N  N   . ASP A 1 30  ? 16.050  82.443 38.204 1.00 66.15  ? 49   ASP A N   1 
+ATOM   137  C  CA  . ASP A 1 30  ? 16.589  81.165 37.735 1.00 64.51  ? 49   ASP A CA  1 
+ATOM   138  C  C   . ASP A 1 30  ? 16.039  80.029 38.579 1.00 60.79  ? 49   ASP A C   1 
+ATOM   139  O  O   . ASP A 1 30  ? 16.607  79.675 39.610 1.00 61.71  ? 49   ASP A O   1 
+ATOM   140  C  CB  . ASP A 1 30  ? 18.131  81.134 37.775 1.00 65.14  ? 49   ASP A CB  1 
+ATOM   141  C  CG  . ASP A 1 30  ? 18.727  79.934 37.002 1.00 64.82  ? 49   ASP A CG  1 
+ATOM   142  O  OD1 . ASP A 1 30  ? 19.979  79.868 36.901 1.00 61.50  ? 49   ASP A OD1 1 
+ATOM   143  O  OD2 . ASP A 1 30  ? 18.031  79.028 36.462 1.00 62.42  ? 49   ASP A OD2 1 
+ATOM   144  N  N   . ILE A 1 31  ? 14.945  79.436 38.127 1.00 57.75  ? 50   ILE A N   1 
+ATOM   145  C  CA  . ILE A 1 31  ? 14.358  78.357 38.883 1.00 57.10  ? 50   ILE A CA  1 
+ATOM   146  C  C   . ILE A 1 31  ? 15.185  77.078 38.816 1.00 54.84  ? 50   ILE A C   1 
+ATOM   147  O  O   . ILE A 1 31  ? 15.099  76.282 39.738 1.00 56.71  ? 50   ILE A O   1 
+ATOM   148  C  CB  . ILE A 1 31  ? 12.849  78.116 38.553 1.00 59.29  ? 50   ILE A CB  1 
+ATOM   149  C  CG1 . ILE A 1 31  ? 12.662  76.997 37.540 1.00 62.83  ? 50   ILE A CG1 1 
+ATOM   150  C  CG2 . ILE A 1 31  ? 12.135  79.399 38.112 1.00 62.14  ? 50   ILE A CG2 1 
+ATOM   151  C  CD1 . ILE A 1 31  ? 12.269  75.679 38.188 1.00 65.22  ? 50   ILE A CD1 1 
+ATOM   152  N  N   . SER A 1 32  ? 15.997  76.867 37.780 1.00 53.80  ? 51   SER A N   1 
+ATOM   153  C  CA  . SER A 1 32  ? 16.840  75.661 37.760 1.00 57.11  ? 51   SER A CA  1 
+ATOM   154  C  C   . SER A 1 32  ? 17.910  75.649 38.865 1.00 59.40  ? 51   SER A C   1 
+ATOM   155  O  O   . SER A 1 32  ? 18.216  74.581 39.420 1.00 56.13  ? 51   SER A O   1 
+ATOM   156  C  CB  . SER A 1 32  ? 17.529  75.430 36.413 1.00 58.90  ? 51   SER A CB  1 
+ATOM   157  O  OG  . SER A 1 32  ? 18.076  74.107 36.380 1.00 52.80  ? 51   SER A OG  1 
+ATOM   158  N  N   . LYS A 1 33  ? 18.477  76.819 39.177 1.00 59.35  ? 52   LYS A N   1 
+ATOM   159  C  CA  . LYS A 1 33  ? 19.409  76.942 40.304 1.00 60.90  ? 52   LYS A CA  1 
+ATOM   160  C  C   . LYS A 1 33  ? 18.731  76.612 41.640 1.00 59.11  ? 52   LYS A C   1 
+ATOM   161  O  O   . LYS A 1 33  ? 19.317  75.938 42.491 1.00 63.39  ? 52   LYS A O   1 
+ATOM   162  C  CB  . LYS A 1 33  ? 20.018  78.347 40.375 1.00 65.61  ? 52   LYS A CB  1 
+ATOM   163  C  CG  . LYS A 1 33  ? 21.506  78.383 40.834 1.00 71.39  ? 52   LYS A CG  1 
+ATOM   164  C  CD  . LYS A 1 33  ? 22.513  77.854 39.767 1.00 72.95  ? 52   LYS A CD  1 
+ATOM   165  C  CE  . LYS A 1 33  ? 22.500  78.668 38.463 1.00 72.86  ? 52   LYS A CE  1 
+ATOM   166  N  NZ  . LYS A 1 33  ? 23.724  78.445 37.643 1.00 73.52  ? 52   LYS A NZ  1 
+ATOM   167  N  N   . SER A 1 34  ? 17.503  77.079 41.823 1.00 51.10  ? 53   SER A N   1 
+ATOM   168  C  CA  . SER A 1 34  ? 16.754  76.777 43.030 1.00 49.20  ? 53   SER A CA  1 
+ATOM   169  C  C   . SER A 1 34  ? 16.494  75.304 43.196 1.00 47.69  ? 53   SER A C   1 
+ATOM   170  O  O   . SER A 1 34  ? 16.495  74.797 44.302 1.00 46.97  ? 53   SER A O   1 
+ATOM   171  C  CB  . SER A 1 34  ? 15.428  77.513 43.018 1.00 48.90  ? 53   SER A CB  1 
+ATOM   172  O  OG  . SER A 1 34  ? 15.682  78.902 43.024 1.00 55.27  ? 53   SER A OG  1 
+ATOM   173  N  N   . LEU A 1 35  ? 16.257  74.616 42.092 1.00 48.67  ? 54   LEU A N   1 
+ATOM   174  C  CA  . LEU A 1 35  ? 16.047  73.178 42.121 1.00 48.30  ? 54   LEU A CA  1 
+ATOM   175  C  C   . LEU A 1 35  ? 17.300  72.388 42.536 1.00 47.43  ? 54   LEU A C   1 
+ATOM   176  O  O   . LEU A 1 35  ? 17.190  71.328 43.138 1.00 47.64  ? 54   LEU A O   1 
+ATOM   177  C  CB  . LEU A 1 35  ? 15.619  72.711 40.746 1.00 48.96  ? 54   LEU A CB  1 
+ATOM   178  C  CG  . LEU A 1 35  ? 14.265  73.182 40.250 1.00 49.52  ? 54   LEU A CG  1 
+ATOM   179  C  CD1 . LEU A 1 35  ? 14.093  72.596 38.867 1.00 53.06  ? 54   LEU A CD1 1 
+ATOM   180  C  CD2 . LEU A 1 35  ? 13.122  72.739 41.160 1.00 49.72  ? 54   LEU A CD2 1 
+ATOM   181  N  N   . THR A 1 36  ? 18.478  72.899 42.193 1.00 45.04  ? 55   THR A N   1 
+ATOM   182  C  CA  . THR A 1 36  ? 19.725  72.219 42.493 1.00 43.51  ? 55   THR A CA  1 
+ATOM   183  C  C   . THR A 1 36  ? 19.951  72.351 43.993 1.00 43.20  ? 55   THR A C   1 
+ATOM   184  O  O   . THR A 1 36  ? 20.258  71.373 44.670 1.00 45.90  ? 55   THR A O   1 
+ATOM   185  C  CB  . THR A 1 36  ? 20.931  72.812 41.639 1.00 43.09  ? 55   THR A CB  1 
+ATOM   186  O  OG1 . THR A 1 36  ? 20.749  72.557 40.223 1.00 40.56  ? 55   THR A OG1 1 
+ATOM   187  C  CG2 . THR A 1 36  ? 22.261  72.121 41.989 1.00 38.93  ? 55   THR A CG2 1 
+ATOM   188  N  N   . ASN A 1 37  ? 19.797  73.574 44.495 1.00 43.15  ? 56   ASN A N   1 
+ATOM   189  C  CA  . ASN A 1 37  ? 19.854  73.879 45.920 1.00 39.02  ? 56   ASN A CA  1 
+ATOM   190  C  C   . ASN A 1 37  ? 18.856  73.041 46.725 1.00 37.78  ? 56   ASN A C   1 
+ATOM   191  O  O   . ASN A 1 37  ? 19.198  72.450 47.732 1.00 36.73  ? 56   ASN A O   1 
+ATOM   192  C  CB  . ASN A 1 37  ? 19.578  75.367 46.134 1.00 40.32  ? 56   ASN A CB  1 
+ATOM   193  C  CG  . ASN A 1 37  ? 20.769  76.255 45.746 1.00 41.95  ? 56   ASN A CG  1 
+ATOM   194  O  OD1 . ASN A 1 37  ? 21.859  75.765 45.460 1.00 44.95  ? 56   ASN A OD1 1 
+ATOM   195  N  ND2 . ASN A 1 37  ? 20.555  77.565 45.740 1.00 35.62  ? 56   ASN A ND2 1 
+ATOM   196  N  N   . LEU A 1 38  ? 17.624  72.951 46.268 1.00 36.18  ? 57   LEU A N   1 
+ATOM   197  C  CA  . LEU A 1 38  ? 16.663  72.091 46.950 1.00 38.01  ? 57   LEU A CA  1 
+ATOM   198  C  C   . LEU A 1 38  ? 17.081  70.629 46.947 1.00 38.39  ? 57   LEU A C   1 
+ATOM   199  O  O   . LEU A 1 38  ? 16.829  69.926 47.916 1.00 41.36  ? 57   LEU A O   1 
+ATOM   200  C  CB  . LEU A 1 38  ? 15.273  72.225 46.346 1.00 40.34  ? 57   LEU A CB  1 
+ATOM   201  C  CG  . LEU A 1 38  ? 14.570  73.533 46.695 1.00 42.27  ? 57   LEU A CG  1 
+ATOM   202  C  CD1 . LEU A 1 38  ? 13.478  73.797 45.673 1.00 44.61  ? 57   LEU A CD1 1 
+ATOM   203  C  CD2 . LEU A 1 38  ? 14.009  73.491 48.119 1.00 45.41  ? 57   LEU A CD2 1 
+ATOM   204  N  N   . SER A 1 39  ? 17.718  70.172 45.871 1.00 40.05  ? 58   SER A N   1 
+ATOM   205  C  CA  . SER A 1 39  ? 18.178  68.783 45.780 1.00 38.99  ? 58   SER A CA  1 
+ATOM   206  C  C   . SER A 1 39  ? 19.220  68.491 46.848 1.00 38.70  ? 58   SER A C   1 
+ATOM   207  O  O   . SER A 1 39  ? 19.289  67.376 47.341 1.00 31.77  ? 58   SER A O   1 
+ATOM   208  C  CB  . SER A 1 39  ? 18.753  68.457 44.394 1.00 37.77  ? 58   SER A CB  1 
+ATOM   209  O  OG  . SER A 1 39  ? 20.006  69.088 44.197 1.00 36.94  ? 58   SER A OG  1 
+ATOM   210  N  N   . LYS A 1 40  ? 20.016  69.505 47.194 1.00 40.55  ? 59   LYS A N   1 
+ATOM   211  C  CA  . LYS A 1 40  ? 21.033  69.397 48.245 1.00 42.29  ? 59   LYS A CA  1 
+ATOM   212  C  C   . LYS A 1 40  ? 20.416  69.100 49.615 1.00 43.07  ? 59   LYS A C   1 
+ATOM   213  O  O   . LYS A 1 40  ? 21.095  68.556 50.477 1.00 41.74  ? 59   LYS A O   1 
+ATOM   214  C  CB  . LYS A 1 40  ? 21.857  70.691 48.333 1.00 43.93  ? 59   LYS A CB  1 
+ATOM   215  C  CG  . LYS A 1 40  ? 23.264  70.609 47.782 1.00 50.14  ? 59   LYS A CG  1 
+ATOM   216  C  CD  . LYS A 1 40  ? 23.314  70.365 46.253 1.00 58.54  ? 59   LYS A CD  1 
+ATOM   217  C  CE  . LYS A 1 40  ? 24.578  70.963 45.612 1.00 60.60  ? 59   LYS A CE  1 
+ATOM   218  N  NZ  . LYS A 1 40  ? 24.806  72.375 46.090 1.00 63.13  ? 59   LYS A NZ  1 
+ATOM   219  N  N   . VAL A 1 41  ? 19.146  69.476 49.828 1.00 43.93  ? 60   VAL A N   1 
+ATOM   220  C  CA  . VAL A 1 41  ? 18.468  69.172 51.091 1.00 39.04  ? 60   VAL A CA  1 
+ATOM   221  C  C   . VAL A 1 41  ? 17.398  68.085 51.001 1.00 40.95  ? 60   VAL A C   1 
+ATOM   222  O  O   . VAL A 1 41  ? 17.209  67.353 51.969 1.00 36.94  ? 60   VAL A O   1 
+ATOM   223  C  CB  . VAL A 1 41  ? 17.888  70.420 51.791 1.00 39.98  ? 60   VAL A CB  1 
+ATOM   224  C  CG1 . VAL A 1 41  ? 18.437  71.732 51.199 1.00 38.84  ? 60   VAL A CG1 1 
+ATOM   225  C  CG2 . VAL A 1 41  ? 16.378  70.406 51.791 1.00 39.59  ? 60   VAL A CG2 1 
+ATOM   226  N  N   . TYR A 1 42  ? 16.707  67.931 49.877 1.00 38.43  ? 61   TYR A N   1 
+ATOM   227  C  CA  . TYR A 1 42  ? 15.653  66.922 49.848 1.00 39.56  ? 61   TYR A CA  1 
+ATOM   228  C  C   . TYR A 1 42  ? 16.045  65.666 49.108 1.00 40.64  ? 61   TYR A C   1 
+ATOM   229  O  O   . TYR A 1 42  ? 15.329  64.662 49.162 1.00 42.58  ? 61   TYR A O   1 
+ATOM   230  C  CB  . TYR A 1 42  ? 14.333  67.503 49.347 1.00 38.41  ? 61   TYR A CB  1 
+ATOM   231  C  CG  . TYR A 1 42  ? 13.850  68.635 50.230 1.00 41.14  ? 61   TYR A CG  1 
+ATOM   232  C  CD1 . TYR A 1 42  ? 13.219  68.379 51.464 1.00 44.54  ? 61   TYR A CD1 1 
+ATOM   233  C  CD2 . TYR A 1 42  ? 14.056  69.979 49.855 1.00 45.52  ? 61   TYR A CD2 1 
+ATOM   234  C  CE1 . TYR A 1 42  ? 12.786  69.446 52.298 1.00 45.74  ? 61   TYR A CE1 1 
+ATOM   235  C  CE2 . TYR A 1 42  ? 13.636  71.042 50.674 1.00 47.77  ? 61   TYR A CE2 1 
+ATOM   236  C  CZ  . TYR A 1 42  ? 12.998  70.768 51.889 1.00 46.80  ? 61   TYR A CZ  1 
+ATOM   237  O  OH  . TYR A 1 42  ? 12.607  71.821 52.675 1.00 45.62  ? 61   TYR A OH  1 
+ATOM   238  N  N   . GLY A 1 43  ? 17.204  65.701 48.459 1.00 42.28  ? 62   GLY A N   1 
+ATOM   239  C  CA  . GLY A 1 43  ? 17.723  64.550 47.732 1.00 38.32  ? 62   GLY A CA  1 
+ATOM   240  C  C   . GLY A 1 43  ? 17.404  64.652 46.260 1.00 38.27  ? 62   GLY A C   1 
+ATOM   241  O  O   . GLY A 1 43  ? 16.932  65.696 45.789 1.00 31.02  ? 62   GLY A O   1 
+ATOM   242  N  N   . PRO A 1 44  ? 17.647  63.568 45.532 1.00 37.41  ? 63   PRO A N   1 
+ATOM   243  C  CA  . PRO A 1 44  ? 17.412  63.528 44.082 1.00 41.74  ? 63   PRO A CA  1 
+ATOM   244  C  C   . PRO A 1 44  ? 15.949  63.440 43.664 1.00 43.12  ? 63   PRO A C   1 
+ATOM   245  O  O   . PRO A 1 44  ? 15.711  63.605 42.479 1.00 46.43  ? 63   PRO A O   1 
+ATOM   246  C  CB  . PRO A 1 44  ? 18.118  62.236 43.653 1.00 41.63  ? 63   PRO A CB  1 
+ATOM   247  C  CG  . PRO A 1 44  ? 17.973  61.366 44.819 1.00 39.11  ? 63   PRO A CG  1 
+ATOM   248  C  CD  . PRO A 1 44  ? 18.148  62.281 46.017 1.00 36.48  ? 63   PRO A CD  1 
+ATOM   249  N  N   . VAL A 1 45  ? 15.012  63.149 44.567 1.00 44.24  ? 64   VAL A N   1 
+ATOM   250  C  CA  . VAL A 1 45  ? 13.585  63.064 44.199 1.00 44.62  ? 64   VAL A CA  1 
+ATOM   251  C  C   . VAL A 1 45  ? 12.714  63.862 45.168 1.00 45.62  ? 64   VAL A C   1 
+ATOM   252  O  O   . VAL A 1 45  ? 12.293  63.344 46.197 1.00 43.30  ? 64   VAL A O   1 
+ATOM   253  C  CB  . VAL A 1 45  ? 13.092  61.615 44.191 1.00 45.28  ? 64   VAL A CB  1 
+ATOM   254  C  CG1 . VAL A 1 45  ? 11.680  61.532 43.669 1.00 45.09  ? 64   VAL A CG1 1 
+ATOM   255  C  CG2 . VAL A 1 45  ? 14.016  60.732 43.360 1.00 48.58  ? 64   VAL A CG2 1 
+ATOM   256  N  N   . PHE A 1 46  ? 12.455  65.127 44.853 1.00 45.92  ? 65   PHE A N   1 
+ATOM   257  C  CA  . PHE A 1 46  ? 11.601  65.910 45.719 1.00 45.96  ? 65   PHE A CA  1 
+ATOM   258  C  C   . PHE A 1 46  ? 10.311  66.370 45.087 1.00 46.81  ? 65   PHE A C   1 
+ATOM   259  O  O   . PHE A 1 46  ? 10.177  66.370 43.866 1.00 39.93  ? 65   PHE A O   1 
+ATOM   260  C  CB  . PHE A 1 46  ? 12.338  67.086 46.342 1.00 46.47  ? 65   PHE A CB  1 
+ATOM   261  C  CG  . PHE A 1 46  ? 12.975  68.039 45.368 1.00 44.03  ? 65   PHE A CG  1 
+ATOM   262  C  CD1 . PHE A 1 46  ? 14.262  67.808 44.907 1.00 41.08  ? 65   PHE A CD1 1 
+ATOM   263  C  CD2 . PHE A 1 46  ? 12.335  69.214 45.004 1.00 44.86  ? 65   PHE A CD2 1 
+ATOM   264  C  CE1 . PHE A 1 46  ? 14.903  68.704 44.074 1.00 40.21  ? 65   PHE A CE1 1 
+ATOM   265  C  CE2 . PHE A 1 46  ? 12.972  70.130 44.159 1.00 47.81  ? 65   PHE A CE2 1 
+ATOM   266  C  CZ  . PHE A 1 46  ? 14.263  69.865 43.691 1.00 45.93  ? 65   PHE A CZ  1 
+ATOM   267  N  N   . THR A 1 47  ? 9.374   66.741 45.976 1.00 47.98  ? 66   THR A N   1 
+ATOM   268  C  CA  . THR A 1 47  ? 8.054   67.268 45.647 1.00 47.44  ? 66   THR A CA  1 
+ATOM   269  C  C   . THR A 1 47  ? 8.069   68.793 45.753 1.00 47.38  ? 66   THR A C   1 
+ATOM   270  O  O   . THR A 1 47  ? 8.704   69.363 46.632 1.00 45.50  ? 66   THR A O   1 
+ATOM   271  C  CB  . THR A 1 47  ? 6.974   66.679 46.578 1.00 47.18  ? 66   THR A CB  1 
+ATOM   272  O  OG1 . THR A 1 47  ? 6.751   65.288 46.281 1.00 49.03  ? 66   THR A OG1 1 
+ATOM   273  C  CG2 . THR A 1 47  ? 5.623   67.314 46.298 1.00 48.72  ? 66   THR A CG2 1 
+ATOM   274  N  N   . LEU A 1 48  ? 7.358   69.445 44.847 1.00 48.54  ? 67   LEU A N   1 
+ATOM   275  C  CA  . LEU A 1 48  ? 7.361   70.893 44.773 1.00 50.54  ? 67   LEU A CA  1 
+ATOM   276  C  C   . LEU A 1 48  ? 5.992   71.393 44.353 1.00 51.85  ? 67   LEU A C   1 
+ATOM   277  O  O   . LEU A 1 48  ? 5.364   70.828 43.459 1.00 52.61  ? 67   LEU A O   1 
+ATOM   278  C  CB  . LEU A 1 48  ? 8.410   71.363 43.776 1.00 51.26  ? 67   LEU A CB  1 
+ATOM   279  C  CG  . LEU A 1 48  ? 9.083   72.677 44.156 1.00 50.62  ? 67   LEU A CG  1 
+ATOM   280  C  CD1 . LEU A 1 48  ? 10.101  72.396 45.222 1.00 50.37  ? 67   LEU A CD1 1 
+ATOM   281  C  CD2 . LEU A 1 48  ? 9.725   73.351 42.942 1.00 53.87  ? 67   LEU A CD2 1 
+ATOM   282  N  N   . TYR A 1 49  ? 5.540   72.470 44.984 1.00 52.53  ? 68   TYR A N   1 
+ATOM   283  C  CA  . TYR A 1 49  ? 4.191   72.975 44.760 1.00 52.74  ? 68   TYR A CA  1 
+ATOM   284  C  C   . TYR A 1 49  ? 4.240   74.231 43.925 1.00 50.64  ? 68   TYR A C   1 
+ATOM   285  O  O   . TYR A 1 49  ? 4.904   75.202 44.293 1.00 48.54  ? 68   TYR A O   1 
+ATOM   286  C  CB  . TYR A 1 49  ? 3.472   73.223 46.098 1.00 53.90  ? 68   TYR A CB  1 
+ATOM   287  C  CG  . TYR A 1 49  ? 3.016   71.927 46.732 1.00 51.78  ? 68   TYR A CG  1 
+ATOM   288  C  CD1 . TYR A 1 49  ? 3.846   71.219 47.588 1.00 53.07  ? 68   TYR A CD1 1 
+ATOM   289  C  CD2 . TYR A 1 49  ? 1.780   71.371 46.415 1.00 53.21  ? 68   TYR A CD2 1 
+ATOM   290  C  CE1 . TYR A 1 49  ? 3.437   70.004 48.147 1.00 52.00  ? 68   TYR A CE1 1 
+ATOM   291  C  CE2 . TYR A 1 49  ? 1.369   70.157 46.962 1.00 50.81  ? 68   TYR A CE2 1 
+ATOM   292  C  CZ  . TYR A 1 49  ? 2.198   69.488 47.828 1.00 49.04  ? 68   TYR A CZ  1 
+ATOM   293  O  OH  . TYR A 1 49  ? 1.799   68.302 48.375 1.00 49.91  ? 68   TYR A OH  1 
+ATOM   294  N  N   . PHE A 1 50  ? 3.554   74.189 42.787 1.00 49.74  ? 69   PHE A N   1 
+ATOM   295  C  CA  . PHE A 1 50  ? 3.350   75.373 41.956 1.00 53.60  ? 69   PHE A CA  1 
+ATOM   296  C  C   . PHE A 1 50  ? 1.951   75.922 42.228 1.00 54.68  ? 69   PHE A C   1 
+ATOM   297  O  O   . PHE A 1 50  ? 0.972   75.501 41.589 1.00 50.49  ? 69   PHE A O   1 
+ATOM   298  C  CB  . PHE A 1 50  ? 3.550   75.005 40.484 1.00 56.56  ? 69   PHE A CB  1 
+ATOM   299  C  CG  . PHE A 1 50  ? 4.980   75.041 40.071 1.00 58.76  ? 69   PHE A CG  1 
+ATOM   300  C  CD1 . PHE A 1 50  ? 5.438   76.008 39.203 1.00 61.14  ? 69   PHE A CD1 1 
+ATOM   301  C  CD2 . PHE A 1 50  ? 5.885   74.146 40.618 1.00 61.18  ? 69   PHE A CD2 1 
+ATOM   302  C  CE1 . PHE A 1 50  ? 6.750   76.056 38.859 1.00 62.77  ? 69   PHE A CE1 1 
+ATOM   303  C  CE2 . PHE A 1 50  ? 7.199   74.195 40.280 1.00 62.51  ? 69   PHE A CE2 1 
+ATOM   304  C  CZ  . PHE A 1 50  ? 7.637   75.154 39.394 1.00 63.28  ? 69   PHE A CZ  1 
+ATOM   305  N  N   . GLY A 1 51  ? 1.872   76.844 43.195 1.00 54.77  ? 70   GLY A N   1 
+ATOM   306  C  CA  . GLY A 1 51  ? 0.630   77.105 43.906 1.00 53.82  ? 70   GLY A CA  1 
+ATOM   307  C  C   . GLY A 1 51  ? 0.129   75.824 44.575 1.00 56.38  ? 70   GLY A C   1 
+ATOM   308  O  O   . GLY A 1 51  ? 0.739   75.363 45.552 1.00 55.79  ? 70   GLY A O   1 
+ATOM   309  N  N   . LEU A 1 52  ? -0.942  75.230 44.025 1.00 55.08  ? 71   LEU A N   1 
+ATOM   310  C  CA  . LEU A 1 52  ? -1.569  74.012 44.576 1.00 55.18  ? 71   LEU A CA  1 
+ATOM   311  C  C   . LEU A 1 52  ? -1.246  72.698 43.845 1.00 57.42  ? 71   LEU A C   1 
+ATOM   312  O  O   . LEU A 1 52  ? -1.674  71.626 44.293 1.00 52.71  ? 71   LEU A O   1 
+ATOM   313  C  CB  . LEU A 1 52  ? -3.089  74.161 44.563 1.00 56.69  ? 71   LEU A CB  1 
+ATOM   314  C  CG  . LEU A 1 52  ? -3.800  75.320 45.276 1.00 56.46  ? 71   LEU A CG  1 
+ATOM   315  C  CD1 . LEU A 1 52  ? -5.292  74.931 45.380 1.00 54.73  ? 71   LEU A CD1 1 
+ATOM   316  C  CD2 . LEU A 1 52  ? -3.188  75.669 46.662 1.00 55.21  ? 71   LEU A CD2 1 
+ATOM   317  N  N   . LYS A 1 53  ? -0.516  72.798 42.723 1.00 61.66  ? 72   LYS A N   1 
+ATOM   318  C  CA  . LYS A 1 53  ? -0.111  71.661 41.863 1.00 60.29  ? 72   LYS A CA  1 
+ATOM   319  C  C   . LYS A 1 53  ? 1.130   70.939 42.422 1.00 59.36  ? 72   LYS A C   1 
+ATOM   320  O  O   . LYS A 1 53  ? 2.147   71.590 42.683 1.00 56.33  ? 72   LYS A O   1 
+ATOM   321  C  CB  . LYS A 1 53  ? 0.209   72.188 40.452 1.00 61.71  ? 72   LYS A CB  1 
+ATOM   322  C  CG  . LYS A 1 53  ? 0.368   71.132 39.350 1.00 59.57  ? 72   LYS A CG  1 
+ATOM   323  C  CD  . LYS A 1 53  ? 0.372   71.806 37.973 1.00 60.32  ? 72   LYS A CD  1 
+ATOM   324  C  CE  . LYS A 1 53  ? 1.078   70.969 36.908 1.00 61.19  ? 72   LYS A CE  1 
+ATOM   325  N  NZ  . LYS A 1 53  ? 0.226   69.892 36.339 1.00 62.02  ? 72   LYS A NZ  1 
+ATOM   326  N  N   . PRO A 1 54  ? 1.054   69.616 42.621 1.00 59.37  ? 73   PRO A N   1 
+ATOM   327  C  CA  . PRO A 1 54  ? 2.209   68.859 43.122 1.00 59.06  ? 73   PRO A CA  1 
+ATOM   328  C  C   . PRO A 1 54  ? 3.083   68.392 41.959 1.00 57.10  ? 73   PRO A C   1 
+ATOM   329  O  O   . PRO A 1 54  ? 2.597   67.736 41.031 1.00 56.75  ? 73   PRO A O   1 
+ATOM   330  C  CB  . PRO A 1 54  ? 1.563   67.674 43.855 1.00 58.64  ? 73   PRO A CB  1 
+ATOM   331  C  CG  . PRO A 1 54  ? 0.253   67.424 43.104 1.00 58.90  ? 73   PRO A CG  1 
+ATOM   332  C  CD  . PRO A 1 54  ? -0.110  68.730 42.404 1.00 59.72  ? 73   PRO A CD  1 
+ATOM   333  N  N   . ILE A 1 55  ? 4.363   68.742 42.030 1.00 56.17  ? 74   ILE A N   1 
+ATOM   334  C  CA  . ILE A 1 55  ? 5.362   68.443 40.999 1.00 53.86  ? 74   ILE A CA  1 
+ATOM   335  C  C   . ILE A 1 55  ? 6.441   67.590 41.621 1.00 50.14  ? 74   ILE A C   1 
+ATOM   336  O  O   . ILE A 1 55  ? 7.025   68.001 42.619 1.00 51.32  ? 74   ILE A O   1 
+ATOM   337  C  CB  . ILE A 1 55  ? 6.014   69.767 40.526 1.00 53.92  ? 74   ILE A CB  1 
+ATOM   338  C  CG1 . ILE A 1 55  ? 4.961   70.705 39.933 1.00 56.77  ? 74   ILE A CG1 1 
+ATOM   339  C  CG2 . ILE A 1 55  ? 7.147   69.526 39.548 1.00 51.49  ? 74   ILE A CG2 1 
+ATOM   340  C  CD1 . ILE A 1 55  ? 4.096   70.067 38.887 1.00 55.94  ? 74   ILE A CD1 1 
+ATOM   341  N  N   . VAL A 1 56  ? 6.722   66.420 41.056 1.00 46.26  ? 75   VAL A N   1 
+ATOM   342  C  CA  . VAL A 1 56  ? 7.957   65.703 41.411 1.00 46.21  ? 75   VAL A CA  1 
+ATOM   343  C  C   . VAL A 1 56  ? 9.150   66.159 40.526 1.00 41.49  ? 75   VAL A C   1 
+ATOM   344  O  O   . VAL A 1 56  ? 9.116   65.971 39.333 1.00 43.55  ? 75   VAL A O   1 
+ATOM   345  C  CB  . VAL A 1 56  ? 7.756   64.180 41.322 1.00 46.55  ? 75   VAL A CB  1 
+ATOM   346  C  CG1 . VAL A 1 56  ? 9.033   63.436 41.645 1.00 47.93  ? 75   VAL A CG1 1 
+ATOM   347  C  CG2 . VAL A 1 56  ? 6.693   63.753 42.283 1.00 49.41  ? 75   VAL A CG2 1 
+ATOM   348  N  N   . VAL A 1 57  ? 10.166  66.793 41.115 1.00 37.92  ? 76   VAL A N   1 
+ATOM   349  C  CA  . VAL A 1 57  ? 11.459  67.063 40.446 1.00 39.38  ? 76   VAL A CA  1 
+ATOM   350  C  C   . VAL A 1 57  ? 12.465  65.877 40.565 1.00 37.99  ? 76   VAL A C   1 
+ATOM   351  O  O   . VAL A 1 57  ? 12.687  65.372 41.663 1.00 38.01  ? 76   VAL A O   1 
+ATOM   352  C  CB  . VAL A 1 57  ? 12.157  68.313 41.052 1.00 38.98  ? 76   VAL A CB  1 
+ATOM   353  C  CG1 . VAL A 1 57  ? 13.475  68.571 40.386 1.00 42.09  ? 76   VAL A CG1 1 
+ATOM   354  C  CG2 . VAL A 1 57  ? 11.307  69.536 40.928 1.00 42.46  ? 76   VAL A CG2 1 
+ATOM   355  N  N   . LEU A 1 58  ? 13.063  65.444 39.445 1.00 38.10  ? 77   LEU A N   1 
+ATOM   356  C  CA  . LEU A 1 58  ? 14.171  64.463 39.432 1.00 35.38  ? 77   LEU A CA  1 
+ATOM   357  C  C   . LEU A 1 58  ? 15.517  65.135 39.127 1.00 34.72  ? 77   LEU A C   1 
+ATOM   358  O  O   . LEU A 1 58  ? 15.652  65.742 38.087 1.00 33.92  ? 77   LEU A O   1 
+ATOM   359  C  CB  . LEU A 1 58  ? 13.926  63.441 38.355 1.00 35.52  ? 77   LEU A CB  1 
+ATOM   360  C  CG  . LEU A 1 58  ? 12.619  62.673 38.325 1.00 35.97  ? 77   LEU A CG  1 
+ATOM   361  C  CD1 . LEU A 1 58  ? 12.766  61.531 37.324 1.00 35.60  ? 77   LEU A CD1 1 
+ATOM   362  C  CD2 . LEU A 1 58  ? 12.199  62.167 39.693 1.00 34.85  ? 77   LEU A CD2 1 
+ATOM   363  N  N   . HIS A 1 59  ? 16.517  65.033 40.001 1.00 38.68  ? 78   HIS A N   1 
+ATOM   364  C  CA  . HIS A 1 59  ? 17.722  65.849 39.824 1.00 39.77  ? 78   HIS A CA  1 
+ATOM   365  C  C   . HIS A 1 59  ? 18.895  65.154 39.115 1.00 44.11  ? 78   HIS A C   1 
+ATOM   366  O  O   . HIS A 1 59  ? 19.109  65.371 37.912 1.00 49.18  ? 78   HIS A O   1 
+ATOM   367  C  CB  . HIS A 1 59  ? 18.182  66.464 41.122 1.00 38.32  ? 78   HIS A CB  1 
+ATOM   368  C  CG  . HIS A 1 59  ? 19.048  67.671 40.940 1.00 37.02  ? 78   HIS A CG  1 
+ATOM   369  N  ND1 . HIS A 1 59  ? 20.373  67.701 41.316 1.00 39.96  ? 78   HIS A ND1 1 
+ATOM   370  C  CD2 . HIS A 1 59  ? 18.770  68.906 40.456 1.00 37.78  ? 78   HIS A CD2 1 
+ATOM   371  C  CE1 . HIS A 1 59  ? 20.879  68.900 41.067 1.00 39.45  ? 78   HIS A CE1 1 
+ATOM   372  N  NE2 . HIS A 1 59  ? 19.925  69.653 40.548 1.00 38.20  ? 78   HIS A NE2 1 
+ATOM   373  N  N   . GLY A 1 60  ? 19.682  64.342 39.791 1.00 39.04  ? 79   GLY A N   1 
+ATOM   374  C  CA  . GLY A 1 60  ? 20.921  63.947 39.138 1.00 38.00  ? 79   GLY A CA  1 
+ATOM   375  C  C   . GLY A 1 60  ? 20.737  62.981 37.976 1.00 36.52  ? 79   GLY A C   1 
+ATOM   376  O  O   . GLY A 1 60  ? 19.630  62.517 37.713 1.00 32.66  ? 79   GLY A O   1 
+ATOM   377  N  N   . TYR A 1 61  ? 21.843  62.656 37.306 1.00 37.59  ? 80   TYR A N   1 
+ATOM   378  C  CA  . TYR A 1 61  ? 21.850  61.683 36.203 1.00 40.74  ? 80   TYR A CA  1 
+ATOM   379  C  C   . TYR A 1 61  ? 21.206  60.367 36.582 1.00 37.19  ? 80   TYR A C   1 
+ATOM   380  O  O   . TYR A 1 61  ? 20.431  59.831 35.816 1.00 36.61  ? 80   TYR A O   1 
+ATOM   381  C  CB  . TYR A 1 61  ? 23.289  61.391 35.724 1.00 44.43  ? 80   TYR A CB  1 
+ATOM   382  C  CG  . TYR A 1 61  ? 23.387  60.217 34.762 1.00 45.09  ? 80   TYR A CG  1 
+ATOM   383  C  CD1 . TYR A 1 61  ? 23.319  60.406 33.382 1.00 46.99  ? 80   TYR A CD1 1 
+ATOM   384  C  CD2 . TYR A 1 61  ? 23.531  58.925 35.223 1.00 44.09  ? 80   TYR A CD2 1 
+ATOM   385  C  CE1 . TYR A 1 61  ? 23.392  59.333 32.499 1.00 43.40  ? 80   TYR A CE1 1 
+ATOM   386  C  CE2 . TYR A 1 61  ? 23.609  57.845 34.336 1.00 46.76  ? 80   TYR A CE2 1 
+ATOM   387  C  CZ  . TYR A 1 61  ? 23.545  58.062 32.986 1.00 44.95  ? 80   TYR A CZ  1 
+ATOM   388  O  OH  . TYR A 1 61  ? 23.627  56.999 32.123 1.00 51.53  ? 80   TYR A OH  1 
+ATOM   389  N  N   . GLU A 1 62  ? 21.539  59.836 37.753 1.00 39.16  ? 81   GLU A N   1 
+ATOM   390  C  CA  . GLU A 1 62  ? 21.082  58.496 38.097 1.00 43.27  ? 81   GLU A CA  1 
+ATOM   391  C  C   . GLU A 1 62  ? 19.545  58.438 38.145 1.00 42.25  ? 81   GLU A C   1 
+ATOM   392  O  O   . GLU A 1 62  ? 18.952  57.531 37.563 1.00 41.60  ? 81   GLU A O   1 
+ATOM   393  C  CB  . GLU A 1 62  ? 21.737  57.976 39.382 1.00 45.28  ? 81   GLU A CB  1 
+ATOM   394  C  CG  . GLU A 1 62  ? 23.194  57.522 39.230 1.00 52.79  ? 81   GLU A CG  1 
+ATOM   395  C  CD  . GLU A 1 62  ? 23.420  56.376 38.209 1.00 60.01  ? 81   GLU A CD  1 
+ATOM   396  O  OE1 . GLU A 1 62  ? 24.518  56.313 37.580 1.00 55.78  ? 81   GLU A OE1 1 
+ATOM   397  O  OE2 . GLU A 1 62  ? 22.509  55.530 38.017 1.00 67.94  ? 81   GLU A OE2 1 
+ATOM   398  N  N   . ALA A 1 63  ? 18.905  59.432 38.760 1.00 39.82  ? 82   ALA A N   1 
+ATOM   399  C  CA  . ALA A 1 63  ? 17.447  59.418 38.884 1.00 38.05  ? 82   ALA A CA  1 
+ATOM   400  C  C   . ALA A 1 63  ? 16.796  59.663 37.525 1.00 42.42  ? 82   ALA A C   1 
+ATOM   401  O  O   . ALA A 1 63  ? 15.833  58.975 37.156 1.00 45.90  ? 82   ALA A O   1 
+ATOM   402  C  CB  . ALA A 1 63  ? 16.983  60.433 39.883 1.00 35.64  ? 82   ALA A CB  1 
+ATOM   403  N  N   . VAL A 1 64  ? 17.338  60.617 36.765 1.00 40.92  ? 83   VAL A N   1 
+ATOM   404  C  CA  . VAL A 1 64  ? 16.842  60.913 35.415 1.00 37.45  ? 83   VAL A CA  1 
+ATOM   405  C  C   . VAL A 1 64  ? 16.948  59.686 34.521 1.00 38.28  ? 83   VAL A C   1 
+ATOM   406  O  O   . VAL A 1 64  ? 16.009  59.343 33.804 1.00 35.61  ? 83   VAL A O   1 
+ATOM   407  C  CB  . VAL A 1 64  ? 17.636  62.046 34.759 1.00 36.54  ? 83   VAL A CB  1 
+ATOM   408  C  CG1 . VAL A 1 64  ? 17.184  62.288 33.348 1.00 34.71  ? 83   VAL A CG1 1 
+ATOM   409  C  CG2 . VAL A 1 64  ? 17.503  63.323 35.549 1.00 38.16  ? 83   VAL A CG2 1 
+ATOM   410  N  N   . LYS A 1 65  ? 18.089  59.008 34.571 1.00 43.42  ? 84   LYS A N   1 
+ATOM   411  C  CA  . LYS A 1 65  ? 18.287  57.820 33.735 1.00 48.36  ? 84   LYS A CA  1 
+ATOM   412  C  C   . LYS A 1 65  ? 17.332  56.711 34.187 1.00 48.71  ? 84   LYS A C   1 
+ATOM   413  O  O   . LYS A 1 65  ? 16.714  56.029 33.363 1.00 48.01  ? 84   LYS A O   1 
+ATOM   414  C  CB  . LYS A 1 65  ? 19.770  57.377 33.714 1.00 50.74  ? 84   LYS A CB  1 
+ATOM   415  C  CG  . LYS A 1 65  ? 20.071  55.884 33.992 1.00 54.01  ? 84   LYS A CG  1 
+ATOM   416  C  CD  . LYS A 1 65  ? 20.160  55.019 32.747 1.00 54.09  ? 84   LYS A CD  1 
+ATOM   417  C  CE  . LYS A 1 65  ? 20.971  53.720 33.010 1.00 58.22  ? 84   LYS A CE  1 
+ATOM   418  N  NZ  . LYS A 1 65  ? 20.152  52.542 33.478 1.00 52.81  ? 84   LYS A NZ  1 
+ATOM   419  N  N   . GLU A 1 66  ? 17.185  56.559 35.499 1.00 48.96  ? 85   GLU A N   1 
+ATOM   420  C  CA  . GLU A 1 66  ? 16.327  55.520 36.032 1.00 49.84  ? 85   GLU A CA  1 
+ATOM   421  C  C   . GLU A 1 66  ? 14.866  55.725 35.639 1.00 49.92  ? 85   GLU A C   1 
+ATOM   422  O  O   . GLU A 1 66  ? 14.159  54.757 35.430 1.00 53.31  ? 85   GLU A O   1 
+ATOM   423  C  CB  . GLU A 1 66  ? 16.463  55.432 37.540 1.00 52.57  ? 85   GLU A CB  1 
+ATOM   424  C  CG  . GLU A 1 66  ? 15.759  54.220 38.131 1.00 55.65  ? 85   GLU A CG  1 
+ATOM   425  C  CD  . GLU A 1 66  ? 16.089  53.999 39.589 1.00 57.08  ? 85   GLU A CD  1 
+ATOM   426  O  OE1 . GLU A 1 66  ? 16.970  54.717 40.110 1.00 52.12  ? 85   GLU A OE1 1 
+ATOM   427  O  OE2 . GLU A 1 66  ? 15.462  53.098 40.202 1.00 59.10  ? 85   GLU A OE2 1 
+ATOM   428  N  N   . ALA A 1 67  ? 14.430  56.975 35.501 1.00 50.27  ? 86   ALA A N   1 
+ATOM   429  C  CA  . ALA A 1 67  ? 13.042  57.290 35.151 1.00 50.40  ? 86   ALA A CA  1 
+ATOM   430  C  C   . ALA A 1 67  ? 12.815  57.312 33.643 1.00 50.49  ? 86   ALA A C   1 
+ATOM   431  O  O   . ALA A 1 67  ? 12.006  56.562 33.109 1.00 53.68  ? 86   ALA A O   1 
+ATOM   432  C  CB  . ALA A 1 67  ? 12.639  58.641 35.752 1.00 49.66  ? 86   ALA A CB  1 
+ATOM   433  N  N   . LEU A 1 68  ? 13.532  58.193 32.965 1.00 50.97  ? 87   LEU A N   1 
+ATOM   434  C  CA  . LEU A 1 68  ? 13.357  58.393 31.530 1.00 50.43  ? 87   LEU A CA  1 
+ATOM   435  C  C   . LEU A 1 68  ? 13.766  57.196 30.657 1.00 49.32  ? 87   LEU A C   1 
+ATOM   436  O  O   . LEU A 1 68  ? 13.161  56.965 29.622 1.00 48.33  ? 87   LEU A O   1 
+ATOM   437  C  CB  . LEU A 1 68  ? 14.115  59.643 31.093 1.00 48.89  ? 87   LEU A CB  1 
+ATOM   438  C  CG  . LEU A 1 68  ? 13.254  60.833 30.691 1.00 48.28  ? 87   LEU A CG  1 
+ATOM   439  C  CD1 . LEU A 1 68  ? 12.218  61.108 31.740 1.00 46.70  ? 87   LEU A CD1 1 
+ATOM   440  C  CD2 . LEU A 1 68  ? 14.162  62.061 30.435 1.00 48.08  ? 87   LEU A CD2 1 
+ATOM   441  N  N   . ILE A 1 69  ? 14.785  56.448 31.072 1.00 51.25  ? 88   ILE A N   1 
+ATOM   442  C  CA  . ILE A 1 69  ? 15.216  55.255 30.338 1.00 51.05  ? 88   ILE A CA  1 
+ATOM   443  C  C   . ILE A 1 69  ? 14.674  53.931 30.934 1.00 51.93  ? 88   ILE A C   1 
+ATOM   444  O  O   . ILE A 1 69  ? 14.034  53.185 30.211 1.00 48.91  ? 88   ILE A O   1 
+ATOM   445  C  CB  . ILE A 1 69  ? 16.765  55.275 30.149 1.00 50.39  ? 88   ILE A CB  1 
+ATOM   446  C  CG1 . ILE A 1 69  ? 17.131  56.242 29.022 1.00 49.14  ? 88   ILE A CG1 1 
+ATOM   447  C  CG2 . ILE A 1 69  ? 17.328  53.904 29.813 1.00 51.32  ? 88   ILE A CG2 1 
+ATOM   448  C  CD1 . ILE A 1 69  ? 18.400  57.022 29.301 1.00 53.36  ? 88   ILE A CD1 1 
+ATOM   449  N  N   . ASP A 1 70  ? 14.879  53.649 32.227 1.00 56.69  ? 89   ASP A N   1 
+ATOM   450  C  CA  . ASP A 1 70  ? 14.497  52.329 32.805 1.00 60.24  ? 89   ASP A CA  1 
+ATOM   451  C  C   . ASP A 1 70  ? 13.000  52.147 33.060 1.00 59.77  ? 89   ASP A C   1 
+ATOM   452  O  O   . ASP A 1 70  ? 12.468  51.045 32.908 1.00 59.13  ? 89   ASP A O   1 
+ATOM   453  C  CB  . ASP A 1 70  ? 15.285  52.004 34.085 1.00 62.06  ? 89   ASP A CB  1 
+ATOM   454  C  CG  . ASP A 1 70  ? 16.788  51.973 33.849 1.00 66.60  ? 89   ASP A CG  1 
+ATOM   455  O  OD1 . ASP A 1 70  ? 17.543  52.398 34.756 1.00 68.57  ? 89   ASP A OD1 1 
+ATOM   456  O  OD2 . ASP A 1 70  ? 17.302  51.564 32.777 1.00 70.62  ? 89   ASP A OD2 1 
+ATOM   457  N  N   . LEU A 1 71  ? 12.319  53.220 33.435 1.00 60.35  ? 90   LEU A N   1 
+ATOM   458  C  CA  . LEU A 1 71  ? 10.862  53.224 33.442 1.00 59.92  ? 90   LEU A CA  1 
+ATOM   459  C  C   . LEU A 1 71  ? 10.353  54.126 32.303 1.00 59.13  ? 90   LEU A C   1 
+ATOM   460  O  O   . LEU A 1 71  ? 9.452   54.940 32.491 1.00 59.17  ? 90   LEU A O   1 
+ATOM   461  C  CB  . LEU A 1 71  ? 10.339  53.685 34.802 1.00 62.58  ? 90   LEU A CB  1 
+ATOM   462  C  CG  . LEU A 1 71  ? 10.470  52.774 36.033 1.00 63.32  ? 90   LEU A CG  1 
+ATOM   463  C  CD1 . LEU A 1 71  ? 9.957   51.354 35.769 1.00 63.36  ? 90   LEU A CD1 1 
+ATOM   464  C  CD2 . LEU A 1 71  ? 11.902  52.749 36.553 1.00 65.74  ? 90   LEU A CD2 1 
+ATOM   465  N  N   . GLY A 1 72  ? 10.931  53.952 31.115 1.00 57.81  ? 91   GLY A N   1 
+ATOM   466  C  CA  . GLY A 1 72  ? 10.658  54.801 29.973 1.00 57.43  ? 91   GLY A CA  1 
+ATOM   467  C  C   . GLY A 1 72  ? 9.193   55.002 29.634 1.00 57.59  ? 91   GLY A C   1 
+ATOM   468  O  O   . GLY A 1 72  ? 8.766   56.146 29.401 1.00 53.65  ? 91   GLY A O   1 
+ATOM   469  N  N   . GLU A 1 73  ? 8.435   53.903 29.594 1.00 58.16  ? 92   GLU A N   1 
+ATOM   470  C  CA  . GLU A 1 73  ? 7.001   53.964 29.282 1.00 59.63  ? 92   GLU A CA  1 
+ATOM   471  C  C   . GLU A 1 73  ? 6.257   54.706 30.385 1.00 58.48  ? 92   GLU A C   1 
+ATOM   472  O  O   . GLU A 1 73  ? 5.418   55.567 30.112 1.00 60.80  ? 92   GLU A O   1 
+ATOM   473  C  CB  . GLU A 1 73  ? 6.379   52.563 29.111 1.00 61.16  ? 92   GLU A CB  1 
+ATOM   474  C  CG  . GLU A 1 73  ? 6.013   52.162 27.678 1.00 64.75  ? 92   GLU A CG  1 
+ATOM   475  C  CD  . GLU A 1 73  ? 5.100   53.153 26.965 1.00 65.78  ? 92   GLU A CD  1 
+ATOM   476  O  OE1 . GLU A 1 73  ? 4.081   53.574 27.558 1.00 61.89  ? 92   GLU A OE1 1 
+ATOM   477  O  OE2 . GLU A 1 73  ? 5.408   53.514 25.800 1.00 72.35  ? 92   GLU A OE2 1 
+ATOM   478  N  N   . GLU A 1 74  ? 6.574   54.374 31.629 1.00 54.37  ? 93   GLU A N   1 
+ATOM   479  C  CA  . GLU A 1 74  ? 5.893   54.969 32.775 1.00 54.63  ? 93   GLU A CA  1 
+ATOM   480  C  C   . GLU A 1 74  ? 6.059   56.485 32.835 1.00 50.70  ? 93   GLU A C   1 
+ATOM   481  O  O   . GLU A 1 74  ? 5.226   57.160 33.402 1.00 51.75  ? 93   GLU A O   1 
+ATOM   482  C  CB  . GLU A 1 74  ? 6.417   54.361 34.085 1.00 56.68  ? 93   GLU A CB  1 
+ATOM   483  C  CG  . GLU A 1 74  ? 5.886   52.970 34.421 1.00 58.27  ? 93   GLU A CG  1 
+ATOM   484  C  CD  . GLU A 1 74  ? 6.401   51.885 33.489 1.00 59.71  ? 93   GLU A CD  1 
+ATOM   485  O  OE1 . GLU A 1 74  ? 7.603   51.559 33.542 1.00 63.03  ? 93   GLU A OE1 1 
+ATOM   486  O  OE2 . GLU A 1 74  ? 5.599   51.349 32.696 1.00 64.13  ? 93   GLU A OE2 1 
+ATOM   487  N  N   . PHE A 1 75  ? 7.145   57.006 32.269 1.00 49.42  ? 94   PHE A N   1 
+ATOM   488  C  CA  . PHE A 1 75  ? 7.463   58.439 32.311 1.00 48.02  ? 94   PHE A CA  1 
+ATOM   489  C  C   . PHE A 1 75  ? 7.324   59.127 30.928 1.00 48.72  ? 94   PHE A C   1 
+ATOM   490  O  O   . PHE A 1 75  ? 7.802   60.259 30.721 1.00 47.69  ? 94   PHE A O   1 
+ATOM   491  C  CB  . PHE A 1 75  ? 8.891   58.629 32.838 1.00 46.40  ? 94   PHE A CB  1 
+ATOM   492  C  CG  . PHE A 1 75  ? 9.019   58.526 34.331 1.00 42.16  ? 94   PHE A CG  1 
+ATOM   493  C  CD1 . PHE A 1 75  ? 9.042   59.657 35.114 1.00 41.43  ? 94   PHE A CD1 1 
+ATOM   494  C  CD2 . PHE A 1 75  ? 9.150   57.294 34.949 1.00 47.22  ? 94   PHE A CD2 1 
+ATOM   495  C  CE1 . PHE A 1 75  ? 9.179   59.570 36.482 1.00 43.68  ? 94   PHE A CE1 1 
+ATOM   496  C  CE2 . PHE A 1 75  ? 9.281   57.197 36.329 1.00 43.19  ? 94   PHE A CE2 1 
+ATOM   497  C  CZ  . PHE A 1 75  ? 9.300   58.334 37.091 1.00 42.87  ? 94   PHE A CZ  1 
+ATOM   498  N  N   . SER A 1 76  ? 6.644   58.451 30.005 1.00 47.35  ? 95   SER A N   1 
+ATOM   499  C  CA  . SER A 1 76  ? 6.501   58.917 28.637 1.00 47.77  ? 95   SER A CA  1 
+ATOM   500  C  C   . SER A 1 76  ? 5.513   60.065 28.501 1.00 47.10  ? 95   SER A C   1 
+ATOM   501  O  O   . SER A 1 76  ? 5.492   60.756 27.486 1.00 46.32  ? 95   SER A O   1 
+ATOM   502  C  CB  . SER A 1 76  ? 6.028   57.773 27.741 1.00 51.35  ? 95   SER A CB  1 
+ATOM   503  O  OG  . SER A 1 76  ? 4.613   57.834 27.561 1.00 55.78  ? 95   SER A OG  1 
+ATOM   504  N  N   . GLY A 1 77  ? 4.659   60.254 29.498 1.00 45.48  ? 96   GLY A N   1 
+ATOM   505  C  CA  . GLY A 1 77  ? 3.635   61.273 29.395 1.00 42.45  ? 96   GLY A CA  1 
+ATOM   506  C  C   . GLY A 1 77  ? 4.199   62.678 29.349 1.00 41.54  ? 96   GLY A C   1 
+ATOM   507  O  O   . GLY A 1 77  ? 5.261   62.968 29.902 1.00 39.29  ? 96   GLY A O   1 
+ATOM   508  N  N   . ARG A 1 78  ? 3.478   63.548 28.651 1.00 43.58  ? 97   ARG A N   1 
+ATOM   509  C  CA  . ARG A 1 78  ? 3.749   64.983 28.634 1.00 41.22  ? 97   ARG A CA  1 
+ATOM   510  C  C   . ARG A 1 78  ? 2.785   65.584 29.613 1.00 44.40  ? 97   ARG A C   1 
+ATOM   511  O  O   . ARG A 1 78  ? 1.631   65.161 29.671 1.00 49.09  ? 97   ARG A O   1 
+ATOM   512  C  CB  . ARG A 1 78  ? 3.480   65.557 27.250 1.00 39.88  ? 97   ARG A CB  1 
+ATOM   513  C  CG  . ARG A 1 78  ? 3.429   67.052 27.170 1.00 40.03  ? 97   ARG A CG  1 
+ATOM   514  C  CD  . ARG A 1 78  ? 4.775   67.706 27.274 1.00 43.34  ? 97   ARG A CD  1 
+ATOM   515  N  NE  . ARG A 1 78  ? 5.662   67.288 26.179 1.00 47.30  ? 97   ARG A NE  1 
+ATOM   516  C  CZ  . ARG A 1 78  ? 6.915   66.858 26.319 1.00 42.48  ? 97   ARG A CZ  1 
+ATOM   517  N  NH1 . ARG A 1 78  ? 7.593   66.515 25.241 1.00 43.86  ? 97   ARG A NH1 1 
+ATOM   518  N  NH2 . ARG A 1 78  ? 7.484   66.749 27.506 1.00 41.33  ? 97   ARG A NH2 1 
+ATOM   519  N  N   . GLY A 1 79  ? 3.250   66.573 30.364 1.00 44.51  ? 98   GLY A N   1 
+ATOM   520  C  CA  . GLY A 1 79  ? 2.448   67.247 31.357 1.00 43.73  ? 98   GLY A CA  1 
+ATOM   521  C  C   . GLY A 1 79  ? 2.387   68.722 31.057 1.00 45.21  ? 98   GLY A C   1 
+ATOM   522  O  O   . GLY A 1 79  ? 3.371   69.319 30.631 1.00 45.34  ? 98   GLY A O   1 
+ATOM   523  N  N   . ILE A 1 80  ? 1.231   69.320 31.320 1.00 46.97  ? 99   ILE A N   1 
+ATOM   524  C  CA  . ILE A 1 80  ? 0.935   70.654 30.834 1.00 47.91  ? 99   ILE A CA  1 
+ATOM   525  C  C   . ILE A 1 80  ? 0.726   71.566 32.019 1.00 48.56  ? 99   ILE A C   1 
+ATOM   526  O  O   . ILE A 1 80  ? -0.078  71.272 32.871 1.00 47.75  ? 99   ILE A O   1 
+ATOM   527  C  CB  . ILE A 1 80  ? -0.313  70.605 29.900 1.00 49.72  ? 99   ILE A CB  1 
+ATOM   528  C  CG1 . ILE A 1 80  ? -0.275  69.307 29.060 1.00 52.59  ? 99   ILE A CG1 1 
+ATOM   529  C  CG2 . ILE A 1 80  ? -0.371  71.853 28.995 1.00 49.85  ? 99   ILE A CG2 1 
+ATOM   530  C  CD1 . ILE A 1 80  ? -1.157  69.295 27.829 1.00 55.61  ? 99   ILE A CD1 1 
+ATOM   531  N  N   . PHE A 1 81  ? 1.489   72.653 32.084 1.00 51.94  ? 100  PHE A N   1 
+ATOM   532  C  CA  . PHE A 1 81  ? 1.243   73.724 33.045 1.00 53.50  ? 100  PHE A CA  1 
+ATOM   533  C  C   . PHE A 1 81  ? 0.040   74.611 32.601 1.00 55.02  ? 100  PHE A C   1 
+ATOM   534  O  O   . PHE A 1 81  ? -0.301  74.663 31.412 1.00 53.13  ? 100  PHE A O   1 
+ATOM   535  C  CB  . PHE A 1 81  ? 2.512   74.574 33.235 1.00 55.89  ? 100  PHE A CB  1 
+ATOM   536  C  CG  . PHE A 1 81  ? 3.527   73.949 34.159 1.00 57.57  ? 100  PHE A CG  1 
+ATOM   537  C  CD1 . PHE A 1 81  ? 4.747   73.504 33.680 1.00 58.45  ? 100  PHE A CD1 1 
+ATOM   538  C  CD2 . PHE A 1 81  ? 3.252   73.795 35.512 1.00 60.83  ? 100  PHE A CD2 1 
+ATOM   539  C  CE1 . PHE A 1 81  ? 5.662   72.901 34.532 1.00 60.05  ? 100  PHE A CE1 1 
+ATOM   540  C  CE2 . PHE A 1 81  ? 4.178   73.192 36.372 1.00 61.66  ? 100  PHE A CE2 1 
+ATOM   541  C  CZ  . PHE A 1 81  ? 5.373   72.746 35.879 1.00 59.07  ? 100  PHE A CZ  1 
+ATOM   542  N  N   . PRO A 1 82  ? -0.613  75.274 33.561 1.00 54.67  ? 101  PRO A N   1 
+ATOM   543  C  CA  . PRO A 1 82  ? -1.755  76.159 33.282 1.00 54.60  ? 101  PRO A CA  1 
+ATOM   544  C  C   . PRO A 1 82  ? -1.680  77.000 32.021 1.00 51.83  ? 101  PRO A C   1 
+ATOM   545  O  O   . PRO A 1 82  ? -2.602  76.945 31.232 1.00 52.60  ? 101  PRO A O   1 
+ATOM   546  C  CB  . PRO A 1 82  ? -1.775  77.074 34.504 1.00 54.91  ? 101  PRO A CB  1 
+ATOM   547  C  CG  . PRO A 1 82  ? -1.370  76.147 35.634 1.00 55.65  ? 101  PRO A CG  1 
+ATOM   548  C  CD  . PRO A 1 82  ? -0.348  75.197 35.013 1.00 55.00  ? 101  PRO A CD  1 
+ATOM   549  N  N   . LEU A 1 83  ? -0.619  77.763 31.832 1.00 50.39  ? 102  LEU A N   1 
+ATOM   550  C  CA  . LEU A 1 83  ? -0.546  78.667 30.684 1.00 49.21  ? 102  LEU A CA  1 
+ATOM   551  C  C   . LEU A 1 83  ? -0.639  77.931 29.349 1.00 49.72  ? 102  LEU A C   1 
+ATOM   552  O  O   . LEU A 1 83  ? -1.327  78.376 28.447 1.00 47.65  ? 102  LEU A O   1 
+ATOM   553  C  CB  . LEU A 1 83  ? 0.745   79.480 30.734 1.00 48.07  ? 102  LEU A CB  1 
+ATOM   554  C  CG  . LEU A 1 83  ? 1.009   80.520 29.638 1.00 49.74  ? 102  LEU A CG  1 
+ATOM   555  C  CD1 . LEU A 1 83  ? 1.726   79.923 28.437 1.00 46.56  ? 102  LEU A CD1 1 
+ATOM   556  C  CD2 . LEU A 1 83  ? -0.277  81.272 29.203 1.00 54.03  ? 102  LEU A CD2 1 
+ATOM   557  N  N   . ALA A 1 84  ? 0.070   76.814 29.221 1.00 51.44  ? 103  ALA A N   1 
+ATOM   558  C  CA  . ALA A 1 84  ? 0.044   76.035 27.990 1.00 52.60  ? 103  ALA A CA  1 
+ATOM   559  C  C   . ALA A 1 84  ? -1.333  75.417 27.746 1.00 52.32  ? 103  ALA A C   1 
+ATOM   560  O  O   . ALA A 1 84  ? -1.799  75.359 26.623 1.00 51.90  ? 103  ALA A O   1 
+ATOM   561  C  CB  . ALA A 1 84  ? 1.121   74.957 28.013 1.00 53.40  ? 103  ALA A CB  1 
+ATOM   562  N  N   . GLU A 1 85  ? -1.975  74.955 28.801 1.00 52.67  ? 104  GLU A N   1 
+ATOM   563  C  CA  . GLU A 1 85  ? -3.311  74.416 28.689 1.00 55.34  ? 104  GLU A CA  1 
+ATOM   564  C  C   . GLU A 1 85  ? -4.221  75.430 28.006 1.00 55.34  ? 104  GLU A C   1 
+ATOM   565  O  O   . GLU A 1 85  ? -4.900  75.099 27.047 1.00 61.03  ? 104  GLU A O   1 
+ATOM   566  C  CB  . GLU A 1 85  ? -3.845  74.060 30.072 1.00 55.38  ? 104  GLU A CB  1 
+ATOM   567  C  CG  . GLU A 1 85  ? -4.636  72.774 30.124 1.00 57.52  ? 104  GLU A CG  1 
+ATOM   568  C  CD  . GLU A 1 85  ? -4.668  72.206 31.534 1.00 62.35  ? 104  GLU A CD  1 
+ATOM   569  O  OE1 . GLU A 1 85  ? -4.759  72.997 32.494 1.00 63.51  ? 104  GLU A OE1 1 
+ATOM   570  O  OE2 . GLU A 1 85  ? -4.587  70.972 31.695 1.00 66.97  ? 104  GLU A OE2 1 
+ATOM   571  N  N   . ARG A 1 86  ? -4.199  76.673 28.468 1.00 54.62  ? 105  ARG A N   1 
+ATOM   572  C  CA  . ARG A 1 86  ? -5.041  77.731 27.903 1.00 56.34  ? 105  ARG A CA  1 
+ATOM   573  C  C   . ARG A 1 86  ? -4.617  78.227 26.528 1.00 55.88  ? 105  ARG A C   1 
+ATOM   574  O  O   . ARG A 1 86  ? -5.460  78.662 25.745 1.00 58.71  ? 105  ARG A O   1 
+ATOM   575  C  CB  . ARG A 1 86  ? -5.088  78.924 28.848 1.00 57.11  ? 105  ARG A CB  1 
+ATOM   576  C  CG  . ARG A 1 86  ? -5.788  78.608 30.142 1.00 63.03  ? 105  ARG A CG  1 
+ATOM   577  C  CD  . ARG A 1 86  ? -7.305  78.506 29.999 1.00 66.22  ? 105  ARG A CD  1 
+ATOM   578  N  NE  . ARG A 1 86  ? -7.900  79.814 29.732 1.00 65.81  ? 105  ARG A NE  1 
+ATOM   579  C  CZ  . ARG A 1 86  ? -8.311  80.672 30.658 1.00 65.18  ? 105  ARG A CZ  1 
+ATOM   580  N  NH1 . ARG A 1 86  ? -8.831  81.837 30.288 1.00 67.37  ? 105  ARG A NH1 1 
+ATOM   581  N  NH2 . ARG A 1 86  ? -8.209  80.386 31.949 1.00 64.57  ? 105  ARG A NH2 1 
+ATOM   582  N  N   . ALA A 1 87  ? -3.318  78.164 26.241 1.00 56.46  ? 106  ALA A N   1 
+ATOM   583  C  CA  . ALA A 1 87  ? -2.749  78.709 25.003 1.00 53.85  ? 106  ALA A CA  1 
+ATOM   584  C  C   . ALA A 1 87  ? -2.742  77.734 23.854 1.00 53.83  ? 106  ALA A C   1 
+ATOM   585  O  O   . ALA A 1 87  ? -2.327  78.103 22.765 1.00 56.04  ? 106  ALA A O   1 
+ATOM   586  C  CB  . ALA A 1 87  ? -1.334  79.214 25.236 1.00 50.11  ? 106  ALA A CB  1 
+ATOM   587  N  N   . ASN A 1 88  ? -3.197  76.504 24.090 1.00 57.65  ? 107  ASN A N   1 
+ATOM   588  C  CA  . ASN A 1 88  ? -3.190  75.451 23.066 1.00 61.91  ? 107  ASN A CA  1 
+ATOM   589  C  C   . ASN A 1 88  ? -4.569  74.852 22.800 1.00 64.72  ? 107  ASN A C   1 
+ATOM   590  O  O   . ASN A 1 88  ? -5.110  74.125 23.635 1.00 69.15  ? 107  ASN A O   1 
+ATOM   591  C  CB  . ASN A 1 88  ? -2.210  74.331 23.439 1.00 61.19  ? 107  ASN A CB  1 
+ATOM   592  C  CG  . ASN A 1 88  ? -0.789  74.674 23.070 1.00 62.31  ? 107  ASN A CG  1 
+ATOM   593  O  OD1 . ASN A 1 88  ? 0.033   75.010 23.925 1.00 66.42  ? 107  ASN A OD1 1 
+ATOM   594  N  ND2 . ASN A 1 88  ? -0.496  74.623 21.782 1.00 58.55  ? 107  ASN A ND2 1 
+ATOM   595  N  N   . ARG A 1 89  ? -5.125  75.176 21.634 1.00 64.73  ? 108  ARG A N   1 
+ATOM   596  C  CA  . ARG A 1 89  ? -6.343  74.549 21.142 1.00 64.12  ? 108  ARG A CA  1 
+ATOM   597  C  C   . ARG A 1 89  ? -5.901  73.498 20.134 1.00 62.68  ? 108  ARG A C   1 
+ATOM   598  O  O   . ARG A 1 89  ? -5.520  73.815 18.999 1.00 67.07  ? 108  ARG A O   1 
+ATOM   599  C  CB  . ARG A 1 89  ? -7.287  75.593 20.493 1.00 64.53  ? 108  ARG A CB  1 
+ATOM   600  C  CG  . ARG A 1 89  ? -8.573  75.846 21.280 1.00 64.43  ? 108  ARG A CG  1 
+ATOM   601  C  CD  . ARG A 1 89  ? -8.335  76.562 22.603 1.00 64.96  ? 108  ARG A CD  1 
+ATOM   602  N  NE  . ARG A 1 89  ? -9.147  77.757 22.875 1.00 63.73  ? 108  ARG A NE  1 
+ATOM   603  C  CZ  . ARG A 1 89  ? -9.375  78.787 22.044 1.00 59.32  ? 108  ARG A CZ  1 
+ATOM   604  N  NH1 . ARG A 1 89  ? -8.913  78.820 20.792 1.00 53.91  ? 108  ARG A NH1 1 
+ATOM   605  N  NH2 . ARG A 1 89  ? -10.105 79.808 22.486 1.00 58.65  ? 108  ARG A NH2 1 
+ATOM   606  N  N   . GLY A 1 90  ? -5.917  72.247 20.558 1.00 61.37  ? 109  GLY A N   1 
+ATOM   607  C  CA  . GLY A 1 90  ? -5.619  71.146 19.659 1.00 60.30  ? 109  GLY A CA  1 
+ATOM   608  C  C   . GLY A 1 90  ? -4.197  70.665 19.830 1.00 59.13  ? 109  GLY A C   1 
+ATOM   609  O  O   . GLY A 1 90  ? -3.286  71.459 19.986 1.00 59.45  ? 109  GLY A O   1 
+ATOM   610  N  N   . PHE A 1 91  ? -4.021  69.352 19.794 1.00 58.15  ? 110  PHE A N   1 
+ATOM   611  C  CA  . PHE A 1 91  ? -2.745  68.726 20.071 1.00 57.37  ? 110  PHE A CA  1 
+ATOM   612  C  C   . PHE A 1 91  ? -2.148  68.015 18.839 1.00 57.14  ? 110  PHE A C   1 
+ATOM   613  O  O   . PHE A 1 91  ? -2.850  67.357 18.075 1.00 57.22  ? 110  PHE A O   1 
+ATOM   614  C  CB  . PHE A 1 91  ? -2.937  67.723 21.212 1.00 58.05  ? 110  PHE A CB  1 
+ATOM   615  C  CG  . PHE A 1 91  ? -3.255  68.350 22.539 1.00 59.34  ? 110  PHE A CG  1 
+ATOM   616  C  CD1 . PHE A 1 91  ? -2.796  69.625 22.871 1.00 62.51  ? 110  PHE A CD1 1 
+ATOM   617  C  CD2 . PHE A 1 91  ? -3.994  67.646 23.474 1.00 60.93  ? 110  PHE A CD2 1 
+ATOM   618  C  CE1 . PHE A 1 91  ? -3.090  70.190 24.110 1.00 64.76  ? 110  PHE A CE1 1 
+ATOM   619  C  CE2 . PHE A 1 91  ? -4.283  68.198 24.713 1.00 64.31  ? 110  PHE A CE2 1 
+ATOM   620  C  CZ  . PHE A 1 91  ? -3.834  69.474 25.031 1.00 65.31  ? 110  PHE A CZ  1 
+ATOM   621  N  N   . GLY A 1 92  ? -0.838  68.146 18.660 1.00 55.91  ? 111  GLY A N   1 
+ATOM   622  C  CA  . GLY A 1 92  ? -0.137  67.458 17.591 1.00 55.12  ? 111  GLY A CA  1 
+ATOM   623  C  C   . GLY A 1 92  ? 0.796   66.391 18.126 1.00 51.98  ? 111  GLY A C   1 
+ATOM   624  O  O   . GLY A 1 92  ? 0.495   65.185 18.112 1.00 49.93  ? 111  GLY A O   1 
+ATOM   625  N  N   . ILE A 1 93  ? 1.939   66.850 18.619 1.00 51.06  ? 112  ILE A N   1 
+ATOM   626  C  CA  . ILE A 1 93  ? 3.018   65.956 19.012 1.00 47.88  ? 112  ILE A CA  1 
+ATOM   627  C  C   . ILE A 1 93  ? 3.631   66.359 20.339 1.00 45.82  ? 112  ILE A C   1 
+ATOM   628  O  O   . ILE A 1 93  ? 3.807   65.509 21.222 1.00 50.50  ? 112  ILE A O   1 
+ATOM   629  C  CB  . ILE A 1 93  ? 4.045   65.887 17.874 1.00 47.88  ? 112  ILE A CB  1 
+ATOM   630  C  CG1 . ILE A 1 93  ? 5.063   64.788 18.108 1.00 48.95  ? 112  ILE A CG1 1 
+ATOM   631  C  CG2 . ILE A 1 93  ? 4.729   67.216 17.652 1.00 52.94  ? 112  ILE A CG2 1 
+ATOM   632  C  CD1 . ILE A 1 93  ? 5.796   64.446 16.841 1.00 48.48  ? 112  ILE A CD1 1 
+ATOM   633  N  N   . VAL A 1 94  ? 3.900   67.654 20.498 1.00 42.41  ? 113  VAL A N   1 
+ATOM   634  C  CA  . VAL A 1 94  ? 4.576   68.181 21.678 1.00 41.54  ? 113  VAL A CA  1 
+ATOM   635  C  C   . VAL A 1 94  ? 3.737   67.995 22.938 1.00 43.55  ? 113  VAL A C   1 
+ATOM   636  O  O   . VAL A 1 94  ? 4.288   67.806 24.015 1.00 42.86  ? 113  VAL A O   1 
+ATOM   637  C  CB  . VAL A 1 94  ? 4.904   69.688 21.522 1.00 39.04  ? 113  VAL A CB  1 
+ATOM   638  C  CG1 . VAL A 1 94  ? 5.368   70.285 22.834 1.00 41.26  ? 113  VAL A CG1 1 
+ATOM   639  C  CG2 . VAL A 1 94  ? 5.961   69.902 20.491 1.00 39.24  ? 113  VAL A CG2 1 
+ATOM   640  N  N   . PHE A 1 95  ? 2.413   68.069 22.792 1.00 45.48  ? 114  PHE A N   1 
+ATOM   641  C  CA  . PHE A 1 95  ? 1.493   68.105 23.928 1.00 45.76  ? 114  PHE A CA  1 
+ATOM   642  C  C   . PHE A 1 95  ? 0.508   66.942 23.944 1.00 45.10  ? 114  PHE A C   1 
+ATOM   643  O  O   . PHE A 1 95  ? -0.343  66.846 24.823 1.00 48.12  ? 114  PHE A O   1 
+ATOM   644  C  CB  . PHE A 1 95  ? 0.735   69.434 23.922 1.00 44.95  ? 114  PHE A CB  1 
+ATOM   645  C  CG  . PHE A 1 95  ? 1.577   70.614 24.297 1.00 44.57  ? 114  PHE A CG  1 
+ATOM   646  C  CD1 . PHE A 1 95  ? 1.682   71.707 23.452 1.00 48.79  ? 114  PHE A CD1 1 
+ATOM   647  C  CD2 . PHE A 1 95  ? 2.245   70.649 25.511 1.00 44.22  ? 114  PHE A CD2 1 
+ATOM   648  C  CE1 . PHE A 1 95  ? 2.461   72.830 23.810 1.00 46.78  ? 114  PHE A CE1 1 
+ATOM   649  C  CE2 . PHE A 1 95  ? 3.026   71.751 25.869 1.00 45.58  ? 114  PHE A CE2 1 
+ATOM   650  C  CZ  . PHE A 1 95  ? 3.129   72.844 25.012 1.00 45.30  ? 114  PHE A CZ  1 
+ATOM   651  N  N   . SER A 1 96  ? 0.627   66.060 22.967 1.00 48.21  ? 115  SER A N   1 
+ATOM   652  C  CA  . SER A 1 96  ? -0.236  64.903 22.857 1.00 48.98  ? 115  SER A CA  1 
+ATOM   653  C  C   . SER A 1 96  ? 0.140   63.874 23.901 1.00 48.86  ? 115  SER A C   1 
+ATOM   654  O  O   . SER A 1 96  ? 1.227   63.933 24.460 1.00 47.57  ? 115  SER A O   1 
+ATOM   655  C  CB  . SER A 1 96  ? -0.079  64.270 21.475 1.00 50.68  ? 115  SER A CB  1 
+ATOM   656  O  OG  . SER A 1 96  ? -0.865  64.946 20.529 1.00 57.15  ? 115  SER A OG  1 
+ATOM   657  N  N   . ASN A 1 97  ? -0.753  62.911 24.113 1.00 47.79  ? 116  ASN A N   1 
+ATOM   658  C  CA  . ASN A 1 97  ? -0.515  61.772 24.994 1.00 47.41  ? 116  ASN A CA  1 
+ATOM   659  C  C   . ASN A 1 97  ? -1.185  60.520 24.409 1.00 48.10  ? 116  ASN A C   1 
+ATOM   660  O  O   . ASN A 1 97  ? -1.844  60.589 23.378 1.00 48.50  ? 116  ASN A O   1 
+ATOM   661  C  CB  . ASN A 1 97  ? -1.034  62.087 26.401 1.00 46.31  ? 116  ASN A CB  1 
+ATOM   662  C  CG  . ASN A 1 97  ? 0.069   62.546 27.342 1.00 46.00  ? 116  ASN A CG  1 
+ATOM   663  O  OD1 . ASN A 1 97  ? 0.993   61.791 27.646 1.00 49.78  ? 116  ASN A OD1 1 
+ATOM   664  N  ND2 . ASN A 1 97  ? -0.029  63.771 27.815 1.00 36.51  ? 116  ASN A ND2 1 
+ATOM   665  N  N   . GLY A 1 98  ? -0.990  59.366 25.026 1.00 49.32  ? 117  GLY A N   1 
+ATOM   666  C  CA  . GLY A 1 98  ? -1.635  58.153 24.542 1.00 51.83  ? 117  GLY A CA  1 
+ATOM   667  C  C   . GLY A 1 98  ? -1.357  57.796 23.084 1.00 54.20  ? 117  GLY A C   1 
+ATOM   668  O  O   . GLY A 1 98  ? -0.298  58.116 22.565 1.00 51.58  ? 117  GLY A O   1 
+ATOM   669  N  N   . LYS A 1 99  ? -2.313  57.127 22.431 1.00 57.51  ? 118  LYS A N   1 
+ATOM   670  C  CA  . LYS A 1 99  ? -2.152  56.696 21.031 1.00 59.71  ? 118  LYS A CA  1 
+ATOM   671  C  C   . LYS A 1 99  ? -2.002  57.877 20.076 1.00 54.70  ? 118  LYS A C   1 
+ATOM   672  O  O   . LYS A 1 99  ? -1.320  57.758 19.076 1.00 57.36  ? 118  LYS A O   1 
+ATOM   673  C  CB  . LYS A 1 99  ? -3.283  55.762 20.497 1.00 64.94  ? 118  LYS A CB  1 
+ATOM   674  C  CG  . LYS A 1 99  ? -4.293  55.194 21.505 1.00 71.36  ? 118  LYS A CG  1 
+ATOM   675  C  CD  . LYS A 1 99  ? -5.430  56.199 21.836 1.00 75.38  ? 118  LYS A CD  1 
+ATOM   676  C  CE  . LYS A 1 99  ? -5.930  56.063 23.292 1.00 74.66  ? 118  LYS A CE  1 
+ATOM   677  N  NZ  . LYS A 1 99  ? -5.133  56.916 24.237 1.00 71.07  ? 118  LYS A NZ  1 
+ATOM   678  N  N   . LYS A 1 100 ? -2.628  59.006 20.352 1.00 49.89  ? 119  LYS A N   1 
+ATOM   679  C  CA  . LYS A 1 100 ? -2.446  60.156 19.475 1.00 50.43  ? 119  LYS A CA  1 
+ATOM   680  C  C   . LYS A 1 100 ? -0.966  60.553 19.389 1.00 52.86  ? 119  LYS A C   1 
+ATOM   681  O  O   . LYS A 1 100 ? -0.408  60.702 18.303 1.00 50.93  ? 119  LYS A O   1 
+ATOM   682  C  CB  . LYS A 1 100 ? -3.293  61.324 19.943 1.00 50.47  ? 119  LYS A CB  1 
+ATOM   683  C  CG  . LYS A 1 100 ? -3.374  62.457 18.970 1.00 54.37  ? 119  LYS A CG  1 
+ATOM   684  C  CD  . LYS A 1 100 ? -4.486  63.439 19.376 1.00 60.71  ? 119  LYS A CD  1 
+ATOM   685  C  CE  . LYS A 1 100 ? -4.274  64.823 18.759 1.00 63.56  ? 119  LYS A CE  1 
+ATOM   686  N  NZ  . LYS A 1 100 ? -5.419  65.242 17.879 1.00 68.27  ? 119  LYS A NZ  1 
+ATOM   687  N  N   . TRP A 1 101 ? -0.320  60.694 20.540 1.00 52.67  ? 120  TRP A N   1 
+ATOM   688  C  CA  . TRP A 1 101 ? 1.102   60.968 20.565 1.00 50.12  ? 120  TRP A CA  1 
+ATOM   689  C  C   . TRP A 1 101 ? 1.900   59.801 19.964 1.00 51.47  ? 120  TRP A C   1 
+ATOM   690  O  O   . TRP A 1 101 ? 2.703   60.025 19.075 1.00 51.60  ? 120  TRP A O   1 
+ATOM   691  C  CB  . TRP A 1 101 ? 1.559   61.269 21.990 1.00 49.66  ? 120  TRP A CB  1 
+ATOM   692  C  CG  . TRP A 1 101 ? 3.013   61.229 22.145 1.00 49.11  ? 120  TRP A CG  1 
+ATOM   693  C  CD1 . TRP A 1 101 ? 3.913   62.137 21.678 1.00 49.51  ? 120  TRP A CD1 1 
+ATOM   694  C  CD2 . TRP A 1 101 ? 3.763   60.218 22.804 1.00 47.73  ? 120  TRP A CD2 1 
+ATOM   695  N  NE1 . TRP A 1 101 ? 5.187   61.744 22.004 1.00 49.33  ? 120  TRP A NE1 1 
+ATOM   696  C  CE2 . TRP A 1 101 ? 5.121   60.567 22.699 1.00 48.36  ? 120  TRP A CE2 1 
+ATOM   697  C  CE3 . TRP A 1 101 ? 3.423   59.045 23.482 1.00 50.33  ? 120  TRP A CE3 1 
+ATOM   698  C  CZ2 . TRP A 1 101 ? 6.134   59.796 23.247 1.00 47.30  ? 120  TRP A CZ2 1 
+ATOM   699  C  CZ3 . TRP A 1 101 ? 4.428   58.275 24.018 1.00 50.98  ? 120  TRP A CZ3 1 
+ATOM   700  C  CH2 . TRP A 1 101 ? 5.770   58.654 23.898 1.00 50.53  ? 120  TRP A CH2 1 
+ATOM   701  N  N   . LYS A 1 102 ? 1.665   58.575 20.439 1.00 51.41  ? 121  LYS A N   1 
+ATOM   702  C  CA  . LYS A 1 102 ? 2.448   57.388 20.048 1.00 54.39  ? 121  LYS A CA  1 
+ATOM   703  C  C   . LYS A 1 102 ? 2.540   57.255 18.538 1.00 55.47  ? 121  LYS A C   1 
+ATOM   704  O  O   . LYS A 1 102 ? 3.594   56.922 17.995 1.00 55.98  ? 121  LYS A O   1 
+ATOM   705  C  CB  . LYS A 1 102 ? 1.826   56.089 20.615 1.00 58.07  ? 121  LYS A CB  1 
+ATOM   706  C  CG  . LYS A 1 102 ? 2.661   55.333 21.673 1.00 64.17  ? 121  LYS A CG  1 
+ATOM   707  C  CD  . LYS A 1 102 ? 3.559   54.233 21.047 1.00 71.75  ? 121  LYS A CD  1 
+ATOM   708  C  CE  . LYS A 1 102 ? 4.678   53.750 22.018 1.00 76.17  ? 121  LYS A CE  1 
+ATOM   709  N  NZ  . LYS A 1 102 ? 5.840   54.721 22.197 1.00 79.05  ? 121  LYS A NZ  1 
+ATOM   710  N  N   . GLU A 1 103 ? 1.427   57.548 17.871 1.00 56.52  ? 122  GLU A N   1 
+ATOM   711  C  CA  . GLU A 1 103 ? 1.268   57.278 16.454 1.00 55.85  ? 122  GLU A CA  1 
+ATOM   712  C  C   . GLU A 1 103 ? 1.696   58.417 15.581 1.00 52.76  ? 122  GLU A C   1 
+ATOM   713  O  O   . GLU A 1 103 ? 2.173   58.186 14.489 1.00 57.78  ? 122  GLU A O   1 
+ATOM   714  C  CB  . GLU A 1 103 ? -0.185  56.955 16.127 1.00 59.20  ? 122  GLU A CB  1 
+ATOM   715  C  CG  . GLU A 1 103 ? -0.628  55.584 16.602 1.00 63.98  ? 122  GLU A CG  1 
+ATOM   716  C  CD  . GLU A 1 103 ? -1.942  55.150 15.989 1.00 68.33  ? 122  GLU A CD  1 
+ATOM   717  O  OE1 . GLU A 1 103 ? -2.385  54.029 16.325 1.00 72.42  ? 122  GLU A OE1 1 
+ATOM   718  O  OE2 . GLU A 1 103 ? -2.519  55.921 15.179 1.00 69.53  ? 122  GLU A OE2 1 
+ATOM   719  N  N   . ILE A 1 104 ? 1.495   59.646 16.022 1.00 49.67  ? 123  ILE A N   1 
+ATOM   720  C  CA  . ILE A 1 104 ? 1.965   60.788 15.250 1.00 48.01  ? 123  ILE A CA  1 
+ATOM   721  C  C   . ILE A 1 104 ? 3.490   60.923 15.389 1.00 46.68  ? 123  ILE A C   1 
+ATOM   722  O  O   . ILE A 1 104 ? 4.186   61.268 14.436 1.00 46.44  ? 123  ILE A O   1 
+ATOM   723  C  CB  . ILE A 1 104 ? 1.217   62.073 15.663 1.00 47.82  ? 123  ILE A CB  1 
+ATOM   724  C  CG1 . ILE A 1 104 ? -0.257  61.935 15.286 1.00 53.60  ? 123  ILE A CG1 1 
+ATOM   725  C  CG2 . ILE A 1 104 ? 1.813   63.321 14.980 1.00 47.05  ? 123  ILE A CG2 1 
+ATOM   726  C  CD1 . ILE A 1 104 ? -1.114  63.159 15.600 1.00 57.92  ? 123  ILE A CD1 1 
+ATOM   727  N  N   . ARG A 1 105 ? 4.014   60.645 16.573 1.00 43.54  ? 124  ARG A N   1 
+ATOM   728  C  CA  . ARG A 1 105 ? 5.431   60.795 16.800 1.00 41.95  ? 124  ARG A CA  1 
+ATOM   729  C  C   . ARG A 1 105 ? 6.143   59.773 15.950 1.00 45.13  ? 124  ARG A C   1 
+ATOM   730  O  O   . ARG A 1 105 ? 7.159   60.081 15.333 1.00 46.42  ? 124  ARG A O   1 
+ATOM   731  C  CB  . ARG A 1 105 ? 5.769   60.582 18.259 1.00 40.13  ? 124  ARG A CB  1 
+ATOM   732  C  CG  . ARG A 1 105 ? 7.217   60.839 18.587 1.00 39.59  ? 124  ARG A CG  1 
+ATOM   733  C  CD  . ARG A 1 105 ? 7.668   60.095 19.799 1.00 39.32  ? 124  ARG A CD  1 
+ATOM   734  N  NE  . ARG A 1 105 ? 9.117   60.021 19.912 1.00 40.38  ? 124  ARG A NE  1 
+ATOM   735  C  CZ  . ARG A 1 105 ? 9.918   61.010 20.332 1.00 41.14  ? 124  ARG A CZ  1 
+ATOM   736  N  NH1 . ARG A 1 105 ? 9.442   62.204 20.664 1.00 38.40  ? 124  ARG A NH1 1 
+ATOM   737  N  NH2 . ARG A 1 105 ? 11.223  60.795 20.417 1.00 39.96  ? 124  ARG A NH2 1 
+ATOM   738  N  N   . ARG A 1 106 ? 5.603   58.557 15.925 1.00 46.98  ? 125  ARG A N   1 
+ATOM   739  C  CA  . ARG A 1 106 ? 6.173   57.479 15.137 1.00 47.65  ? 125  ARG A CA  1 
+ATOM   740  C  C   . ARG A 1 106 ? 6.170   57.892 13.671 1.00 44.52  ? 125  ARG A C   1 
+ATOM   741  O  O   . ARG A 1 106 ? 7.164   57.762 12.983 1.00 48.37  ? 125  ARG A O   1 
+ATOM   742  C  CB  . ARG A 1 106 ? 5.395   56.181 15.362 1.00 51.70  ? 125  ARG A CB  1 
+ATOM   743  C  CG  . ARG A 1 106 ? 5.584   55.135 14.288 1.00 59.34  ? 125  ARG A CG  1 
+ATOM   744  C  CD  . ARG A 1 106 ? 5.388   53.695 14.751 1.00 67.71  ? 125  ARG A CD  1 
+ATOM   745  N  NE  . ARG A 1 106 ? 6.514   52.855 14.316 1.00 79.38  ? 125  ARG A NE  1 
+ATOM   746  C  CZ  . ARG A 1 106 ? 6.671   51.556 14.604 1.00 84.24  ? 125  ARG A CZ  1 
+ATOM   747  N  NH1 . ARG A 1 106 ? 5.771   50.893 15.332 1.00 85.90  ? 125  ARG A NH1 1 
+ATOM   748  N  NH2 . ARG A 1 106 ? 7.743   50.911 14.151 1.00 84.59  ? 125  ARG A NH2 1 
+ATOM   749  N  N   . PHE A 1 107 ? 5.066   58.434 13.200 1.00 41.96  ? 126  PHE A N   1 
+ATOM   750  C  CA  . PHE A 1 107 ? 4.975   58.855 11.805 1.00 41.52  ? 126  PHE A CA  1 
+ATOM   751  C  C   . PHE A 1 107 ? 6.031   59.883 11.468 1.00 42.83  ? 126  PHE A C   1 
+ATOM   752  O  O   . PHE A 1 107 ? 6.657   59.820 10.422 1.00 46.75  ? 126  PHE A O   1 
+ATOM   753  C  CB  . PHE A 1 107 ? 3.591   59.457 11.511 1.00 38.31  ? 126  PHE A CB  1 
+ATOM   754  C  CG  . PHE A 1 107 ? 3.492   60.131 10.174 1.00 35.89  ? 126  PHE A CG  1 
+ATOM   755  C  CD1 . PHE A 1 107 ? 3.519   61.503 10.076 1.00 40.13  ? 126  PHE A CD1 1 
+ATOM   756  C  CD2 . PHE A 1 107 ? 3.387   59.387 9.012  1.00 40.11  ? 126  PHE A CD2 1 
+ATOM   757  C  CE1 . PHE A 1 107 ? 3.443   62.125 8.853  1.00 41.93  ? 126  PHE A CE1 1 
+ATOM   758  C  CE2 . PHE A 1 107 ? 3.316   60.003 7.788  1.00 40.01  ? 126  PHE A CE2 1 
+ATOM   759  C  CZ  . PHE A 1 107 ? 3.335   61.382 7.713  1.00 42.67  ? 126  PHE A CZ  1 
+ATOM   760  N  N   . SER A 1 108 ? 6.204   60.836 12.368 1.00 46.04  ? 127  SER A N   1 
+ATOM   761  C  CA  . SER A 1 108 ? 7.041   61.994 12.134 1.00 48.10  ? 127  SER A CA  1 
+ATOM   762  C  C   . SER A 1 108 ? 8.520   61.623 12.042 1.00 46.15  ? 127  SER A C   1 
+ATOM   763  O  O   . SER A 1 108 ? 9.233   62.141 11.198 1.00 49.40  ? 127  SER A O   1 
+ATOM   764  C  CB  . SER A 1 108 ? 6.808   63.016 13.252 1.00 50.05  ? 127  SER A CB  1 
+ATOM   765  O  OG  . SER A 1 108 ? 5.438   63.390 13.306 1.00 47.88  ? 127  SER A OG  1 
+ATOM   766  N  N   . LEU A 1 109 ? 8.971   60.726 12.901 1.00 43.47  ? 128  LEU A N   1 
+ATOM   767  C  CA  . LEU A 1 109 ? 10.348  60.243 12.856 1.00 46.04  ? 128  LEU A CA  1 
+ATOM   768  C  C   . LEU A 1 109 ? 10.676  59.527 11.550 1.00 50.43  ? 128  LEU A C   1 
+ATOM   769  O  O   . LEU A 1 109 ? 11.792  59.653 11.010 1.00 51.40  ? 128  LEU A O   1 
+ATOM   770  C  CB  . LEU A 1 109 ? 10.588  59.268 13.987 1.00 42.96  ? 128  LEU A CB  1 
+ATOM   771  C  CG  . LEU A 1 109 ? 10.686  59.892 15.358 1.00 44.34  ? 128  LEU A CG  1 
+ATOM   772  C  CD1 . LEU A 1 109 ? 10.647  58.746 16.350 1.00 43.52  ? 128  LEU A CD1 1 
+ATOM   773  C  CD2 . LEU A 1 109 ? 11.959  60.761 15.490 1.00 45.14  ? 128  LEU A CD2 1 
+ATOM   774  N  N   . MET A 1 110 ? 9.709   58.735 11.097 1.00 53.55  ? 129  MET A N   1 
+ATOM   775  C  CA  . MET A 1 110 ? 9.753   58.078 9.808  1.00 56.49  ? 129  MET A CA  1 
+ATOM   776  C  C   . MET A 1 110 ? 10.076  59.085 8.731  1.00 56.03  ? 129  MET A C   1 
+ATOM   777  O  O   . MET A 1 110 ? 11.023  58.907 7.986  1.00 55.52  ? 129  MET A O   1 
+ATOM   778  C  CB  . MET A 1 110 ? 8.399   57.446 9.492  1.00 62.45  ? 129  MET A CB  1 
+ATOM   779  C  CG  . MET A 1 110 ? 8.487   56.113 8.790  1.00 69.75  ? 129  MET A CG  1 
+ATOM   780  S  SD  . MET A 1 110 ? 8.948   54.849 9.981  1.00 82.31  ? 129  MET A SD  1 
+ATOM   781  C  CE  . MET A 1 110 ? 7.282   53.892 10.141 1.00 79.95  ? 129  MET A CE  1 
+ATOM   782  N  N   . THR A 1 111 ? 9.311   60.167 8.671  1.00 54.31  ? 130  THR A N   1 
+ATOM   783  C  CA  . THR A 1 111 ? 9.472   61.119 7.586  1.00 56.12  ? 130  THR A CA  1 
+ATOM   784  C  C   . THR A 1 111 ? 10.656  62.070 7.806  1.00 56.43  ? 130  THR A C   1 
+ATOM   785  O  O   . THR A 1 111 ? 11.105  62.741 6.871  1.00 60.41  ? 130  THR A O   1 
+ATOM   786  C  CB  . THR A 1 111 ? 8.164   61.912 7.334  1.00 56.96  ? 130  THR A CB  1 
+ATOM   787  O  OG1 . THR A 1 111 ? 8.071   63.006 8.245  1.00 59.65  ? 130  THR A OG1 1 
+ATOM   788  C  CG2 . THR A 1 111 ? 6.912   61.069 7.625  1.00 59.18  ? 130  THR A CG2 1 
+ATOM   789  N  N   . LEU A 1 112 ? 11.167  62.133 9.027  1.00 55.40  ? 131  LEU A N   1 
+ATOM   790  C  CA  . LEU A 1 112 ? 12.301  62.994 9.329  1.00 55.81  ? 131  LEU A CA  1 
+ATOM   791  C  C   . LEU A 1 112 ? 13.649  62.309 9.109  1.00 54.44  ? 131  LEU A C   1 
+ATOM   792  O  O   . LEU A 1 112 ? 14.694  62.954 9.244  1.00 55.06  ? 131  LEU A O   1 
+ATOM   793  C  CB  . LEU A 1 112 ? 12.223  63.480 10.772 1.00 58.24  ? 131  LEU A CB  1 
+ATOM   794  C  CG  . LEU A 1 112 ? 11.366  64.718 10.986 1.00 60.14  ? 131  LEU A CG  1 
+ATOM   795  C  CD1 . LEU A 1 112 ? 11.154  64.922 12.465 1.00 60.66  ? 131  LEU A CD1 1 
+ATOM   796  C  CD2 . LEU A 1 112 ? 12.029  65.926 10.375 1.00 60.60  ? 131  LEU A CD2 1 
+ATOM   797  N  N   . ARG A 1 113 ? 13.637  61.015 8.796  1.00 51.19  ? 132  ARG A N   1 
+ATOM   798  C  CA  . ARG A 1 113 ? 14.867  60.315 8.442  1.00 49.85  ? 132  ARG A CA  1 
+ATOM   799  C  C   . ARG A 1 113 ? 15.424  60.975 7.200  1.00 48.75  ? 132  ARG A C   1 
+ATOM   800  O  O   . ARG A 1 113 ? 14.673  61.559 6.414  1.00 47.35  ? 132  ARG A O   1 
+ATOM   801  C  CB  . ARG A 1 113 ? 14.602  58.851 8.132  1.00 50.88  ? 132  ARG A CB  1 
+ATOM   802  C  CG  . ARG A 1 113 ? 14.000  58.042 9.276  1.00 57.04  ? 132  ARG A CG  1 
+ATOM   803  C  CD  . ARG A 1 113 ? 13.512  56.663 8.861  1.00 63.37  ? 132  ARG A CD  1 
+ATOM   804  N  NE  . ARG A 1 113 ? 12.635  56.752 7.685  1.00 71.37  ? 132  ARG A NE  1 
+ATOM   805  C  CZ  . ARG A 1 113 ? 12.199  55.724 6.962  1.00 73.89  ? 132  ARG A CZ  1 
+ATOM   806  N  NH1 . ARG A 1 113 ? 12.547  54.475 7.269  1.00 76.71  ? 132  ARG A NH1 1 
+ATOM   807  N  NH2 . ARG A 1 113 ? 11.409  55.957 5.915  1.00 71.69  ? 132  ARG A NH2 1 
+ATOM   808  N  N   . ASN A 1 114 ? 16.735  60.875 7.011  1.00 48.50  ? 133  ASN A N   1 
+ATOM   809  C  CA  . ASN A 1 114 ? 17.395  61.563 5.905  1.00 48.08  ? 133  ASN A CA  1 
+ATOM   810  C  C   . ASN A 1 114 ? 16.696  61.311 4.562  1.00 51.67  ? 133  ASN A C   1 
+ATOM   811  O  O   . ASN A 1 114 ? 16.365  62.261 3.837  1.00 43.89  ? 133  ASN A O   1 
+ATOM   812  C  CB  . ASN A 1 114 ? 18.874  61.177 5.820  1.00 44.64  ? 133  ASN A CB  1 
+ATOM   813  C  CG  . ASN A 1 114 ? 19.678  62.164 5.024  1.00 45.89  ? 133  ASN A CG  1 
+ATOM   814  O  OD1 . ASN A 1 114 ? 20.524  61.792 4.220  1.00 55.72  ? 133  ASN A OD1 1 
+ATOM   815  N  ND2 . ASN A 1 114 ? 19.416  63.434 5.236  1.00 48.44  ? 133  ASN A ND2 1 
+ATOM   816  N  N   . PHE A 1 115 ? 16.467  60.034 4.245  1.00 55.60  ? 134  PHE A N   1 
+ATOM   817  C  CA  . PHE A 1 115 ? 15.808  59.670 2.984  1.00 61.26  ? 134  PHE A CA  1 
+ATOM   818  C  C   . PHE A 1 115 ? 14.434  59.098 3.284  1.00 59.66  ? 134  PHE A C   1 
+ATOM   819  O  O   . PHE A 1 115 ? 14.121  57.988 2.886  1.00 60.82  ? 134  PHE A O   1 
+ATOM   820  C  CB  . PHE A 1 115 ? 16.629  58.652 2.172  1.00 62.26  ? 134  PHE A CB  1 
+ATOM   821  C  CG  . PHE A 1 115 ? 17.871  59.222 1.537  1.00 63.93  ? 134  PHE A CG  1 
+ATOM   822  C  CD1 . PHE A 1 115 ? 17.790  59.980 0.366  1.00 63.88  ? 134  PHE A CD1 1 
+ATOM   823  C  CD2 . PHE A 1 115 ? 19.129  58.978 2.099  1.00 60.58  ? 134  PHE A CD2 1 
+ATOM   824  C  CE1 . PHE A 1 115 ? 18.957  60.498 -0.231 1.00 65.42  ? 134  PHE A CE1 1 
+ATOM   825  C  CE2 . PHE A 1 115 ? 20.284  59.489 1.518  1.00 62.20  ? 134  PHE A CE2 1 
+ATOM   826  C  CZ  . PHE A 1 115 ? 20.204  60.255 0.356  1.00 62.84  ? 134  PHE A CZ  1 
+ATOM   827  N  N   . GLY A 1 116 ? 13.612  59.863 3.984  1.00 59.60  ? 135  GLY A N   1 
+ATOM   828  C  CA  . GLY A 1 116 ? 12.353  59.343 4.480  1.00 58.32  ? 135  GLY A CA  1 
+ATOM   829  C  C   . GLY A 1 116 ? 11.146  59.821 3.712  1.00 57.90  ? 135  GLY A C   1 
+ATOM   830  O  O   . GLY A 1 116 ? 10.051  59.467 4.074  1.00 51.97  ? 135  GLY A O   1 
+ATOM   831  N  N   . MET A 1 117 ? 11.342  60.624 2.666  1.00 62.38  ? 136  MET A N   1 
+ATOM   832  C  CA  . MET A 1 117 ? 10.223  61.203 1.910  1.00 61.45  ? 136  MET A CA  1 
+ATOM   833  C  C   . MET A 1 117 ? 10.677  61.864 0.610  1.00 62.10  ? 136  MET A C   1 
+ATOM   834  O  O   . MET A 1 117 ? 10.813  63.083 0.504  1.00 62.35  ? 136  MET A O   1 
+ATOM   835  C  CB  . MET A 1 117 ? 9.432   62.214 2.760  1.00 59.70  ? 136  MET A CB  1 
+ATOM   836  C  CG  . MET A 1 117 ? 10.261  63.222 3.520  1.00 58.21  ? 136  MET A CG  1 
+ATOM   837  S  SD  . MET A 1 117 ? 9.277   64.508 4.356  1.00 57.90  ? 136  MET A SD  1 
+ATOM   838  C  CE  . MET A 1 117 ? 10.468  65.793 4.566  1.00 56.52  ? 136  MET A CE  1 
+ATOM   839  N  N   . GLY A 1 118 ? 10.898  61.041 -0.395 1.00 63.89  ? 137  GLY A N   1 
+ATOM   840  C  CA  . GLY A 1 118 ? 11.162  61.557 -1.718 1.00 64.42  ? 137  GLY A CA  1 
+ATOM   841  C  C   . GLY A 1 118 ? 12.598  61.386 -2.121 1.00 64.03  ? 137  GLY A C   1 
+ATOM   842  O  O   . GLY A 1 118 ? 13.378  60.668 -1.486 1.00 55.86  ? 137  GLY A O   1 
+ATOM   843  N  N   . LYS A 1 119 ? 12.933  62.059 -3.210 1.00 65.53  ? 138  LYS A N   1 
+ATOM   844  C  CA  . LYS A 1 119 ? 14.271  61.975 -3.776 1.00 67.98  ? 138  LYS A CA  1 
+ATOM   845  C  C   . LYS A 1 119 ? 15.225  62.870 -2.994 1.00 62.52  ? 138  LYS A C   1 
+ATOM   846  O  O   . LYS A 1 119 ? 16.409  62.550 -2.877 1.00 64.39  ? 138  LYS A O   1 
+ATOM   847  C  CB  . LYS A 1 119 ? 14.252  62.356 -5.268 1.00 70.59  ? 138  LYS A CB  1 
+ATOM   848  C  CG  . LYS A 1 119 ? 13.207  61.586 -6.095 1.00 72.33  ? 138  LYS A CG  1 
+ATOM   849  C  CD  . LYS A 1 119 ? 13.452  60.069 -6.062 1.00 72.37  ? 138  LYS A CD  1 
+ATOM   850  C  CE  . LYS A 1 119 ? 12.774  59.359 -7.248 1.00 73.72  ? 138  LYS A CE  1 
+ATOM   851  N  NZ  . LYS A 1 119 ? 13.111  59.942 -8.597 1.00 68.91  ? 138  LYS A NZ  1 
+ATOM   852  N  N   . ARG A 1 120 ? 14.689  63.964 -2.441 1.00 57.18  ? 139  ARG A N   1 
+ATOM   853  C  CA  . ARG A 1 120 ? 15.483  64.965 -1.718 1.00 53.63  ? 139  ARG A CA  1 
+ATOM   854  C  C   . ARG A 1 120 ? 15.707  64.575 -0.262 1.00 48.42  ? 139  ARG A C   1 
+ATOM   855  O  O   . ARG A 1 120 ? 14.776  64.262 0.458  1.00 48.97  ? 139  ARG A O   1 
+ATOM   856  C  CB  . ARG A 1 120 ? 14.812  66.336 -1.782 1.00 54.62  ? 139  ARG A CB  1 
+ATOM   857  C  CG  . ARG A 1 120 ? 15.780  67.490 -1.938 1.00 57.33  ? 139  ARG A CG  1 
+ATOM   858  C  CD  . ARG A 1 120 ? 15.295  68.559 -2.873 1.00 60.51  ? 139  ARG A CD  1 
+ATOM   859  N  NE  . ARG A 1 120 ? 14.863  69.764 -2.162 1.00 61.30  ? 139  ARG A NE  1 
+ATOM   860  C  CZ  . ARG A 1 120 ? 15.678  70.708 -1.716 1.00 58.70  ? 139  ARG A CZ  1 
+ATOM   861  N  NH1 . ARG A 1 120 ? 15.169  71.774 -1.108 1.00 64.36  ? 139  ARG A NH1 1 
+ATOM   862  N  NH2 . ARG A 1 120 ? 16.993  70.590 -1.865 1.00 53.81  ? 139  ARG A NH2 1 
+ATOM   863  N  N   . SER A 1 121 ? 16.954  64.598 0.176  1.00 46.12  ? 140  SER A N   1 
+ATOM   864  C  CA  . SER A 1 121 ? 17.251  64.242 1.559  1.00 44.19  ? 140  SER A CA  1 
+ATOM   865  C  C   . SER A 1 121 ? 17.133  65.451 2.480  1.00 41.55  ? 140  SER A C   1 
+ATOM   866  O  O   . SER A 1 121 ? 17.271  66.614 2.046  1.00 42.46  ? 140  SER A O   1 
+ATOM   867  C  CB  . SER A 1 121 ? 18.650  63.640 1.674  1.00 41.52  ? 140  SER A CB  1 
+ATOM   868  O  OG  . SER A 1 121 ? 19.632  64.603 1.380  1.00 41.89  ? 140  SER A OG  1 
+ATOM   869  N  N   . ILE A 1 122 ? 16.904  65.174 3.754  1.00 34.61  ? 141  ILE A N   1 
+ATOM   870  C  CA  . ILE A 1 122 ? 17.007  66.207 4.768  1.00 33.30  ? 141  ILE A CA  1 
+ATOM   871  C  C   . ILE A 1 122 ? 18.339  66.938 4.627  1.00 33.98  ? 141  ILE A C   1 
+ATOM   872  O  O   . ILE A 1 122 ? 18.395  68.170 4.728  1.00 32.09  ? 141  ILE A O   1 
+ATOM   873  C  CB  . ILE A 1 122 ? 16.906  65.571 6.169  1.00 33.29  ? 141  ILE A CB  1 
+ATOM   874  C  CG1 . ILE A 1 122 ? 15.480  65.065 6.432  1.00 35.29  ? 141  ILE A CG1 1 
+ATOM   875  C  CG2 . ILE A 1 122 ? 17.367  66.541 7.250  1.00 33.65  ? 141  ILE A CG2 1 
+ATOM   876  C  CD1 . ILE A 1 122 ? 14.354  66.153 6.336  1.00 36.02  ? 141  ILE A CD1 1 
+ATOM   877  N  N   . GLU A 1 123 ? 19.417  66.187 4.385  1.00 35.58  ? 142  GLU A N   1 
+ATOM   878  C  CA  . GLU A 1 123 ? 20.736  66.791 4.363  1.00 37.56  ? 142  GLU A CA  1 
+ATOM   879  C  C   . GLU A 1 123 ? 20.840  67.797 3.267  1.00 36.99  ? 142  GLU A C   1 
+ATOM   880  O  O   . GLU A 1 123 ? 21.389  68.847 3.465  1.00 34.74  ? 142  GLU A O   1 
+ATOM   881  C  CB  . GLU A 1 123 ? 21.832  65.765 4.185  1.00 42.88  ? 142  GLU A CB  1 
+ATOM   882  C  CG  . GLU A 1 123 ? 23.222  66.353 4.413  1.00 44.00  ? 142  GLU A CG  1 
+ATOM   883  C  CD  . GLU A 1 123 ? 24.308  65.304 4.383  1.00 47.02  ? 142  GLU A CD  1 
+ATOM   884  O  OE1 . GLU A 1 123 ? 24.080  64.176 4.893  1.00 48.33  ? 142  GLU A OE1 1 
+ATOM   885  O  OE2 . GLU A 1 123 ? 25.382  65.616 3.835  1.00 49.70  ? 142  GLU A OE2 1 
+ATOM   886  N  N   . ASP A 1 124 ? 20.283  67.487 2.111  1.00 40.14  ? 143  ASP A N   1 
+ATOM   887  C  CA  . ASP A 1 124 ? 20.368  68.404 0.999  1.00 45.19  ? 143  ASP A CA  1 
+ATOM   888  C  C   . ASP A 1 124 ? 19.581  69.670 1.245  1.00 40.39  ? 143  ASP A C   1 
+ATOM   889  O  O   . ASP A 1 124 ? 19.942  70.745 0.794  1.00 39.88  ? 143  ASP A O   1 
+ATOM   890  C  CB  . ASP A 1 124 ? 19.886  67.752 -0.294 1.00 52.89  ? 143  ASP A CB  1 
+ATOM   891  C  CG  . ASP A 1 124 ? 20.649  68.275 -1.498 1.00 60.06  ? 143  ASP A CG  1 
+ATOM   892  O  OD1 . ASP A 1 124 ? 20.582  69.507 -1.798 1.00 57.28  ? 143  ASP A OD1 1 
+ATOM   893  O  OD2 . ASP A 1 124 ? 21.390  67.517 -2.159 1.00 70.20  ? 143  ASP A OD2 1 
+ATOM   894  N  N   . ARG A 1 125 ? 18.475  69.528 1.946  1.00 38.83  ? 144  ARG A N   1 
+ATOM   895  C  CA  . ARG A 1 125 ? 17.761  70.683 2.436  1.00 36.66  ? 144  ARG A CA  1 
+ATOM   896  C  C   . ARG A 1 125 ? 18.682  71.530 3.333  1.00 33.38  ? 144  ARG A C   1 
+ATOM   897  O  O   . ARG A 1 125 ? 18.887  72.723 3.078  1.00 32.43  ? 144  ARG A O   1 
+ATOM   898  C  CB  . ARG A 1 125 ? 16.526  70.220 3.178  1.00 39.28  ? 144  ARG A CB  1 
+ATOM   899  C  CG  . ARG A 1 125 ? 15.515  69.491 2.289  1.00 41.44  ? 144  ARG A CG  1 
+ATOM   900  C  CD  . ARG A 1 125 ? 14.285  69.098 3.061  1.00 44.89  ? 144  ARG A CD  1 
+ATOM   901  N  NE  . ARG A 1 125 ? 13.419  68.146 2.379  1.00 46.72  ? 144  ARG A NE  1 
+ATOM   902  C  CZ  . ARG A 1 125 ? 12.602  68.441 1.367  1.00 48.65  ? 144  ARG A CZ  1 
+ATOM   903  N  NH1 . ARG A 1 125 ? 12.536  69.670 0.854  1.00 48.96  ? 144  ARG A NH1 1 
+ATOM   904  N  NH2 . ARG A 1 125 ? 11.855  67.482 0.862  1.00 49.97  ? 144  ARG A NH2 1 
+ATOM   905  N  N   . VAL A 1 126 ? 19.288  70.921 4.344  1.00 28.27  ? 145  VAL A N   1 
+ATOM   906  C  CA  . VAL A 1 126 ? 20.120  71.699 5.259  1.00 27.07  ? 145  VAL A CA  1 
+ATOM   907  C  C   . VAL A 1 126 ? 21.324  72.343 4.529  1.00 28.29  ? 145  VAL A C   1 
+ATOM   908  O  O   . VAL A 1 126 ? 21.615  73.528 4.733  1.00 29.76  ? 145  VAL A O   1 
+ATOM   909  C  CB  . VAL A 1 126 ? 20.533  70.867 6.488  1.00 28.35  ? 145  VAL A CB  1 
+ATOM   910  C  CG1 . VAL A 1 126 ? 21.457  71.678 7.421  1.00 28.98  ? 145  VAL A CG1 1 
+ATOM   911  C  CG2 . VAL A 1 126 ? 19.271  70.366 7.247  1.00 20.49  ? 145  VAL A CG2 1 
+ATOM   912  N  N   . GLN A 1 127 ? 21.959  71.624 3.610  1.00 29.99  ? 146  GLN A N   1 
+ATOM   913  C  CA  . GLN A 1 127 ? 23.050  72.204 2.806  1.00 32.25  ? 146  GLN A CA  1 
+ATOM   914  C  C   . GLN A 1 127 ? 22.639  73.396 1.937  1.00 32.76  ? 146  GLN A C   1 
+ATOM   915  O  O   . GLN A 1 127 ? 23.370  74.371 1.835  1.00 33.88  ? 146  GLN A O   1 
+ATOM   916  C  CB  . GLN A 1 127 ? 23.680  71.151 1.912  1.00 35.37  ? 146  GLN A CB  1 
+ATOM   917  C  CG  . GLN A 1 127 ? 24.211  69.968 2.669  1.00 39.75  ? 146  GLN A CG  1 
+ATOM   918  C  CD  . GLN A 1 127 ? 25.081  69.083 1.836  1.00 38.10  ? 146  GLN A CD  1 
+ATOM   919  O  OE1 . GLN A 1 127 ? 26.254  69.332 1.770  1.00 42.58  ? 146  GLN A OE1 1 
+ATOM   920  N  NE2 . GLN A 1 127 ? 24.521  68.032 1.232  1.00 34.88  ? 146  GLN A NE2 1 
+ATOM   921  N  N   . GLU A 1 128 ? 21.469  73.322 1.309  1.00 38.41  ? 147  GLU A N   1 
+ATOM   922  C  CA  . GLU A 1 128 ? 20.954  74.447 0.517  1.00 38.47  ? 147  GLU A CA  1 
+ATOM   923  C  C   . GLU A 1 128 ? 20.792  75.659 1.405  1.00 39.35  ? 147  GLU A C   1 
+ATOM   924  O  O   . GLU A 1 128 ? 21.222  76.758 1.070  1.00 40.41  ? 147  GLU A O   1 
+ATOM   925  C  CB  . GLU A 1 128 ? 19.629  74.094 -0.139 1.00 39.29  ? 147  GLU A CB  1 
+ATOM   926  C  CG  . GLU A 1 128 ? 19.192  75.093 -1.194 1.00 42.12  ? 147  GLU A CG  1 
+ATOM   927  C  CD  . GLU A 1 128 ? 17.845  74.750 -1.834 1.00 47.56  ? 147  GLU A CD  1 
+ATOM   928  O  OE1 . GLU A 1 128 ? 17.416  73.558 -1.817 1.00 43.64  ? 147  GLU A OE1 1 
+ATOM   929  O  OE2 . GLU A 1 128 ? 17.223  75.690 -2.382 1.00 48.35  ? 147  GLU A OE2 1 
+ATOM   930  N  N   . GLU A 1 129 ? 20.202  75.447 2.570  1.00 40.17  ? 148  GLU A N   1 
+ATOM   931  C  CA  . GLU A 1 129 ? 20.104  76.520 3.552  1.00 40.28  ? 148  GLU A CA  1 
+ATOM   932  C  C   . GLU A 1 129 ? 21.473  77.086 3.986  1.00 36.84  ? 148  GLU A C   1 
+ATOM   933  O  O   . GLU A 1 129 ? 21.633  78.288 4.150  1.00 28.95  ? 148  GLU A O   1 
+ATOM   934  C  CB  . GLU A 1 129 ? 19.315  76.034 4.773  1.00 41.17  ? 148  GLU A CB  1 
+ATOM   935  C  CG  . GLU A 1 129 ? 18.467  77.130 5.397  1.00 45.34  ? 148  GLU A CG  1 
+ATOM   936  C  CD  . GLU A 1 129 ? 17.477  77.744 4.423  1.00 46.39  ? 148  GLU A CD  1 
+ATOM   937  O  OE1 . GLU A 1 129 ? 16.708  76.930 3.793  1.00 44.62  ? 148  GLU A OE1 1 
+ATOM   938  O  OE2 . GLU A 1 129 ? 17.488  79.016 4.303  1.00 33.39  ? 148  GLU A OE2 1 
+ATOM   939  N  N   . ALA A 1 130 ? 22.460  76.215 4.165  1.00 36.05  ? 149  ALA A N   1 
+ATOM   940  C  CA  . ALA A 1 130 ? 23.755  76.660 4.641  1.00 34.36  ? 149  ALA A CA  1 
+ATOM   941  C  C   . ALA A 1 130 ? 24.352  77.659 3.667  1.00 35.13  ? 149  ALA A C   1 
+ATOM   942  O  O   . ALA A 1 130 ? 24.697  78.775 4.074  1.00 26.86  ? 149  ALA A O   1 
+ATOM   943  C  CB  . ALA A 1 130 ? 24.686  75.480 4.885  1.00 34.44  ? 149  ALA A CB  1 
+ATOM   944  N  N   . ARG A 1 131 ? 24.418  77.322 2.372  1.00 39.67  ? 150  ARG A N   1 
+ATOM   945  C  CA  . ARG A 1 131 ? 24.936  78.329 1.413  1.00 43.65  ? 150  ARG A CA  1 
+ATOM   946  C  C   . ARG A 1 131 ? 24.067  79.600 1.205  1.00 39.17  ? 150  ARG A C   1 
+ATOM   947  O  O   . ARG A 1 131 ? 24.601  80.613 0.819  1.00 40.73  ? 150  ARG A O   1 
+ATOM   948  C  CB  . ARG A 1 131 ? 25.402  77.736 0.078  1.00 43.66  ? 150  ARG A CB  1 
+ATOM   949  C  CG  . ARG A 1 131 ? 24.405  76.959 -0.690 1.00 49.22  ? 150  ARG A CG  1 
+ATOM   950  C  CD  . ARG A 1 131 ? 24.747  76.843 -2.187 1.00 53.59  ? 150  ARG A CD  1 
+ATOM   951  N  NE  . ARG A 1 131 ? 23.587  76.389 -2.960 1.00 57.71  ? 150  ARG A NE  1 
+ATOM   952  C  CZ  . ARG A 1 131 ? 23.081  75.156 -2.900 1.00 57.07  ? 150  ARG A CZ  1 
+ATOM   953  N  NH1 . ARG A 1 131 ? 22.006  74.857 -3.622 1.00 62.26  ? 150  ARG A NH1 1 
+ATOM   954  N  NH2 . ARG A 1 131 ? 23.636  74.216 -2.125 1.00 53.39  ? 150  ARG A NH2 1 
+ATOM   955  N  N   . CYS A 1 132 ? 22.770  79.569 1.508  1.00 41.27  ? 151  CYS A N   1 
+ATOM   956  C  CA  . CYS A 1 132 ? 21.967  80.812 1.545  1.00 43.12  ? 151  CYS A CA  1 
+ATOM   957  C  C   . CYS A 1 132 ? 22.239  81.630 2.771  1.00 42.41  ? 151  CYS A C   1 
+ATOM   958  O  O   . CYS A 1 132 ? 22.250  82.852 2.705  1.00 42.89  ? 151  CYS A O   1 
+ATOM   959  C  CB  . CYS A 1 132 ? 20.485  80.527 1.518  1.00 43.27  ? 151  CYS A CB  1 
+ATOM   960  S  SG  . CYS A 1 132 ? 20.027  79.494 0.119  1.00 57.47  ? 151  CYS A SG  1 
+ATOM   961  N  N   . LEU A 1 133 ? 22.430  80.941 3.893  1.00 43.11  ? 152  LEU A N   1 
+ATOM   962  C  CA  . LEU A 1 133 ? 22.810  81.573 5.148  1.00 44.10  ? 152  LEU A CA  1 
+ATOM   963  C  C   . LEU A 1 133 ? 24.087  82.370 4.939  1.00 42.72  ? 152  LEU A C   1 
+ATOM   964  O  O   . LEU A 1 133 ? 24.206  83.493 5.423  1.00 39.30  ? 152  LEU A O   1 
+ATOM   965  C  CB  . LEU A 1 133 ? 23.055  80.507 6.218  1.00 46.14  ? 152  LEU A CB  1 
+ATOM   966  C  CG  . LEU A 1 133 ? 22.789  80.831 7.683  1.00 48.05  ? 152  LEU A CG  1 
+ATOM   967  C  CD1 . LEU A 1 133 ? 23.258  79.686 8.505  1.00 48.48  ? 152  LEU A CD1 1 
+ATOM   968  C  CD2 . LEU A 1 133 ? 23.506  82.080 8.111  1.00 52.41  ? 152  LEU A CD2 1 
+ATOM   969  N  N   . VAL A 1 134 ? 25.031  81.756 4.223  1.00 44.41  ? 153  VAL A N   1 
+ATOM   970  C  CA  . VAL A 1 134 ? 26.323  82.360 3.908  1.00 48.03  ? 153  VAL A CA  1 
+ATOM   971  C  C   . VAL A 1 134 ? 26.180  83.543 2.948  1.00 48.42  ? 153  VAL A C   1 
+ATOM   972  O  O   . VAL A 1 134 ? 26.801  84.576 3.146  1.00 43.33  ? 153  VAL A O   1 
+ATOM   973  C  CB  . VAL A 1 134 ? 27.301  81.316 3.310  1.00 49.48  ? 153  VAL A CB  1 
+ATOM   974  C  CG1 . VAL A 1 134 ? 28.537  81.993 2.698  1.00 49.91  ? 153  VAL A CG1 1 
+ATOM   975  C  CG2 . VAL A 1 134 ? 27.727  80.329 4.376  1.00 50.79  ? 153  VAL A CG2 1 
+ATOM   976  N  N   . GLU A 1 135 ? 25.345  83.393 1.926  1.00 53.36  ? 154  GLU A N   1 
+ATOM   977  C  CA  . GLU A 1 135 ? 25.060  84.496 1.017  1.00 58.51  ? 154  GLU A CA  1 
+ATOM   978  C  C   . GLU A 1 135 ? 24.488  85.718 1.753  1.00 55.90  ? 154  GLU A C   1 
+ATOM   979  O  O   . GLU A 1 135 ? 24.933  86.848 1.531  1.00 56.80  ? 154  GLU A O   1 
+ATOM   980  C  CB  . GLU A 1 135 ? 24.122  84.043 -0.115 1.00 64.45  ? 154  GLU A CB  1 
+ATOM   981  C  CG  . GLU A 1 135 ? 24.051  85.008 -1.306 1.00 71.79  ? 154  GLU A CG  1 
+ATOM   982  C  CD  . GLU A 1 135 ? 25.422  85.521 -1.754 1.00 76.51  ? 154  GLU A CD  1 
+ATOM   983  O  OE1 . GLU A 1 135 ? 25.593  86.757 -1.866 1.00 75.35  ? 154  GLU A OE1 1 
+ATOM   984  O  OE2 . GLU A 1 135 ? 26.335  84.686 -1.986 1.00 82.18  ? 154  GLU A OE2 1 
+ATOM   985  N  N   . GLU A 1 136 ? 23.538  85.496 2.655  1.00 53.55  ? 155  GLU A N   1 
+ATOM   986  C  CA  . GLU A 1 136 ? 22.923  86.605 3.398  1.00 54.56  ? 155  GLU A CA  1 
+ATOM   987  C  C   . GLU A 1 136 ? 23.873  87.263 4.385  1.00 51.95  ? 155  GLU A C   1 
+ATOM   988  O  O   . GLU A 1 136 ? 23.731  88.447 4.690  1.00 53.66  ? 155  GLU A O   1 
+ATOM   989  C  CB  . GLU A 1 136 ? 21.669  86.153 4.155  1.00 54.70  ? 155  GLU A CB  1 
+ATOM   990  C  CG  . GLU A 1 136 ? 20.437  86.012 3.287  1.00 58.49  ? 155  GLU A CG  1 
+ATOM   991  C  CD  . GLU A 1 136 ? 19.997  87.311 2.637  1.00 58.74  ? 155  GLU A CD  1 
+ATOM   992  O  OE1 . GLU A 1 136 ? 19.935  87.334 1.391  1.00 58.52  ? 155  GLU A OE1 1 
+ATOM   993  O  OE2 . GLU A 1 136 ? 19.724  88.291 3.375  1.00 57.96  ? 155  GLU A OE2 1 
+ATOM   994  N  N   . LEU A 1 137 ? 24.823  86.496 4.904  1.00 48.31  ? 156  LEU A N   1 
+ATOM   995  C  CA  . LEU A 1 137 ? 25.786  87.048 5.830  1.00 46.54  ? 156  LEU A CA  1 
+ATOM   996  C  C   . LEU A 1 137 ? 26.795  87.854 5.018  1.00 45.39  ? 156  LEU A C   1 
+ATOM   997  O  O   . LEU A 1 137 ? 27.451  88.765 5.527  1.00 35.77  ? 156  LEU A O   1 
+ATOM   998  C  CB  . LEU A 1 137 ? 26.454  85.932 6.634  1.00 47.86  ? 156  LEU A CB  1 
+ATOM   999  C  CG  . LEU A 1 137 ? 25.615  85.273 7.737  1.00 45.75  ? 156  LEU A CG  1 
+ATOM   1000 C  CD1 . LEU A 1 137 ? 26.284  83.995 8.204  1.00 44.99  ? 156  LEU A CD1 1 
+ATOM   1001 C  CD2 . LEU A 1 137 ? 25.410  86.214 8.918  1.00 47.40  ? 156  LEU A CD2 1 
+ATOM   1002 N  N   . ARG A 1 138 ? 26.896  87.512 3.738  1.00 48.77  ? 157  ARG A N   1 
+ATOM   1003 C  CA  . ARG A 1 138 ? 27.772  88.216 2.822  1.00 53.69  ? 157  ARG A CA  1 
+ATOM   1004 C  C   . ARG A 1 138 ? 27.162  89.548 2.413  1.00 54.60  ? 157  ARG A C   1 
+ATOM   1005 O  O   . ARG A 1 138 ? 27.885  90.480 2.064  1.00 56.46  ? 157  ARG A O   1 
+ATOM   1006 C  CB  . ARG A 1 138 ? 28.093  87.362 1.600  1.00 56.23  ? 157  ARG A CB  1 
+ATOM   1007 C  CG  . ARG A 1 138 ? 29.527  87.543 1.119  1.00 62.61  ? 157  ARG A CG  1 
+ATOM   1008 C  CD  . ARG A 1 138 ? 29.781  86.950 -0.245 1.00 65.68  ? 157  ARG A CD  1 
+ATOM   1009 N  NE  . ARG A 1 138 ? 29.685  85.489 -0.223 1.00 64.97  ? 157  ARG A NE  1 
+ATOM   1010 C  CZ  . ARG A 1 138 ? 30.667  84.671 0.147  1.00 64.06  ? 157  ARG A CZ  1 
+ATOM   1011 N  NH1 . ARG A 1 138 ? 31.846  85.148 0.548  1.00 61.90  ? 157  ARG A NH1 1 
+ATOM   1012 N  NH2 . ARG A 1 138 ? 30.463  83.359 0.129  1.00 66.43  ? 157  ARG A NH2 1 
+ATOM   1013 N  N   . LYS A 1 139 ? 25.837  89.639 2.478  1.00 56.05  ? 158  LYS A N   1 
+ATOM   1014 C  CA  . LYS A 1 139 ? 25.152  90.908 2.281  1.00 56.82  ? 158  LYS A CA  1 
+ATOM   1015 C  C   . LYS A 1 139 ? 25.524  91.896 3.369  1.00 56.32  ? 158  LYS A C   1 
+ATOM   1016 O  O   . LYS A 1 139 ? 25.559  93.088 3.102  1.00 60.21  ? 158  LYS A O   1 
+ATOM   1017 C  CB  . LYS A 1 139 ? 23.623  90.736 2.219  1.00 58.92  ? 158  LYS A CB  1 
+ATOM   1018 C  CG  . LYS A 1 139 ? 23.124  90.098 0.900  1.00 64.95  ? 158  LYS A CG  1 
+ATOM   1019 C  CD  . LYS A 1 139 ? 21.590  90.275 0.698  1.00 71.12  ? 158  LYS A CD  1 
+ATOM   1020 C  CE  . LYS A 1 139 ? 20.972  89.273 -0.318 1.00 72.65  ? 158  LYS A CE  1 
+ATOM   1021 N  NZ  . LYS A 1 139 ? 20.892  89.780 -1.715 1.00 74.50  ? 158  LYS A NZ  1 
+ATOM   1022 N  N   . THR A 1 140 ? 25.840  91.425 4.575  1.00 56.43  ? 159  THR A N   1 
+ATOM   1023 C  CA  . THR A 1 140 ? 26.150  92.346 5.686  1.00 54.95  ? 159  THR A CA  1 
+ATOM   1024 C  C   . THR A 1 140 ? 27.407  93.184 5.493  1.00 56.29  ? 159  THR A C   1 
+ATOM   1025 O  O   . THR A 1 140 ? 27.663  94.074 6.306  1.00 55.37  ? 159  THR A O   1 
+ATOM   1026 C  CB  . THR A 1 140 ? 26.237  91.625 7.067  1.00 55.64  ? 159  THR A CB  1 
+ATOM   1027 O  OG1 . THR A 1 140 ? 27.495  90.929 7.214  1.00 55.93  ? 159  THR A OG1 1 
+ATOM   1028 C  CG2 . THR A 1 140 ? 25.131  90.585 7.228  1.00 52.60  ? 159  THR A CG2 1 
+ATOM   1029 N  N   . LYS A 1 141 ? 28.191  92.907 4.445  1.00 60.69  ? 160  LYS A N   1 
+ATOM   1030 C  CA  . LYS A 1 141 ? 29.292  93.797 4.028  1.00 65.70  ? 160  LYS A CA  1 
+ATOM   1031 C  C   . LYS A 1 141 ? 30.311  94.069 5.160  1.00 66.08  ? 160  LYS A C   1 
+ATOM   1032 O  O   . LYS A 1 141 ? 30.830  95.178 5.290  1.00 67.10  ? 160  LYS A O   1 
+ATOM   1033 C  CB  . LYS A 1 141 ? 28.729  95.127 3.467  1.00 68.27  ? 160  LYS A CB  1 
+ATOM   1034 C  CG  . LYS A 1 141 ? 28.795  95.275 1.931  1.00 74.88  ? 160  LYS A CG  1 
+ATOM   1035 C  CD  . LYS A 1 141 ? 28.280  96.677 1.453  1.00 80.57  ? 160  LYS A CD  1 
+ATOM   1036 C  CE  . LYS A 1 141 ? 29.295  97.408 0.519  1.00 83.25  ? 160  LYS A CE  1 
+ATOM   1037 N  NZ  . LYS A 1 141 ? 28.878  98.789 0.088  1.00 83.93  ? 160  LYS A NZ  1 
+ATOM   1038 N  N   . ALA A 1 142 ? 30.573  93.053 5.984  1.00 66.43  ? 161  ALA A N   1 
+ATOM   1039 C  CA  . ALA A 1 142 ? 31.623  93.101 7.004  1.00 66.06  ? 161  ALA A CA  1 
+ATOM   1040 C  C   . ALA A 1 142 ? 31.419  94.231 8.003  1.00 65.07  ? 161  ALA A C   1 
+ATOM   1041 O  O   . ALA A 1 142 ? 32.377  94.796 8.529  1.00 62.43  ? 161  ALA A O   1 
+ATOM   1042 C  CB  . ALA A 1 142 ? 32.999  93.218 6.344  1.00 66.69  ? 161  ALA A CB  1 
+ATOM   1043 N  N   . SER A 1 143 ? 30.163  94.545 8.275  1.00 65.45  ? 162  SER A N   1 
+ATOM   1044 C  CA  . SER A 1 143 ? 29.832  95.657 9.150  1.00 68.18  ? 162  SER A CA  1 
+ATOM   1045 C  C   . SER A 1 143 ? 29.036  95.135 10.324 1.00 66.16  ? 162  SER A C   1 
+ATOM   1046 O  O   . SER A 1 143 ? 28.299  94.160 10.176 1.00 64.15  ? 162  SER A O   1 
+ATOM   1047 C  CB  . SER A 1 143 ? 28.994  96.691 8.393  1.00 70.83  ? 162  SER A CB  1 
+ATOM   1048 O  OG  . SER A 1 143 ? 27.735  96.147 8.039  1.00 72.63  ? 162  SER A OG  1 
+ATOM   1049 N  N   . PRO A 1 144 ? 29.148  95.795 11.478 1.00 65.13  ? 163  PRO A N   1 
+ATOM   1050 C  CA  . PRO A 1 144 ? 28.485  95.320 12.694 1.00 63.42  ? 163  PRO A CA  1 
+ATOM   1051 C  C   . PRO A 1 144 ? 27.035  94.950 12.439 1.00 61.26  ? 163  PRO A C   1 
+ATOM   1052 O  O   . PRO A 1 144 ? 26.341  95.615 11.672 1.00 64.84  ? 163  PRO A O   1 
+ATOM   1053 C  CB  . PRO A 1 144 ? 28.584  96.520 13.654 1.00 63.20  ? 163  PRO A CB  1 
+ATOM   1054 C  CG  . PRO A 1 144 ? 29.119  97.638 12.852 1.00 63.18  ? 163  PRO A CG  1 
+ATOM   1055 C  CD  . PRO A 1 144 ? 29.900  97.034 11.733 1.00 63.70  ? 163  PRO A CD  1 
+ATOM   1056 N  N   . CYS A 1 145 ? 26.596  93.880 13.082 1.00 58.64  ? 164  CYS A N   1 
+ATOM   1057 C  CA  . CYS A 1 145 ? 25.249  93.392 12.905 1.00 54.97  ? 164  CYS A CA  1 
+ATOM   1058 C  C   . CYS A 1 145 ? 24.825  92.451 14.030 1.00 50.89  ? 164  CYS A C   1 
+ATOM   1059 O  O   . CYS A 1 145 ? 25.629  91.740 14.618 1.00 47.31  ? 164  CYS A O   1 
+ATOM   1060 C  CB  . CYS A 1 145 ? 25.148  92.681 11.562 1.00 56.83  ? 164  CYS A CB  1 
+ATOM   1061 S  SG  . CYS A 1 145 ? 25.054  90.894 11.708 1.00 55.47  ? 164  CYS A SG  1 
+ATOM   1062 N  N   . ASP A 1 146 ? 23.537  92.465 14.313 1.00 48.25  ? 165  ASP A N   1 
+ATOM   1063 C  CA  . ASP A 1 146 ? 22.941  91.575 15.282 1.00 45.59  ? 165  ASP A CA  1 
+ATOM   1064 C  C   . ASP A 1 146 ? 22.449  90.363 14.487 1.00 45.22  ? 165  ASP A C   1 
+ATOM   1065 O  O   . ASP A 1 146 ? 21.518  90.489 13.687 1.00 49.44  ? 165  ASP A O   1 
+ATOM   1066 C  CB  . ASP A 1 146 ? 21.793  92.291 15.991 1.00 44.75  ? 165  ASP A CB  1 
+ATOM   1067 C  CG  . ASP A 1 146 ? 20.934  91.359 16.801 1.00 46.52  ? 165  ASP A CG  1 
+ATOM   1068 O  OD1 . ASP A 1 146 ? 19.878  91.782 17.323 1.00 44.23  ? 165  ASP A OD1 1 
+ATOM   1069 O  OD2 . ASP A 1 146 ? 21.226  90.171 16.966 1.00 49.56  ? 165  ASP A OD2 1 
+ATOM   1070 N  N   . PRO A 1 147 ? 23.054  89.192 14.694 1.00 40.66  ? 166  PRO A N   1 
+ATOM   1071 C  CA  . PRO A 1 147 ? 22.727  88.023 13.873 1.00 36.45  ? 166  PRO A CA  1 
+ATOM   1072 C  C   . PRO A 1 147 ? 21.403  87.383 14.246 1.00 33.37  ? 166  PRO A C   1 
+ATOM   1073 O  O   . PRO A 1 147 ? 20.977  86.471 13.559 1.00 35.64  ? 166  PRO A O   1 
+ATOM   1074 C  CB  . PRO A 1 147 ? 23.899  87.078 14.138 1.00 37.27  ? 166  PRO A CB  1 
+ATOM   1075 C  CG  . PRO A 1 147 ? 24.336  87.400 15.516 1.00 38.75  ? 166  PRO A CG  1 
+ATOM   1076 C  CD  . PRO A 1 147 ? 24.061  88.866 15.724 1.00 40.23  ? 166  PRO A CD  1 
+ATOM   1077 N  N   . THR A 1 148 ? 20.731  87.881 15.281 1.00 32.44  ? 167  THR A N   1 
+ATOM   1078 C  CA  . THR A 1 148 ? 19.504  87.248 15.787 1.00 33.73  ? 167  THR A CA  1 
+ATOM   1079 C  C   . THR A 1 148 ? 18.508  86.857 14.707 1.00 36.83  ? 167  THR A C   1 
+ATOM   1080 O  O   . THR A 1 148 ? 17.893  85.789 14.777 1.00 36.36  ? 167  THR A O   1 
+ATOM   1081 C  CB  . THR A 1 148 ? 18.769  88.183 16.760 1.00 31.29  ? 167  THR A CB  1 
+ATOM   1082 O  OG1 . THR A 1 148 ? 19.681  88.693 17.735 1.00 26.72  ? 167  THR A OG1 1 
+ATOM   1083 C  CG2 . THR A 1 148 ? 17.704  87.421 17.562 1.00 26.17  ? 167  THR A CG2 1 
+ATOM   1084 N  N   . PHE A 1 149 ? 18.346  87.746 13.729 1.00 40.24  ? 168  PHE A N   1 
+ATOM   1085 C  CA  . PHE A 1 149 ? 17.313  87.591 12.723 1.00 42.35  ? 168  PHE A CA  1 
+ATOM   1086 C  C   . PHE A 1 149 ? 17.760  86.604 11.655 1.00 40.71  ? 168  PHE A C   1 
+ATOM   1087 O  O   . PHE A 1 149 ? 17.052  85.626 11.383 1.00 34.14  ? 168  PHE A O   1 
+ATOM   1088 C  CB  . PHE A 1 149 ? 16.921  88.929 12.074 1.00 41.38  ? 168  PHE A CB  1 
+ATOM   1089 C  CG  . PHE A 1 149 ? 15.983  88.754 10.927 1.00 37.74  ? 168  PHE A CG  1 
+ATOM   1090 C  CD1 . PHE A 1 149 ? 16.446  88.848 9.607  1.00 41.02  ? 168  PHE A CD1 1 
+ATOM   1091 C  CD2 . PHE A 1 149 ? 14.656  88.408 11.161 1.00 35.99  ? 168  PHE A CD2 1 
+ATOM   1092 C  CE1 . PHE A 1 149 ? 15.578  88.637 8.528  1.00 40.89  ? 168  PHE A CE1 1 
+ATOM   1093 C  CE2 . PHE A 1 149 ? 13.765  88.191 10.089 1.00 37.83  ? 168  PHE A CE2 1 
+ATOM   1094 C  CZ  . PHE A 1 149 ? 14.224  88.309 8.775  1.00 39.68  ? 168  PHE A CZ  1 
+ATOM   1095 N  N   . ILE A 1 150 ? 18.926  86.858 11.054 1.00 40.23  ? 169  ILE A N   1 
+ATOM   1096 C  CA  . ILE A 1 150 ? 19.434  85.958 10.005 1.00 39.29  ? 169  ILE A CA  1 
+ATOM   1097 C  C   . ILE A 1 150 ? 19.546  84.480 10.488 1.00 35.83  ? 169  ILE A C   1 
+ATOM   1098 O  O   . ILE A 1 150 ? 19.010  83.592 9.870  1.00 35.12  ? 169  ILE A O   1 
+ATOM   1099 C  CB  . ILE A 1 150 ? 20.757  86.458 9.488  1.00 39.44  ? 169  ILE A CB  1 
+ATOM   1100 C  CG1 . ILE A 1 150 ? 20.580  87.814 8.808  1.00 45.10  ? 169  ILE A CG1 1 
+ATOM   1101 C  CG2 . ILE A 1 150 ? 21.322  85.486 8.486  1.00 43.82  ? 169  ILE A CG2 1 
+ATOM   1102 C  CD1 . ILE A 1 150 ? 21.856  88.693 8.817  1.00 47.89  ? 169  ILE A CD1 1 
+ATOM   1103 N  N   . LEU A 1 151 ? 20.210  84.239 11.608 1.00 32.18  ? 170  LEU A N   1 
+ATOM   1104 C  CA  . LEU A 1 151 ? 20.224  82.918 12.241 1.00 33.85  ? 170  LEU A CA  1 
+ATOM   1105 C  C   . LEU A 1 151 ? 18.847  82.364 12.553 1.00 37.36  ? 170  LEU A C   1 
+ATOM   1106 O  O   . LEU A 1 151 ? 18.662  81.158 12.548 1.00 40.31  ? 170  LEU A O   1 
+ATOM   1107 C  CB  . LEU A 1 151 ? 21.017  82.959 13.553 1.00 32.98  ? 170  LEU A CB  1 
+ATOM   1108 C  CG  . LEU A 1 151 ? 22.551  82.890 13.547 1.00 29.96  ? 170  LEU A CG  1 
+ATOM   1109 C  CD1 . LEU A 1 151 ? 23.203  83.468 12.372 1.00 29.51  ? 170  LEU A CD1 1 
+ATOM   1110 C  CD2 . LEU A 1 151 ? 23.065  83.579 14.770 1.00 31.09  ? 170  LEU A CD2 1 
+ATOM   1111 N  N   . GLY A 1 152 ? 17.891  83.227 12.894 1.00 40.57  ? 171  GLY A N   1 
+ATOM   1112 C  CA  . GLY A 1 152 ? 16.523  82.786 13.128 1.00 38.18  ? 171  GLY A CA  1 
+ATOM   1113 C  C   . GLY A 1 152 ? 15.853  82.228 11.877 1.00 39.26  ? 171  GLY A C   1 
+ATOM   1114 O  O   . GLY A 1 152 ? 15.087  81.265 11.967 1.00 35.50  ? 171  GLY A O   1 
+ATOM   1115 N  N   . CYS A 1 153 ? 16.154  82.814 10.714 1.00 40.37  ? 172  CYS A N   1 
+ATOM   1116 C  CA  . CYS A 1 153 ? 15.505  82.442 9.442  1.00 44.27  ? 172  CYS A CA  1 
+ATOM   1117 C  C   . CYS A 1 153 ? 15.940  81.066 8.917  1.00 43.39  ? 172  CYS A C   1 
+ATOM   1118 O  O   . CYS A 1 153 ? 15.110  80.303 8.401  1.00 42.85  ? 172  CYS A O   1 
+ATOM   1119 C  CB  . CYS A 1 153 ? 15.772  83.501 8.351  1.00 47.47  ? 172  CYS A CB  1 
+ATOM   1120 S  SG  . CYS A 1 153 ? 15.048  85.131 8.657  1.00 48.52  ? 172  CYS A SG  1 
+ATOM   1121 N  N   . ALA A 1 154 ? 17.228  80.747 9.048  1.00 36.70  ? 173  ALA A N   1 
+ATOM   1122 C  CA  . ALA A 1 154 ? 17.735  79.499 8.508  1.00 32.73  ? 173  ALA A CA  1 
+ATOM   1123 C  C   . ALA A 1 154 ? 17.043  78.222 9.058  1.00 35.97  ? 173  ALA A C   1 
+ATOM   1124 O  O   . ALA A 1 154 ? 16.622  77.405 8.243  1.00 43.22  ? 173  ALA A O   1 
+ATOM   1125 C  CB  . ALA A 1 154 ? 19.210  79.430 8.655  1.00 35.53  ? 173  ALA A CB  1 
+ATOM   1126 N  N   . PRO A 1 155 ? 16.902  78.023 10.384 1.00 32.20  ? 174  PRO A N   1 
+ATOM   1127 C  CA  . PRO A 1 155 ? 16.187  76.858 10.913 1.00 28.23  ? 174  PRO A CA  1 
+ATOM   1128 C  C   . PRO A 1 155 ? 14.704  76.865 10.541 1.00 33.65  ? 174  PRO A C   1 
+ATOM   1129 O  O   . PRO A 1 155 ? 14.158  75.829 10.191 1.00 30.35  ? 174  PRO A O   1 
+ATOM   1130 C  CB  . PRO A 1 155 ? 16.326  76.997 12.410 1.00 24.23  ? 174  PRO A CB  1 
+ATOM   1131 C  CG  . PRO A 1 155 ? 17.414  77.892 12.612 1.00 29.97  ? 174  PRO A CG  1 
+ATOM   1132 C  CD  . PRO A 1 155 ? 17.430  78.845 11.471 1.00 33.27  ? 174  PRO A CD  1 
+ATOM   1133 N  N   . CYS A 1 156 ? 14.059  78.022 10.607 1.00 38.10  ? 175  CYS A N   1 
+ATOM   1134 C  CA  . CYS A 1 156 ? 12.654  78.107 10.238 1.00 39.75  ? 175  CYS A CA  1 
+ATOM   1135 C  C   . CYS A 1 156 ? 12.484  77.638 8.787  1.00 38.34  ? 175  CYS A C   1 
+ATOM   1136 O  O   . CYS A 1 156 ? 11.584  76.856 8.465  1.00 32.04  ? 175  CYS A O   1 
+ATOM   1137 C  CB  . CYS A 1 156 ? 12.143  79.543 10.391 1.00 41.38  ? 175  CYS A CB  1 
+ATOM   1138 S  SG  . CYS A 1 156 ? 10.421  79.693 9.894  1.00 47.82  ? 175  CYS A SG  1 
+ATOM   1139 N  N   . ASN A 1 157 ? 13.394  78.091 7.930  1.00 37.00  ? 176  ASN A N   1 
+ATOM   1140 C  CA  . ASN A 1 157 ? 13.362  77.743 6.512  1.00 35.80  ? 176  ASN A CA  1 
+ATOM   1141 C  C   . ASN A 1 157 ? 13.633  76.269 6.181  1.00 30.89  ? 176  ASN A C   1 
+ATOM   1142 O  O   . ASN A 1 157 ? 13.188  75.765 5.162  1.00 28.37  ? 176  ASN A O   1 
+ATOM   1143 C  CB  . ASN A 1 157 ? 14.341  78.622 5.745  1.00 35.67  ? 176  ASN A CB  1 
+ATOM   1144 C  CG  . ASN A 1 157 ? 13.734  79.195 4.499  1.00 35.23  ? 176  ASN A CG  1 
+ATOM   1145 O  OD1 . ASN A 1 157 ? 12.577  78.940 4.189  1.00 36.40  ? 176  ASN A OD1 1 
+ATOM   1146 N  ND2 . ASN A 1 157 ? 14.505  79.985 3.784  1.00 34.37  ? 176  ASN A ND2 1 
+ATOM   1147 N  N   . VAL A 1 158 ? 14.358  75.591 7.053  1.00 29.80  ? 177  VAL A N   1 
+ATOM   1148 C  CA  . VAL A 1 158 ? 14.573  74.163 6.913  1.00 30.27  ? 177  VAL A CA  1 
+ATOM   1149 C  C   . VAL A 1 158 ? 13.279  73.434 7.157  1.00 30.62  ? 177  VAL A C   1 
+ATOM   1150 O  O   . VAL A 1 158 ? 12.983  72.431 6.497  1.00 30.45  ? 177  VAL A O   1 
+ATOM   1151 C  CB  . VAL A 1 158 ? 15.600  73.662 7.940  1.00 30.07  ? 177  VAL A CB  1 
+ATOM   1152 C  CG1 . VAL A 1 158 ? 15.641  72.133 7.980  1.00 30.96  ? 177  VAL A CG1 1 
+ATOM   1153 C  CG2 . VAL A 1 158 ? 16.942  74.210 7.643  1.00 26.94  ? 177  VAL A CG2 1 
+ATOM   1154 N  N   . ILE A 1 159 ? 12.527  73.915 8.143  1.00 32.05  ? 178  ILE A N   1 
+ATOM   1155 C  CA  . ILE A 1 159 ? 11.217  73.352 8.425  1.00 35.82  ? 178  ILE A CA  1 
+ATOM   1156 C  C   . ILE A 1 159 ? 10.240  73.719 7.285  1.00 31.93  ? 178  ILE A C   1 
+ATOM   1157 O  O   . ILE A 1 159 ? 9.518   72.843 6.810  1.00 28.92  ? 178  ILE A O   1 
+ATOM   1158 C  CB  . ILE A 1 159 ? 10.730  73.719 9.868  1.00 39.05  ? 178  ILE A CB  1 
+ATOM   1159 C  CG1 . ILE A 1 159 ? 11.500  72.895 10.906 1.00 42.49  ? 178  ILE A CG1 1 
+ATOM   1160 C  CG2 . ILE A 1 159 ? 9.283   73.322 10.098 1.00 37.53  ? 178  ILE A CG2 1 
+ATOM   1161 C  CD1 . ILE A 1 159 ? 12.835  73.471 11.314 1.00 48.45  ? 178  ILE A CD1 1 
+ATOM   1162 N  N   . CYS A 1 160 ? 10.274  74.959 6.791  1.00 31.89  ? 179  CYS A N   1 
+ATOM   1163 C  CA  . CYS A 1 160 ? 9.500   75.323 5.586  1.00 32.66  ? 179  CYS A CA  1 
+ATOM   1164 C  C   . CYS A 1 160 ? 9.762   74.339 4.445  1.00 32.80  ? 179  CYS A C   1 
+ATOM   1165 O  O   . CYS A 1 160 ? 8.828   73.831 3.832  1.00 32.63  ? 179  CYS A O   1 
+ATOM   1166 C  CB  . CYS A 1 160 ? 9.809   76.728 5.115  1.00 30.18  ? 179  CYS A CB  1 
+ATOM   1167 S  SG  . CYS A 1 160 ? 9.120   77.981 6.208  1.00 36.53  ? 179  CYS A SG  1 
+ATOM   1168 N  N   . SER A 1 161 ? 11.026  74.037 4.188  1.00 32.16  ? 180  SER A N   1 
+ATOM   1169 C  CA  . SER A 1 161 ? 11.372  73.151 3.082  1.00 32.38  ? 180  SER A CA  1 
+ATOM   1170 C  C   . SER A 1 161 ? 10.953  71.717 3.387  1.00 29.96  ? 180  SER A C   1 
+ATOM   1171 O  O   . SER A 1 161 ? 10.608  70.980 2.497  1.00 30.63  ? 180  SER A O   1 
+ATOM   1172 C  CB  . SER A 1 161 ? 12.868  73.242 2.759  1.00 34.29  ? 180  SER A CB  1 
+ATOM   1173 O  OG  . SER A 1 161 ? 13.292  72.158 1.939  1.00 40.31  ? 180  SER A OG  1 
+ATOM   1174 N  N   . ILE A 1 162 ? 10.955  71.319 4.647  1.00 33.14  ? 181  ILE A N   1 
+ATOM   1175 C  CA  . ILE A 1 162 ? 10.601  69.946 4.996  1.00 33.11  ? 181  ILE A CA  1 
+ATOM   1176 C  C   . ILE A 1 162 ? 9.094   69.738 4.892  1.00 36.68  ? 181  ILE A C   1 
+ATOM   1177 O  O   . ILE A 1 162 ? 8.644   68.650 4.555  1.00 35.38  ? 181  ILE A O   1 
+ATOM   1178 C  CB  . ILE A 1 162 ? 11.064  69.624 6.443  1.00 34.14  ? 181  ILE A CB  1 
+ATOM   1179 C  CG1 . ILE A 1 162 ? 12.565  69.334 6.495  1.00 32.42  ? 181  ILE A CG1 1 
+ATOM   1180 C  CG2 . ILE A 1 162 ? 10.286  68.415 7.042  1.00 30.28  ? 181  ILE A CG2 1 
+ATOM   1181 C  CD1 . ILE A 1 162 ? 13.055  69.028 7.918  1.00 33.02  ? 181  ILE A CD1 1 
+ATOM   1182 N  N   . ILE A 1 163 ? 8.324   70.774 5.230  1.00 38.18  ? 182  ILE A N   1 
+ATOM   1183 C  CA  . ILE A 1 163 ? 6.867   70.679 5.285  1.00 40.14  ? 182  ILE A CA  1 
+ATOM   1184 C  C   . ILE A 1 163 ? 6.263   70.995 3.910  1.00 38.74  ? 182  ILE A C   1 
+ATOM   1185 O  O   . ILE A 1 163 ? 5.252   70.412 3.553  1.00 34.78  ? 182  ILE A O   1 
+ATOM   1186 C  CB  . ILE A 1 163 ? 6.261   71.686 6.337  1.00 43.67  ? 182  ILE A CB  1 
+ATOM   1187 C  CG1 . ILE A 1 163 ? 6.874   71.526 7.745  1.00 42.58  ? 182  ILE A CG1 1 
+ATOM   1188 C  CG2 . ILE A 1 163 ? 4.717   71.598 6.357  1.00 40.36  ? 182  ILE A CG2 1 
+ATOM   1189 C  CD1 . ILE A 1 163 ? 6.299   70.414 8.560  1.00 44.10  ? 182  ILE A CD1 1 
+ATOM   1190 N  N   . PHE A 1 164 ? 6.878   71.931 3.180  1.00 39.11  ? 183  PHE A N   1 
+ATOM   1191 C  CA  . PHE A 1 164 ? 6.375   72.443 1.897  1.00 43.95  ? 183  PHE A CA  1 
+ATOM   1192 C  C   . PHE A 1 164 ? 7.240   72.096 0.637  1.00 50.81  ? 183  PHE A C   1 
+ATOM   1193 O  O   . PHE A 1 164 ? 7.042   72.668 -0.425 1.00 54.29  ? 183  PHE A O   1 
+ATOM   1194 C  CB  . PHE A 1 164 ? 6.283   73.976 1.939  1.00 42.42  ? 183  PHE A CB  1 
+ATOM   1195 C  CG  . PHE A 1 164 ? 5.619   74.557 3.161  1.00 39.70  ? 183  PHE A CG  1 
+ATOM   1196 C  CD1 . PHE A 1 164 ? 6.051   75.776 3.661  1.00 41.57  ? 183  PHE A CD1 1 
+ATOM   1197 C  CD2 . PHE A 1 164 ? 4.541   73.954 3.764  1.00 42.45  ? 183  PHE A CD2 1 
+ATOM   1198 C  CE1 . PHE A 1 164 ? 5.441   76.362 4.775  1.00 42.25  ? 183  PHE A CE1 1 
+ATOM   1199 C  CE2 . PHE A 1 164 ? 3.930   74.537 4.886  1.00 43.12  ? 183  PHE A CE2 1 
+ATOM   1200 C  CZ  . PHE A 1 164 ? 4.383   75.741 5.385  1.00 38.50  ? 183  PHE A CZ  1 
+ATOM   1201 N  N   . HIS A 1 165 ? 8.203   71.189 0.753  1.00 57.66  ? 184  HIS A N   1 
+ATOM   1202 C  CA  . HIS A 1 165 ? 9.186   70.893 -0.321 1.00 63.00  ? 184  HIS A CA  1 
+ATOM   1203 C  C   . HIS A 1 165 ? 10.127  71.994 -0.795 1.00 61.31  ? 184  HIS A C   1 
+ATOM   1204 O  O   . HIS A 1 165 ? 11.017  71.733 -1.598 1.00 65.36  ? 184  HIS A O   1 
+ATOM   1205 C  CB  . HIS A 1 165 ? 8.526   70.332 -1.589 1.00 67.13  ? 184  HIS A CB  1 
+ATOM   1206 C  CG  . HIS A 1 165 ? 9.408   69.372 -2.344 1.00 75.19  ? 184  HIS A CG  1 
+ATOM   1207 N  ND1 . HIS A 1 165 ? 9.175   69.007 -3.653 1.00 83.48  ? 184  HIS A ND1 1 
+ATOM   1208 C  CD2 . HIS A 1 165 ? 10.521  68.699 -1.963 1.00 76.50  ? 184  HIS A CD2 1 
+ATOM   1209 C  CE1 . HIS A 1 165 ? 10.104  68.146 -4.043 1.00 82.69  ? 184  HIS A CE1 1 
+ATOM   1210 N  NE2 . HIS A 1 165 ? 10.933  67.945 -3.035 1.00 80.28  ? 184  HIS A NE2 1 
+ATOM   1211 N  N   . LYS A 1 166 ? 9.962   73.211 -0.327 1.00 60.37  ? 185  LYS A N   1 
+ATOM   1212 C  CA  . LYS A 1 166 ? 10.511  74.323 -1.067 1.00 60.66  ? 185  LYS A CA  1 
+ATOM   1213 C  C   . LYS A 1 166 ? 10.694  75.477 -0.114 1.00 57.15  ? 185  LYS A C   1 
+ATOM   1214 O  O   . LYS A 1 166 ? 9.725   76.042 0.405  1.00 58.77  ? 185  LYS A O   1 
+ATOM   1215 C  CB  . LYS A 1 166 ? 9.526   74.660 -2.206 1.00 65.10  ? 185  LYS A CB  1 
+ATOM   1216 C  CG  . LYS A 1 166 ? 9.923   75.770 -3.184 1.00 67.90  ? 185  LYS A CG  1 
+ATOM   1217 C  CD  . LYS A 1 166 ? 8.673   76.512 -3.744 1.00 69.66  ? 185  LYS A CD  1 
+ATOM   1218 C  CE  . LYS A 1 166 ? 8.723   78.058 -3.494 1.00 72.47  ? 185  LYS A CE  1 
+ATOM   1219 N  NZ  . LYS A 1 166 ? 8.413   78.518 -2.086 1.00 69.48  ? 185  LYS A NZ  1 
+ATOM   1220 N  N   . ARG A 1 167 ? 11.944  75.816 0.137  1.00 52.65  ? 186  ARG A N   1 
+ATOM   1221 C  CA  . ARG A 1 167 ? 12.246  76.972 0.943  1.00 49.80  ? 186  ARG A CA  1 
+ATOM   1222 C  C   . ARG A 1 167 ? 11.735  78.249 0.274  1.00 51.88  ? 186  ARG A C   1 
+ATOM   1223 O  O   . ARG A 1 167 ? 11.399  78.263 -0.917 1.00 54.16  ? 186  ARG A O   1 
+ATOM   1224 C  CB  . ARG A 1 167 ? 13.749  77.067 1.177  1.00 50.42  ? 186  ARG A CB  1 
+ATOM   1225 C  CG  . ARG A 1 167 ? 14.548  77.620 0.000  1.00 47.13  ? 186  ARG A CG  1 
+ATOM   1226 C  CD  . ARG A 1 167 ? 16.018  77.627 0.223  1.00 45.71  ? 186  ARG A CD  1 
+ATOM   1227 N  NE  . ARG A 1 167 ? 16.439  78.662 1.173  1.00 45.96  ? 186  ARG A NE  1 
+ATOM   1228 C  CZ  . ARG A 1 167 ? 16.669  79.932 0.858  1.00 45.84  ? 186  ARG A CZ  1 
+ATOM   1229 N  NH1 . ARG A 1 167 ? 16.480  80.372 -0.373 1.00 45.35  ? 186  ARG A NH1 1 
+ATOM   1230 N  NH2 . ARG A 1 167 ? 17.080  80.782 1.788  1.00 46.24  ? 186  ARG A NH2 1 
+ATOM   1231 N  N   . PHE A 1 168 ? 11.680  79.315 1.064  1.00 50.39  ? 187  PHE A N   1 
+ATOM   1232 C  CA  . PHE A 1 168 ? 11.311  80.636 0.602  1.00 49.44  ? 187  PHE A CA  1 
+ATOM   1233 C  C   . PHE A 1 168 ? 12.532  81.490 0.586  1.00 48.68  ? 187  PHE A C   1 
+ATOM   1234 O  O   . PHE A 1 168 ? 13.327  81.382 1.491  1.00 49.53  ? 187  PHE A O   1 
+ATOM   1235 C  CB  . PHE A 1 168 ? 10.361  81.283 1.595  1.00 49.32  ? 187  PHE A CB  1 
+ATOM   1236 C  CG  . PHE A 1 168 ? 9.076   80.558 1.769  1.00 45.79  ? 187  PHE A CG  1 
+ATOM   1237 C  CD1 . PHE A 1 168 ? 8.821   79.845 2.922  1.00 45.38  ? 187  PHE A CD1 1 
+ATOM   1238 C  CD2 . PHE A 1 168 ? 8.105   80.628 0.796  1.00 48.18  ? 187  PHE A CD2 1 
+ATOM   1239 C  CE1 . PHE A 1 168 ? 7.621   79.196 3.093  1.00 50.10  ? 187  PHE A CE1 1 
+ATOM   1240 C  CE2 . PHE A 1 168 ? 6.904   79.978 0.953  1.00 50.11  ? 187  PHE A CE2 1 
+ATOM   1241 C  CZ  . PHE A 1 168 ? 6.661   79.255 2.102  1.00 51.53  ? 187  PHE A CZ  1 
+ATOM   1242 N  N   . ASP A 1 169 ? 12.674  82.363 -0.404 1.00 51.42  ? 188  ASP A N   1 
+ATOM   1243 C  CA  . ASP A 1 169 ? 13.615  83.482 -0.286 1.00 54.11  ? 188  ASP A CA  1 
+ATOM   1244 C  C   . ASP A 1 169 ? 13.307  84.196 1.035  1.00 53.31  ? 188  ASP A C   1 
+ATOM   1245 O  O   . ASP A 1 169 ? 12.157  84.245 1.457  1.00 52.92  ? 188  ASP A O   1 
+ATOM   1246 C  CB  . ASP A 1 169 ? 13.474  84.450 -1.467 1.00 56.25  ? 188  ASP A CB  1 
+ATOM   1247 C  CG  . ASP A 1 169 ? 14.674  85.370 -1.617 1.00 61.68  ? 188  ASP A CG  1 
+ATOM   1248 O  OD1 . ASP A 1 169 ? 14.801  86.334 -0.833 1.00 65.45  ? 188  ASP A OD1 1 
+ATOM   1249 O  OD2 . ASP A 1 169 ? 15.549  85.218 -2.498 1.00 69.39  ? 188  ASP A OD2 1 
+ATOM   1250 N  N   . TYR A 1 170 ? 14.328  84.728 1.697  1.00 54.95  ? 189  TYR A N   1 
+ATOM   1251 C  CA  . TYR A 1 170 ? 14.147  85.360 3.011  1.00 57.69  ? 189  TYR A CA  1 
+ATOM   1252 C  C   . TYR A 1 170 ? 13.396  86.708 2.966  1.00 59.64  ? 189  TYR A C   1 
+ATOM   1253 O  O   . TYR A 1 170 ? 13.168  87.331 4.010  1.00 60.26  ? 189  TYR A O   1 
+ATOM   1254 C  CB  . TYR A 1 170 ? 15.508  85.598 3.691  1.00 58.20  ? 189  TYR A CB  1 
+ATOM   1255 C  CG  . TYR A 1 170 ? 16.351  84.367 4.057  1.00 58.28  ? 189  TYR A CG  1 
+ATOM   1256 C  CD1 . TYR A 1 170 ? 17.731  84.410 3.934  1.00 55.33  ? 189  TYR A CD1 1 
+ATOM   1257 C  CD2 . TYR A 1 170 ? 15.786  83.190 4.554  1.00 59.01  ? 189  TYR A CD2 1 
+ATOM   1258 C  CE1 . TYR A 1 170 ? 18.545  83.323 4.270  1.00 54.84  ? 189  TYR A CE1 1 
+ATOM   1259 C  CE2 . TYR A 1 170 ? 16.603  82.088 4.899  1.00 57.86  ? 189  TYR A CE2 1 
+ATOM   1260 C  CZ  . TYR A 1 170 ? 17.980  82.170 4.750  1.00 54.57  ? 189  TYR A CZ  1 
+ATOM   1261 O  OH  . TYR A 1 170 ? 18.786  81.095 5.066  1.00 52.78  ? 189  TYR A OH  1 
+ATOM   1262 N  N   . LYS A 1 171 ? 13.070  87.176 1.762  1.00 61.50  ? 190  LYS A N   1 
+ATOM   1263 C  CA  . LYS A 1 171 ? 12.296  88.410 1.560  1.00 63.56  ? 190  LYS A CA  1 
+ATOM   1264 C  C   . LYS A 1 171 ? 10.831  88.094 1.174  1.00 58.32  ? 190  LYS A C   1 
+ATOM   1265 O  O   . LYS A 1 171 ? 9.954   88.949 1.272  1.00 56.42  ? 190  LYS A O   1 
+ATOM   1266 C  CB  . LYS A 1 171 ? 12.960  89.286 0.484  1.00 65.95  ? 190  LYS A CB  1 
+ATOM   1267 C  CG  . LYS A 1 171 ? 14.114  90.185 0.981  1.00 69.10  ? 190  LYS A CG  1 
+ATOM   1268 C  CD  . LYS A 1 171 ? 15.494  89.809 0.375  1.00 74.58  ? 190  LYS A CD  1 
+ATOM   1269 C  CE  . LYS A 1 171 ? 15.487  89.583 -1.157 1.00 76.46  ? 190  LYS A CE  1 
+ATOM   1270 N  NZ  . LYS A 1 171 ? 14.482  90.405 -1.914 1.00 76.18  ? 190  LYS A NZ  1 
+ATOM   1271 N  N   . ASP A 1 172 ? 10.585  86.869 0.727  1.00 53.42  ? 191  ASP A N   1 
+ATOM   1272 C  CA  . ASP A 1 172 ? 9.231   86.364 0.553  1.00 54.37  ? 191  ASP A CA  1 
+ATOM   1273 C  C   . ASP A 1 172 ? 8.381   86.749 1.744  1.00 54.60  ? 191  ASP A C   1 
+ATOM   1274 O  O   . ASP A 1 172 ? 8.742   86.473 2.881  1.00 56.67  ? 191  ASP A O   1 
+ATOM   1275 C  CB  . ASP A 1 172 ? 9.246   84.840 0.412  1.00 54.94  ? 191  ASP A CB  1 
+ATOM   1276 C  CG  . ASP A 1 172 ? 7.947   84.281 -0.151 1.00 58.73  ? 191  ASP A CG  1 
+ATOM   1277 O  OD1 . ASP A 1 172 ? 8.046   83.511 -1.128 1.00 62.18  ? 191  ASP A OD1 1 
+ATOM   1278 O  OD2 . ASP A 1 172 ? 6.798   84.523 0.311  1.00 57.59  ? 191  ASP A OD2 1 
+ATOM   1279 N  N   . GLN A 1 173 ? 7.243   87.378 1.480  1.00 54.58  ? 192  GLN A N   1 
+ATOM   1280 C  CA  . GLN A 1 173 ? 6.360   87.853 2.542  1.00 52.89  ? 192  GLN A CA  1 
+ATOM   1281 C  C   . GLN A 1 173 ? 5.617   86.713 3.295  1.00 49.16  ? 192  GLN A C   1 
+ATOM   1282 O  O   . GLN A 1 173 ? 5.283   86.869 4.461  1.00 45.83  ? 192  GLN A O   1 
+ATOM   1283 C  CB  . GLN A 1 173 ? 5.377   88.896 1.975  1.00 52.65  ? 192  GLN A CB  1 
+ATOM   1284 C  CG  . GLN A 1 173 ? 4.540   89.640 3.028  1.00 51.74  ? 192  GLN A CG  1 
+ATOM   1285 C  CD  . GLN A 1 173 ? 5.388   90.448 3.978  1.00 51.89  ? 192  GLN A CD  1 
+ATOM   1286 O  OE1 . GLN A 1 173 ? 6.241   91.213 3.540  1.00 52.72  ? 192  GLN A OE1 1 
+ATOM   1287 N  NE2 . GLN A 1 173 ? 5.177   90.257 5.282  1.00 48.28  ? 192  GLN A NE2 1 
+ATOM   1288 N  N   . GLN A 1 174 ? 5.352   85.583 2.642  1.00 46.84  ? 193  GLN A N   1 
+ATOM   1289 C  CA  . GLN A 1 174 ? 4.797   84.428 3.348  1.00 49.33  ? 193  GLN A CA  1 
+ATOM   1290 C  C   . GLN A 1 174 ? 5.724   84.135 4.541  1.00 50.69  ? 193  GLN A C   1 
+ATOM   1291 O  O   . GLN A 1 174 ? 5.298   84.025 5.694  1.00 48.49  ? 193  GLN A O   1 
+ATOM   1292 C  CB  . GLN A 1 174 ? 4.736   83.184 2.439  1.00 51.92  ? 193  GLN A CB  1 
+ATOM   1293 C  CG  . GLN A 1 174 ? 3.870   83.278 1.167  1.00 55.09  ? 193  GLN A CG  1 
+ATOM   1294 C  CD  . GLN A 1 174 ? 3.564   81.902 0.506  1.00 58.87  ? 193  GLN A CD  1 
+ATOM   1295 O  OE1 . GLN A 1 174 ? 3.320   80.897 1.189  1.00 55.73  ? 193  GLN A OE1 1 
+ATOM   1296 N  NE2 . GLN A 1 174 ? 3.554   81.876 -0.827 1.00 62.20  ? 193  GLN A NE2 1 
+ATOM   1297 N  N   . PHE A 1 175 ? 7.011   84.048 4.214  1.00 47.17  ? 194  PHE A N   1 
+ATOM   1298 C  CA  . PHE A 1 175 ? 8.067   83.688 5.125  1.00 42.15  ? 194  PHE A CA  1 
+ATOM   1299 C  C   . PHE A 1 175 ? 8.221   84.655 6.274  1.00 43.38  ? 194  PHE A C   1 
+ATOM   1300 O  O   . PHE A 1 175 ? 8.341   84.222 7.419  1.00 45.14  ? 194  PHE A O   1 
+ATOM   1301 C  CB  . PHE A 1 175 ? 9.393   83.594 4.358  1.00 42.17  ? 194  PHE A CB  1 
+ATOM   1302 C  CG  . PHE A 1 175 ? 10.518  83.068 5.184  1.00 39.67  ? 194  PHE A CG  1 
+ATOM   1303 C  CD1 . PHE A 1 175 ? 11.556  83.898 5.564  1.00 35.94  ? 194  PHE A CD1 1 
+ATOM   1304 C  CD2 . PHE A 1 175 ? 10.513  81.751 5.626  1.00 37.61  ? 194  PHE A CD2 1 
+ATOM   1305 C  CE1 . PHE A 1 175 ? 12.563  83.427 6.334  1.00 32.98  ? 194  PHE A CE1 1 
+ATOM   1306 C  CE2 . PHE A 1 175 ? 11.518  81.276 6.413  1.00 33.26  ? 194  PHE A CE2 1 
+ATOM   1307 C  CZ  . PHE A 1 175 ? 12.556  82.119 6.754  1.00 35.97  ? 194  PHE A CZ  1 
+ATOM   1308 N  N   . LEU A 1 176 ? 8.228   85.955 5.987  1.00 42.94  ? 195  LEU A N   1 
+ATOM   1309 C  CA  . LEU A 1 176 ? 8.374   86.969 7.039  1.00 42.68  ? 195  LEU A CA  1 
+ATOM   1310 C  C   . LEU A 1 176 ? 7.222   87.014 8.040  1.00 41.37  ? 195  LEU A C   1 
+ATOM   1311 O  O   . LEU A 1 176 ? 7.438   87.420 9.183  1.00 39.33  ? 195  LEU A O   1 
+ATOM   1312 C  CB  . LEU A 1 176 ? 8.513   88.353 6.437  1.00 46.79  ? 195  LEU A CB  1 
+ATOM   1313 C  CG  . LEU A 1 176 ? 9.769   88.587 5.611  1.00 50.19  ? 195  LEU A CG  1 
+ATOM   1314 C  CD1 . LEU A 1 176 ? 9.539   89.744 4.650  1.00 50.37  ? 195  LEU A CD1 1 
+ATOM   1315 C  CD2 . LEU A 1 176 ? 10.947  88.855 6.521  1.00 52.11  ? 195  LEU A CD2 1 
+ATOM   1316 N  N   . ASN A 1 177 ? 6.014   86.629 7.602  1.00 41.66  ? 196  ASN A N   1 
+ATOM   1317 C  CA  . ASN A 1 177 ? 4.803   86.601 8.451  1.00 41.30  ? 196  ASN A CA  1 
+ATOM   1318 C  C   . ASN A 1 177 ? 4.832   85.445 9.434  1.00 42.99  ? 196  ASN A C   1 
+ATOM   1319 O  O   . ASN A 1 177 ? 4.434   85.568 10.604 1.00 44.63  ? 196  ASN A O   1 
+ATOM   1320 C  CB  . ASN A 1 177 ? 3.523   86.410 7.626  1.00 39.02  ? 196  ASN A CB  1 
+ATOM   1321 C  CG  . ASN A 1 177 ? 3.215   87.571 6.700  1.00 41.86  ? 196  ASN A CG  1 
+ATOM   1322 O  OD1 . ASN A 1 177 ? 2.618   87.351 5.645  1.00 43.84  ? 196  ASN A OD1 1 
+ATOM   1323 N  ND2 . ASN A 1 177 ? 3.596   88.802 7.079  1.00 35.35  ? 196  ASN A ND2 1 
+ATOM   1324 N  N   . LEU A 1 178 ? 5.248   84.300 8.913  1.00 44.26  ? 197  LEU A N   1 
+ATOM   1325 C  CA  . LEU A 1 178 ? 5.456   83.108 9.694  1.00 42.43  ? 197  LEU A CA  1 
+ATOM   1326 C  C   . LEU A 1 178 ? 6.566   83.387 10.698 1.00 45.66  ? 197  LEU A C   1 
+ATOM   1327 O  O   . LEU A 1 178 ? 6.488   82.978 11.858 1.00 42.76  ? 197  LEU A O   1 
+ATOM   1328 C  CB  . LEU A 1 178 ? 5.865   82.007 8.754  1.00 44.28  ? 197  LEU A CB  1 
+ATOM   1329 C  CG  . LEU A 1 178 ? 6.133   80.645 9.351  1.00 48.34  ? 197  LEU A CG  1 
+ATOM   1330 C  CD1 . LEU A 1 178 ? 4.959   80.194 10.203 1.00 50.31  ? 197  LEU A CD1 1 
+ATOM   1331 C  CD2 . LEU A 1 178 ? 6.405   79.684 8.201  1.00 49.42  ? 197  LEU A CD2 1 
+ATOM   1332 N  N   . MET A 1 179 ? 7.584   84.124 10.255 1.00 47.43  ? 198  MET A N   1 
+ATOM   1333 C  CA  . MET A 1 179 ? 8.740   84.435 11.095 1.00 49.82  ? 198  MET A CA  1 
+ATOM   1334 C  C   . MET A 1 179 ? 8.310   85.392 12.204 1.00 50.53  ? 198  MET A C   1 
+ATOM   1335 O  O   . MET A 1 179 ? 8.573   85.165 13.366 1.00 55.66  ? 198  MET A O   1 
+ATOM   1336 C  CB  . MET A 1 179 ? 9.859   85.035 10.238 1.00 52.28  ? 198  MET A CB  1 
+ATOM   1337 C  CG  . MET A 1 179 ? 11.276  84.759 10.698 1.00 55.14  ? 198  MET A CG  1 
+ATOM   1338 S  SD  . MET A 1 179 ? 11.839  83.052 10.516 1.00 60.24  ? 198  MET A SD  1 
+ATOM   1339 C  CE  . MET A 1 179 ? 12.203  82.627 12.372 1.00 57.85  ? 198  MET A CE  1 
+ATOM   1340 N  N   . GLU A 1 180 ? 7.603   86.439 11.832 1.00 51.13  ? 199  GLU A N   1 
+ATOM   1341 C  CA  . GLU A 1 180 ? 7.091   87.427 12.772 1.00 53.76  ? 199  GLU A CA  1 
+ATOM   1342 C  C   . GLU A 1 180 ? 6.192   86.800 13.845 1.00 51.44  ? 199  GLU A C   1 
+ATOM   1343 O  O   . GLU A 1 180 ? 6.199   87.204 15.008 1.00 50.03  ? 199  GLU A O   1 
+ATOM   1344 C  CB  . GLU A 1 180 ? 6.313   88.462 11.965 1.00 55.79  ? 199  GLU A CB  1 
+ATOM   1345 C  CG  . GLU A 1 180 ? 5.763   89.649 12.719 1.00 60.71  ? 199  GLU A CG  1 
+ATOM   1346 C  CD  . GLU A 1 180 ? 4.840   90.467 11.823 1.00 68.78  ? 199  GLU A CD  1 
+ATOM   1347 O  OE1 . GLU A 1 180 ? 5.288   91.510 11.291 1.00 70.05  ? 199  GLU A OE1 1 
+ATOM   1348 O  OE2 . GLU A 1 180 ? 3.671   90.044 11.620 1.00 73.02  ? 199  GLU A OE2 1 
+ATOM   1349 N  N   . LYS A 1 181 ? 5.426   85.803 13.430 1.00 50.25  ? 200  LYS A N   1 
+ATOM   1350 C  CA  . LYS A 1 181 ? 4.429   85.163 14.273 1.00 49.18  ? 200  LYS A CA  1 
+ATOM   1351 C  C   . LYS A 1 181 ? 5.160   84.241 15.259 1.00 47.56  ? 200  LYS A C   1 
+ATOM   1352 O  O   . LYS A 1 181 ? 4.780   84.132 16.425 1.00 47.66  ? 200  LYS A O   1 
+ATOM   1353 C  CB  . LYS A 1 181 ? 3.440   84.372 13.375 1.00 51.30  ? 200  LYS A CB  1 
+ATOM   1354 C  CG  . LYS A 1 181 ? 1.929   84.494 13.670 1.00 56.17  ? 200  LYS A CG  1 
+ATOM   1355 C  CD  . LYS A 1 181 ? 1.332   85.934 13.638 1.00 57.06  ? 200  LYS A CD  1 
+ATOM   1356 C  CE  . LYS A 1 181 ? 1.592   86.687 12.349 1.00 56.82  ? 200  LYS A CE  1 
+ATOM   1357 N  NZ  . LYS A 1 181 ? 1.230   88.106 12.542 1.00 55.60  ? 200  LYS A NZ  1 
+ATOM   1358 N  N   . LEU A 1 182 ? 6.227   83.587 14.789 1.00 44.36  ? 201  LEU A N   1 
+ATOM   1359 C  CA  . LEU A 1 182 ? 6.975   82.642 15.624 1.00 39.52  ? 201  LEU A CA  1 
+ATOM   1360 C  C   . LEU A 1 182 ? 7.774   83.353 16.692 1.00 37.81  ? 201  LEU A C   1 
+ATOM   1361 O  O   . LEU A 1 182 ? 7.807   82.898 17.833 1.00 31.41  ? 201  LEU A O   1 
+ATOM   1362 C  CB  . LEU A 1 182 ? 7.919   81.806 14.786 1.00 36.24  ? 201  LEU A CB  1 
+ATOM   1363 C  CG  . LEU A 1 182 ? 7.252   80.681 14.008 1.00 35.44  ? 201  LEU A CG  1 
+ATOM   1364 C  CD1 . LEU A 1 182 ? 8.230   80.091 13.018 1.00 35.58  ? 201  LEU A CD1 1 
+ATOM   1365 C  CD2 . LEU A 1 182 ? 6.740   79.617 14.941 1.00 35.36  ? 201  LEU A CD2 1 
+ATOM   1366 N  N   . ASN A 1 183 ? 8.382   84.481 16.305 1.00 40.64  ? 202  ASN A N   1 
+ATOM   1367 C  CA  . ASN A 1 183 ? 9.241   85.287 17.180 1.00 43.14  ? 202  ASN A CA  1 
+ATOM   1368 C  C   . ASN A 1 183 ? 8.443   85.984 18.259 1.00 47.46  ? 202  ASN A C   1 
+ATOM   1369 O  O   . ASN A 1 183 ? 8.926   86.127 19.389 1.00 50.12  ? 202  ASN A O   1 
+ATOM   1370 C  CB  . ASN A 1 183 ? 10.071  86.326 16.398 1.00 42.69  ? 202  ASN A CB  1 
+ATOM   1371 C  CG  . ASN A 1 183 ? 11.172  85.689 15.531 1.00 46.05  ? 202  ASN A CG  1 
+ATOM   1372 O  OD1 . ASN A 1 183 ? 11.711  86.327 14.640 1.00 50.20  ? 202  ASN A OD1 1 
+ATOM   1373 N  ND2 . ASN A 1 183 ? 11.489  84.430 15.788 1.00 50.10  ? 202  ASN A ND2 1 
+ATOM   1374 N  N   . GLU A 1 184 ? 7.220   86.402 17.929 1.00 50.66  ? 203  GLU A N   1 
+ATOM   1375 C  CA  . GLU A 1 184 ? 6.345   87.044 18.916 1.00 51.50  ? 203  GLU A CA  1 
+ATOM   1376 C  C   . GLU A 1 184 ? 5.939   86.056 19.995 1.00 45.44  ? 203  GLU A C   1 
+ATOM   1377 O  O   . GLU A 1 184 ? 5.925   86.377 21.170 1.00 46.07  ? 203  GLU A O   1 
+ATOM   1378 C  CB  . GLU A 1 184 ? 5.112   87.631 18.238 1.00 57.63  ? 203  GLU A CB  1 
+ATOM   1379 C  CG  . GLU A 1 184 ? 4.750   89.049 18.661 1.00 61.15  ? 203  GLU A CG  1 
+ATOM   1380 C  CD  . GLU A 1 184 ? 3.256   89.269 18.592 1.00 65.93  ? 203  GLU A CD  1 
+ATOM   1381 O  OE1 . GLU A 1 184 ? 2.689   89.008 17.503 1.00 70.80  ? 203  GLU A OE1 1 
+ATOM   1382 O  OE2 . GLU A 1 184 ? 2.653   89.657 19.628 1.00 71.90  ? 203  GLU A OE2 1 
+ATOM   1383 N  N   . ASN A 1 185 ? 5.637   84.836 19.599 1.00 46.07  ? 204  ASN A N   1 
+ATOM   1384 C  CA  . ASN A 1 185 ? 5.390   83.768 20.568 1.00 46.43  ? 204  ASN A CA  1 
+ATOM   1385 C  C   . ASN A 1 185 ? 6.568   83.507 21.523 1.00 46.76  ? 204  ASN A C   1 
+ATOM   1386 O  O   . ASN A 1 185 ? 6.373   83.199 22.689 1.00 45.84  ? 204  ASN A O   1 
+ATOM   1387 C  CB  . ASN A 1 185 ? 5.004   82.491 19.831 1.00 47.59  ? 204  ASN A CB  1 
+ATOM   1388 C  CG  . ASN A 1 185 ? 3.523   82.433 19.485 1.00 48.09  ? 204  ASN A CG  1 
+ATOM   1389 O  OD1 . ASN A 1 185 ? 2.990   81.358 19.222 1.00 52.90  ? 204  ASN A OD1 1 
+ATOM   1390 N  ND2 . ASN A 1 185 ? 2.856   83.579 19.483 1.00 46.97  ? 204  ASN A ND2 1 
+ATOM   1391 N  N   . ILE A 1 186 ? 7.788   83.643 21.017 1.00 47.49  ? 205  ILE A N   1 
+ATOM   1392 C  CA  . ILE A 1 186 ? 8.992   83.492 21.826 1.00 46.00  ? 205  ILE A CA  1 
+ATOM   1393 C  C   . ILE A 1 186 ? 9.199   84.650 22.834 1.00 47.40  ? 205  ILE A C   1 
+ATOM   1394 O  O   . ILE A 1 186 ? 9.728   84.441 23.925 1.00 48.95  ? 205  ILE A O   1 
+ATOM   1395 C  CB  . ILE A 1 186 ? 10.202  83.354 20.883 1.00 43.90  ? 205  ILE A CB  1 
+ATOM   1396 C  CG1 . ILE A 1 186 ? 10.162  82.007 20.154 1.00 45.62  ? 205  ILE A CG1 1 
+ATOM   1397 C  CG2 . ILE A 1 186 ? 11.495  83.476 21.637 1.00 41.05  ? 205  ILE A CG2 1 
+ATOM   1398 C  CD1 . ILE A 1 186 ? 10.894  82.037 18.774 1.00 48.88  ? 205  ILE A CD1 1 
+ATOM   1399 N  N   . GLU A 1 187 ? 8.794   85.854 22.444 1.00 50.70  ? 206  GLU A N   1 
+ATOM   1400 C  CA  . GLU A 1 187 ? 8.860   87.064 23.266 1.00 54.17  ? 206  GLU A CA  1 
+ATOM   1401 C  C   . GLU A 1 187 ? 7.831   87.024 24.395 1.00 53.40  ? 206  GLU A C   1 
+ATOM   1402 O  O   . GLU A 1 187 ? 8.155   87.223 25.560 1.00 51.08  ? 206  GLU A O   1 
+ATOM   1403 C  CB  . GLU A 1 187 ? 8.567   88.259 22.367 1.00 60.32  ? 206  GLU A CB  1 
+ATOM   1404 C  CG  . GLU A 1 187 ? 8.713   89.641 22.979 1.00 68.00  ? 206  GLU A CG  1 
+ATOM   1405 C  CD  . GLU A 1 187 ? 9.237   90.639 21.954 1.00 73.22  ? 206  GLU A CD  1 
+ATOM   1406 O  OE1 . GLU A 1 187 ? 10.129  91.449 22.299 1.00 78.78  ? 206  GLU A OE1 1 
+ATOM   1407 O  OE2 . GLU A 1 187 ? 8.766   90.594 20.789 1.00 78.02  ? 206  GLU A OE2 1 
+ATOM   1408 N  N   . ILE A 1 188 ? 6.580   86.758 24.038 1.00 50.83  ? 207  ILE A N   1 
+ATOM   1409 C  CA  . ILE A 1 188 ? 5.533   86.575 25.026 1.00 48.09  ? 207  ILE A CA  1 
+ATOM   1410 C  C   . ILE A 1 188 ? 5.966   85.496 26.017 1.00 48.59  ? 207  ILE A C   1 
+ATOM   1411 O  O   . ILE A 1 188 ? 5.845   85.680 27.221 1.00 46.31  ? 207  ILE A O   1 
+ATOM   1412 C  CB  . ILE A 1 188 ? 4.205   86.175 24.341 1.00 48.12  ? 207  ILE A CB  1 
+ATOM   1413 C  CG1 . ILE A 1 188 ? 3.639   87.327 23.508 1.00 52.10  ? 207  ILE A CG1 1 
+ATOM   1414 C  CG2 . ILE A 1 188 ? 3.183   85.762 25.353 1.00 47.85  ? 207  ILE A CG2 1 
+ATOM   1415 C  CD1 . ILE A 1 188 ? 2.685   86.853 22.410 1.00 53.71  ? 207  ILE A CD1 1 
+ATOM   1416 N  N   . LEU A 1 189 ? 6.488   84.382 25.502 1.00 48.71  ? 208  LEU A N   1 
+ATOM   1417 C  CA  . LEU A 1 189 ? 6.795   83.215 26.324 1.00 48.91  ? 208  LEU A CA  1 
+ATOM   1418 C  C   . LEU A 1 189 ? 8.046   83.382 27.204 1.00 51.49  ? 208  LEU A C   1 
+ATOM   1419 O  O   . LEU A 1 189 ? 8.259   82.589 28.121 1.00 49.89  ? 208  LEU A O   1 
+ATOM   1420 C  CB  . LEU A 1 189 ? 6.947   81.974 25.451 1.00 47.58  ? 208  LEU A CB  1 
+ATOM   1421 C  CG  . LEU A 1 189 ? 5.642   81.334 24.968 1.00 51.21  ? 208  LEU A CG  1 
+ATOM   1422 C  CD1 . LEU A 1 189 ? 5.877   80.283 23.879 1.00 49.13  ? 208  LEU A CD1 1 
+ATOM   1423 C  CD2 . LEU A 1 189 ? 4.852   80.712 26.142 1.00 54.28  ? 208  LEU A CD2 1 
+ATOM   1424 N  N   . SER A 1 190 ? 8.852   84.407 26.937 1.00 54.38  ? 209  SER A N   1 
+ATOM   1425 C  CA  . SER A 1 190 ? 10.083  84.655 27.698 1.00 59.49  ? 209  SER A CA  1 
+ATOM   1426 C  C   . SER A 1 190 ? 9.948   85.744 28.791 1.00 60.23  ? 209  SER A C   1 
+ATOM   1427 O  O   . SER A 1 190 ? 10.915  86.059 29.496 1.00 59.89  ? 209  SER A O   1 
+ATOM   1428 C  CB  . SER A 1 190 ? 11.211  85.028 26.730 1.00 60.13  ? 209  SER A CB  1 
+ATOM   1429 O  OG  . SER A 1 190 ? 11.047  86.364 26.299 1.00 61.15  ? 209  SER A OG  1 
+ATOM   1430 N  N   . SER A 1 191 ? 8.751   86.311 28.915 1.00 61.29  ? 210  SER A N   1 
+ATOM   1431 C  CA  . SER A 1 191 ? 8.443   87.289 29.952 1.00 61.46  ? 210  SER A CA  1 
+ATOM   1432 C  C   . SER A 1 191 ? 8.435   86.593 31.305 1.00 61.08  ? 210  SER A C   1 
+ATOM   1433 O  O   . SER A 1 191 ? 7.770   85.580 31.464 1.00 57.03  ? 210  SER A O   1 
+ATOM   1434 C  CB  . SER A 1 191 ? 7.082   87.936 29.690 1.00 62.69  ? 210  SER A CB  1 
+ATOM   1435 O  OG  . SER A 1 191 ? 6.486   88.417 30.881 1.00 64.51  ? 210  SER A OG  1 
+ATOM   1436 N  N   . PRO A 1 192 ? 9.192   87.120 32.267 1.00 63.64  ? 211  PRO A N   1 
+ATOM   1437 C  CA  . PRO A 1 192 ? 9.287   86.518 33.609 1.00 62.21  ? 211  PRO A CA  1 
+ATOM   1438 C  C   . PRO A 1 192 ? 7.974   86.226 34.287 1.00 61.22  ? 211  PRO A C   1 
+ATOM   1439 O  O   . PRO A 1 192 ? 7.900   85.284 35.065 1.00 54.39  ? 211  PRO A O   1 
+ATOM   1440 C  CB  . PRO A 1 192 ? 10.045  87.570 34.408 1.00 64.15  ? 211  PRO A CB  1 
+ATOM   1441 C  CG  . PRO A 1 192 ? 10.935  88.202 33.385 1.00 66.77  ? 211  PRO A CG  1 
+ATOM   1442 C  CD  . PRO A 1 192 ? 10.079  88.295 32.130 1.00 64.74  ? 211  PRO A CD  1 
+ATOM   1443 N  N   . TRP A 1 193 ? 6.937   86.997 34.011 1.00 65.86  ? 212  TRP A N   1 
+ATOM   1444 C  CA  . TRP A 1 193 ? 5.697   86.750 34.719 1.00 72.63  ? 212  TRP A CA  1 
+ATOM   1445 C  C   . TRP A 1 193 ? 4.799   85.678 34.036 1.00 70.15  ? 212  TRP A C   1 
+ATOM   1446 O  O   . TRP A 1 193 ? 3.594   85.643 34.230 1.00 75.34  ? 212  TRP A O   1 
+ATOM   1447 C  CB  . TRP A 1 193 ? 5.062   88.092 35.201 1.00 76.71  ? 212  TRP A CB  1 
+ATOM   1448 C  CG  . TRP A 1 193 ? 4.011   88.788 34.388 1.00 88.22  ? 212  TRP A CG  1 
+ATOM   1449 C  CD1 . TRP A 1 193 ? 3.923   88.882 33.026 1.00 93.41  ? 212  TRP A CD1 1 
+ATOM   1450 C  CD2 . TRP A 1 193 ? 2.898   89.541 34.912 1.00 96.01  ? 212  TRP A CD2 1 
+ATOM   1451 N  NE1 . TRP A 1 193 ? 2.815   89.620 32.669 1.00 96.35  ? 212  TRP A NE1 1 
+ATOM   1452 C  CE2 . TRP A 1 193 ? 2.166   90.039 33.804 1.00 97.47  ? 212  TRP A CE2 1 
+ATOM   1453 C  CE3 . TRP A 1 193 ? 2.437   89.835 36.213 1.00 97.14  ? 212  TRP A CE3 1 
+ATOM   1454 C  CZ2 . TRP A 1 193 ? 1.005   90.817 33.952 1.00 98.51  ? 212  TRP A CZ2 1 
+ATOM   1455 C  CZ3 . TRP A 1 193 ? 1.281   90.604 36.362 1.00 98.81  ? 212  TRP A CZ3 1 
+ATOM   1456 C  CH2 . TRP A 1 193 ? 0.580   91.089 35.233 1.00 99.46  ? 212  TRP A CH2 1 
+ATOM   1457 N  N   . ILE A 1 194 ? 5.442   84.752 33.308 1.00 68.79  ? 213  ILE A N   1 
+ATOM   1458 C  CA  . ILE A 1 194 ? 4.830   83.509 32.811 1.00 67.36  ? 213  ILE A CA  1 
+ATOM   1459 C  C   . ILE A 1 194 ? 4.820   82.423 33.879 1.00 68.71  ? 213  ILE A C   1 
+ATOM   1460 O  O   . ILE A 1 194 ? 3.929   81.571 33.887 1.00 72.27  ? 213  ILE A O   1 
+ATOM   1461 C  CB  . ILE A 1 194 ? 5.586   82.938 31.555 1.00 66.57  ? 213  ILE A CB  1 
+ATOM   1462 C  CG1 . ILE A 1 194 ? 5.360   83.819 30.324 1.00 66.86  ? 213  ILE A CG1 1 
+ATOM   1463 C  CG2 . ILE A 1 194 ? 5.178   81.463 31.245 1.00 61.89  ? 213  ILE A CG2 1 
+ATOM   1464 C  CD1 . ILE A 1 194 ? 4.087   83.531 29.549 1.00 67.87  ? 213  ILE A CD1 1 
+ATOM   1465 N  N   . GLN A 1 195 ? 5.827   82.395 34.745 1.00 68.14  ? 214  GLN A N   1 
+ATOM   1466 C  CA  . GLN A 1 195 ? 5.780   81.454 35.861 1.00 67.56  ? 214  GLN A CA  1 
+ATOM   1467 C  C   . GLN A 1 195 ? 4.797   81.926 36.944 1.00 65.97  ? 214  GLN A C   1 
+ATOM   1468 O  O   . GLN A 1 195 ? 4.375   81.135 37.803 1.00 63.32  ? 214  GLN A O   1 
+ATOM   1469 C  CB  . GLN A 1 195 ? 7.170   81.194 36.444 1.00 68.84  ? 214  GLN A CB  1 
+ATOM   1470 C  CG  . GLN A 1 195 ? 7.501   79.702 36.540 1.00 70.83  ? 214  GLN A CG  1 
+ATOM   1471 C  CD  . GLN A 1 195 ? 7.420   78.997 35.182 1.00 74.02  ? 214  GLN A CD  1 
+ATOM   1472 O  OE1 . GLN A 1 195 ? 7.870   79.539 34.167 1.00 77.71  ? 214  GLN A OE1 1 
+ATOM   1473 N  NE2 . GLN A 1 195 ? 6.834   77.803 35.161 1.00 71.90  ? 214  GLN A NE2 1 
+ATOM   1474 N  N   . VAL A 1 196 ? 4.420   83.206 36.893 1.00 61.28  ? 215  VAL A N   1 
+ATOM   1475 C  CA  . VAL A 1 196 ? 3.383   83.711 37.781 1.00 62.05  ? 215  VAL A CA  1 
+ATOM   1476 C  C   . VAL A 1 196 ? 2.038   83.094 37.424 1.00 59.68  ? 215  VAL A C   1 
+ATOM   1477 O  O   . VAL A 1 196 ? 1.206   82.878 38.295 1.00 63.70  ? 215  VAL A O   1 
+ATOM   1478 C  CB  . VAL A 1 196 ? 3.252   85.251 37.732 1.00 63.15  ? 215  VAL A CB  1 
+ATOM   1479 C  CG1 . VAL A 1 196 ? 2.097   85.743 38.620 1.00 62.15  ? 215  VAL A CG1 1 
+ATOM   1480 C  CG2 . VAL A 1 196 ? 4.524   85.892 38.174 1.00 65.08  ? 215  VAL A CG2 1 
+ATOM   1481 N  N   . TYR A 1 197 ? 1.808   82.833 36.146 1.00 55.28  ? 216  TYR A N   1 
+ATOM   1482 C  CA  . TYR A 1 197 ? 0.575   82.182 35.745 1.00 52.57  ? 216  TYR A CA  1 
+ATOM   1483 C  C   . TYR A 1 197 ? 0.506   80.746 36.242 1.00 50.90  ? 216  TYR A C   1 
+ATOM   1484 O  O   . TYR A 1 197 ? -0.537  80.309 36.718 1.00 49.20  ? 216  TYR A O   1 
+ATOM   1485 C  CB  . TYR A 1 197 ? 0.431   82.195 34.245 1.00 53.55  ? 216  TYR A CB  1 
+ATOM   1486 C  CG  . TYR A 1 197 ? 0.139   83.550 33.652 1.00 56.08  ? 216  TYR A CG  1 
+ATOM   1487 C  CD1 . TYR A 1 197 ? -1.064  84.190 33.906 1.00 58.62  ? 216  TYR A CD1 1 
+ATOM   1488 C  CD2 . TYR A 1 197 ? 1.047   84.171 32.797 1.00 56.58  ? 216  TYR A CD2 1 
+ATOM   1489 C  CE1 . TYR A 1 197 ? -1.354  85.430 33.345 1.00 58.60  ? 216  TYR A CE1 1 
+ATOM   1490 C  CE2 . TYR A 1 197 ? 0.767   85.399 32.226 1.00 58.16  ? 216  TYR A CE2 1 
+ATOM   1491 C  CZ  . TYR A 1 197 ? -0.440  86.022 32.506 1.00 60.16  ? 216  TYR A CZ  1 
+ATOM   1492 O  OH  . TYR A 1 197 ? -0.751  87.240 31.952 1.00 66.31  ? 216  TYR A OH  1 
+ATOM   1493 N  N   . ASN A 1 198 ? 1.618   80.020 36.151 1.00 51.67  ? 217  ASN A N   1 
+ATOM   1494 C  CA  . ASN A 1 198 ? 1.647   78.609 36.542 1.00 51.80  ? 217  ASN A CA  1 
+ATOM   1495 C  C   . ASN A 1 198 ? 1.539   78.418 38.046 1.00 53.34  ? 217  ASN A C   1 
+ATOM   1496 O  O   . ASN A 1 198 ? 1.116   77.371 38.515 1.00 53.22  ? 217  ASN A O   1 
+ATOM   1497 C  CB  . ASN A 1 198 ? 2.897   77.916 36.003 1.00 52.32  ? 217  ASN A CB  1 
+ATOM   1498 C  CG  . ASN A 1 198 ? 2.925   77.853 34.483 1.00 54.34  ? 217  ASN A CG  1 
+ATOM   1499 O  OD1 . ASN A 1 198 ? 1.889   77.695 33.825 1.00 53.14  ? 217  ASN A OD1 1 
+ATOM   1500 N  ND2 . ASN A 1 198 ? 4.119   77.982 33.916 1.00 54.77  ? 217  ASN A ND2 1 
+ATOM   1501 N  N   . ASN A 1 199 ? 1.907   79.440 38.801 1.00 57.80  ? 218  ASN A N   1 
+ATOM   1502 C  CA  . ASN A 1 199 ? 1.730   79.411 40.243 1.00 61.66  ? 218  ASN A CA  1 
+ATOM   1503 C  C   . ASN A 1 199 ? 0.300   79.782 40.619 1.00 61.90  ? 218  ASN A C   1 
+ATOM   1504 O  O   . ASN A 1 199 ? -0.313  79.087 41.418 1.00 62.42  ? 218  ASN A O   1 
+ATOM   1505 C  CB  . ASN A 1 199 ? 2.739   80.339 40.935 1.00 65.93  ? 218  ASN A CB  1 
+ATOM   1506 C  CG  . ASN A 1 199 ? 4.023   79.619 41.295 1.00 68.66  ? 218  ASN A CG  1 
+ATOM   1507 O  OD1 . ASN A 1 199 ? 4.721   79.102 40.420 1.00 70.17  ? 218  ASN A OD1 1 
+ATOM   1508 N  ND2 . ASN A 1 199 ? 4.321   79.557 42.586 1.00 71.46  ? 218  ASN A ND2 1 
+ATOM   1509 N  N   . PHE A 1 200 ? -0.227  80.869 40.047 1.00 60.25  ? 219  PHE A N   1 
+ATOM   1510 C  CA  . PHE A 1 200 ? -1.598  81.307 40.302 1.00 59.29  ? 219  PHE A CA  1 
+ATOM   1511 C  C   . PHE A 1 200 ? -2.417  81.358 39.021 1.00 57.50  ? 219  PHE A C   1 
+ATOM   1512 O  O   . PHE A 1 200 ? -2.590  82.438 38.453 1.00 59.24  ? 219  PHE A O   1 
+ATOM   1513 C  CB  . PHE A 1 200 ? -1.594  82.689 40.931 1.00 61.54  ? 219  PHE A CB  1 
+ATOM   1514 C  CG  . PHE A 1 200 ? -0.519  82.887 41.923 1.00 65.00  ? 219  PHE A CG  1 
+ATOM   1515 C  CD1 . PHE A 1 200 ? 0.170   84.085 41.973 1.00 71.57  ? 219  PHE A CD1 1 
+ATOM   1516 C  CD2 . PHE A 1 200 ? -0.205  81.893 42.828 1.00 69.65  ? 219  PHE A CD2 1 
+ATOM   1517 C  CE1 . PHE A 1 200 ? 1.170   84.291 42.908 1.00 74.73  ? 219  PHE A CE1 1 
+ATOM   1518 C  CE2 . PHE A 1 200 ? 0.788   82.078 43.760 1.00 72.97  ? 219  PHE A CE2 1 
+ATOM   1519 C  CZ  . PHE A 1 200 ? 1.482   83.284 43.803 1.00 75.22  ? 219  PHE A CZ  1 
+ATOM   1520 N  N   . PRO A 1 201 ? -2.918  80.214 38.554 1.00 54.68  ? 220  PRO A N   1 
+ATOM   1521 C  CA  . PRO A 1 201 ? -3.673  80.169 37.296 1.00 54.01  ? 220  PRO A CA  1 
+ATOM   1522 C  C   . PRO A 1 201 ? -4.928  81.058 37.258 1.00 55.78  ? 220  PRO A C   1 
+ATOM   1523 O  O   . PRO A 1 201 ? -5.319  81.453 36.171 1.00 59.42  ? 220  PRO A O   1 
+ATOM   1524 C  CB  . PRO A 1 201 ? -4.018  78.685 37.128 1.00 52.15  ? 220  PRO A CB  1 
+ATOM   1525 C  CG  . PRO A 1 201 ? -3.746  78.054 38.389 1.00 52.55  ? 220  PRO A CG  1 
+ATOM   1526 C  CD  . PRO A 1 201 ? -2.780  78.881 39.153 1.00 54.22  ? 220  PRO A CD  1 
+ATOM   1527 N  N   . ALA A 1 202 ? -5.528  81.367 38.402 1.00 56.62  ? 221  ALA A N   1 
+ATOM   1528 C  CA  . ALA A 1 202 ? -6.605  82.355 38.485 1.00 57.16  ? 221  ALA A CA  1 
+ATOM   1529 C  C   . ALA A 1 202 ? -6.310  83.629 37.693 1.00 55.85  ? 221  ALA A C   1 
+ATOM   1530 O  O   . ALA A 1 202 ? -7.184  84.180 37.049 1.00 57.09  ? 221  ALA A O   1 
+ATOM   1531 C  CB  . ALA A 1 202 ? -6.872  82.710 39.946 1.00 59.39  ? 221  ALA A CB  1 
+ATOM   1532 N  N   . LEU A 1 203 ? -5.070  84.084 37.745 1.00 58.19  ? 222  LEU A N   1 
+ATOM   1533 C  CA  . LEU A 1 203 ? -4.635  85.263 37.004 1.00 60.63  ? 222  LEU A CA  1 
+ATOM   1534 C  C   . LEU A 1 203 ? -4.742  85.176 35.480 1.00 61.19  ? 222  LEU A C   1 
+ATOM   1535 O  O   . LEU A 1 203 ? -4.657  86.193 34.806 1.00 60.36  ? 222  LEU A O   1 
+ATOM   1536 C  CB  . LEU A 1 203 ? -3.182  85.584 37.346 1.00 61.13  ? 222  LEU A CB  1 
+ATOM   1537 C  CG  . LEU A 1 203 ? -2.904  86.065 38.766 1.00 64.57  ? 222  LEU A CG  1 
+ATOM   1538 C  CD1 . LEU A 1 203 ? -1.462  86.509 38.827 1.00 66.52  ? 222  LEU A CD1 1 
+ATOM   1539 C  CD2 . LEU A 1 203 ? -3.839  87.196 39.208 1.00 63.43  ? 222  LEU A CD2 1 
+ATOM   1540 N  N   . LEU A 1 204 ? -4.883  83.982 34.924 1.00 62.41  ? 223  LEU A N   1 
+ATOM   1541 C  CA  . LEU A 1 204 ? -5.058  83.867 33.482 1.00 62.51  ? 223  LEU A CA  1 
+ATOM   1542 C  C   . LEU A 1 204 ? -6.323  84.608 33.040 1.00 64.96  ? 223  LEU A C   1 
+ATOM   1543 O  O   . LEU A 1 204 ? -6.294  85.337 32.035 1.00 64.77  ? 223  LEU A O   1 
+ATOM   1544 C  CB  . LEU A 1 204 ? -5.107  82.406 33.059 1.00 62.23  ? 223  LEU A CB  1 
+ATOM   1545 C  CG  . LEU A 1 204 ? -3.751  81.706 33.109 1.00 60.05  ? 223  LEU A CG  1 
+ATOM   1546 C  CD1 . LEU A 1 204 ? -3.896  80.186 33.308 1.00 59.50  ? 223  LEU A CD1 1 
+ATOM   1547 C  CD2 . LEU A 1 204 ? -2.987  82.017 31.847 1.00 59.98  ? 223  LEU A CD2 1 
+ATOM   1548 N  N   . ASP A 1 205 ? -7.405  84.450 33.810 1.00 65.49  ? 224  ASP A N   1 
+ATOM   1549 C  CA  . ASP A 1 205 ? -8.658  85.184 33.563 1.00 67.38  ? 224  ASP A CA  1 
+ATOM   1550 C  C   . ASP A 1 205 ? -8.515  86.701 33.772 1.00 68.14  ? 224  ASP A C   1 
+ATOM   1551 O  O   . ASP A 1 205 ? -8.988  87.473 32.953 1.00 69.23  ? 224  ASP A O   1 
+ATOM   1552 C  CB  . ASP A 1 205 ? -9.808  84.674 34.438 1.00 66.21  ? 224  ASP A CB  1 
+ATOM   1553 C  CG  . ASP A 1 205 ? -9.785  83.177 34.625 1.00 69.83  ? 224  ASP A CG  1 
+ATOM   1554 O  OD1 . ASP A 1 205 ? -10.275 82.461 33.718 1.00 72.82  ? 224  ASP A OD1 1 
+ATOM   1555 O  OD2 . ASP A 1 205 ? -9.298  82.631 35.648 1.00 67.52  ? 224  ASP A OD2 1 
+ATOM   1556 N  N   . TYR A 1 206 ? -7.858  87.124 34.853 1.00 70.59  ? 225  TYR A N   1 
+ATOM   1557 C  CA  . TYR A 1 206 ? -7.687  88.564 35.149 1.00 73.27  ? 225  TYR A CA  1 
+ATOM   1558 C  C   . TYR A 1 206 ? -6.685  89.275 34.220 1.00 72.38  ? 225  TYR A C   1 
+ATOM   1559 O  O   . TYR A 1 206 ? -6.679  90.506 34.160 1.00 73.38  ? 225  TYR A O   1 
+ATOM   1560 C  CB  . TYR A 1 206 ? -7.299  88.794 36.634 1.00 73.47  ? 225  TYR A CB  1 
+ATOM   1561 C  CG  . TYR A 1 206 ? -8.339  88.285 37.633 1.00 76.54  ? 225  TYR A CG  1 
+ATOM   1562 C  CD1 . TYR A 1 206 ? -8.069  87.194 38.470 1.00 79.95  ? 225  TYR A CD1 1 
+ATOM   1563 C  CD2 . TYR A 1 206 ? -9.595  88.886 37.730 1.00 78.61  ? 225  TYR A CD2 1 
+ATOM   1564 C  CE1 . TYR A 1 206 ? -9.025  86.720 39.375 1.00 81.08  ? 225  TYR A CE1 1 
+ATOM   1565 C  CE2 . TYR A 1 206 ? -10.556 88.417 38.625 1.00 79.83  ? 225  TYR A CE2 1 
+ATOM   1566 C  CZ  . TYR A 1 206 ? -10.266 87.339 39.442 1.00 81.46  ? 225  TYR A CZ  1 
+ATOM   1567 O  OH  . TYR A 1 206 ? -11.217 86.893 40.326 1.00 81.15  ? 225  TYR A OH  1 
+ATOM   1568 N  N   . PHE A 1 207 ? -5.852  88.502 33.511 1.00 72.88  ? 226  PHE A N   1 
+ATOM   1569 C  CA  . PHE A 1 207 ? -4.867  89.030 32.550 1.00 72.94  ? 226  PHE A CA  1 
+ATOM   1570 C  C   . PHE A 1 207 ? -4.757  88.150 31.305 1.00 71.13  ? 226  PHE A C   1 
+ATOM   1571 O  O   . PHE A 1 207 ? -3.695  87.592 31.030 1.00 71.60  ? 226  PHE A O   1 
+ATOM   1572 C  CB  . PHE A 1 207 ? -3.481  89.130 33.188 1.00 74.16  ? 226  PHE A CB  1 
+ATOM   1573 C  CG  . PHE A 1 207 ? -3.410  90.084 34.326 1.00 78.08  ? 226  PHE A CG  1 
+ATOM   1574 C  CD1 . PHE A 1 207 ? -3.686  89.658 35.620 1.00 80.01  ? 226  PHE A CD1 1 
+ATOM   1575 C  CD2 . PHE A 1 207 ? -3.066  91.410 34.111 1.00 80.50  ? 226  PHE A CD2 1 
+ATOM   1576 C  CE1 . PHE A 1 207 ? -3.623  90.538 36.680 1.00 79.75  ? 226  PHE A CE1 1 
+ATOM   1577 C  CE2 . PHE A 1 207 ? -2.998  92.293 35.165 1.00 81.05  ? 226  PHE A CE2 1 
+ATOM   1578 C  CZ  . PHE A 1 207 ? -3.280  91.856 36.455 1.00 80.67  ? 226  PHE A CZ  1 
+ATOM   1579 N  N   . PRO A 1 208 ? -5.823  88.056 30.518 1.00 70.87  ? 227  PRO A N   1 
+ATOM   1580 C  CA  . PRO A 1 208 ? -5.830  87.125 29.388 1.00 69.87  ? 227  PRO A CA  1 
+ATOM   1581 C  C   . PRO A 1 208 ? -5.006  87.578 28.174 1.00 66.45  ? 227  PRO A C   1 
+ATOM   1582 O  O   . PRO A 1 208 ? -4.903  86.789 27.247 1.00 66.06  ? 227  PRO A O   1 
+ATOM   1583 C  CB  . PRO A 1 208 ? -7.322  87.005 29.025 1.00 70.75  ? 227  PRO A CB  1 
+ATOM   1584 C  CG  . PRO A 1 208 ? -8.066  87.883 29.976 1.00 72.12  ? 227  PRO A CG  1 
+ATOM   1585 C  CD  . PRO A 1 208 ? -7.074  88.828 30.586 1.00 72.55  ? 227  PRO A CD  1 
+ATOM   1586 N  N   . GLY A 1 209 ? -4.442  88.786 28.169 1.00 65.33  ? 228  GLY A N   1 
+ATOM   1587 C  CA  . GLY A 1 209 ? -3.568  89.229 27.083 1.00 64.08  ? 228  GLY A CA  1 
+ATOM   1588 C  C   . GLY A 1 209 ? -2.633  88.129 26.594 1.00 62.88  ? 228  GLY A C   1 
+ATOM   1589 O  O   . GLY A 1 209 ? -2.652  87.747 25.428 1.00 63.67  ? 228  GLY A O   1 
+ATOM   1590 N  N   . THR A 1 210 ? -1.817  87.603 27.499 1.00 61.75  ? 229  THR A N   1 
+ATOM   1591 C  CA  . THR A 1 210 ? -1.003  86.423 27.212 1.00 59.21  ? 229  THR A CA  1 
+ATOM   1592 C  C   . THR A 1 210 ? -1.929  85.250 27.114 1.00 58.21  ? 229  THR A C   1 
+ATOM   1593 O  O   . THR A 1 210 ? -2.748  85.055 28.006 1.00 63.36  ? 229  THR A O   1 
+ATOM   1594 C  CB  . THR A 1 210 ? -0.049  86.111 28.373 1.00 58.11  ? 229  THR A CB  1 
+ATOM   1595 O  OG1 . THR A 1 210 ? 0.645   87.291 28.797 1.00 52.63  ? 229  THR A OG1 1 
+ATOM   1596 C  CG2 . THR A 1 210 ? 1.032   85.117 27.930 1.00 57.82  ? 229  THR A CG2 1 
+ATOM   1597 N  N   . HIS A 1 211 ? -1.770  84.444 26.082 1.00 55.55  ? 230  HIS A N   1 
+ATOM   1598 C  CA  . HIS A 1 211 ? -2.633  83.272 25.840 1.00 54.64  ? 230  HIS A CA  1 
+ATOM   1599 C  C   . HIS A 1 211 ? -3.656  83.596 24.770 1.00 56.27  ? 230  HIS A C   1 
+ATOM   1600 O  O   . HIS A 1 211 ? -3.878  82.782 23.903 1.00 56.85  ? 230  HIS A O   1 
+ATOM   1601 C  CB  . HIS A 1 211 ? -3.180  82.560 27.127 1.00 53.08  ? 230  HIS A CB  1 
+ATOM   1602 C  CG  . HIS A 1 211 ? -4.605  82.873 27.527 1.00 56.08  ? 230  HIS A CG  1 
+ATOM   1603 N  ND1 . HIS A 1 211 ? -4.979  83.014 28.852 1.00 56.51  ? 230  HIS A ND1 1 
+ATOM   1604 C  CD2 . HIS A 1 211 ? -5.754  82.955 26.808 1.00 58.43  ? 230  HIS A CD2 1 
+ATOM   1605 C  CE1 . HIS A 1 211 ? -6.280  83.228 28.922 1.00 54.04  ? 230  HIS A CE1 1 
+ATOM   1606 N  NE2 . HIS A 1 211 ? -6.774  83.200 27.697 1.00 54.50  ? 230  HIS A NE2 1 
+ATOM   1607 N  N   . ASN A 1 212 ? -4.240  84.792 24.794 1.00 56.80  ? 231  ASN A N   1 
+ATOM   1608 C  CA  . ASN A 1 212 ? -5.050  85.259 23.665 1.00 55.30  ? 231  ASN A CA  1 
+ATOM   1609 C  C   . ASN A 1 212 ? -4.150  85.610 22.470 1.00 53.19  ? 231  ASN A C   1 
+ATOM   1610 O  O   . ASN A 1 212 ? -4.502  85.369 21.323 1.00 51.96  ? 231  ASN A O   1 
+ATOM   1611 C  CB  . ASN A 1 212 ? -5.898  86.490 24.040 1.00 54.87  ? 231  ASN A CB  1 
+ATOM   1612 C  CG  . ASN A 1 212 ? -7.193  86.142 24.816 1.00 56.08  ? 231  ASN A CG  1 
+ATOM   1613 O  OD1 . ASN A 1 212 ? -7.606  84.972 24.967 1.00 46.40  ? 231  ASN A OD1 1 
+ATOM   1614 N  ND2 . ASN A 1 212 ? -7.841  87.195 25.319 1.00 55.22  ? 231  ASN A ND2 1 
+ATOM   1615 N  N   . LYS A 1 213 ? -2.982  86.175 22.747 1.00 53.09  ? 232  LYS A N   1 
+ATOM   1616 C  CA  . LYS A 1 213 ? -2.043  86.535 21.689 1.00 53.35  ? 232  LYS A CA  1 
+ATOM   1617 C  C   . LYS A 1 213 ? -1.376  85.264 21.147 1.00 52.07  ? 232  LYS A C   1 
+ATOM   1618 O  O   . LYS A 1 213 ? -1.106  85.155 19.949 1.00 51.02  ? 232  LYS A O   1 
+ATOM   1619 C  CB  . LYS A 1 213 ? -1.002  87.519 22.210 1.00 55.54  ? 232  LYS A CB  1 
+ATOM   1620 C  CG  . LYS A 1 213 ? -0.968  88.848 21.478 1.00 61.56  ? 232  LYS A CG  1 
+ATOM   1621 C  CD  . LYS A 1 213 ? -0.023  89.862 22.174 1.00 68.68  ? 232  LYS A CD  1 
+ATOM   1622 C  CE  . LYS A 1 213 ? -0.516  90.310 23.581 1.00 70.50  ? 232  LYS A CE  1 
+ATOM   1623 N  NZ  . LYS A 1 213 ? 0.601   90.842 24.442 1.00 72.70  ? 232  LYS A NZ  1 
+ATOM   1624 N  N   . LEU A 1 214 ? -1.138  84.300 22.035 1.00 47.60  ? 233  LEU A N   1 
+ATOM   1625 C  CA  . LEU A 1 214 ? -0.608  83.000 21.636 1.00 45.83  ? 233  LEU A CA  1 
+ATOM   1626 C  C   . LEU A 1 214 ? -1.629  82.273 20.795 1.00 44.64  ? 233  LEU A C   1 
+ATOM   1627 O  O   . LEU A 1 214 ? -1.272  81.673 19.795 1.00 45.11  ? 233  LEU A O   1 
+ATOM   1628 C  CB  . LEU A 1 214 ? -0.175  82.134 22.856 1.00 41.69  ? 233  LEU A CB  1 
+ATOM   1629 C  CG  . LEU A 1 214 ? 0.983   82.727 23.667 1.00 43.48  ? 233  LEU A CG  1 
+ATOM   1630 C  CD1 . LEU A 1 214 ? 1.300   81.921 24.893 1.00 44.31  ? 233  LEU A CD1 1 
+ATOM   1631 C  CD2 . LEU A 1 214 ? 2.231   82.896 22.806 1.00 45.55  ? 233  LEU A CD2 1 
+ATOM   1632 N  N   . LEU A 1 215 ? -2.901  82.351 21.185 1.00 46.27  ? 234  LEU A N   1 
+ATOM   1633 C  CA  . LEU A 1 215 ? -3.967  81.600 20.496 1.00 45.84  ? 234  LEU A CA  1 
+ATOM   1634 C  C   . LEU A 1 215 ? -4.252  82.172 19.126 1.00 42.32  ? 234  LEU A C   1 
+ATOM   1635 O  O   . LEU A 1 215 ? -4.659  81.447 18.223 1.00 43.50  ? 234  LEU A O   1 
+ATOM   1636 C  CB  . LEU A 1 215 ? -5.268  81.555 21.324 1.00 43.46  ? 234  LEU A CB  1 
+ATOM   1637 C  CG  . LEU A 1 215 ? -5.315  80.479 22.421 1.00 42.93  ? 234  LEU A CG  1 
+ATOM   1638 C  CD1 . LEU A 1 215 ? -6.603  80.598 23.210 1.00 42.67  ? 234  LEU A CD1 1 
+ATOM   1639 C  CD2 . LEU A 1 215 ? -5.142  79.074 21.885 1.00 43.52  ? 234  LEU A CD2 1 
+ATOM   1640 N  N   . LYS A 1 216 ? -4.033  83.473 18.999 1.00 43.92  ? 235  LYS A N   1 
+ATOM   1641 C  CA  . LYS A 1 216 ? -4.330  84.205 17.789 1.00 48.59  ? 235  LYS A CA  1 
+ATOM   1642 C  C   . LYS A 1 216 ? -3.232  83.885 16.788 1.00 48.11  ? 235  LYS A C   1 
+ATOM   1643 O  O   . LYS A 1 216 ? -3.507  83.632 15.621 1.00 49.77  ? 235  LYS A O   1 
+ATOM   1644 C  CB  . LYS A 1 216 ? -4.412  85.706 18.107 1.00 51.39  ? 235  LYS A CB  1 
+ATOM   1645 C  CG  . LYS A 1 216 ? -4.705  86.622 16.927 1.00 59.27  ? 235  LYS A CG  1 
+ATOM   1646 C  CD  . LYS A 1 216 ? -4.754  88.104 17.345 1.00 66.01  ? 235  LYS A CD  1 
+ATOM   1647 C  CE  . LYS A 1 216 ? -6.163  88.549 17.807 1.00 72.32  ? 235  LYS A CE  1 
+ATOM   1648 N  NZ  . LYS A 1 216 ? -6.355  88.430 19.302 1.00 75.88  ? 235  LYS A NZ  1 
+ATOM   1649 N  N   . ASN A 1 217 ? -1.990  83.851 17.277 1.00 50.14  ? 236  ASN A N   1 
+ATOM   1650 C  CA  . ASN A 1 217 ? -0.798  83.579 16.461 1.00 46.04  ? 236  ASN A CA  1 
+ATOM   1651 C  C   . ASN A 1 217 ? -0.747  82.150 15.960 1.00 41.46  ? 236  ASN A C   1 
+ATOM   1652 O  O   . ASN A 1 217 ? -0.410  81.885 14.811 1.00 41.84  ? 236  ASN A O   1 
+ATOM   1653 C  CB  . ASN A 1 217 ? 0.471   83.872 17.266 1.00 48.35  ? 236  ASN A CB  1 
+ATOM   1654 C  CG  . ASN A 1 217 ? 0.767   85.362 17.383 1.00 48.94  ? 236  ASN A CG  1 
+ATOM   1655 O  OD1 . ASN A 1 217 ? 1.597   85.788 18.205 1.00 45.95  ? 236  ASN A OD1 1 
+ATOM   1656 N  ND2 . ASN A 1 217 ? 0.094   86.161 16.562 1.00 46.81  ? 236  ASN A ND2 1 
+ATOM   1657 N  N   . VAL A 1 218 ? -1.085  81.223 16.826 1.00 38.83  ? 237  VAL A N   1 
+ATOM   1658 C  CA  . VAL A 1 218 ? -1.133  79.843 16.426 1.00 40.75  ? 237  VAL A CA  1 
+ATOM   1659 C  C   . VAL A 1 218 ? -2.199  79.690 15.350 1.00 46.92  ? 237  VAL A C   1 
+ATOM   1660 O  O   . VAL A 1 218 ? -1.983  78.983 14.356 1.00 51.43  ? 237  VAL A O   1 
+ATOM   1661 C  CB  . VAL A 1 218 ? -1.400  78.933 17.620 1.00 40.19  ? 237  VAL A CB  1 
+ATOM   1662 C  CG1 . VAL A 1 218 ? -1.768  77.524 17.180 1.00 41.79  ? 237  VAL A CG1 1 
+ATOM   1663 C  CG2 . VAL A 1 218 ? -0.172  78.892 18.505 1.00 42.04  ? 237  VAL A CG2 1 
+ATOM   1664 N  N   . ALA A 1 219 ? -3.342  80.356 15.518 1.00 49.30  ? 238  ALA A N   1 
+ATOM   1665 C  CA  . ALA A 1 219 ? -4.458  80.124 14.599 1.00 47.64  ? 238  ALA A CA  1 
+ATOM   1666 C  C   . ALA A 1 219 ? -4.148  80.761 13.256 1.00 42.47  ? 238  ALA A C   1 
+ATOM   1667 O  O   . ALA A 1 219 ? -4.586  80.264 12.233 1.00 43.29  ? 238  ALA A O   1 
+ATOM   1668 C  CB  . ALA A 1 219 ? -5.750  80.633 15.163 1.00 48.80  ? 238  ALA A CB  1 
+ATOM   1669 N  N   . PHE A 1 220 ? -3.368  81.836 13.267 1.00 38.51  ? 239  PHE A N   1 
+ATOM   1670 C  CA  . PHE A 1 220 ? -2.882  82.452 12.034 1.00 40.83  ? 239  PHE A CA  1 
+ATOM   1671 C  C   . PHE A 1 220 ? -2.031  81.462 11.272 1.00 43.35  ? 239  PHE A C   1 
+ATOM   1672 O  O   . PHE A 1 220 ? -2.202  81.281 10.077 1.00 46.74  ? 239  PHE A O   1 
+ATOM   1673 C  CB  . PHE A 1 220 ? -2.033  83.677 12.347 1.00 39.27  ? 239  PHE A CB  1 
+ATOM   1674 C  CG  . PHE A 1 220 ? -1.491  84.363 11.133 1.00 43.25  ? 239  PHE A CG  1 
+ATOM   1675 C  CD1 . PHE A 1 220 ? -0.413  83.834 10.432 1.00 43.21  ? 239  PHE A CD1 1 
+ATOM   1676 C  CD2 . PHE A 1 220 ? -2.055  85.559 10.690 1.00 44.68  ? 239  PHE A CD2 1 
+ATOM   1677 C  CE1 . PHE A 1 220 ? 0.100   84.495 9.303  1.00 47.45  ? 239  PHE A CE1 1 
+ATOM   1678 C  CE2 . PHE A 1 220 ? -1.558  86.216 9.552  1.00 46.91  ? 239  PHE A CE2 1 
+ATOM   1679 C  CZ  . PHE A 1 220 ? -0.478  85.687 8.861  1.00 46.14  ? 239  PHE A CZ  1 
+ATOM   1680 N  N   . MET A 1 221 ? -1.102  80.843 11.992 1.00 46.36  ? 240  MET A N   1 
+ATOM   1681 C  CA  . MET A 1 221 ? -0.192  79.877 11.426 1.00 46.87  ? 240  MET A CA  1 
+ATOM   1682 C  C   . MET A 1 221 ? -0.978  78.665 10.949 1.00 47.03  ? 240  MET A C   1 
+ATOM   1683 O  O   . MET A 1 221 ? -0.726  78.162 9.870  1.00 45.17  ? 240  MET A O   1 
+ATOM   1684 C  CB  . MET A 1 221 ? 0.863   79.456 12.459 1.00 47.39  ? 240  MET A CB  1 
+ATOM   1685 C  CG  . MET A 1 221 ? 2.152   80.263 12.401 1.00 48.81  ? 240  MET A CG  1 
+ATOM   1686 S  SD  . MET A 1 221 ? 2.981   80.487 14.005 1.00 50.96  ? 240  MET A SD  1 
+ATOM   1687 C  CE  . MET A 1 221 ? 2.853   78.881 14.700 1.00 55.49  ? 240  MET A CE  1 
+ATOM   1688 N  N   . LYS A 1 222 ? -1.934  78.201 11.743 1.00 48.17  ? 241  LYS A N   1 
+ATOM   1689 C  CA  . LYS A 1 222 ? -2.758  77.058 11.346 1.00 49.86  ? 241  LYS A CA  1 
+ATOM   1690 C  C   . LYS A 1 222 ? -3.496  77.322 10.010 1.00 51.85  ? 241  LYS A C   1 
+ATOM   1691 O  O   . LYS A 1 222 ? -3.606  76.428 9.185  1.00 53.51  ? 241  LYS A O   1 
+ATOM   1692 C  CB  . LYS A 1 222 ? -3.753  76.705 12.448 1.00 49.36  ? 241  LYS A CB  1 
+ATOM   1693 C  CG  . LYS A 1 222 ? -3.159  75.947 13.621 1.00 50.82  ? 241  LYS A CG  1 
+ATOM   1694 C  CD  . LYS A 1 222 ? -4.106  75.945 14.822 1.00 53.94  ? 241  LYS A CD  1 
+ATOM   1695 C  CE  . LYS A 1 222 ? -4.403  74.555 15.339 1.00 54.13  ? 241  LYS A CE  1 
+ATOM   1696 N  NZ  . LYS A 1 222 ? -5.170  73.722 14.334 1.00 55.90  ? 241  LYS A NZ  1 
+ATOM   1697 N  N   . SER A 1 223 ? -3.969  78.549 9.794  1.00 51.73  ? 242  SER A N   1 
+ATOM   1698 C  CA  . SER A 1 223 ? -4.656  78.915 8.557  1.00 52.02  ? 242  SER A CA  1 
+ATOM   1699 C  C   . SER A 1 223 ? -3.744  78.872 7.371  1.00 51.51  ? 242  SER A C   1 
+ATOM   1700 O  O   . SER A 1 223 ? -4.130  78.413 6.301  1.00 51.97  ? 242  SER A O   1 
+ATOM   1701 C  CB  . SER A 1 223 ? -5.192  80.343 8.622  1.00 50.89  ? 242  SER A CB  1 
+ATOM   1702 O  OG  . SER A 1 223 ? -6.501  80.311 9.095  1.00 54.27  ? 242  SER A OG  1 
+ATOM   1703 N  N   . TYR A 1 224 ? -2.560  79.442 7.560  1.00 52.12  ? 243  TYR A N   1 
+ATOM   1704 C  CA  . TYR A 1 224 ? -1.548  79.541 6.525  1.00 50.57  ? 243  TYR A CA  1 
+ATOM   1705 C  C   . TYR A 1 224 ? -1.169  78.150 6.058  1.00 48.84  ? 243  TYR A C   1 
+ATOM   1706 O  O   . TYR A 1 224 ? -1.086  77.870 4.879  1.00 50.21  ? 243  TYR A O   1 
+ATOM   1707 C  CB  . TYR A 1 224 ? -0.318  80.254 7.081  1.00 51.77  ? 243  TYR A CB  1 
+ATOM   1708 C  CG  . TYR A 1 224 ? 0.826   80.234 6.127  1.00 56.12  ? 243  TYR A CG  1 
+ATOM   1709 C  CD1 . TYR A 1 224 ? 0.956   81.217 5.162  1.00 61.57  ? 243  TYR A CD1 1 
+ATOM   1710 C  CD2 . TYR A 1 224 ? 1.755   79.203 6.154  1.00 58.09  ? 243  TYR A CD2 1 
+ATOM   1711 C  CE1 . TYR A 1 224 ? 1.994   81.191 4.258  1.00 64.35  ? 243  TYR A CE1 1 
+ATOM   1712 C  CE2 . TYR A 1 224 ? 2.790   79.159 5.261  1.00 61.72  ? 243  TYR A CE2 1 
+ATOM   1713 C  CZ  . TYR A 1 224 ? 2.912   80.160 4.310  1.00 65.98  ? 243  TYR A CZ  1 
+ATOM   1714 O  OH  . TYR A 1 224 ? 3.955   80.133 3.404  1.00 71.78  ? 243  TYR A OH  1 
+ATOM   1715 N  N   . ILE A 1 225 ? -0.945  77.272 7.014  1.00 48.82  ? 244  ILE A N   1 
+ATOM   1716 C  CA  . ILE A 1 225 ? -0.622  75.898 6.725  1.00 48.19  ? 244  ILE A CA  1 
+ATOM   1717 C  C   . ILE A 1 225 ? -1.764  75.247 5.989  1.00 48.17  ? 244  ILE A C   1 
+ATOM   1718 O  O   . ILE A 1 225 ? -1.537  74.458 5.100  1.00 55.33  ? 244  ILE A O   1 
+ATOM   1719 C  CB  . ILE A 1 225 ? -0.301  75.146 8.045  1.00 47.73  ? 244  ILE A CB  1 
+ATOM   1720 C  CG1 . ILE A 1 225 ? 1.052   75.626 8.580  1.00 46.84  ? 244  ILE A CG1 1 
+ATOM   1721 C  CG2 . ILE A 1 225 ? -0.300  73.593 7.862  1.00 44.68  ? 244  ILE A CG2 1 
+ATOM   1722 C  CD1 . ILE A 1 225 ? 1.159   75.625 10.073 1.00 46.59  ? 244  ILE A CD1 1 
+ATOM   1723 N  N   . LEU A 1 226 ? -2.986  75.568 6.372  1.00 49.93  ? 245  LEU A N   1 
+ATOM   1724 C  CA  . LEU A 1 226 ? -4.171  74.979 5.758  1.00 49.94  ? 245  LEU A CA  1 
+ATOM   1725 C  C   . LEU A 1 226 ? -4.220  75.269 4.262  1.00 51.59  ? 245  LEU A C   1 
+ATOM   1726 O  O   . LEU A 1 226 ? -4.519  74.382 3.474  1.00 51.28  ? 245  LEU A O   1 
+ATOM   1727 C  CB  . LEU A 1 226 ? -5.440  75.523 6.418  1.00 48.78  ? 245  LEU A CB  1 
+ATOM   1728 C  CG  . LEU A 1 226 ? -6.706  74.657 6.492  1.00 53.41  ? 245  LEU A CG  1 
+ATOM   1729 C  CD1 . LEU A 1 226 ? -7.850  75.328 5.740  1.00 54.25  ? 245  LEU A CD1 1 
+ATOM   1730 C  CD2 . LEU A 1 226 ? -6.523  73.195 6.014  1.00 52.87  ? 245  LEU A CD2 1 
+ATOM   1731 N  N   . GLU A 1 227 ? -3.917  76.505 3.870  1.00 52.44  ? 246  GLU A N   1 
+ATOM   1732 C  CA  . GLU A 1 227 ? -3.987  76.874 2.469  1.00 56.00  ? 246  GLU A CA  1 
+ATOM   1733 C  C   . GLU A 1 227 ? -2.821  76.218 1.729  1.00 57.66  ? 246  GLU A C   1 
+ATOM   1734 O  O   . GLU A 1 227 ? -2.864  75.997 0.524  1.00 61.85  ? 246  GLU A O   1 
+ATOM   1735 C  CB  . GLU A 1 227 ? -4.075  78.402 2.289  1.00 57.06  ? 246  GLU A CB  1 
+ATOM   1736 C  CG  . GLU A 1 227 ? -2.776  79.186 2.283  1.00 61.11  ? 246  GLU A CG  1 
+ATOM   1737 C  CD  . GLU A 1 227 ? -2.991  80.698 2.471  1.00 66.31  ? 246  GLU A CD  1 
+ATOM   1738 O  OE1 . GLU A 1 227 ? -3.758  81.115 3.369  1.00 68.79  ? 246  GLU A OE1 1 
+ATOM   1739 O  OE2 . GLU A 1 227 ? -2.371  81.490 1.730  1.00 70.62  ? 246  GLU A OE2 1 
+ATOM   1740 N  N   . LYS A 1 228 ? -1.791  75.869 2.478  1.00 58.99  ? 247  LYS A N   1 
+ATOM   1741 C  CA  . LYS A 1 228 ? -0.685  75.097 1.941  1.00 56.02  ? 247  LYS A CA  1 
+ATOM   1742 C  C   . LYS A 1 228 ? -1.052  73.646 1.667  1.00 53.51  ? 247  LYS A C   1 
+ATOM   1743 O  O   . LYS A 1 228 ? -0.640  73.109 0.642  1.00 55.97  ? 247  LYS A O   1 
+ATOM   1744 C  CB  . LYS A 1 228 ? 0.511   75.163 2.883  1.00 56.27  ? 247  LYS A CB  1 
+ATOM   1745 C  CG  . LYS A 1 228 ? 1.720   75.782 2.241  1.00 58.18  ? 247  LYS A CG  1 
+ATOM   1746 C  CD  . LYS A 1 228 ? 1.497   77.245 1.959  1.00 58.98  ? 247  LYS A CD  1 
+ATOM   1747 C  CE  . LYS A 1 228 ? 2.790   77.951 1.584  1.00 58.06  ? 247  LYS A CE  1 
+ATOM   1748 N  NZ  . LYS A 1 228 ? 2.948   78.155 0.127  1.00 58.10  ? 247  LYS A NZ  1 
+ATOM   1749 N  N   . VAL A 1 229 ? -1.815  73.012 2.561  1.00 50.22  ? 248  VAL A N   1 
+ATOM   1750 C  CA  . VAL A 1 229 ? -2.176  71.607 2.391  1.00 51.81  ? 248  VAL A CA  1 
+ATOM   1751 C  C   . VAL A 1 229 ? -3.278  71.467 1.333  1.00 56.28  ? 248  VAL A C   1 
+ATOM   1752 O  O   . VAL A 1 229 ? -3.585  70.360 0.868  1.00 52.54  ? 248  VAL A O   1 
+ATOM   1753 C  CB  . VAL A 1 229 ? -2.624  70.907 3.716  1.00 52.96  ? 248  VAL A CB  1 
+ATOM   1754 C  CG1 . VAL A 1 229 ? -1.950  71.490 4.924  1.00 52.69  ? 248  VAL A CG1 1 
+ATOM   1755 C  CG2 . VAL A 1 229 ? -4.143  70.939 3.901  1.00 56.45  ? 248  VAL A CG2 1 
+ATOM   1756 N  N   . LYS A 1 230 ? -3.891  72.596 0.986  1.00 58.87  ? 249  LYS A N   1 
+ATOM   1757 C  CA  . LYS A 1 230 ? -4.911  72.610 -0.037 1.00 61.75  ? 249  LYS A CA  1 
+ATOM   1758 C  C   . LYS A 1 230 ? -4.199  72.528 -1.377 1.00 60.57  ? 249  LYS A C   1 
+ATOM   1759 O  O   . LYS A 1 230 ? -4.456  71.599 -2.141 1.00 59.79  ? 249  LYS A O   1 
+ATOM   1760 C  CB  . LYS A 1 230 ? -5.809  73.850 0.090  1.00 63.22  ? 249  LYS A CB  1 
+ATOM   1761 C  CG  . LYS A 1 230 ? -6.979  73.645 1.084  1.00 64.58  ? 249  LYS A CG  1 
+ATOM   1762 C  CD  . LYS A 1 230 ? -8.028  74.776 1.008  1.00 65.22  ? 249  LYS A CD  1 
+ATOM   1763 C  CE  . LYS A 1 230 ? -8.996  74.788 2.217  1.00 63.09  ? 249  LYS A CE  1 
+ATOM   1764 N  NZ  . LYS A 1 230 ? -9.215  73.439 2.821  1.00 57.26  ? 249  LYS A NZ  1 
+ATOM   1765 N  N   . GLU A 1 231 ? -3.275  73.463 -1.624 1.00 59.92  ? 250  GLU A N   1 
+ATOM   1766 C  CA  . GLU A 1 231 ? -2.381  73.408 -2.791 1.00 61.16  ? 250  GLU A CA  1 
+ATOM   1767 C  C   . GLU A 1 231 ? -1.755  72.029 -2.956 1.00 61.04  ? 250  GLU A C   1 
+ATOM   1768 O  O   . GLU A 1 231 ? -1.480  71.609 -4.074 1.00 65.27  ? 250  GLU A O   1 
+ATOM   1769 C  CB  . GLU A 1 231 ? -1.232  74.412 -2.688 1.00 62.86  ? 250  GLU A CB  1 
+ATOM   1770 C  CG  . GLU A 1 231 ? -1.626  75.881 -2.640 1.00 67.59  ? 250  GLU A CG  1 
+ATOM   1771 C  CD  . GLU A 1 231 ? -0.447  76.810 -2.335 1.00 71.94  ? 250  GLU A CD  1 
+ATOM   1772 O  OE1 . GLU A 1 231 ? -0.490  77.990 -2.743 1.00 73.52  ? 250  GLU A OE1 1 
+ATOM   1773 O  OE2 . GLU A 1 231 ? 0.534   76.377 -1.686 1.00 77.91  ? 250  GLU A OE2 1 
+ATOM   1774 N  N   . HIS A 1 232 ? -1.513  71.341 -1.843 1.00 60.36  ? 251  HIS A N   1 
+ATOM   1775 C  CA  . HIS A 1 232 ? -0.931  70.001 -1.868 1.00 58.63  ? 251  HIS A CA  1 
+ATOM   1776 C  C   . HIS A 1 232 ? -1.973  68.965 -2.258 1.00 60.22  ? 251  HIS A C   1 
+ATOM   1777 O  O   . HIS A 1 232 ? -1.722  68.153 -3.130 1.00 62.92  ? 251  HIS A O   1 
+ATOM   1778 C  CB  . HIS A 1 232 ? -0.281  69.650 -0.517 1.00 55.86  ? 251  HIS A CB  1 
+ATOM   1779 C  CG  . HIS A 1 232 ? 1.114   70.169 -0.382 1.00 51.67  ? 251  HIS A CG  1 
+ATOM   1780 N  ND1 . HIS A 1 232 ? 1.427   71.500 -0.555 1.00 52.27  ? 251  HIS A ND1 1 
+ATOM   1781 C  CD2 . HIS A 1 232 ? 2.284   69.535 -0.136 1.00 47.73  ? 251  HIS A CD2 1 
+ATOM   1782 C  CE1 . HIS A 1 232 ? 2.728   71.667 -0.407 1.00 51.11  ? 251  HIS A CE1 1 
+ATOM   1783 N  NE2 . HIS A 1 232 ? 3.271   70.490 -0.148 1.00 47.36  ? 251  HIS A NE2 1 
+ATOM   1784 N  N   . GLN A 1 233 ? -3.143  69.006 -1.629 1.00 62.22  ? 252  GLN A N   1 
+ATOM   1785 C  CA  . GLN A 1 233 ? -4.233  68.077 -1.950 1.00 61.02  ? 252  GLN A CA  1 
+ATOM   1786 C  C   . GLN A 1 233 ? -4.576  68.121 -3.439 1.00 61.34  ? 252  GLN A C   1 
+ATOM   1787 O  O   . GLN A 1 233 ? -5.036  67.143 -4.011 1.00 57.70  ? 252  GLN A O   1 
+ATOM   1788 C  CB  . GLN A 1 233 ? -5.472  68.399 -1.104 1.00 59.10  ? 252  GLN A CB  1 
+ATOM   1789 C  CG  . GLN A 1 233 ? -5.469  67.681 0.235  1.00 59.83  ? 252  GLN A CG  1 
+ATOM   1790 C  CD  . GLN A 1 233 ? -6.558  68.135 1.193  1.00 58.75  ? 252  GLN A CD  1 
+ATOM   1791 O  OE1 . GLN A 1 233 ? -7.075  67.323 1.965  1.00 55.04  ? 252  GLN A OE1 1 
+ATOM   1792 N  NE2 . GLN A 1 233 ? -6.885  69.426 1.164  1.00 58.72  ? 252  GLN A NE2 1 
+ATOM   1793 N  N   . GLU A 1 234 ? -4.318  69.263 -4.057 1.00 65.32  ? 253  GLU A N   1 
+ATOM   1794 C  CA  . GLU A 1 234 ? -4.649  69.493 -5.445 1.00 71.50  ? 253  GLU A CA  1 
+ATOM   1795 C  C   . GLU A 1 234 ? -3.614  68.822 -6.347 1.00 74.24  ? 253  GLU A C   1 
+ATOM   1796 O  O   . GLU A 1 234 ? -3.958  67.984 -7.185 1.00 78.02  ? 253  GLU A O   1 
+ATOM   1797 C  CB  . GLU A 1 234 ? -4.718  71.006 -5.693 1.00 73.40  ? 253  GLU A CB  1 
+ATOM   1798 C  CG  . GLU A 1 234 ? -5.157  71.409 -7.089 1.00 78.32  ? 253  GLU A CG  1 
+ATOM   1799 C  CD  . GLU A 1 234 ? -3.994  71.436 -8.064 1.00 82.83  ? 253  GLU A CD  1 
+ATOM   1800 O  OE1 . GLU A 1 234 ? -4.089  70.790 -9.139 1.00 86.38  ? 253  GLU A OE1 1 
+ATOM   1801 O  OE2 . GLU A 1 234 ? -2.978  72.092 -7.740 1.00 84.17  ? 253  GLU A OE2 1 
+ATOM   1802 N  N   . SER A 1 235 ? -2.343  69.171 -6.152 1.00 76.13  ? 254  SER A N   1 
+ATOM   1803 C  CA  . SER A 1 235 ? -1.256  68.733 -7.041 1.00 76.24  ? 254  SER A CA  1 
+ATOM   1804 C  C   . SER A 1 235 ? -0.568  67.461 -6.565 1.00 73.53  ? 254  SER A C   1 
+ATOM   1805 O  O   . SER A 1 235 ? 0.496   67.107 -7.043 1.00 72.87  ? 254  SER A O   1 
+ATOM   1806 C  CB  . SER A 1 235 ? -0.202  69.837 -7.161 1.00 75.95  ? 254  SER A CB  1 
+ATOM   1807 O  OG  . SER A 1 235 ? 0.651   69.825 -6.030 1.00 75.05  ? 254  SER A OG  1 
+ATOM   1808 N  N   . MET A 1 236 ? -1.185  66.767 -5.631 1.00 72.79  ? 255  MET A N   1 
+ATOM   1809 C  CA  . MET A 1 236 ? -0.501  65.706 -4.926 1.00 72.92  ? 255  MET A CA  1 
+ATOM   1810 C  C   . MET A 1 236 ? -0.397  64.489 -5.814 1.00 70.64  ? 255  MET A C   1 
+ATOM   1811 O  O   . MET A 1 236 ? -1.389  64.020 -6.344 1.00 69.10  ? 255  MET A O   1 
+ATOM   1812 C  CB  . MET A 1 236 ? -1.278  65.339 -3.662 1.00 75.31  ? 255  MET A CB  1 
+ATOM   1813 C  CG  . MET A 1 236 ? -0.430  65.021 -2.462 1.00 77.46  ? 255  MET A CG  1 
+ATOM   1814 S  SD  . MET A 1 236 ? -0.903  63.416 -1.805 1.00 85.77  ? 255  MET A SD  1 
+ATOM   1815 C  CE  . MET A 1 236 ? -2.808  63.633 -1.530 1.00 84.85  ? 255  MET A CE  1 
+ATOM   1816 N  N   . ASP A 1 237 ? 0.815   63.978 -5.959 1.00 70.94  ? 256  ASP A N   1 
+ATOM   1817 C  CA  . ASP A 1 237 ? 1.045   62.719 -6.638 1.00 70.30  ? 256  ASP A CA  1 
+ATOM   1818 C  C   . ASP A 1 237 ? 1.310   61.642 -5.601 1.00 69.99  ? 256  ASP A C   1 
+ATOM   1819 O  O   . ASP A 1 237 ? 2.367   61.620 -4.983 1.00 69.26  ? 256  ASP A O   1 
+ATOM   1820 C  CB  . ASP A 1 237 ? 2.241   62.862 -7.580 1.00 70.60  ? 256  ASP A CB  1 
+ATOM   1821 C  CG  . ASP A 1 237 ? 2.568   61.581 -8.339 1.00 69.39  ? 256  ASP A CG  1 
+ATOM   1822 O  OD1 . ASP A 1 237 ? 1.807   60.580 -8.243 1.00 61.05  ? 256  ASP A OD1 1 
+ATOM   1823 O  OD2 . ASP A 1 237 ? 3.588   61.515 -9.073 1.00 67.87  ? 256  ASP A OD2 1 
+ATOM   1824 N  N   . MET A 1 238 ? 0.340   60.753 -5.421 1.00 72.26  ? 257  MET A N   1 
+ATOM   1825 C  CA  . MET A 1 238 ? 0.512   59.546 -4.605 1.00 74.43  ? 257  MET A CA  1 
+ATOM   1826 C  C   . MET A 1 238 ? 1.531   58.622 -5.289 1.00 74.66  ? 257  MET A C   1 
+ATOM   1827 O  O   . MET A 1 238 ? 1.711   58.691 -6.507 1.00 78.70  ? 257  MET A O   1 
+ATOM   1828 C  CB  . MET A 1 238 ? -0.825  58.818 -4.431 1.00 77.61  ? 257  MET A CB  1 
+ATOM   1829 C  CG  . MET A 1 238 ? -2.030  59.715 -4.032 1.00 80.92  ? 257  MET A CG  1 
+ATOM   1830 S  SD  . MET A 1 238 ? -2.225  59.934 -2.238 1.00 84.86  ? 257  MET A SD  1 
+ATOM   1831 C  CE  . MET A 1 238 ? -2.604  58.182 -1.700 1.00 82.19  ? 257  MET A CE  1 
+ATOM   1832 N  N   . ASN A 1 239 ? 2.187   57.754 -4.517 1.00 72.39  ? 258  ASN A N   1 
+ATOM   1833 C  CA  . ASN A 1 239 ? 3.394   57.012 -4.969 1.00 70.60  ? 258  ASN A CA  1 
+ATOM   1834 C  C   . ASN A 1 239 ? 4.624   57.889 -5.209 1.00 66.47  ? 258  ASN A C   1 
+ATOM   1835 O  O   . ASN A 1 239 ? 5.659   57.372 -5.626 1.00 62.36  ? 258  ASN A O   1 
+ATOM   1836 C  CB  . ASN A 1 239 ? 3.190   56.183 -6.261 1.00 72.71  ? 258  ASN A CB  1 
+ATOM   1837 C  CG  . ASN A 1 239 ? 1.813   55.568 -6.376 1.00 73.74  ? 258  ASN A CG  1 
+ATOM   1838 O  OD1 . ASN A 1 239 ? 1.531   54.524 -5.779 1.00 73.92  ? 258  ASN A OD1 1 
+ATOM   1839 N  ND2 . ASN A 1 239 ? 0.952   56.202 -7.174 1.00 71.60  ? 258  ASN A ND2 1 
+ATOM   1840 N  N   . ASN A 1 240 ? 4.503   59.197 -4.966 1.00 63.68  ? 259  ASN A N   1 
+ATOM   1841 C  CA  . ASN A 1 240 ? 5.598   60.148 -5.175 1.00 62.22  ? 259  ASN A CA  1 
+ATOM   1842 C  C   . ASN A 1 240 ? 5.575   61.364 -4.237 1.00 59.52  ? 259  ASN A C   1 
+ATOM   1843 O  O   . ASN A 1 240 ? 5.686   62.513 -4.680 1.00 52.55  ? 259  ASN A O   1 
+ATOM   1844 C  CB  . ASN A 1 240 ? 5.586   60.626 -6.626 1.00 65.76  ? 259  ASN A CB  1 
+ATOM   1845 C  CG  . ASN A 1 240 ? 6.264   59.662 -7.547 1.00 64.03  ? 259  ASN A CG  1 
+ATOM   1846 O  OD1 . ASN A 1 240 ? 7.362   59.194 -7.255 1.00 62.09  ? 259  ASN A OD1 1 
+ATOM   1847 N  ND2 . ASN A 1 240 ? 5.617   59.344 -8.663 1.00 64.02  ? 259  ASN A ND2 1 
+ATOM   1848 N  N   . PRO A 1 241 ? 5.478   61.100 -2.938 1.00 59.32  ? 260  PRO A N   1 
+ATOM   1849 C  CA  . PRO A 1 241 ? 5.464   62.165 -1.944 1.00 58.61  ? 260  PRO A CA  1 
+ATOM   1850 C  C   . PRO A 1 241 ? 6.820   62.850 -1.865 1.00 57.41  ? 260  PRO A C   1 
+ATOM   1851 O  O   . PRO A 1 241 ? 7.855   62.203 -1.987 1.00 56.10  ? 260  PRO A O   1 
+ATOM   1852 C  CB  . PRO A 1 241 ? 5.151   61.421 -0.645 1.00 59.31  ? 260  PRO A CB  1 
+ATOM   1853 C  CG  . PRO A 1 241 ? 5.665   60.045 -0.863 1.00 60.10  ? 260  PRO A CG  1 
+ATOM   1854 C  CD  . PRO A 1 241 ? 5.425   59.768 -2.305 1.00 60.45  ? 260  PRO A CD  1 
+ATOM   1855 N  N   . GLN A 1 242 ? 6.784   64.160 -1.664 1.00 56.85  ? 261  GLN A N   1 
+ATOM   1856 C  CA  . GLN A 1 242 ? 7.971   64.991 -1.663 1.00 57.72  ? 261  GLN A CA  1 
+ATOM   1857 C  C   . GLN A 1 242 ? 8.197   65.758 -0.344 1.00 56.68  ? 261  GLN A C   1 
+ATOM   1858 O  O   . GLN A 1 242 ? 9.301   66.248 -0.112 1.00 57.10  ? 261  GLN A O   1 
+ATOM   1859 C  CB  . GLN A 1 242 ? 7.892   65.976 -2.828 1.00 58.58  ? 261  GLN A CB  1 
+ATOM   1860 C  CG  . GLN A 1 242 ? 7.455   65.355 -4.159 1.00 61.87  ? 261  GLN A CG  1 
+ATOM   1861 C  CD  . GLN A 1 242 ? 8.533   65.395 -5.209 1.00 62.74  ? 261  GLN A CD  1 
+ATOM   1862 O  OE1 . GLN A 1 242 ? 9.532   64.677 -5.111 1.00 62.95  ? 261  GLN A OE1 1 
+ATOM   1863 N  NE2 . GLN A 1 242 ? 8.343   66.237 -6.219 1.00 64.98  ? 261  GLN A NE2 1 
+ATOM   1864 N  N   . ASP A 1 243 ? 7.172   65.896 0.502  1.00 52.62  ? 262  ASP A N   1 
+ATOM   1865 C  CA  . ASP A 1 243 ? 7.358   66.553 1.796  1.00 49.85  ? 262  ASP A CA  1 
+ATOM   1866 C  C   . ASP A 1 243 ? 6.451   65.993 2.873  1.00 49.13  ? 262  ASP A C   1 
+ATOM   1867 O  O   . ASP A 1 243 ? 5.782   64.976 2.668  1.00 47.88  ? 262  ASP A O   1 
+ATOM   1868 C  CB  . ASP A 1 243 ? 7.243   68.089 1.677  1.00 48.27  ? 262  ASP A CB  1 
+ATOM   1869 C  CG  . ASP A 1 243 ? 5.952   68.540 1.072  1.00 47.71  ? 262  ASP A CG  1 
+ATOM   1870 O  OD1 . ASP A 1 243 ? 5.891   69.701 0.577  1.00 39.28  ? 262  ASP A OD1 1 
+ATOM   1871 O  OD2 . ASP A 1 243 ? 4.945   67.804 1.054  1.00 49.62  ? 262  ASP A OD2 1 
+ATOM   1872 N  N   . PHE A 1 244 ? 6.480   66.637 4.037  1.00 47.02  ? 263  PHE A N   1 
+ATOM   1873 C  CA  . PHE A 1 244 ? 5.750   66.185 5.211  1.00 43.00  ? 263  PHE A CA  1 
+ATOM   1874 C  C   . PHE A 1 244 ? 4.270   66.155 4.935  1.00 42.34  ? 263  PHE A C   1 
+ATOM   1875 O  O   . PHE A 1 244 ? 3.608   65.141 5.177  1.00 41.90  ? 263  PHE A O   1 
+ATOM   1876 C  CB  . PHE A 1 244 ? 6.016   67.129 6.361  1.00 43.77  ? 263  PHE A CB  1 
+ATOM   1877 C  CG  . PHE A 1 244 ? 5.528   66.631 7.656  1.00 46.20  ? 263  PHE A CG  1 
+ATOM   1878 C  CD1 . PHE A 1 244 ? 6.225   65.647 8.328  1.00 48.61  ? 263  PHE A CD1 1 
+ATOM   1879 C  CD2 . PHE A 1 244 ? 4.369   67.148 8.223  1.00 48.33  ? 263  PHE A CD2 1 
+ATOM   1880 C  CE1 . PHE A 1 244 ? 5.778   65.169 9.554  1.00 48.10  ? 263  PHE A CE1 1 
+ATOM   1881 C  CE2 . PHE A 1 244 ? 3.918   66.678 9.448  1.00 47.50  ? 263  PHE A CE2 1 
+ATOM   1882 C  CZ  . PHE A 1 244 ? 4.627   65.683 10.110 1.00 48.92  ? 263  PHE A CZ  1 
+ATOM   1883 N  N   . ILE A 1 245 ? 3.748   67.268 4.427  1.00 39.65  ? 264  ILE A N   1 
+ATOM   1884 C  CA  . ILE A 1 245 ? 2.329   67.335 4.089  1.00 41.65  ? 264  ILE A CA  1 
+ATOM   1885 C  C   . ILE A 1 245 ? 1.898   66.132 3.185  1.00 44.29  ? 264  ILE A C   1 
+ATOM   1886 O  O   . ILE A 1 245 ? 0.968   65.416 3.546  1.00 41.67  ? 264  ILE A O   1 
+ATOM   1887 C  CB  . ILE A 1 245 ? 1.987   68.708 3.449  1.00 40.36  ? 264  ILE A CB  1 
+ATOM   1888 C  CG1 . ILE A 1 245 ? 1.931   69.789 4.521  1.00 36.77  ? 264  ILE A CG1 1 
+ATOM   1889 C  CG2 . ILE A 1 245 ? 0.635   68.676 2.701  1.00 41.67  ? 264  ILE A CG2 1 
+ATOM   1890 C  CD1 . ILE A 1 245 ? 1.892   71.207 3.949  1.00 34.91  ? 264  ILE A CD1 1 
+ATOM   1891 N  N   . ASP A 1 246 ? 2.586   65.916 2.050  1.00 43.52  ? 265  ASP A N   1 
+ATOM   1892 C  CA  . ASP A 1 246 ? 2.300   64.801 1.136  1.00 43.71  ? 265  ASP A CA  1 
+ATOM   1893 C  C   . ASP A 1 246 ? 2.189   63.506 1.919  1.00 43.17  ? 265  ASP A C   1 
+ATOM   1894 O  O   . ASP A 1 246 ? 1.190   62.831 1.818  1.00 51.04  ? 265  ASP A O   1 
+ATOM   1895 C  CB  . ASP A 1 246 ? 3.398   64.596 0.055  1.00 46.04  ? 265  ASP A CB  1 
+ATOM   1896 C  CG  . ASP A 1 246 ? 3.342   65.603 -1.104 1.00 46.70  ? 265  ASP A CG  1 
+ATOM   1897 O  OD1 . ASP A 1 246 ? 2.337   66.325 -1.268 1.00 55.07  ? 265  ASP A OD1 1 
+ATOM   1898 O  OD2 . ASP A 1 246 ? 4.288   65.733 -1.923 1.00 49.15  ? 265  ASP A OD2 1 
+ATOM   1899 N  N   . CYS A 1 247 ? 3.203   63.155 2.705  1.00 45.23  ? 266  CYS A N   1 
+ATOM   1900 C  CA  . CYS A 1 247 ? 3.200   61.870 3.437  1.00 46.23  ? 266  CYS A CA  1 
+ATOM   1901 C  C   . CYS A 1 247 ? 2.064   61.755 4.456  1.00 44.09  ? 266  CYS A C   1 
+ATOM   1902 O  O   . CYS A 1 247 ? 1.621   60.674 4.774  1.00 43.60  ? 266  CYS A O   1 
+ATOM   1903 C  CB  . CYS A 1 247 ? 4.515   61.651 4.177  1.00 44.31  ? 266  CYS A CB  1 
+ATOM   1904 S  SG  . CYS A 1 247 ? 5.964   61.788 3.142  1.00 50.87  ? 266  CYS A SG  1 
+ATOM   1905 N  N   . PHE A 1 248 ? 1.643   62.880 5.002  1.00 46.05  ? 267  PHE A N   1 
+ATOM   1906 C  CA  . PHE A 1 248 ? 0.567   62.890 5.960  1.00 48.61  ? 267  PHE A CA  1 
+ATOM   1907 C  C   . PHE A 1 248 ? -0.734  62.662 5.186  1.00 48.39  ? 267  PHE A C   1 
+ATOM   1908 O  O   . PHE A 1 248 ? -1.564  61.843 5.585  1.00 46.99  ? 267  PHE A O   1 
+ATOM   1909 C  CB  . PHE A 1 248 ? 0.557   64.219 6.734  1.00 48.87  ? 267  PHE A CB  1 
+ATOM   1910 C  CG  . PHE A 1 248 ? -0.221  64.175 8.036  1.00 49.96  ? 267  PHE A CG  1 
+ATOM   1911 C  CD1 . PHE A 1 248 ? 0.437   64.182 9.259  1.00 51.26  ? 267  PHE A CD1 1 
+ATOM   1912 C  CD2 . PHE A 1 248 ? -1.607  64.160 8.032  1.00 49.61  ? 267  PHE A CD2 1 
+ATOM   1913 C  CE1 . PHE A 1 248 ? -0.270  64.165 10.441 1.00 50.33  ? 267  PHE A CE1 1 
+ATOM   1914 C  CE2 . PHE A 1 248 ? -2.308  64.132 9.205  1.00 52.02  ? 267  PHE A CE2 1 
+ATOM   1915 C  CZ  . PHE A 1 248 ? -1.635  64.138 10.416 1.00 52.31  ? 267  PHE A CZ  1 
+ATOM   1916 N  N   . LEU A 1 249 ? -0.891  63.367 4.069  1.00 47.84  ? 268  LEU A N   1 
+ATOM   1917 C  CA  . LEU A 1 249 ? -2.106  63.275 3.259  1.00 49.38  ? 268  LEU A CA  1 
+ATOM   1918 C  C   . LEU A 1 249 ? -2.325  61.829 2.830  1.00 52.08  ? 268  LEU A C   1 
+ATOM   1919 O  O   . LEU A 1 249 ? -3.439  61.302 2.898  1.00 53.44  ? 268  LEU A O   1 
+ATOM   1920 C  CB  . LEU A 1 249 ? -2.033  64.209 2.041  1.00 45.56  ? 268  LEU A CB  1 
+ATOM   1921 C  CG  . LEU A 1 249 ? -2.891  65.488 2.006  1.00 47.97  ? 268  LEU A CG  1 
+ATOM   1922 C  CD1 . LEU A 1 249 ? -3.402  65.963 3.350  1.00 52.53  ? 268  LEU A CD1 1 
+ATOM   1923 C  CD2 . LEU A 1 249 ? -2.134  66.609 1.342  1.00 47.02  ? 268  LEU A CD2 1 
+ATOM   1924 N  N   . MET A 1 250 ? -1.243  61.172 2.441  1.00 55.67  ? 269  MET A N   1 
+ATOM   1925 C  CA  . MET A 1 250 ? -1.336  59.817 1.952  1.00 60.40  ? 269  MET A CA  1 
+ATOM   1926 C  C   . MET A 1 250 ? -1.343  58.790 3.074  1.00 56.12  ? 269  MET A C   1 
+ATOM   1927 O  O   . MET A 1 250 ? -1.759  57.655 2.871  1.00 59.69  ? 269  MET A O   1 
+ATOM   1928 C  CB  . MET A 1 250 ? -0.245  59.545 0.919  1.00 64.46  ? 269  MET A CB  1 
+ATOM   1929 C  CG  . MET A 1 250 ? 1.153   59.419 1.447  1.00 70.20  ? 269  MET A CG  1 
+ATOM   1930 S  SD  . MET A 1 250 ? 2.194   58.561 0.228  1.00 81.82  ? 269  MET A SD  1 
+ATOM   1931 C  CE  . MET A 1 250 ? 1.912   59.560 -1.275 1.00 79.83  ? 269  MET A CE  1 
+ATOM   1932 N  N   . LYS A 1 251 ? -0.898  59.185 4.253  1.00 55.16  ? 270  LYS A N   1 
+ATOM   1933 C  CA  . LYS A 1 251 ? -1.143  58.382 5.441  1.00 56.18  ? 270  LYS A CA  1 
+ATOM   1934 C  C   . LYS A 1 251 ? -2.645  58.404 5.748  1.00 58.13  ? 270  LYS A C   1 
+ATOM   1935 O  O   . LYS A 1 251 ? -3.178  57.422 6.233  1.00 57.10  ? 270  LYS A O   1 
+ATOM   1936 C  CB  . LYS A 1 251 ? -0.327  58.893 6.628  1.00 54.94  ? 270  LYS A CB  1 
+ATOM   1937 C  CG  . LYS A 1 251 ? -0.560  58.179 7.962  1.00 53.34  ? 270  LYS A CG  1 
+ATOM   1938 C  CD  . LYS A 1 251 ? -0.315  56.686 7.896  1.00 54.42  ? 270  LYS A CD  1 
+ATOM   1939 C  CE  . LYS A 1 251 ? -0.414  56.066 9.287  1.00 55.33  ? 270  LYS A CE  1 
+ATOM   1940 N  NZ  . LYS A 1 251 ? 0.384   54.841 9.379  1.00 56.41  ? 270  LYS A NZ  1 
+ATOM   1941 N  N   . MET A 1 252 ? -3.329  59.507 5.437  1.00 61.89  ? 271  MET A N   1 
+ATOM   1942 C  CA  . MET A 1 252 ? -4.764  59.606 5.689  1.00 65.56  ? 271  MET A CA  1 
+ATOM   1943 C  C   . MET A 1 252 ? -5.532  58.658 4.796  1.00 70.40  ? 271  MET A C   1 
+ATOM   1944 O  O   . MET A 1 252 ? -6.546  58.104 5.217  1.00 72.98  ? 271  MET A O   1 
+ATOM   1945 C  CB  . MET A 1 252 ? -5.269  61.028 5.491  1.00 64.81  ? 271  MET A CB  1 
+ATOM   1946 C  CG  . MET A 1 252 ? -4.523  62.035 6.334  1.00 64.90  ? 271  MET A CG  1 
+ATOM   1947 S  SD  . MET A 1 252 ? -5.512  63.386 6.897  1.00 64.75  ? 271  MET A SD  1 
+ATOM   1948 C  CE  . MET A 1 252 ? -6.023  64.107 5.349  1.00 60.52  ? 271  MET A CE  1 
+ATOM   1949 N  N   . GLU A 1 253 ? -5.034  58.460 3.576  1.00 75.30  ? 272  GLU A N   1 
+ATOM   1950 C  CA  . GLU A 1 253 ? -5.635  57.516 2.642  1.00 79.34  ? 272  GLU A CA  1 
+ATOM   1951 C  C   . GLU A 1 253 ? -5.464  56.057 3.085  1.00 80.00  ? 272  GLU A C   1 
+ATOM   1952 O  O   . GLU A 1 253 ? -6.394  55.272 2.986  1.00 81.67  ? 272  GLU A O   1 
+ATOM   1953 C  CB  . GLU A 1 253 ? -5.059  57.710 1.239  1.00 82.63  ? 272  GLU A CB  1 
+ATOM   1954 C  CG  . GLU A 1 253 ? -6.006  57.288 0.121  1.00 85.33  ? 272  GLU A CG  1 
+ATOM   1955 C  CD  . GLU A 1 253 ? -6.800  58.457 -0.444 1.00 87.12  ? 272  GLU A CD  1 
+ATOM   1956 O  OE1 . GLU A 1 253 ? -7.605  59.060 0.305  1.00 86.17  ? 272  GLU A OE1 1 
+ATOM   1957 O  OE2 . GLU A 1 253 ? -6.614  58.780 -1.637 1.00 88.86  ? 272  GLU A OE2 1 
+ATOM   1958 N  N   . LYS A 1 254 ? -4.292  55.691 3.587  1.00 81.63  ? 273  LYS A N   1 
+ATOM   1959 C  CA  . LYS A 1 254 ? -4.083  54.323 4.063  1.00 84.64  ? 273  LYS A CA  1 
+ATOM   1960 C  C   . LYS A 1 254 ? -4.848  54.069 5.368  1.00 85.52  ? 273  LYS A C   1 
+ATOM   1961 O  O   . LYS A 1 254 ? -4.909  52.942 5.846  1.00 85.12  ? 273  LYS A O   1 
+ATOM   1962 C  CB  . LYS A 1 254 ? -2.581  54.018 4.216  1.00 86.22  ? 273  LYS A CB  1 
+ATOM   1963 C  CG  . LYS A 1 254 ? -1.839  53.924 2.852  1.00 90.66  ? 273  LYS A CG  1 
+ATOM   1964 C  CD  . LYS A 1 254 ? -0.300  54.098 2.952  1.00 94.00  ? 273  LYS A CD  1 
+ATOM   1965 C  CE  . LYS A 1 254 ? 0.437   52.754 3.103  1.00 94.28  ? 273  LYS A CE  1 
+ATOM   1966 N  NZ  . LYS A 1 254 ? 0.158   52.102 4.422  1.00 95.57  ? 273  LYS A NZ  1 
+ATOM   1967 N  N   . GLU A 1 255 ? -5.434  55.124 5.933  1.00 87.84  ? 274  GLU A N   1 
+ATOM   1968 C  CA  . GLU A 1 255 ? -6.228  55.034 7.153  1.00 91.15  ? 274  GLU A CA  1 
+ATOM   1969 C  C   . GLU A 1 255 ? -7.701  55.361 6.931  1.00 93.99  ? 274  GLU A C   1 
+ATOM   1970 O  O   . GLU A 1 255 ? -8.520  55.128 7.821  1.00 95.67  ? 274  GLU A O   1 
+ATOM   1971 C  CB  . GLU A 1 255 ? -5.670  55.995 8.203  1.00 91.31  ? 274  GLU A CB  1 
+ATOM   1972 C  CG  . GLU A 1 255 ? -4.388  55.517 8.868  1.00 92.06  ? 274  GLU A CG  1 
+ATOM   1973 C  CD  . GLU A 1 255 ? -4.618  54.844 10.209 1.00 92.75  ? 274  GLU A CD  1 
+ATOM   1974 O  OE1 . GLU A 1 255 ? -5.480  55.311 10.986 1.00 92.91  ? 274  GLU A OE1 1 
+ATOM   1975 O  OE2 . GLU A 1 255 ? -3.921  53.846 10.487 1.00 94.12  ? 274  GLU A OE2 1 
+ATOM   1976 N  N   . LYS A 1 256 ? -8.045  55.876 5.749  1.00 97.48  ? 275  LYS A N   1 
+ATOM   1977 C  CA  . LYS A 1 256 ? -9.407  56.363 5.477  1.00 99.30  ? 275  LYS A CA  1 
+ATOM   1978 C  C   . LYS A 1 256 ? -10.482 55.301 5.734  1.00 100.02 ? 275  LYS A C   1 
+ATOM   1979 O  O   . LYS A 1 256 ? -11.649 55.639 5.937  1.00 100.57 ? 275  LYS A O   1 
+ATOM   1980 C  CB  . LYS A 1 256 ? -9.541  56.929 4.045  1.00 99.38  ? 275  LYS A CB  1 
+ATOM   1981 C  CG  . LYS A 1 256 ? -9.802  55.892 2.919  1.00 100.16 ? 275  LYS A CG  1 
+ATOM   1982 C  CD  . LYS A 1 256 ? -10.784 56.407 1.833  1.00 100.38 ? 275  LYS A CD  1 
+ATOM   1983 C  CE  . LYS A 1 256 ? -10.070 57.168 0.696  1.00 99.77  ? 275  LYS A CE  1 
+ATOM   1984 N  NZ  . LYS A 1 256 ? -10.751 57.060 -0.630 1.00 96.83  ? 275  LYS A NZ  1 
+ATOM   1985 N  N   . HIS A 1 257 ? -10.092 54.026 5.717  1.00 99.95  ? 276  HIS A N   1 
+ATOM   1986 C  CA  . HIS A 1 257 ? -11.025 52.955 6.015  1.00 99.80  ? 276  HIS A CA  1 
+ATOM   1987 C  C   . HIS A 1 257 ? -11.259 52.862 7.516  1.00 98.85  ? 276  HIS A C   1 
+ATOM   1988 O  O   . HIS A 1 257 ? -12.236 53.438 7.987  1.00 98.10  ? 276  HIS A O   1 
+ATOM   1989 C  CB  . HIS A 1 257 ? -10.597 51.635 5.369  1.00 101.63 ? 276  HIS A CB  1 
+ATOM   1990 C  CG  . HIS A 1 257 ? -11.112 51.475 3.967  1.00 105.46 ? 276  HIS A CG  1 
+ATOM   1991 N  ND1 . HIS A 1 257 ? -12.163 50.638 3.644  1.00 106.73 ? 276  HIS A ND1 1 
+ATOM   1992 C  CD2 . HIS A 1 257 ? -10.742 52.078 2.808  1.00 107.41 ? 276  HIS A CD2 1 
+ATOM   1993 C  CE1 . HIS A 1 257 ? -12.404 50.716 2.346  1.00 107.55 ? 276  HIS A CE1 1 
+ATOM   1994 N  NE2 . HIS A 1 257 ? -11.555 51.583 1.815  1.00 107.81 ? 276  HIS A NE2 1 
+ATOM   1995 N  N   . ASN A 1 258 ? -10.393 52.184 8.275  1.00 99.13  ? 277  ASN A N   1 
+ATOM   1996 C  CA  . ASN A 1 258 ? -10.599 52.121 9.739  1.00 100.08 ? 277  ASN A CA  1 
+ATOM   1997 C  C   . ASN A 1 258 ? -10.510 53.533 10.345 1.00 99.48  ? 277  ASN A C   1 
+ATOM   1998 O  O   . ASN A 1 258 ? -9.425  54.044 10.644 1.00 97.70  ? 277  ASN A O   1 
+ATOM   1999 C  CB  . ASN A 1 258 ? -9.689  51.104 10.469 1.00 100.64 ? 277  ASN A CB  1 
+ATOM   2000 C  CG  . ASN A 1 258 ? -8.254  51.110 9.968  1.00 101.67 ? 277  ASN A CG  1 
+ATOM   2001 O  OD1 . ASN A 1 258 ? -7.965  50.592 8.893  1.00 100.42 ? 277  ASN A OD1 1 
+ATOM   2002 N  ND2 . ASN A 1 258 ? -7.348  51.683 10.757 1.00 102.60 ? 277  ASN A ND2 1 
+ATOM   2003 N  N   . GLN A 1 259 ? -11.689 54.131 10.537 1.00 98.37  ? 278  GLN A N   1 
+ATOM   2004 C  CA  . GLN A 1 259 ? -11.852 55.574 10.689 1.00 96.27  ? 278  GLN A CA  1 
+ATOM   2005 C  C   . GLN A 1 259 ? -12.287 56.043 12.085 1.00 94.50  ? 278  GLN A C   1 
+ATOM   2006 O  O   . GLN A 1 259 ? -13.097 56.965 12.185 1.00 93.82  ? 278  GLN A O   1 
+ATOM   2007 C  CB  . GLN A 1 259 ? -12.869 56.068 9.642  1.00 97.68  ? 278  GLN A CB  1 
+ATOM   2008 C  CG  . GLN A 1 259 ? -12.989 57.591 9.439  1.00 98.08  ? 278  GLN A CG  1 
+ATOM   2009 C  CD  . GLN A 1 259 ? -11.878 58.187 8.590  1.00 99.23  ? 278  GLN A CD  1 
+ATOM   2010 O  OE1 . GLN A 1 259 ? -11.328 57.531 7.708  1.00 98.25  ? 278  GLN A OE1 1 
+ATOM   2011 N  NE2 . GLN A 1 259 ? -11.554 59.442 8.854  1.00 101.33 ? 278  GLN A NE2 1 
+ATOM   2012 N  N   . PRO A 1 260 ? -11.774 55.446 13.167 1.00 92.31  ? 279  PRO A N   1 
+ATOM   2013 C  CA  . PRO A 1 260 ? -11.590 56.257 14.378 1.00 88.11  ? 279  PRO A CA  1 
+ATOM   2014 C  C   . PRO A 1 260 ? -10.559 57.342 13.976 1.00 83.50  ? 279  PRO A C   1 
+ATOM   2015 O  O   . PRO A 1 260 ? -10.969 58.485 13.803 1.00 80.58  ? 279  PRO A O   1 
+ATOM   2016 C  CB  . PRO A 1 260 ? -11.089 55.252 15.440 1.00 90.15  ? 279  PRO A CB  1 
+ATOM   2017 C  CG  . PRO A 1 260 ? -11.308 53.850 14.850 1.00 91.73  ? 279  PRO A CG  1 
+ATOM   2018 C  CD  . PRO A 1 260 ? -11.378 54.032 13.364 1.00 92.73  ? 279  PRO A CD  1 
+ATOM   2019 N  N   . SER A 1 261 ? -9.291  56.957 13.771 1.00 78.03  ? 280  SER A N   1 
+ATOM   2020 C  CA  . SER A 1 261 ? -8.244  57.736 13.051 1.00 74.66  ? 280  SER A CA  1 
+ATOM   2021 C  C   . SER A 1 261 ? -7.597  58.987 13.676 1.00 70.18  ? 280  SER A C   1 
+ATOM   2022 O  O   . SER A 1 261 ? -8.230  60.020 13.855 1.00 67.75  ? 280  SER A O   1 
+ATOM   2023 C  CB  . SER A 1 261 ? -8.695  58.115 11.651 1.00 75.52  ? 280  SER A CB  1 
+ATOM   2024 O  OG  . SER A 1 261 ? -7.550  58.460 10.889 1.00 76.29  ? 280  SER A OG  1 
+ATOM   2025 N  N   . GLU A 1 262 ? -6.286  58.899 13.879 1.00 67.03  ? 281  GLU A N   1 
+ATOM   2026 C  CA  . GLU A 1 262 ? -5.479  59.936 14.531 1.00 61.09  ? 281  GLU A CA  1 
+ATOM   2027 C  C   . GLU A 1 262 ? -4.934  60.999 13.537 1.00 58.10  ? 281  GLU A C   1 
+ATOM   2028 O  O   . GLU A 1 262 ? -4.644  62.155 13.927 1.00 55.70  ? 281  GLU A O   1 
+ATOM   2029 C  CB  . GLU A 1 262 ? -4.327  59.241 15.274 1.00 61.08  ? 281  GLU A CB  1 
+ATOM   2030 C  CG  . GLU A 1 262 ? -4.287  59.374 16.796 1.00 62.72  ? 281  GLU A CG  1 
+ATOM   2031 C  CD  . GLU A 1 262 ? -5.625  59.298 17.543 1.00 64.31  ? 281  GLU A CD  1 
+ATOM   2032 O  OE1 . GLU A 1 262 ? -6.344  60.335 17.603 1.00 64.70  ? 281  GLU A OE1 1 
+ATOM   2033 O  OE2 . GLU A 1 262 ? -5.923  58.231 18.136 1.00 57.12  ? 281  GLU A OE2 1 
+ATOM   2034 N  N   . PHE A 1 263 ? -4.816  60.616 12.261 1.00 51.61  ? 282  PHE A N   1 
+ATOM   2035 C  CA  . PHE A 1 263 ? -4.368  61.527 11.211 1.00 49.30  ? 282  PHE A CA  1 
+ATOM   2036 C  C   . PHE A 1 263 ? -5.543  62.169 10.529 1.00 47.44  ? 282  PHE A C   1 
+ATOM   2037 O  O   . PHE A 1 263 ? -6.362  61.489 9.953  1.00 53.30  ? 282  PHE A O   1 
+ATOM   2038 C  CB  . PHE A 1 263 ? -3.526  60.785 10.192 1.00 49.52  ? 282  PHE A CB  1 
+ATOM   2039 C  CG  . PHE A 1 263 ? -2.345  60.148 10.799 1.00 51.00  ? 282  PHE A CG  1 
+ATOM   2040 C  CD1 . PHE A 1 263 ? -2.480  58.946 11.476 1.00 51.75  ? 282  PHE A CD1 1 
+ATOM   2041 C  CD2 . PHE A 1 263 ? -1.116  60.791 10.790 1.00 49.66  ? 282  PHE A CD2 1 
+ATOM   2042 C  CE1 . PHE A 1 263 ? -1.398  58.358 12.087 1.00 55.89  ? 282  PHE A CE1 1 
+ATOM   2043 C  CE2 . PHE A 1 263 ? -0.033  60.223 11.395 1.00 50.75  ? 282  PHE A CE2 1 
+ATOM   2044 C  CZ  . PHE A 1 263 ? -0.159  58.999 12.048 1.00 53.72  ? 282  PHE A CZ  1 
+ATOM   2045 N  N   . THR A 1 264 ? -5.606  63.486 10.623 1.00 45.49  ? 283  THR A N   1 
+ATOM   2046 C  CA  . THR A 1 264 ? -6.675  64.311 10.079 1.00 45.32  ? 283  THR A CA  1 
+ATOM   2047 C  C   . THR A 1 264 ? -6.066  65.657 9.680  1.00 47.50  ? 283  THR A C   1 
+ATOM   2048 O  O   . THR A 1 264 ? -4.886  65.921 9.956  1.00 50.63  ? 283  THR A O   1 
+ATOM   2049 C  CB  . THR A 1 264 ? -7.756  64.578 11.146 1.00 46.15  ? 283  THR A CB  1 
+ATOM   2050 O  OG1 . THR A 1 264 ? -7.227  65.446 12.165 1.00 44.74  ? 283  THR A OG1 1 
+ATOM   2051 C  CG2 . THR A 1 264 ? -8.160  63.297 11.903 1.00 44.72  ? 283  THR A CG2 1 
+ATOM   2052 N  N   . ILE A 1 265 ? -6.863  66.522 9.065  1.00 46.32  ? 284  ILE A N   1 
+ATOM   2053 C  CA  . ILE A 1 265 ? -6.365  67.828 8.680  1.00 46.94  ? 284  ILE A CA  1 
+ATOM   2054 C  C   . ILE A 1 265 ? -6.098  68.619 9.952  1.00 50.28  ? 284  ILE A C   1 
+ATOM   2055 O  O   . ILE A 1 265 ? -5.105  69.309 10.029 1.00 49.78  ? 284  ILE A O   1 
+ATOM   2056 C  CB  . ILE A 1 265 ? -7.347  68.580 7.752  1.00 48.34  ? 284  ILE A CB  1 
+ATOM   2057 C  CG1 . ILE A 1 265 ? -7.650  67.789 6.468  1.00 50.76  ? 284  ILE A CG1 1 
+ATOM   2058 C  CG2 . ILE A 1 265 ? -6.778  69.927 7.374  1.00 51.69  ? 284  ILE A CG2 1 
+ATOM   2059 C  CD1 . ILE A 1 265 ? -6.417  67.413 5.621  1.00 53.62  ? 284  ILE A CD1 1 
+ATOM   2060 N  N   . GLU A 1 266 ? -6.967  68.515 10.956 1.00 53.93  ? 285  GLU A N   1 
+ATOM   2061 C  CA  . GLU A 1 266 ? -6.713  69.187 12.229 1.00 56.06  ? 285  GLU A CA  1 
+ATOM   2062 C  C   . GLU A 1 266 ? -5.293  68.823 12.720 1.00 54.91  ? 285  GLU A C   1 
+ATOM   2063 O  O   . GLU A 1 266 ? -4.474  69.696 12.962 1.00 51.12  ? 285  GLU A O   1 
+ATOM   2064 C  CB  . GLU A 1 266 ? -7.752  68.791 13.301 1.00 59.76  ? 285  GLU A CB  1 
+ATOM   2065 C  CG  . GLU A 1 266 ? -8.853  69.811 13.561 1.00 67.71  ? 285  GLU A CG  1 
+ATOM   2066 C  CD  . GLU A 1 266 ? -8.429  70.993 14.438 1.00 75.61  ? 285  GLU A CD  1 
+ATOM   2067 O  OE1 . GLU A 1 266 ? -7.905  70.762 15.559 1.00 77.36  ? 285  GLU A OE1 1 
+ATOM   2068 O  OE2 . GLU A 1 266 ? -8.645  72.165 14.013 1.00 80.87  ? 285  GLU A OE2 1 
+ATOM   2069 N  N   . SER A 1 267 ? -5.006  67.526 12.841 1.00 54.84  ? 286  SER A N   1 
+ATOM   2070 C  CA  . SER A 1 267 ? -3.767  67.055 13.485 1.00 52.23  ? 286  SER A CA  1 
+ATOM   2071 C  C   . SER A 1 267 ? -2.500  67.320 12.677 1.00 51.76  ? 286  SER A C   1 
+ATOM   2072 O  O   . SER A 1 267 ? -1.408  67.365 13.238 1.00 49.06  ? 286  SER A O   1 
+ATOM   2073 C  CB  . SER A 1 267 ? -3.846  65.563 13.872 1.00 52.69  ? 286  SER A CB  1 
+ATOM   2074 O  OG  . SER A 1 267 ? -4.087  64.708 12.774 1.00 51.94  ? 286  SER A OG  1 
+ATOM   2075 N  N   . LEU A 1 268 ? -2.657  67.507 11.371 1.00 49.90  ? 287  LEU A N   1 
+ATOM   2076 C  CA  . LEU A 1 268 ? -1.551  67.852 10.512 1.00 47.85  ? 287  LEU A CA  1 
+ATOM   2077 C  C   . LEU A 1 268 ? -1.214  69.315 10.736 1.00 48.42  ? 287  LEU A C   1 
+ATOM   2078 O  O   . LEU A 1 268 ? -0.051  69.665 10.844 1.00 52.77  ? 287  LEU A O   1 
+ATOM   2079 C  CB  . LEU A 1 268 ? -1.909  67.560 9.060  1.00 48.14  ? 287  LEU A CB  1 
+ATOM   2080 C  CG  . LEU A 1 268 ? -1.028  68.130 7.954  1.00 50.70  ? 287  LEU A CG  1 
+ATOM   2081 C  CD1 . LEU A 1 268 ? 0.393   67.692 8.096  1.00 48.07  ? 287  LEU A CD1 1 
+ATOM   2082 C  CD2 . LEU A 1 268 ? -1.575  67.709 6.595  1.00 53.36  ? 287  LEU A CD2 1 
+ATOM   2083 N  N   . GLU A 1 269 ? -2.227  70.170 10.818 1.00 49.64  ? 288  GLU A N   1 
+ATOM   2084 C  CA  . GLU A 1 269 ? -2.027  71.588 11.138 1.00 48.59  ? 288  GLU A CA  1 
+ATOM   2085 C  C   . GLU A 1 269 ? -1.302  71.716 12.471 1.00 46.65  ? 288  GLU A C   1 
+ATOM   2086 O  O   . GLU A 1 269 ? -0.434  72.575 12.624 1.00 44.39  ? 288  GLU A O   1 
+ATOM   2087 C  CB  . GLU A 1 269 ? -3.369  72.334 11.255 1.00 51.54  ? 288  GLU A CB  1 
+ATOM   2088 C  CG  . GLU A 1 269 ? -3.931  72.976 9.989  1.00 54.59  ? 288  GLU A CG  1 
+ATOM   2089 C  CD  . GLU A 1 269 ? -5.436  73.231 10.090 1.00 59.08  ? 288  GLU A CD  1 
+ATOM   2090 O  OE1 . GLU A 1 269 ? -5.898  73.816 11.093 1.00 60.72  ? 288  GLU A OE1 1 
+ATOM   2091 O  OE2 . GLU A 1 269 ? -6.175  72.823 9.175  1.00 66.14  ? 288  GLU A OE2 1 
+ATOM   2092 N  N   . ASN A 1 270 ? -1.692  70.863 13.424 1.00 42.83  ? 289  ASN A N   1 
+ATOM   2093 C  CA  . ASN A 1 270 ? -1.199  70.901 14.794 1.00 42.88  ? 289  ASN A CA  1 
+ATOM   2094 C  C   . ASN A 1 270 ? 0.233   70.408 14.847 1.00 43.15  ? 289  ASN A C   1 
+ATOM   2095 O  O   . ASN A 1 270 ? 1.070   70.966 15.551 1.00 44.21  ? 289  ASN A O   1 
+ATOM   2096 C  CB  . ASN A 1 270 ? -2.045  70.003 15.736 1.00 46.25  ? 289  ASN A CB  1 
+ATOM   2097 C  CG  . ASN A 1 270 ? -3.445  70.582 16.071 1.00 47.88  ? 289  ASN A CG  1 
+ATOM   2098 O  OD1 . ASN A 1 270 ? -4.270  69.899 16.655 1.00 49.16  ? 289  ASN A OD1 1 
+ATOM   2099 N  ND2 . ASN A 1 270 ? -3.701  71.820 15.692 1.00 53.97  ? 289  ASN A ND2 1 
+ATOM   2100 N  N   . THR A 1 271 ? 0.511   69.340 14.113 1.00 41.61  ? 290  THR A N   1 
+ATOM   2101 C  CA  . THR A 1 271 ? 1.847   68.793 14.080 1.00 39.87  ? 290  THR A CA  1 
+ATOM   2102 C  C   . THR A 1 271 ? 2.763   69.759 13.350 1.00 40.05  ? 290  THR A C   1 
+ATOM   2103 O  O   . THR A 1 271 ? 3.914   69.954 13.730 1.00 42.37  ? 290  THR A O   1 
+ATOM   2104 C  CB  . THR A 1 271 ? 1.847   67.428 13.424 1.00 39.78  ? 290  THR A CB  1 
+ATOM   2105 O  OG1 . THR A 1 271 ? 1.144   66.500 14.259 1.00 40.52  ? 290  THR A OG1 1 
+ATOM   2106 C  CG2 . THR A 1 271 ? 3.237   66.855 13.400 1.00 41.10  ? 290  THR A CG2 1 
+ATOM   2107 N  N   . ALA A 1 272 ? 2.233   70.397 12.321 1.00 38.79  ? 291  ALA A N   1 
+ATOM   2108 C  CA  . ALA A 1 272 ? 2.987   71.395 11.595 1.00 35.99  ? 291  ALA A CA  1 
+ATOM   2109 C  C   . ALA A 1 272 ? 3.381   72.573 12.482 1.00 36.34  ? 291  ALA A C   1 
+ATOM   2110 O  O   . ALA A 1 272 ? 4.531   72.964 12.436 1.00 36.86  ? 291  ALA A O   1 
+ATOM   2111 C  CB  . ALA A 1 272 ? 2.219   71.870 10.382 1.00 33.56  ? 291  ALA A CB  1 
+ATOM   2112 N  N   . VAL A 1 273 ? 2.467   73.137 13.283 1.00 35.96  ? 292  VAL A N   1 
+ATOM   2113 C  CA  . VAL A 1 273 ? 2.826   74.326 14.066 1.00 40.42  ? 292  VAL A CA  1 
+ATOM   2114 C  C   . VAL A 1 273 ? 3.869   73.963 15.104 1.00 41.40  ? 292  VAL A C   1 
+ATOM   2115 O  O   . VAL A 1 273 ? 4.780   74.749 15.355 1.00 40.89  ? 292  VAL A O   1 
+ATOM   2116 C  CB  . VAL A 1 273 ? 1.631   75.084 14.762 1.00 42.90  ? 292  VAL A CB  1 
+ATOM   2117 C  CG1 . VAL A 1 273 ? 0.639   75.547 13.746 1.00 46.24  ? 292  VAL A CG1 1 
+ATOM   2118 C  CG2 . VAL A 1 273 ? 0.943   74.247 15.833 1.00 45.29  ? 292  VAL A CG2 1 
+ATOM   2119 N  N   . ASP A 1 274 ? 3.727   72.768 15.683 1.00 41.45  ? 293  ASP A N   1 
+ATOM   2120 C  CA  . ASP A 1 274 ? 4.695   72.219 16.636 1.00 41.81  ? 293  ASP A CA  1 
+ATOM   2121 C  C   . ASP A 1 274 ? 6.107   72.149 16.048 1.00 40.69  ? 293  ASP A C   1 
+ATOM   2122 O  O   . ASP A 1 274 ? 7.029   72.752 16.585 1.00 39.04  ? 293  ASP A O   1 
+ATOM   2123 C  CB  . ASP A 1 274 ? 4.263   70.821 17.093 1.00 43.08  ? 293  ASP A CB  1 
+ATOM   2124 C  CG  . ASP A 1 274 ? 3.151   70.863 18.126 1.00 45.73  ? 293  ASP A CG  1 
+ATOM   2125 O  OD1 . ASP A 1 274 ? 2.770   69.781 18.644 1.00 43.55  ? 293  ASP A OD1 1 
+ATOM   2126 O  OD2 . ASP A 1 274 ? 2.589   71.933 18.474 1.00 49.62  ? 293  ASP A OD2 1 
+ATOM   2127 N  N   . LEU A 1 275 ? 6.259   71.428 14.941 1.00 36.50  ? 294  LEU A N   1 
+ATOM   2128 C  CA  . LEU A 1 275 ? 7.532   71.358 14.241 1.00 34.20  ? 294  LEU A CA  1 
+ATOM   2129 C  C   . LEU A 1 275 ? 8.115   72.740 14.070 1.00 34.11  ? 294  LEU A C   1 
+ATOM   2130 O  O   . LEU A 1 275 ? 9.277   72.933 14.401 1.00 38.59  ? 294  LEU A O   1 
+ATOM   2131 C  CB  . LEU A 1 275 ? 7.403   70.652 12.883 1.00 35.35  ? 294  LEU A CB  1 
+ATOM   2132 C  CG  . LEU A 1 275 ? 6.925   69.190 12.940 1.00 36.58  ? 294  LEU A CG  1 
+ATOM   2133 C  CD1 . LEU A 1 275 ? 6.905   68.586 11.585 1.00 37.77  ? 294  LEU A CD1 1 
+ATOM   2134 C  CD2 . LEU A 1 275 ? 7.774   68.334 13.863 1.00 40.10  ? 294  LEU A CD2 1 
+ATOM   2135 N  N   . PHE A 1 276 ? 7.327   73.713 13.606 1.00 33.64  ? 295  PHE A N   1 
+ATOM   2136 C  CA  . PHE A 1 276 ? 7.842   75.101 13.449 1.00 34.16  ? 295  PHE A CA  1 
+ATOM   2137 C  C   . PHE A 1 276 ? 8.302   75.704 14.767 1.00 35.16  ? 295  PHE A C   1 
+ATOM   2138 O  O   . PHE A 1 276 ? 9.290   76.422 14.803 1.00 38.42  ? 295  PHE A O   1 
+ATOM   2139 C  CB  . PHE A 1 276 ? 6.811   76.054 12.816 1.00 33.42  ? 295  PHE A CB  1 
+ATOM   2140 C  CG  . PHE A 1 276 ? 6.737   75.957 11.327 1.00 33.85  ? 295  PHE A CG  1 
+ATOM   2141 C  CD1 . PHE A 1 276 ? 7.709   76.521 10.541 1.00 34.65  ? 295  PHE A CD1 1 
+ATOM   2142 C  CD2 . PHE A 1 276 ? 5.702   75.291 10.711 1.00 37.99  ? 295  PHE A CD2 1 
+ATOM   2143 C  CE1 . PHE A 1 276 ? 7.657   76.416 9.158  1.00 38.58  ? 295  PHE A CE1 1 
+ATOM   2144 C  CE2 . PHE A 1 276 ? 5.646   75.185 9.325  1.00 38.83  ? 295  PHE A CE2 1 
+ATOM   2145 C  CZ  . PHE A 1 276 ? 6.627   75.749 8.554  1.00 37.71  ? 295  PHE A CZ  1 
+ATOM   2146 N  N   . GLY A 1 277 ? 7.572   75.422 15.844 1.00 37.08  ? 296  GLY A N   1 
+ATOM   2147 C  CA  . GLY A 1 277 ? 7.825   76.058 17.117 1.00 38.41  ? 296  GLY A CA  1 
+ATOM   2148 C  C   . GLY A 1 277 ? 8.998   75.407 17.826 1.00 39.23  ? 296  GLY A C   1 
+ATOM   2149 O  O   . GLY A 1 277 ? 9.917   76.098 18.293 1.00 34.32  ? 296  GLY A O   1 
+ATOM   2150 N  N   . ALA A 1 278 ? 8.931   74.075 17.903 1.00 38.83  ? 297  ALA A N   1 
+ATOM   2151 C  CA  . ALA A 1 278 ? 10.013  73.226 18.410 1.00 40.50  ? 297  ALA A CA  1 
+ATOM   2152 C  C   . ALA A 1 278 ? 11.283  73.228 17.564 1.00 41.11  ? 297  ALA A C   1 
+ATOM   2153 O  O   . ALA A 1 278 ? 12.352  72.904 18.083 1.00 50.32  ? 297  ALA A O   1 
+ATOM   2154 C  CB  . ALA A 1 278 ? 9.526   71.782 18.596 1.00 40.25  ? 297  ALA A CB  1 
+ATOM   2155 N  N   . GLY A 1 279 ? 11.179  73.610 16.295 1.00 41.08  ? 298  GLY A N   1 
+ATOM   2156 C  CA  . GLY A 1 279 ? 12.275  73.477 15.343 1.00 41.53  ? 298  GLY A CA  1 
+ATOM   2157 C  C   . GLY A 1 279 ? 13.008  74.759 14.998 1.00 41.91  ? 298  GLY A C   1 
+ATOM   2158 O  O   . GLY A 1 279 ? 14.022  74.743 14.277 1.00 43.26  ? 298  GLY A O   1 
+ATOM   2159 N  N   . THR A 1 280 ? 12.508  75.866 15.533 1.00 40.02  ? 299  THR A N   1 
+ATOM   2160 C  CA  . THR A 1 280 ? 13.052  77.176 15.255 1.00 39.54  ? 299  THR A CA  1 
+ATOM   2161 C  C   . THR A 1 280 ? 13.814  77.786 16.436 1.00 38.00  ? 299  THR A C   1 
+ATOM   2162 O  O   . THR A 1 280 ? 15.007  78.042 16.328 1.00 34.23  ? 299  THR A O   1 
+ATOM   2163 C  CB  . THR A 1 280 ? 11.906  78.101 14.824 1.00 40.04  ? 299  THR A CB  1 
+ATOM   2164 O  OG1 . THR A 1 280 ? 11.409  77.660 13.551 1.00 44.05  ? 299  THR A OG1 1 
+ATOM   2165 C  CG2 . THR A 1 280 ? 12.412  79.522 14.569 1.00 42.04  ? 299  THR A CG2 1 
+ATOM   2166 N  N   . GLU A 1 281 ? 13.111  78.033 17.541 1.00 36.60  ? 300  GLU A N   1 
+ATOM   2167 C  CA  . GLU A 1 281 ? 13.624  78.843 18.645 1.00 38.58  ? 300  GLU A CA  1 
+ATOM   2168 C  C   . GLU A 1 281 ? 14.954  78.302 19.202 1.00 38.56  ? 300  GLU A C   1 
+ATOM   2169 O  O   . GLU A 1 281 ? 15.941  79.051 19.270 1.00 31.89  ? 300  GLU A O   1 
+ATOM   2170 C  CB  . GLU A 1 281 ? 12.550  78.946 19.756 1.00 45.95  ? 300  GLU A CB  1 
+ATOM   2171 C  CG  . GLU A 1 281 ? 12.940  79.580 21.109 1.00 47.39  ? 300  GLU A CG  1 
+ATOM   2172 C  CD  . GLU A 1 281 ? 13.737  80.878 20.989 1.00 54.95  ? 300  GLU A CD  1 
+ATOM   2173 O  OE1 . GLU A 1 281 ? 14.247  81.352 22.047 1.00 61.15  ? 300  GLU A OE1 1 
+ATOM   2174 O  OE2 . GLU A 1 281 ? 13.862  81.441 19.859 1.00 58.44  ? 300  GLU A OE2 1 
+ATOM   2175 N  N   . THR A 1 282 ? 14.970  77.012 19.567 1.00 32.62  ? 301  THR A N   1 
+ATOM   2176 C  CA  . THR A 1 282 ? 16.129  76.378 20.178 1.00 31.86  ? 301  THR A CA  1 
+ATOM   2177 C  C   . THR A 1 282 ? 17.359  76.306 19.278 1.00 31.96  ? 301  THR A C   1 
+ATOM   2178 O  O   . THR A 1 282 ? 18.463  76.640 19.705 1.00 33.40  ? 301  THR A O   1 
+ATOM   2179 C  CB  . THR A 1 282 ? 15.798  74.957 20.606 1.00 34.91  ? 301  THR A CB  1 
+ATOM   2180 O  OG1 . THR A 1 282 ? 14.553  74.918 21.319 1.00 33.48  ? 301  THR A OG1 1 
+ATOM   2181 C  CG2 . THR A 1 282 ? 16.808  74.497 21.623 1.00 36.38  ? 301  THR A CG2 1 
+ATOM   2182 N  N   . THR A 1 283 ? 17.184  75.842 18.045 1.00 31.06  ? 302  THR A N   1 
+ATOM   2183 C  CA  . THR A 1 283 ? 18.268  75.841 17.057 1.00 30.46  ? 302  THR A CA  1 
+ATOM   2184 C  C   . THR A 1 283 ? 18.837  77.260 16.828 1.00 34.33  ? 302  THR A C   1 
+ATOM   2185 O  O   . THR A 1 283 ? 20.070  77.494 16.761 1.00 32.95  ? 302  THR A O   1 
+ATOM   2186 C  CB  . THR A 1 283 ? 17.734  75.300 15.750 1.00 32.28  ? 302  THR A CB  1 
+ATOM   2187 O  OG1 . THR A 1 283 ? 17.138  74.012 15.960 1.00 33.94  ? 302  THR A OG1 1 
+ATOM   2188 C  CG2 . THR A 1 283 ? 18.840  75.044 14.750 1.00 36.15  ? 302  THR A CG2 1 
+ATOM   2189 N  N   . SER A 1 284 ? 17.922  78.215 16.719 1.00 34.01  ? 303  SER A N   1 
+ATOM   2190 C  CA  . SER A 1 284 ? 18.283  79.592 16.444 1.00 33.01  ? 303  SER A CA  1 
+ATOM   2191 C  C   . SER A 1 284 ? 19.187  80.103 17.562 1.00 35.18  ? 303  SER A C   1 
+ATOM   2192 O  O   . SER A 1 284 ? 20.242  80.697 17.308 1.00 37.37  ? 303  SER A O   1 
+ATOM   2193 C  CB  . SER A 1 284 ? 17.017  80.452 16.326 1.00 31.80  ? 303  SER A CB  1 
+ATOM   2194 O  OG  . SER A 1 284 ? 17.338  81.811 16.088 1.00 32.26  ? 303  SER A OG  1 
+ATOM   2195 N  N   . THR A 1 285 ? 18.774  79.842 18.799 1.00 31.60  ? 304  THR A N   1 
+ATOM   2196 C  CA  . THR A 1 285 ? 19.437  80.404 19.949 1.00 31.47  ? 304  THR A CA  1 
+ATOM   2197 C  C   . THR A 1 285 ? 20.771  79.694 20.133 1.00 30.71  ? 304  THR A C   1 
+ATOM   2198 O  O   . THR A 1 285 ? 21.757  80.301 20.564 1.00 24.09  ? 304  THR A O   1 
+ATOM   2199 C  CB  . THR A 1 285 ? 18.551  80.243 21.199 1.00 32.14  ? 304  THR A CB  1 
+ATOM   2200 O  OG1 . THR A 1 285 ? 17.343  80.976 21.026 1.00 30.00  ? 304  THR A OG1 1 
+ATOM   2201 C  CG2 . THR A 1 285 ? 19.180  80.893 22.400 1.00 33.91  ? 304  THR A CG2 1 
+ATOM   2202 N  N   . THR A 1 286 ? 20.797  78.408 19.784 1.00 30.00  ? 305  THR A N   1 
+ATOM   2203 C  CA  . THR A 1 286 ? 22.001  77.620 19.961 1.00 28.42  ? 305  THR A CA  1 
+ATOM   2204 C  C   . THR A 1 286 ? 23.045  78.158 19.031 1.00 26.10  ? 305  THR A C   1 
+ATOM   2205 O  O   . THR A 1 286 ? 24.174  78.312 19.431 1.00 22.87  ? 305  THR A O   1 
+ATOM   2206 C  CB  . THR A 1 286 ? 21.743  76.155 19.682 1.00 29.92  ? 305  THR A CB  1 
+ATOM   2207 O  OG1 . THR A 1 286 ? 20.893  75.616 20.706 1.00 30.77  ? 305  THR A OG1 1 
+ATOM   2208 C  CG2 . THR A 1 286 ? 23.020  75.379 19.824 1.00 28.77  ? 305  THR A CG2 1 
+ATOM   2209 N  N   . LEU A 1 287 ? 22.644  78.496 17.808 1.00 27.20  ? 306  LEU A N   1 
+ATOM   2210 C  CA  . LEU A 1 287 ? 23.567  79.065 16.824 1.00 29.72  ? 306  LEU A CA  1 
+ATOM   2211 C  C   . LEU A 1 287 ? 24.027  80.431 17.217 1.00 27.45  ? 306  LEU A C   1 
+ATOM   2212 O  O   . LEU A 1 287 ? 25.170  80.767 17.000 1.00 29.07  ? 306  LEU A O   1 
+ATOM   2213 C  CB  . LEU A 1 287 ? 22.907  79.202 15.458 1.00 32.27  ? 306  LEU A CB  1 
+ATOM   2214 C  CG  . LEU A 1 287 ? 22.742  77.875 14.735 1.00 34.35  ? 306  LEU A CG  1 
+ATOM   2215 C  CD1 . LEU A 1 287 ? 21.603  77.917 13.716 1.00 32.41  ? 306  LEU A CD1 1 
+ATOM   2216 C  CD2 . LEU A 1 287 ? 24.073  77.545 14.081 1.00 38.64  ? 306  LEU A CD2 1 
+ATOM   2217 N  N   . ARG A 1 288 ? 23.122  81.234 17.757 1.00 29.64  ? 307  ARG A N   1 
+ATOM   2218 C  CA  . ARG A 1 288 ? 23.444  82.621 18.103 1.00 31.55  ? 307  ARG A CA  1 
+ATOM   2219 C  C   . ARG A 1 288 ? 24.466  82.545 19.260 1.00 34.39  ? 307  ARG A C   1 
+ATOM   2220 O  O   . ARG A 1 288 ? 25.480  83.278 19.285 1.00 27.41  ? 307  ARG A O   1 
+ATOM   2221 C  CB  . ARG A 1 288 ? 22.178  83.396 18.501 1.00 27.30  ? 307  ARG A CB  1 
+ATOM   2222 C  CG  . ARG A 1 288 ? 22.304  84.929 18.451 1.00 36.10  ? 307  ARG A CG  1 
+ATOM   2223 C  CD  . ARG A 1 288 ? 21.204  85.739 19.249 1.00 38.87  ? 307  ARG A CD  1 
+ATOM   2224 N  NE  . ARG A 1 288 ? 19.969  84.969 19.415 1.00 41.45  ? 307  ARG A NE  1 
+ATOM   2225 C  CZ  . ARG A 1 288 ? 19.190  84.967 20.487 1.00 43.13  ? 307  ARG A CZ  1 
+ATOM   2226 N  NH1 . ARG A 1 288 ? 19.443  85.729 21.550 1.00 47.61  ? 307  ARG A NH1 1 
+ATOM   2227 N  NH2 . ARG A 1 288 ? 18.126  84.181 20.495 1.00 45.73  ? 307  ARG A NH2 1 
+ATOM   2228 N  N   . TYR A 1 289 ? 24.228  81.589 20.168 1.00 31.21  ? 308  TYR A N   1 
+ATOM   2229 C  CA  . TYR A 1 289 ? 25.071  81.435 21.339 1.00 27.58  ? 308  TYR A CA  1 
+ATOM   2230 C  C   . TYR A 1 289 ? 26.410  80.857 20.920 1.00 27.36  ? 308  TYR A C   1 
+ATOM   2231 O  O   . TYR A 1 289 ? 27.445  81.228 21.482 1.00 24.15  ? 308  TYR A O   1 
+ATOM   2232 C  CB  . TYR A 1 289 ? 24.407  80.540 22.356 1.00 25.46  ? 308  TYR A CB  1 
+ATOM   2233 C  CG  . TYR A 1 289 ? 24.548  81.002 23.764 1.00 24.94  ? 308  TYR A CG  1 
+ATOM   2234 C  CD1 . TYR A 1 289 ? 23.490  80.874 24.647 1.00 25.41  ? 308  TYR A CD1 1 
+ATOM   2235 C  CD2 . TYR A 1 289 ? 25.723  81.549 24.230 1.00 27.96  ? 308  TYR A CD2 1 
+ATOM   2236 C  CE1 . TYR A 1 289 ? 23.591  81.258 25.952 1.00 26.04  ? 308  TYR A CE1 1 
+ATOM   2237 C  CE2 . TYR A 1 289 ? 25.834  81.962 25.551 1.00 33.68  ? 308  TYR A CE2 1 
+ATOM   2238 C  CZ  . TYR A 1 289 ? 24.753  81.798 26.403 1.00 32.31  ? 308  TYR A CZ  1 
+ATOM   2239 O  OH  . TYR A 1 289 ? 24.818  82.194 27.700 1.00 30.13  ? 308  TYR A OH  1 
+ATOM   2240 N  N   . ALA A 1 290 ? 26.389  79.974 19.914 1.00 23.03  ? 309  ALA A N   1 
+ATOM   2241 C  CA  . ALA A 1 290 ? 27.622  79.401 19.386 1.00 22.10  ? 309  ALA A CA  1 
+ATOM   2242 C  C   . ALA A 1 290 ? 28.522  80.524 18.919 1.00 25.09  ? 309  ALA A C   1 
+ATOM   2243 O  O   . ALA A 1 290 ? 29.645  80.656 19.407 1.00 26.55  ? 309  ALA A O   1 
+ATOM   2244 C  CB  . ALA A 1 290 ? 27.350  78.437 18.273 1.00 22.15  ? 309  ALA A CB  1 
+ATOM   2245 N  N   . LEU A 1 291 ? 28.014  81.390 18.042 1.00 27.53  ? 310  LEU A N   1 
+ATOM   2246 C  CA  . LEU A 1 291 ? 28.835  82.497 17.549 1.00 28.69  ? 310  LEU A CA  1 
+ATOM   2247 C  C   . LEU A 1 291 ? 29.342  83.415 18.675 1.00 30.02  ? 310  LEU A C   1 
+ATOM   2248 O  O   . LEU A 1 291 ? 30.466  83.881 18.636 1.00 33.84  ? 310  LEU A O   1 
+ATOM   2249 C  CB  . LEU A 1 291 ? 28.099  83.312 16.495 1.00 28.15  ? 310  LEU A CB  1 
+ATOM   2250 C  CG  . LEU A 1 291 ? 27.592  82.572 15.265 1.00 30.57  ? 310  LEU A CG  1 
+ATOM   2251 C  CD1 . LEU A 1 291 ? 27.051  83.598 14.257 1.00 32.46  ? 310  LEU A CD1 1 
+ATOM   2252 C  CD2 . LEU A 1 291 ? 28.663  81.665 14.625 1.00 30.26  ? 310  LEU A CD2 1 
+ATOM   2253 N  N   . LEU A 1 292 ? 28.528  83.656 19.687 1.00 31.65  ? 311  LEU A N   1 
+ATOM   2254 C  CA  . LEU A 1 292 ? 28.958  84.483 20.805 1.00 31.86  ? 311  LEU A CA  1 
+ATOM   2255 C  C   . LEU A 1 292 ? 30.199  83.890 21.464 1.00 31.53  ? 311  LEU A C   1 
+ATOM   2256 O  O   . LEU A 1 292 ? 31.157  84.596 21.752 1.00 29.89  ? 311  LEU A O   1 
+ATOM   2257 C  CB  . LEU A 1 292 ? 27.843  84.614 21.849 1.00 30.46  ? 311  LEU A CB  1 
+ATOM   2258 C  CG  . LEU A 1 292 ? 28.185  85.412 23.111 1.00 30.68  ? 311  LEU A CG  1 
+ATOM   2259 C  CD1 . LEU A 1 292 ? 28.769  86.814 22.799 1.00 29.23  ? 311  LEU A CD1 1 
+ATOM   2260 C  CD2 . LEU A 1 292 ? 26.943  85.567 23.927 1.00 32.79  ? 311  LEU A CD2 1 
+ATOM   2261 N  N   . LEU A 1 293 ? 30.158  82.586 21.695 1.00 31.55  ? 312  LEU A N   1 
+ATOM   2262 C  CA  . LEU A 1 293 ? 31.238  81.871 22.341 1.00 29.52  ? 312  LEU A CA  1 
+ATOM   2263 C  C   . LEU A 1 293 ? 32.456  81.792 21.428 1.00 31.79  ? 312  LEU A C   1 
+ATOM   2264 O  O   . LEU A 1 293 ? 33.582  81.840 21.888 1.00 31.97  ? 312  LEU A O   1 
+ATOM   2265 C  CB  . LEU A 1 293 ? 30.754  80.481 22.742 1.00 27.41  ? 312  LEU A CB  1 
+ATOM   2266 C  CG  . LEU A 1 293 ? 29.695  80.479 23.860 1.00 23.64  ? 312  LEU A CG  1 
+ATOM   2267 C  CD1 . LEU A 1 293 ? 28.952  79.162 23.970 1.00 20.86  ? 312  LEU A CD1 1 
+ATOM   2268 C  CD2 . LEU A 1 293 ? 30.332  80.779 25.180 1.00 23.48  ? 312  LEU A CD2 1 
+ATOM   2269 N  N   . LEU A 1 294 ? 32.234  81.702 20.126 1.00 36.18  ? 313  LEU A N   1 
+ATOM   2270 C  CA  . LEU A 1 294 ? 33.348  81.671 19.184 1.00 37.69  ? 313  LEU A CA  1 
+ATOM   2271 C  C   . LEU A 1 294 ? 34.054  83.035 19.120 1.00 39.17  ? 313  LEU A C   1 
+ATOM   2272 O  O   . LEU A 1 294 ? 35.239  83.111 18.779 1.00 37.28  ? 313  LEU A O   1 
+ATOM   2273 C  CB  . LEU A 1 294 ? 32.869  81.216 17.807 1.00 34.93  ? 313  LEU A CB  1 
+ATOM   2274 C  CG  . LEU A 1 294 ? 32.417  79.753 17.784 1.00 35.90  ? 313  LEU A CG  1 
+ATOM   2275 C  CD1 . LEU A 1 294 ? 31.724  79.377 16.455 1.00 34.07  ? 313  LEU A CD1 1 
+ATOM   2276 C  CD2 . LEU A 1 294 ? 33.576  78.838 18.057 1.00 34.24  ? 313  LEU A CD2 1 
+ATOM   2277 N  N   . LEU A 1 295 ? 33.328  84.099 19.461 1.00 40.06  ? 314  LEU A N   1 
+ATOM   2278 C  CA  . LEU A 1 295 ? 33.919  85.432 19.575 1.00 44.01  ? 314  LEU A CA  1 
+ATOM   2279 C  C   . LEU A 1 295 ? 34.781  85.536 20.825 1.00 44.45  ? 314  LEU A C   1 
+ATOM   2280 O  O   . LEU A 1 295 ? 35.891  86.038 20.777 1.00 46.24  ? 314  LEU A O   1 
+ATOM   2281 C  CB  . LEU A 1 295 ? 32.830  86.498 19.672 1.00 45.41  ? 314  LEU A CB  1 
+ATOM   2282 C  CG  . LEU A 1 295 ? 32.280  87.109 18.392 1.00 46.40  ? 314  LEU A CG  1 
+ATOM   2283 C  CD1 . LEU A 1 295 ? 31.401  88.300 18.757 1.00 46.13  ? 314  LEU A CD1 1 
+ATOM   2284 C  CD2 . LEU A 1 295 ? 33.393  87.531 17.468 1.00 45.33  ? 314  LEU A CD2 1 
+ATOM   2285 N  N   . LYS A 1 296 ? 34.229  85.071 21.938 1.00 44.37  ? 315  LYS A N   1 
+ATOM   2286 C  CA  . LYS A 1 296 ? 34.851  85.159 23.249 1.00 46.08  ? 315  LYS A CA  1 
+ATOM   2287 C  C   . LYS A 1 296 ? 36.145  84.347 23.274 1.00 47.76  ? 315  LYS A C   1 
+ATOM   2288 O  O   . LYS A 1 296 ? 37.145  84.797 23.833 1.00 50.82  ? 315  LYS A O   1 
+ATOM   2289 C  CB  . LYS A 1 296 ? 33.849  84.663 24.306 1.00 46.00  ? 315  LYS A CB  1 
+ATOM   2290 C  CG  . LYS A 1 296 ? 34.362  84.538 25.738 1.00 49.15  ? 315  LYS A CG  1 
+ATOM   2291 C  CD  . LYS A 1 296 ? 34.574  85.875 26.401 1.00 48.81  ? 315  LYS A CD  1 
+ATOM   2292 C  CE  . LYS A 1 296 ? 34.587  85.743 27.904 1.00 50.48  ? 315  LYS A CE  1 
+ATOM   2293 N  NZ  . LYS A 1 296 ? 34.792  87.086 28.514 1.00 53.61  ? 315  LYS A NZ  1 
+ATOM   2294 N  N   . HIS A 1 297 ? 36.120  83.183 22.619 1.00 47.65  ? 316  HIS A N   1 
+ATOM   2295 C  CA  . HIS A 1 297 ? 37.242  82.235 22.579 1.00 46.06  ? 316  HIS A CA  1 
+ATOM   2296 C  C   . HIS A 1 297 ? 37.807  82.070 21.142 1.00 42.64  ? 316  HIS A C   1 
+ATOM   2297 O  O   . HIS A 1 297 ? 37.522  81.086 20.481 1.00 45.71  ? 316  HIS A O   1 
+ATOM   2298 C  CB  . HIS A 1 297 ? 36.792  80.865 23.172 1.00 43.82  ? 316  HIS A CB  1 
+ATOM   2299 C  CG  . HIS A 1 297 ? 36.068  80.988 24.477 1.00 44.15  ? 316  HIS A CG  1 
+ATOM   2300 N  ND1 . HIS A 1 297 ? 36.712  81.269 25.659 1.00 49.16  ? 316  HIS A ND1 1 
+ATOM   2301 C  CD2 . HIS A 1 297 ? 34.747  80.930 24.781 1.00 48.82  ? 316  HIS A CD2 1 
+ATOM   2302 C  CE1 . HIS A 1 297 ? 35.826  81.361 26.640 1.00 48.59  ? 316  HIS A CE1 1 
+ATOM   2303 N  NE2 . HIS A 1 297 ? 34.625  81.144 26.136 1.00 45.44  ? 316  HIS A NE2 1 
+ATOM   2304 N  N   . PRO A 1 298 ? 38.609  83.012 20.652 1.00 40.21  ? 317  PRO A N   1 
+ATOM   2305 C  CA  . PRO A 1 298 ? 39.135  82.916 19.279 1.00 39.19  ? 317  PRO A CA  1 
+ATOM   2306 C  C   . PRO A 1 298 ? 40.152  81.788 19.056 1.00 39.94  ? 317  PRO A C   1 
+ATOM   2307 O  O   . PRO A 1 298 ? 40.286  81.358 17.924 1.00 38.48  ? 317  PRO A O   1 
+ATOM   2308 C  CB  . PRO A 1 298 ? 39.787  84.285 19.040 1.00 38.72  ? 317  PRO A CB  1 
+ATOM   2309 C  CG  . PRO A 1 298 ? 40.094  84.806 20.382 1.00 41.48  ? 317  PRO A CG  1 
+ATOM   2310 C  CD  . PRO A 1 298 ? 39.076  84.226 21.338 1.00 41.29  ? 317  PRO A CD  1 
+ATOM   2311 N  N   . GLU A 1 299 ? 40.874  81.358 20.089 1.00 40.35  ? 318  GLU A N   1 
+ATOM   2312 C  CA  . GLU A 1 299 ? 41.747  80.189 19.990 1.00 39.59  ? 318  GLU A CA  1 
+ATOM   2313 C  C   . GLU A 1 299 ? 40.950  79.005 19.505 1.00 37.24  ? 318  GLU A C   1 
+ATOM   2314 O  O   . GLU A 1 299 ? 41.421  78.252 18.641 1.00 37.37  ? 318  GLU A O   1 
+ATOM   2315 C  CB  . GLU A 1 299 ? 42.367  79.810 21.337 1.00 45.60  ? 318  GLU A CB  1 
+ATOM   2316 C  CG  . GLU A 1 299 ? 43.855  80.091 21.467 1.00 54.53  ? 318  GLU A CG  1 
+ATOM   2317 C  CD  . GLU A 1 299 ? 44.141  81.544 21.833 1.00 64.90  ? 318  GLU A CD  1 
+ATOM   2318 O  OE1 . GLU A 1 299 ? 44.620  82.294 20.941 1.00 69.05  ? 318  GLU A OE1 1 
+ATOM   2319 O  OE2 . GLU A 1 299 ? 43.874  81.939 23.002 1.00 70.01  ? 318  GLU A OE2 1 
+ATOM   2320 N  N   . VAL A 1 300 ? 39.750  78.846 20.073 1.00 32.73  ? 319  VAL A N   1 
+ATOM   2321 C  CA  . VAL A 1 300 ? 38.834  77.759 19.723 1.00 27.37  ? 319  VAL A CA  1 
+ATOM   2322 C  C   . VAL A 1 300 ? 38.366  77.872 18.279 1.00 31.18  ? 319  VAL A C   1 
+ATOM   2323 O  O   . VAL A 1 300 ? 38.243  76.877 17.556 1.00 28.15  ? 319  VAL A O   1 
+ATOM   2324 C  CB  . VAL A 1 300 ? 37.617  77.766 20.615 1.00 26.11  ? 319  VAL A CB  1 
+ATOM   2325 C  CG1 . VAL A 1 300 ? 36.608  76.738 20.151 1.00 25.40  ? 319  VAL A CG1 1 
+ATOM   2326 C  CG2 . VAL A 1 300 ? 38.032  77.502 22.077 1.00 28.17  ? 319  VAL A CG2 1 
+ATOM   2327 N  N   . THR A 1 301 ? 38.102  79.098 17.860 1.00 32.86  ? 320  THR A N   1 
+ATOM   2328 C  CA  . THR A 1 301 ? 37.666  79.366 16.501 1.00 34.09  ? 320  THR A CA  1 
+ATOM   2329 C  C   . THR A 1 301 ? 38.782  79.050 15.479 1.00 36.30  ? 320  THR A C   1 
+ATOM   2330 O  O   . THR A 1 301 ? 38.574  78.299 14.523 1.00 35.76  ? 320  THR A O   1 
+ATOM   2331 C  CB  . THR A 1 301 ? 37.231  80.820 16.456 1.00 34.43  ? 320  THR A CB  1 
+ATOM   2332 O  OG1 . THR A 1 301 ? 36.133  80.982 17.364 1.00 41.73  ? 320  THR A OG1 1 
+ATOM   2333 C  CG2 . THR A 1 301 ? 36.680  81.212 15.120 1.00 32.24  ? 320  THR A CG2 1 
+ATOM   2334 N  N   . ALA A 1 302 ? 39.965  79.609 15.708 1.00 37.21  ? 321  ALA A N   1 
+ATOM   2335 C  CA  . ALA A 1 302 ? 41.171  79.262 14.953 1.00 35.47  ? 321  ALA A CA  1 
+ATOM   2336 C  C   . ALA A 1 302 ? 41.378  77.757 14.825 1.00 35.65  ? 321  ALA A C   1 
+ATOM   2337 O  O   . ALA A 1 302 ? 41.700  77.271 13.740 1.00 40.89  ? 321  ALA A O   1 
+ATOM   2338 C  CB  . ALA A 1 302 ? 42.369  79.882 15.598 1.00 33.30  ? 321  ALA A CB  1 
+ATOM   2339 N  N   . LYS A 1 303 ? 41.169  77.010 15.906 1.00 35.57  ? 322  LYS A N   1 
+ATOM   2340 C  CA  . LYS A 1 303 ? 41.341  75.555 15.843 1.00 36.74  ? 322  LYS A CA  1 
+ATOM   2341 C  C   . LYS A 1 303 ? 40.294  74.895 14.967 1.00 34.24  ? 322  LYS A C   1 
+ATOM   2342 O  O   . LYS A 1 303 ? 40.621  73.979 14.237 1.00 33.49  ? 322  LYS A O   1 
+ATOM   2343 C  CB  . LYS A 1 303 ? 41.362  74.913 17.231 1.00 40.60  ? 322  LYS A CB  1 
+ATOM   2344 C  CG  . LYS A 1 303 ? 42.676  75.165 18.015 1.00 47.44  ? 322  LYS A CG  1 
+ATOM   2345 C  CD  . LYS A 1 303 ? 42.932  74.115 19.119 1.00 52.90  ? 322  LYS A CD  1 
+ATOM   2346 C  CE  . LYS A 1 303 ? 43.940  74.612 20.170 1.00 54.64  ? 322  LYS A CE  1 
+ATOM   2347 N  NZ  . LYS A 1 303 ? 43.343  74.635 21.543 1.00 58.60  ? 322  LYS A NZ  1 
+ATOM   2348 N  N   . VAL A 1 304 ? 39.051  75.381 15.015 1.00 35.07  ? 323  VAL A N   1 
+ATOM   2349 C  CA  . VAL A 1 304 ? 37.973  74.839 14.181 1.00 32.36  ? 323  VAL A CA  1 
+ATOM   2350 C  C   . VAL A 1 304 ? 38.267  75.102 12.703 1.00 32.87  ? 323  VAL A C   1 
+ATOM   2351 O  O   . VAL A 1 304 ? 38.047  74.227 11.859 1.00 25.56  ? 323  VAL A O   1 
+ATOM   2352 C  CB  . VAL A 1 304 ? 36.577  75.405 14.559 1.00 31.22  ? 323  VAL A CB  1 
+ATOM   2353 C  CG1 . VAL A 1 304 ? 35.512  74.988 13.545 1.00 27.76  ? 323  VAL A CG1 1 
+ATOM   2354 C  CG2 . VAL A 1 304 ? 36.168  74.928 15.927 1.00 32.45  ? 323  VAL A CG2 1 
+ATOM   2355 N  N   . GLN A 1 305 ? 38.783  76.291 12.397 1.00 33.29  ? 324  GLN A N   1 
+ATOM   2356 C  CA  . GLN A 1 305 ? 39.142  76.632 11.018 1.00 35.05  ? 324  GLN A CA  1 
+ATOM   2357 C  C   . GLN A 1 305 ? 40.299  75.790 10.464 1.00 37.37  ? 324  GLN A C   1 
+ATOM   2358 O  O   . GLN A 1 305 ? 40.287  75.500 9.284  1.00 36.64  ? 324  GLN A O   1 
+ATOM   2359 C  CB  . GLN A 1 305 ? 39.378  78.135 10.851 1.00 33.36  ? 324  GLN A CB  1 
+ATOM   2360 C  CG  . GLN A 1 305 ? 38.058  78.895 10.954 1.00 36.13  ? 324  GLN A CG  1 
+ATOM   2361 C  CD  . GLN A 1 305 ? 38.211  80.394 11.048 1.00 39.46  ? 324  GLN A CD  1 
+ATOM   2362 O  OE1 . GLN A 1 305 ? 37.653  81.117 10.225 1.00 45.13  ? 324  GLN A OE1 1 
+ATOM   2363 N  NE2 . GLN A 1 305 ? 38.939  80.871 12.055 1.00 37.61  ? 324  GLN A NE2 1 
+ATOM   2364 N  N   . GLU A 1 306 ? 41.264  75.376 11.292 1.00 41.50  ? 325  GLU A N   1 
+ATOM   2365 C  CA  . GLU A 1 306 ? 42.322  74.471 10.810 1.00 45.85  ? 325  GLU A CA  1 
+ATOM   2366 C  C   . GLU A 1 306 ? 41.702  73.145 10.340 1.00 41.29  ? 325  GLU A C   1 
+ATOM   2367 O  O   . GLU A 1 306 ? 42.127  72.570 9.330  1.00 39.43  ? 325  GLU A O   1 
+ATOM   2368 C  CB  . GLU A 1 306 ? 43.389  74.147 11.876 1.00 49.45  ? 325  GLU A CB  1 
+ATOM   2369 C  CG  . GLU A 1 306 ? 44.199  75.311 12.443 1.00 55.86  ? 325  GLU A CG  1 
+ATOM   2370 C  CD  . GLU A 1 306 ? 44.723  75.050 13.894 1.00 63.74  ? 325  GLU A CD  1 
+ATOM   2371 O  OE1 . GLU A 1 306 ? 45.136  76.032 14.578 1.00 66.43  ? 325  GLU A OE1 1 
+ATOM   2372 O  OE2 . GLU A 1 306 ? 44.730  73.879 14.382 1.00 60.05  ? 325  GLU A OE2 1 
+ATOM   2373 N  N   . GLU A 1 307 ? 40.727  72.649 11.097 1.00 37.26  ? 326  GLU A N   1 
+ATOM   2374 C  CA  . GLU A 1 307 ? 40.058  71.387 10.759 1.00 36.36  ? 326  GLU A CA  1 
+ATOM   2375 C  C   . GLU A 1 307 ? 39.231  71.519 9.484  1.00 33.91  ? 326  GLU A C   1 
+ATOM   2376 O  O   . GLU A 1 307 ? 39.096  70.579 8.721  1.00 34.90  ? 326  GLU A O   1 
+ATOM   2377 C  CB  . GLU A 1 307 ? 39.151  70.942 11.894 1.00 36.25  ? 326  GLU A CB  1 
+ATOM   2378 C  CG  . GLU A 1 307 ? 39.680  69.760 12.666 1.00 44.16  ? 326  GLU A CG  1 
+ATOM   2379 C  CD  . GLU A 1 307 ? 38.692  69.235 13.699 1.00 45.43  ? 326  GLU A CD  1 
+ATOM   2380 O  OE1 . GLU A 1 307 ? 38.870  68.098 14.156 1.00 42.07  ? 326  GLU A OE1 1 
+ATOM   2381 O  OE2 . GLU A 1 307 ? 37.747  69.958 14.055 1.00 51.06  ? 326  GLU A OE2 1 
+ATOM   2382 N  N   . ILE A 1 308 ? 38.673  72.703 9.264  1.00 36.11  ? 327  ILE A N   1 
+ATOM   2383 C  CA  . ILE A 1 308 ? 37.868  72.959 8.088  1.00 35.38  ? 327  ILE A CA  1 
+ATOM   2384 C  C   . ILE A 1 308 ? 38.794  72.978 6.858  1.00 36.05  ? 327  ILE A C   1 
+ATOM   2385 O  O   . ILE A 1 308 ? 38.494  72.297 5.899  1.00 35.24  ? 327  ILE A O   1 
+ATOM   2386 C  CB  . ILE A 1 308 ? 37.031  74.272 8.236  1.00 34.85  ? 327  ILE A CB  1 
+ATOM   2387 C  CG1 . ILE A 1 308 ? 35.808  74.072 9.161  1.00 32.43  ? 327  ILE A CG1 1 
+ATOM   2388 C  CG2 . ILE A 1 308 ? 36.528  74.727 6.910  1.00 36.52  ? 327  ILE A CG2 1 
+ATOM   2389 C  CD1 . ILE A 1 308 ? 35.255  75.406 9.769  1.00 27.91  ? 327  ILE A CD1 1 
+ATOM   2390 N  N   . GLU A 1 309 ? 39.933  73.676 6.907  1.00 31.70  ? 328  GLU A N   1 
+ATOM   2391 C  CA  . GLU A 1 309 ? 40.818  73.769 5.744  1.00 35.70  ? 328  GLU A CA  1 
+ATOM   2392 C  C   . GLU A 1 309 ? 41.395  72.434 5.390  1.00 32.26  ? 328  GLU A C   1 
+ATOM   2393 O  O   . GLU A 1 309 ? 41.567  72.111 4.232  1.00 39.89  ? 328  GLU A O   1 
+ATOM   2394 C  CB  . GLU A 1 309 ? 41.978  74.733 5.974  1.00 42.58  ? 328  GLU A CB  1 
+ATOM   2395 C  CG  . GLU A 1 309 ? 41.547  76.090 6.530  1.00 55.27  ? 328  GLU A CG  1 
+ATOM   2396 C  CD  . GLU A 1 309 ? 41.939  77.281 5.669  1.00 61.81  ? 328  GLU A CD  1 
+ATOM   2397 O  OE1 . GLU A 1 309 ? 42.042  78.388 6.262  1.00 63.73  ? 328  GLU A OE1 1 
+ATOM   2398 O  OE2 . GLU A 1 309 ? 42.134  77.115 4.431  1.00 64.09  ? 328  GLU A OE2 1 
+ATOM   2399 N  N   . ARG A 1 310 ? 41.689  71.657 6.405  1.00 33.18  ? 329  ARG A N   1 
+ATOM   2400 C  CA  . ARG A 1 310 ? 42.295  70.367 6.247  1.00 32.33  ? 329  ARG A CA  1 
+ATOM   2401 C  C   . ARG A 1 310 ? 41.322  69.352 5.719  1.00 32.80  ? 329  ARG A C   1 
+ATOM   2402 O  O   . ARG A 1 310 ? 41.640  68.638 4.798  1.00 36.99  ? 329  ARG A O   1 
+ATOM   2403 C  CB  . ARG A 1 310 ? 42.824  69.914 7.594  1.00 37.29  ? 329  ARG A CB  1 
+ATOM   2404 C  CG  . ARG A 1 310 ? 43.601  68.609 7.591  1.00 37.86  ? 329  ARG A CG  1 
+ATOM   2405 C  CD  . ARG A 1 310 ? 44.437  68.435 8.850  1.00 40.77  ? 329  ARG A CD  1 
+ATOM   2406 N  NE  . ARG A 1 310 ? 43.617  68.429 10.059 1.00 43.88  ? 329  ARG A NE  1 
+ATOM   2407 C  CZ  . ARG A 1 310 ? 42.789  67.444 10.390 1.00 48.37  ? 329  ARG A CZ  1 
+ATOM   2408 N  NH1 . ARG A 1 310 ? 42.073  67.528 11.507 1.00 53.84  ? 329  ARG A NH1 1 
+ATOM   2409 N  NH2 . ARG A 1 310 ? 42.660  66.373 9.609  1.00 48.46  ? 329  ARG A NH2 1 
+ATOM   2410 N  N   . VAL A 1 311 ? 40.130  69.280 6.289  1.00 35.10  ? 330  VAL A N   1 
+ATOM   2411 C  CA  . VAL A 1 311 ? 39.210  68.179 5.964  1.00 34.67  ? 330  VAL A CA  1 
+ATOM   2412 C  C   . VAL A 1 311 ? 38.307  68.450 4.756  1.00 36.91  ? 330  VAL A C   1 
+ATOM   2413 O  O   . VAL A 1 311 ? 38.000  67.579 3.948  1.00 37.51  ? 330  VAL A O   1 
+ATOM   2414 C  CB  . VAL A 1 311 ? 38.355  67.883 7.163  1.00 29.56  ? 330  VAL A CB  1 
+ATOM   2415 C  CG1 . VAL A 1 311 ? 37.335  66.817 6.841  1.00 27.52  ? 330  VAL A CG1 1 
+ATOM   2416 C  CG2 . VAL A 1 311 ? 39.265  67.442 8.312  1.00 33.13  ? 330  VAL A CG2 1 
+ATOM   2417 N  N   . ILE A 1 312 ? 37.866  69.685 4.706  1.00 40.47  ? 331  ILE A N   1 
+ATOM   2418 C  CA  . ILE A 1 312 ? 37.004  70.234 3.696  1.00 43.36  ? 331  ILE A CA  1 
+ATOM   2419 C  C   . ILE A 1 312 ? 37.882  71.285 3.056  1.00 44.48  ? 331  ILE A C   1 
+ATOM   2420 O  O   . ILE A 1 312 ? 38.740  71.866 3.704  1.00 49.14  ? 331  ILE A O   1 
+ATOM   2421 C  CB  . ILE A 1 312 ? 35.813  70.939 4.436  1.00 44.90  ? 331  ILE A CB  1 
+ATOM   2422 C  CG1 . ILE A 1 312 ? 34.958  69.909 5.177  1.00 40.90  ? 331  ILE A CG1 1 
+ATOM   2423 C  CG2 . ILE A 1 312 ? 34.991  71.787 3.477  1.00 47.75  ? 331  ILE A CG2 1 
+ATOM   2424 C  CD1 . ILE A 1 312 ? 34.104  70.486 6.285  1.00 42.14  ? 331  ILE A CD1 1 
+ATOM   2425 N  N   . GLY A 1 313 ? 37.731  71.588 1.806  1.00 46.66  ? 332  GLY A N   1 
+ATOM   2426 C  CA  . GLY A 1 313 ? 38.594  72.657 1.341  1.00 52.01  ? 332  GLY A CA  1 
+ATOM   2427 C  C   . GLY A 1 313 ? 38.040  74.022 1.710  1.00 56.70  ? 332  GLY A C   1 
+ATOM   2428 O  O   . GLY A 1 313 ? 37.224  74.173 2.624  1.00 52.62  ? 332  GLY A O   1 
+ATOM   2429 N  N   . ARG A 1 314 ? 38.503  75.023 0.974  1.00 61.43  ? 333  ARG A N   1 
+ATOM   2430 C  CA  . ARG A 1 314 ? 37.792  76.272 0.877  1.00 65.02  ? 333  ARG A CA  1 
+ATOM   2431 C  C   . ARG A 1 314 ? 36.790  76.175 -0.275 1.00 64.51  ? 333  ARG A C   1 
+ATOM   2432 O  O   . ARG A 1 314 ? 35.810  76.914 -0.314 1.00 66.27  ? 333  ARG A O   1 
+ATOM   2433 C  CB  . ARG A 1 314 ? 38.759  77.433 0.665  1.00 69.20  ? 333  ARG A CB  1 
+ATOM   2434 C  CG  . ARG A 1 314 ? 38.386  78.673 1.477  1.00 76.16  ? 333  ARG A CG  1 
+ATOM   2435 C  CD  . ARG A 1 314 ? 39.563  79.582 1.773  1.00 82.47  ? 333  ARG A CD  1 
+ATOM   2436 N  NE  . ARG A 1 314 ? 39.718  79.825 3.208  1.00 87.57  ? 333  ARG A NE  1 
+ATOM   2437 C  CZ  . ARG A 1 314 ? 40.822  80.304 3.785  1.00 89.41  ? 333  ARG A CZ  1 
+ATOM   2438 N  NH1 . ARG A 1 314 ? 41.905  80.596 3.062  1.00 87.42  ? 333  ARG A NH1 1 
+ATOM   2439 N  NH2 . ARG A 1 314 ? 40.841  80.494 5.105  1.00 91.93  ? 333  ARG A NH2 1 
+ATOM   2440 N  N   . ASN A 1 315 ? 37.026  75.258 -1.207 1.00 63.43  ? 334  ASN A N   1 
+ATOM   2441 C  CA  . ASN A 1 315 ? 36.159  75.118 -2.373 1.00 62.62  ? 334  ASN A CA  1 
+ATOM   2442 C  C   . ASN A 1 315 ? 34.781  74.564 -1.979 1.00 60.85  ? 334  ASN A C   1 
+ATOM   2443 O  O   . ASN A 1 315 ? 33.877  75.356 -1.681 1.00 68.90  ? 334  ASN A O   1 
+ATOM   2444 C  CB  . ASN A 1 315 ? 36.845  74.293 -3.479 1.00 62.79  ? 334  ASN A CB  1 
+ATOM   2445 C  CG  . ASN A 1 315 ? 38.063  75.007 -4.069 1.00 62.48  ? 334  ASN A CG  1 
+ATOM   2446 O  OD1 . ASN A 1 315 ? 39.160  74.997 -3.494 1.00 55.74  ? 334  ASN A OD1 1 
+ATOM   2447 N  ND2 . ASN A 1 315 ? 37.867  75.638 -5.220 1.00 64.99  ? 334  ASN A ND2 1 
+ATOM   2448 N  N   . ARG A 1 316 ? 34.614  73.241 -1.933 1.00 54.09  ? 335  ARG A N   1 
+ATOM   2449 C  CA  . ARG A 1 316 ? 33.302  72.629 -1.665 1.00 48.24  ? 335  ARG A CA  1 
+ATOM   2450 C  C   . ARG A 1 316 ? 32.648  72.935 -0.308 1.00 47.83  ? 335  ARG A C   1 
+ATOM   2451 O  O   . ARG A 1 316 ? 33.186  73.619 0.562  1.00 46.26  ? 335  ARG A O   1 
+ATOM   2452 C  CB  . ARG A 1 316 ? 33.361  71.116 -1.860 1.00 45.29  ? 335  ARG A CB  1 
+ATOM   2453 C  CG  . ARG A 1 316 ? 34.009  70.372 -0.750 1.00 45.12  ? 335  ARG A CG  1 
+ATOM   2454 C  CD  . ARG A 1 316 ? 33.907  68.877 -0.902 1.00 48.01  ? 335  ARG A CD  1 
+ATOM   2455 N  NE  . ARG A 1 316 ? 33.777  68.230 0.396  1.00 53.18  ? 335  ARG A NE  1 
+ATOM   2456 C  CZ  . ARG A 1 316 ? 34.784  67.900 1.183  1.00 56.61  ? 335  ARG A CZ  1 
+ATOM   2457 N  NH1 . ARG A 1 316 ? 36.048  68.125 0.824  1.00 62.37  ? 335  ARG A NH1 1 
+ATOM   2458 N  NH2 . ARG A 1 316 ? 34.522  67.328 2.344  1.00 55.54  ? 335  ARG A NH2 1 
+ATOM   2459 N  N   . SER A 1 317 ? 31.442  72.434 -0.148 1.00 47.11  ? 336  SER A N   1 
+ATOM   2460 C  CA  . SER A 1 317 ? 30.660  72.794 0.999  1.00 47.48  ? 336  SER A CA  1 
+ATOM   2461 C  C   . SER A 1 317 ? 30.751  71.606 1.943  1.00 42.70  ? 336  SER A C   1 
+ATOM   2462 O  O   . SER A 1 317 ? 31.072  70.481 1.505  1.00 42.29  ? 336  SER A O   1 
+ATOM   2463 C  CB  . SER A 1 317 ? 29.223  73.091 0.573  1.00 50.15  ? 336  SER A CB  1 
+ATOM   2464 O  OG  . SER A 1 317 ? 28.445  71.905 0.594  1.00 50.68  ? 336  SER A OG  1 
+ATOM   2465 N  N   . PRO A 1 318 ? 30.557  71.858 3.237  1.00 31.47  ? 337  PRO A N   1 
+ATOM   2466 C  CA  . PRO A 1 318 ? 30.601  70.792 4.219  1.00 26.65  ? 337  PRO A CA  1 
+ATOM   2467 C  C   . PRO A 1 318 ? 29.468  69.855 4.002  1.00 30.64  ? 337  PRO A C   1 
+ATOM   2468 O  O   . PRO A 1 318 ? 28.549  70.205 3.285  1.00 35.50  ? 337  PRO A O   1 
+ATOM   2469 C  CB  . PRO A 1 318 ? 30.433  71.522 5.528  1.00 25.01  ? 337  PRO A CB  1 
+ATOM   2470 C  CG  . PRO A 1 318 ? 30.892  72.855 5.241  1.00 28.90  ? 337  PRO A CG  1 
+ATOM   2471 C  CD  . PRO A 1 318 ? 30.396  73.169 3.876  1.00 31.55  ? 337  PRO A CD  1 
+ATOM   2472 N  N   . CYS A 1 319 ? 29.546  68.694 4.628  1.00 31.91  ? 338  CYS A N   1 
+ATOM   2473 C  CA  . CYS A 1 319 ? 28.492  67.721 4.617  1.00 34.56  ? 338  CYS A CA  1 
+ATOM   2474 C  C   . CYS A 1 319 ? 28.700  66.801 5.823  1.00 34.88  ? 338  CYS A C   1 
+ATOM   2475 O  O   . CYS A 1 319 ? 29.690  66.912 6.538  1.00 33.84  ? 338  CYS A O   1 
+ATOM   2476 C  CB  . CYS A 1 319 ? 28.586  66.931 3.332  1.00 39.53  ? 338  CYS A CB  1 
+ATOM   2477 S  SG  . CYS A 1 319 ? 30.004  65.816 3.386  1.00 48.28  ? 338  CYS A SG  1 
+ATOM   2478 N  N   . MET A 1 320 ? 27.793  65.869 6.046  1.00 35.59  ? 339  MET A N   1 
+ATOM   2479 C  CA  . MET A 1 320 ? 27.802  65.153 7.312  1.00 40.47  ? 339  MET A CA  1 
+ATOM   2480 C  C   . MET A 1 320 ? 28.945  64.145 7.423  1.00 43.56  ? 339  MET A C   1 
+ATOM   2481 O  O   . MET A 1 320 ? 29.474  63.902 8.518  1.00 46.39  ? 339  MET A O   1 
+ATOM   2482 C  CB  . MET A 1 320 ? 26.427  64.515 7.584  1.00 40.15  ? 339  MET A CB  1 
+ATOM   2483 C  CG  . MET A 1 320 ? 25.325  65.558 7.776  1.00 43.91  ? 339  MET A CG  1 
+ATOM   2484 S  SD  . MET A 1 320 ? 25.677  66.827 9.074  1.00 44.24  ? 339  MET A SD  1 
+ATOM   2485 C  CE  . MET A 1 320 ? 26.032  65.750 10.418 1.00 45.49  ? 339  MET A CE  1 
+ATOM   2486 N  N   . GLN A 1 321 ? 29.339  63.569 6.297  1.00 47.33  ? 340  GLN A N   1 
+ATOM   2487 C  CA  . GLN A 1 321 ? 30.466  62.634 6.298  1.00 50.71  ? 340  GLN A CA  1 
+ATOM   2488 C  C   . GLN A 1 321 ? 31.751  63.260 6.822  1.00 45.23  ? 340  GLN A C   1 
+ATOM   2489 O  O   . GLN A 1 321 ? 32.596  62.561 7.335  1.00 45.26  ? 340  GLN A O   1 
+ATOM   2490 C  CB  . GLN A 1 321 ? 30.726  62.102 4.900  1.00 53.74  ? 340  GLN A CB  1 
+ATOM   2491 C  CG  . GLN A 1 321 ? 30.274  60.695 4.704  1.00 60.69  ? 340  GLN A CG  1 
+ATOM   2492 C  CD  . GLN A 1 321 ? 30.684  60.197 3.340  1.00 68.40  ? 340  GLN A CD  1 
+ATOM   2493 O  OE1 . GLN A 1 321 ? 31.827  60.418 2.911  1.00 71.59  ? 340  GLN A OE1 1 
+ATOM   2494 N  NE2 . GLN A 1 321 ? 29.758  59.546 2.639  1.00 70.63  ? 340  GLN A NE2 1 
+ATOM   2495 N  N   . ASP A 1 322 ? 31.893  64.571 6.694  1.00 40.58  ? 341  ASP A N   1 
+ATOM   2496 C  CA  . ASP A 1 322 ? 33.072  65.254 7.204  1.00 41.29  ? 341  ASP A CA  1 
+ATOM   2497 C  C   . ASP A 1 322 ? 33.195  65.300 8.712  1.00 41.93  ? 341  ASP A C   1 
+ATOM   2498 O  O   . ASP A 1 322 ? 34.258  65.674 9.235  1.00 38.54  ? 341  ASP A O   1 
+ATOM   2499 C  CB  . ASP A 1 322 ? 33.086  66.701 6.740  1.00 43.34  ? 341  ASP A CB  1 
+ATOM   2500 C  CG  . ASP A 1 322 ? 33.111  66.834 5.253  1.00 42.57  ? 341  ASP A CG  1 
+ATOM   2501 O  OD1 . ASP A 1 322 ? 33.576  65.898 4.575  1.00 50.82  ? 341  ASP A OD1 1 
+ATOM   2502 O  OD2 . ASP A 1 322 ? 32.677  67.843 4.676  1.00 42.69  ? 341  ASP A OD2 1 
+ATOM   2503 N  N   . ARG A 1 323 ? 32.119  64.981 9.421  1.00 41.23  ? 342  ARG A N   1 
+ATOM   2504 C  CA  . ARG A 1 323 ? 32.104  65.252 10.844 1.00 39.88  ? 342  ARG A CA  1 
+ATOM   2505 C  C   . ARG A 1 323 ? 32.914  64.231 11.622 1.00 39.24  ? 342  ARG A C   1 
+ATOM   2506 O  O   . ARG A 1 323 ? 33.579  64.585 12.608 1.00 39.28  ? 342  ARG A O   1 
+ATOM   2507 C  CB  . ARG A 1 323 ? 30.684  65.312 11.384 1.00 43.34  ? 342  ARG A CB  1 
+ATOM   2508 C  CG  . ARG A 1 323 ? 30.683  65.659 12.859 1.00 44.67  ? 342  ARG A CG  1 
+ATOM   2509 C  CD  . ARG A 1 323 ? 29.371  65.881 13.450 1.00 44.32  ? 342  ARG A CD  1 
+ATOM   2510 N  NE  . ARG A 1 323 ? 28.512  64.753 13.200 1.00 45.15  ? 342  ARG A NE  1 
+ATOM   2511 C  CZ  . ARG A 1 323 ? 27.247  64.706 13.555 1.00 48.54  ? 342  ARG A CZ  1 
+ATOM   2512 N  NH1 . ARG A 1 323 ? 26.683  65.728 14.208 1.00 52.80  ? 342  ARG A NH1 1 
+ATOM   2513 N  NH2 . ARG A 1 323 ? 26.540  63.626 13.245 1.00 46.52  ? 342  ARG A NH2 1 
+ATOM   2514 N  N   . SER A 1 324 ? 32.857  62.972 11.201 1.00 35.93  ? 343  SER A N   1 
+ATOM   2515 C  CA  . SER A 1 324 ? 33.697  61.945 11.814 1.00 37.90  ? 343  SER A CA  1 
+ATOM   2516 C  C   . SER A 1 324 ? 35.202  62.282 11.747 1.00 38.28  ? 343  SER A C   1 
+ATOM   2517 O  O   . SER A 1 324 ? 35.956  61.893 12.637 1.00 42.41  ? 343  SER A O   1 
+ATOM   2518 C  CB  . SER A 1 324 ? 33.461  60.590 11.160 1.00 38.38  ? 343  SER A CB  1 
+ATOM   2519 O  OG  . SER A 1 324 ? 34.019  60.586 9.862  1.00 45.58  ? 343  SER A OG  1 
+ATOM   2520 N  N   . HIS A 1 325 ? 35.631  63.008 10.717 1.00 34.71  ? 344  HIS A N   1 
+ATOM   2521 C  CA  . HIS A 1 325 ? 37.035  63.401 10.568 1.00 37.79  ? 344  HIS A CA  1 
+ATOM   2522 C  C   . HIS A 1 325 ? 37.324  64.781 11.169 1.00 36.62  ? 344  HIS A C   1 
+ATOM   2523 O  O   . HIS A 1 325 ? 38.409  65.324 10.965 1.00 34.12  ? 344  HIS A O   1 
+ATOM   2524 C  CB  . HIS A 1 325 ? 37.487  63.342 9.071  1.00 42.68  ? 344  HIS A CB  1 
+ATOM   2525 C  CG  . HIS A 1 325 ? 37.088  62.069 8.368  1.00 51.64  ? 344  HIS A CG  1 
+ATOM   2526 N  ND1 . HIS A 1 325 ? 37.186  60.822 8.962  1.00 56.47  ? 344  HIS A ND1 1 
+ATOM   2527 C  CD2 . HIS A 1 325 ? 36.554  61.854 7.140  1.00 53.78  ? 344  HIS A CD2 1 
+ATOM   2528 C  CE1 . HIS A 1 325 ? 36.735  59.898 8.130  1.00 53.78  ? 344  HIS A CE1 1 
+ATOM   2529 N  NE2 . HIS A 1 325 ? 36.341  60.498 7.020  1.00 56.05  ? 344  HIS A NE2 1 
+ATOM   2530 N  N   . MET A 1 326 ? 36.378  65.347 11.921 1.00 37.59  ? 345  MET A N   1 
+ATOM   2531 C  CA  . MET A 1 326 ? 36.568  66.675 12.526 1.00 39.28  ? 345  MET A CA  1 
+ATOM   2532 C  C   . MET A 1 326 ? 36.211  66.735 14.028 1.00 40.50  ? 345  MET A C   1 
+ATOM   2533 O  O   . MET A 1 326 ? 35.282  67.475 14.423 1.00 33.64  ? 345  MET A O   1 
+ATOM   2534 C  CB  . MET A 1 326 ? 35.719  67.702 11.776 1.00 40.86  ? 345  MET A CB  1 
+ATOM   2535 C  CG  . MET A 1 326 ? 36.162  67.967 10.377 1.00 38.41  ? 345  MET A CG  1 
+ATOM   2536 S  SD  . MET A 1 326 ? 34.935  68.863 9.555  1.00 35.01  ? 345  MET A SD  1 
+ATOM   2537 C  CE  . MET A 1 326 ? 35.346  70.485 9.970  1.00 32.94  ? 345  MET A CE  1 
+ATOM   2538 N  N   . PRO A 1 327 ? 36.980  66.023 14.863 1.00 38.22  ? 346  PRO A N   1 
+ATOM   2539 C  CA  . PRO A 1 327 ? 36.623  65.825 16.270 1.00 36.95  ? 346  PRO A CA  1 
+ATOM   2540 C  C   . PRO A 1 327 ? 36.552  67.107 17.074 1.00 32.38  ? 346  PRO A C   1 
+ATOM   2541 O  O   . PRO A 1 327 ? 35.610  67.264 17.833 1.00 35.28  ? 346  PRO A O   1 
+ATOM   2542 C  CB  . PRO A 1 327 ? 37.764  64.955 16.807 1.00 39.03  ? 346  PRO A CB  1 
+ATOM   2543 C  CG  . PRO A 1 327 ? 38.425  64.423 15.639 1.00 40.66  ? 346  PRO A CG  1 
+ATOM   2544 C  CD  . PRO A 1 327 ? 38.281  65.408 14.557 1.00 38.22  ? 346  PRO A CD  1 
+ATOM   2545 N  N   . TYR A 1 328 ? 37.537  67.985 16.929 1.00 29.23  ? 347  TYR A N   1 
+ATOM   2546 C  CA  . TYR A 1 328 ? 37.505  69.301 17.576 1.00 30.79  ? 347  TYR A CA  1 
+ATOM   2547 C  C   . TYR A 1 328 ? 36.207  70.090 17.332 1.00 30.63  ? 347  TYR A C   1 
+ATOM   2548 O  O   . TYR A 1 328 ? 35.684  70.696 18.254 1.00 33.45  ? 347  TYR A O   1 
+ATOM   2549 C  CB  . TYR A 1 328 ? 38.687  70.172 17.152 1.00 26.79  ? 347  TYR A CB  1 
+ATOM   2550 C  CG  . TYR A 1 328 ? 38.894  71.302 18.103 1.00 27.59  ? 347  TYR A CG  1 
+ATOM   2551 C  CD1 . TYR A 1 328 ? 39.497  71.099 19.333 1.00 28.08  ? 347  TYR A CD1 1 
+ATOM   2552 C  CD2 . TYR A 1 328 ? 38.458  72.571 17.794 1.00 29.80  ? 347  TYR A CD2 1 
+ATOM   2553 C  CE1 . TYR A 1 328 ? 39.677  72.139 20.214 1.00 30.53  ? 347  TYR A CE1 1 
+ATOM   2554 C  CE2 . TYR A 1 328 ? 38.627  73.622 18.669 1.00 30.41  ? 347  TYR A CE2 1 
+ATOM   2555 C  CZ  . TYR A 1 328 ? 39.236  73.413 19.877 1.00 32.26  ? 347  TYR A CZ  1 
+ATOM   2556 O  OH  . TYR A 1 328 ? 39.390  74.482 20.747 1.00 32.11  ? 347  TYR A OH  1 
+ATOM   2557 N  N   . THR A 1 329 ? 35.702  70.065 16.106 1.00 28.69  ? 348  THR A N   1 
+ATOM   2558 C  CA  . THR A 1 329 ? 34.530  70.824 15.731 1.00 28.87  ? 348  THR A CA  1 
+ATOM   2559 C  C   . THR A 1 329 ? 33.288  70.149 16.301 1.00 30.11  ? 348  THR A C   1 
+ATOM   2560 O  O   . THR A 1 329 ? 32.350  70.805 16.755 1.00 29.96  ? 348  THR A O   1 
+ATOM   2561 C  CB  . THR A 1 329 ? 34.445  70.917 14.198 1.00 29.32  ? 348  THR A CB  1 
+ATOM   2562 O  OG1 . THR A 1 329 ? 35.600  71.593 13.678 1.00 30.03  ? 348  THR A OG1 1 
+ATOM   2563 C  CG2 . THR A 1 329 ? 33.293  71.791 13.777 1.00 25.69  ? 348  THR A CG2 1 
+ATOM   2564 N  N   . ASP A 1 330 ? 33.304  68.824 16.294 1.00 30.40  ? 349  ASP A N   1 
+ATOM   2565 C  CA  . ASP A 1 330 ? 32.268  68.039 16.944 1.00 29.58  ? 349  ASP A CA  1 
+ATOM   2566 C  C   . ASP A 1 330 ? 32.248  68.306 18.463 1.00 30.96  ? 349  ASP A C   1 
+ATOM   2567 O  O   . ASP A 1 330 ? 31.211  68.252 19.103 1.00 29.35  ? 349  ASP A O   1 
+ATOM   2568 C  CB  . ASP A 1 330 ? 32.496  66.558 16.662 1.00 27.72  ? 349  ASP A CB  1 
+ATOM   2569 C  CG  . ASP A 1 330 ? 31.218  65.759 16.657 1.00 31.62  ? 349  ASP A CG  1 
+ATOM   2570 O  OD1 . ASP A 1 330 ? 30.124  66.341 16.852 1.00 37.09  ? 349  ASP A OD1 1 
+ATOM   2571 O  OD2 . ASP A 1 330 ? 31.213  64.522 16.483 1.00 33.39  ? 349  ASP A OD2 1 
+ATOM   2572 N  N   . ALA A 1 331 ? 33.402  68.613 19.032 1.00 32.56  ? 350  ALA A N   1 
+ATOM   2573 C  CA  . ALA A 1 331 ? 33.494  68.867 20.454 1.00 29.14  ? 350  ALA A CA  1 
+ATOM   2574 C  C   . ALA A 1 331 ? 32.954  70.250 20.772 1.00 29.04  ? 350  ALA A C   1 
+ATOM   2575 O  O   . ALA A 1 331 ? 32.184  70.403 21.721 1.00 28.25  ? 350  ALA A O   1 
+ATOM   2576 C  CB  . ALA A 1 331 ? 34.928  68.739 20.914 1.00 27.84  ? 350  ALA A CB  1 
+ATOM   2577 N  N   . VAL A 1 332 ? 33.381  71.252 20.002 1.00 24.90  ? 351  VAL A N   1 
+ATOM   2578 C  CA  . VAL A 1 332 ? 32.851  72.598 20.125 1.00 23.26  ? 351  VAL A CA  1 
+ATOM   2579 C  C   . VAL A 1 332 ? 31.304  72.602 20.062 1.00 26.71  ? 351  VAL A C   1 
+ATOM   2580 O  O   . VAL A 1 332 ? 30.657  73.227 20.902 1.00 19.33  ? 351  VAL A O   1 
+ATOM   2581 C  CB  . VAL A 1 332 ? 33.371  73.502 19.031 1.00 24.46  ? 351  VAL A CB  1 
+ATOM   2582 C  CG1 . VAL A 1 332 ? 32.549  74.768 18.967 1.00 27.54  ? 351  VAL A CG1 1 
+ATOM   2583 C  CG2 . VAL A 1 332 ? 34.817  73.886 19.289 1.00 29.26  ? 351  VAL A CG2 1 
+ATOM   2584 N  N   . VAL A 1 333 ? 30.719  71.907 19.079 1.00 24.41  ? 352  VAL A N   1 
+ATOM   2585 C  CA  . VAL A 1 333 ? 29.265  71.895 18.928 1.00 23.82  ? 352  VAL A CA  1 
+ATOM   2586 C  C   . VAL A 1 333 ? 28.611  71.271 20.170 1.00 21.66  ? 352  VAL A C   1 
+ATOM   2587 O  O   . VAL A 1 333 ? 27.647  71.784 20.764 1.00 20.83  ? 352  VAL A O   1 
+ATOM   2588 C  CB  . VAL A 1 333 ? 28.854  71.151 17.652 1.00 24.18  ? 352  VAL A CB  1 
+ATOM   2589 C  CG1 . VAL A 1 333 ? 27.387  70.771 17.672 1.00 30.61  ? 352  VAL A CG1 1 
+ATOM   2590 C  CG2 . VAL A 1 333 ? 29.132  72.020 16.468 1.00 28.06  ? 352  VAL A CG2 1 
+ATOM   2591 N  N   . HIS A 1 334 ? 29.159  70.139 20.547 1.00 23.41  ? 353  HIS A N   1 
+ATOM   2592 C  CA  . HIS A 1 334 ? 28.716  69.394 21.710 1.00 21.24  ? 353  HIS A CA  1 
+ATOM   2593 C  C   . HIS A 1 334 ? 28.804  70.298 22.962 1.00 25.94  ? 353  HIS A C   1 
+ATOM   2594 O  O   . HIS A 1 334 ? 27.870  70.343 23.760 1.00 22.38  ? 353  HIS A O   1 
+ATOM   2595 C  CB  . HIS A 1 334 ? 29.549  68.100 21.825 1.00 16.51  ? 353  HIS A CB  1 
+ATOM   2596 C  CG  . HIS A 1 334 ? 28.936  66.948 21.100 1.00 16.58  ? 353  HIS A CG  1 
+ATOM   2597 N  ND1 . HIS A 1 334 ? 27.944  66.212 21.690 1.00 17.64  ? 353  HIS A ND1 1 
+ATOM   2598 C  CD2 . HIS A 1 334 ? 29.176  66.363 19.891 1.00 19.51  ? 353  HIS A CD2 1 
+ATOM   2599 C  CE1 . HIS A 1 334 ? 27.519  65.285 20.848 1.00 22.78  ? 353  HIS A CE1 1 
+ATOM   2600 N  NE2 . HIS A 1 334 ? 28.250  65.354 19.750 1.00 20.64  ? 353  HIS A NE2 1 
+ATOM   2601 N  N   . GLU A 1 335 ? 29.886  71.074 23.073 1.00 27.24  ? 354  GLU A N   1 
+ATOM   2602 C  CA  . GLU A 1 335 ? 30.156  71.840 24.280 1.00 30.89  ? 354  GLU A CA  1 
+ATOM   2603 C  C   . GLU A 1 335 ? 29.371  73.145 24.343 1.00 33.73  ? 354  GLU A C   1 
+ATOM   2604 O  O   . GLU A 1 335 ? 29.126  73.650 25.437 1.00 39.55  ? 354  GLU A O   1 
+ATOM   2605 C  CB  . GLU A 1 335 ? 31.660  72.110 24.438 1.00 31.53  ? 354  GLU A CB  1 
+ATOM   2606 C  CG  . GLU A 1 335 ? 32.073  73.027 25.592 1.00 27.07  ? 354  GLU A CG  1 
+ATOM   2607 C  CD  . GLU A 1 335 ? 31.830  72.451 26.979 1.00 27.40  ? 354  GLU A CD  1 
+ATOM   2608 O  OE1 . GLU A 1 335 ? 31.411  71.277 27.113 1.00 32.29  ? 354  GLU A OE1 1 
+ATOM   2609 O  OE2 . GLU A 1 335 ? 32.091  73.178 27.960 1.00 26.04  ? 354  GLU A OE2 1 
+ATOM   2610 N  N   . VAL A 1 336 ? 28.996  73.707 23.200 1.00 32.77  ? 355  VAL A N   1 
+ATOM   2611 C  CA  . VAL A 1 336 ? 28.028  74.783 23.201 1.00 29.22  ? 355  VAL A CA  1 
+ATOM   2612 C  C   . VAL A 1 336 ? 26.707  74.238 23.784 1.00 30.25  ? 355  VAL A C   1 
+ATOM   2613 O  O   . VAL A 1 336 ? 26.129  74.839 24.662 1.00 30.12  ? 355  VAL A O   1 
+ATOM   2614 C  CB  . VAL A 1 336 ? 27.743  75.322 21.791 1.00 31.89  ? 355  VAL A CB  1 
+ATOM   2615 C  CG1 . VAL A 1 336 ? 26.503  76.251 21.817 1.00 34.46  ? 355  VAL A CG1 1 
+ATOM   2616 C  CG2 . VAL A 1 336 ? 28.922  76.074 21.254 1.00 31.17  ? 355  VAL A CG2 1 
+ATOM   2617 N  N   . GLN A 1 337 ? 26.219  73.106 23.307 1.00 24.15  ? 356  GLN A N   1 
+ATOM   2618 C  CA  . GLN A 1 337 ? 24.900  72.707 23.724 1.00 25.64  ? 356  GLN A CA  1 
+ATOM   2619 C  C   . GLN A 1 337 ? 24.848  72.435 25.229 1.00 27.20  ? 356  GLN A C   1 
+ATOM   2620 O  O   . GLN A 1 337 ? 23.850  72.729 25.880 1.00 32.37  ? 356  GLN A O   1 
+ATOM   2621 C  CB  . GLN A 1 337 ? 24.408  71.497 22.939 1.00 26.62  ? 356  GLN A CB  1 
+ATOM   2622 C  CG  . GLN A 1 337 ? 23.998  71.796 21.501 1.00 26.68  ? 356  GLN A CG  1 
+ATOM   2623 C  CD  . GLN A 1 337 ? 23.187  70.659 20.912 1.00 32.23  ? 356  GLN A CD  1 
+ATOM   2624 O  OE1 . GLN A 1 337 ? 23.745  69.740 20.293 1.00 25.54  ? 356  GLN A OE1 1 
+ATOM   2625 N  NE2 . GLN A 1 337 ? 21.867  70.689 21.143 1.00 31.83  ? 356  GLN A NE2 1 
+ATOM   2626 N  N   . ARG A 1 338 ? 25.915  71.871 25.775 1.00 32.46  ? 357  ARG A N   1 
+ATOM   2627 C  CA  . ARG A 1 338 ? 25.968  71.456 27.185 1.00 29.00  ? 357  ARG A CA  1 
+ATOM   2628 C  C   . ARG A 1 338 ? 26.123  72.690 28.081 1.00 30.68  ? 357  ARG A C   1 
+ATOM   2629 O  O   . ARG A 1 338 ? 25.471  72.813 29.100 1.00 28.19  ? 357  ARG A O   1 
+ATOM   2630 C  CB  . ARG A 1 338 ? 27.155  70.517 27.393 1.00 28.92  ? 357  ARG A CB  1 
+ATOM   2631 C  CG  . ARG A 1 338 ? 27.389  70.013 28.834 1.00 27.34  ? 357  ARG A CG  1 
+ATOM   2632 C  CD  . ARG A 1 338 ? 28.850  69.761 29.183 1.00 21.76  ? 357  ARG A CD  1 
+ATOM   2633 N  NE  . ARG A 1 338 ? 29.613  71.006 29.239 1.00 20.30  ? 357  ARG A NE  1 
+ATOM   2634 C  CZ  . ARG A 1 338 ? 29.607  71.832 30.275 1.00 26.65  ? 357  ARG A CZ  1 
+ATOM   2635 N  NH1 . ARG A 1 338 ? 30.327  72.966 30.246 1.00 28.28  ? 357  ARG A NH1 1 
+ATOM   2636 N  NH2 . ARG A 1 338 ? 28.864  71.553 31.344 1.00 29.58  ? 357  ARG A NH2 1 
+ATOM   2637 N  N   . TYR A 1 339 ? 27.031  73.578 27.714 1.00 31.54  ? 358  TYR A N   1 
+ATOM   2638 C  CA  . TYR A 1 339 ? 27.294  74.775 28.508 1.00 33.57  ? 358  TYR A CA  1 
+ATOM   2639 C  C   . TYR A 1 339 ? 26.015  75.598 28.678 1.00 35.24  ? 358  TYR A C   1 
+ATOM   2640 O  O   . TYR A 1 339 ? 25.637  75.904 29.807 1.00 34.42  ? 358  TYR A O   1 
+ATOM   2641 C  CB  . TYR A 1 339 ? 28.390  75.621 27.841 1.00 33.35  ? 358  TYR A CB  1 
+ATOM   2642 C  CG  . TYR A 1 339 ? 28.602  77.013 28.411 1.00 35.89  ? 358  TYR A CG  1 
+ATOM   2643 C  CD1 . TYR A 1 339 ? 28.162  78.124 27.730 1.00 37.80  ? 358  TYR A CD1 1 
+ATOM   2644 C  CD2 . TYR A 1 339 ? 29.267  77.214 29.611 1.00 38.26  ? 358  TYR A CD2 1 
+ATOM   2645 C  CE1 . TYR A 1 339 ? 28.349  79.386 28.221 1.00 38.98  ? 358  TYR A CE1 1 
+ATOM   2646 C  CE2 . TYR A 1 339 ? 29.466  78.498 30.117 1.00 39.61  ? 358  TYR A CE2 1 
+ATOM   2647 C  CZ  . TYR A 1 339 ? 29.001  79.583 29.410 1.00 40.53  ? 358  TYR A CZ  1 
+ATOM   2648 O  OH  . TYR A 1 339 ? 29.178  80.882 29.863 1.00 45.09  ? 358  TYR A OH  1 
+ATOM   2649 N  N   . ILE A 1 340 ? 25.359  75.919 27.555 1.00 33.12  ? 359  ILE A N   1 
+ATOM   2650 C  CA  . ILE A 1 340 ? 24.249  76.890 27.513 1.00 31.80  ? 359  ILE A CA  1 
+ATOM   2651 C  C   . ILE A 1 340 ? 22.920  76.405 28.122 1.00 33.24  ? 359  ILE A C   1 
+ATOM   2652 O  O   . ILE A 1 340 ? 22.084  77.238 28.473 1.00 35.91  ? 359  ILE A O   1 
+ATOM   2653 C  CB  . ILE A 1 340 ? 23.972  77.407 26.078 1.00 25.98  ? 359  ILE A CB  1 
+ATOM   2654 C  CG1 . ILE A 1 340 ? 23.379  76.311 25.196 1.00 27.10  ? 359  ILE A CG1 1 
+ATOM   2655 C  CG2 . ILE A 1 340 ? 25.207  77.995 25.473 1.00 26.65  ? 359  ILE A CG2 1 
+ATOM   2656 C  CD1 . ILE A 1 340 ? 23.143  76.767 23.766 1.00 29.84  ? 359  ILE A CD1 1 
+ATOM   2657 N  N   . ASP A 1 341 ? 22.725  75.086 28.189 1.00 32.41  ? 360  ASP A N   1 
+ATOM   2658 C  CA  . ASP A 1 341 ? 21.607  74.468 28.917 1.00 36.39  ? 360  ASP A CA  1 
+ATOM   2659 C  C   . ASP A 1 341 ? 20.277  75.225 28.708 1.00 34.02  ? 360  ASP A C   1 
+ATOM   2660 O  O   . ASP A 1 341 ? 19.709  75.792 29.627 1.00 39.31  ? 360  ASP A O   1 
+ATOM   2661 C  CB  . ASP A 1 341 ? 22.015  74.340 30.399 1.00 35.84  ? 360  ASP A CB  1 
+ATOM   2662 C  CG  . ASP A 1 341 ? 20.963  73.677 31.266 1.00 38.31  ? 360  ASP A CG  1 
+ATOM   2663 O  OD1 . ASP A 1 341 ? 20.823  74.124 32.440 1.00 43.89  ? 360  ASP A OD1 1 
+ATOM   2664 O  OD2 . ASP A 1 341 ? 20.230  72.745 30.865 1.00 35.52  ? 360  ASP A OD2 1 
+ATOM   2665 N  N   . LEU A 1 342 ? 19.822  75.229 27.466 1.00 37.37  ? 361  LEU A N   1 
+ATOM   2666 C  CA  . LEU A 1 342 ? 18.712  76.083 26.969 1.00 37.08  ? 361  LEU A CA  1 
+ATOM   2667 C  C   . LEU A 1 342 ? 17.317  75.647 27.484 1.00 34.38  ? 361  LEU A C   1 
+ATOM   2668 O  O   . LEU A 1 342 ? 16.384  76.437 27.550 1.00 33.64  ? 361  LEU A O   1 
+ATOM   2669 C  CB  . LEU A 1 342 ? 18.715  76.073 25.411 1.00 34.27  ? 361  LEU A CB  1 
+ATOM   2670 C  CG  . LEU A 1 342 ? 19.147  77.342 24.658 1.00 36.22  ? 361  LEU A CG  1 
+ATOM   2671 C  CD1 . LEU A 1 342 ? 20.318  78.066 25.291 1.00 38.73  ? 361  LEU A CD1 1 
+ATOM   2672 C  CD2 . LEU A 1 342 ? 19.454  77.033 23.212 1.00 37.36  ? 361  LEU A CD2 1 
+ATOM   2673 N  N   . LEU A 1 343 ? 17.198  74.374 27.828 1.00 31.81  ? 362  LEU A N   1 
+ATOM   2674 C  CA  . LEU A 1 343 ? 16.001  73.816 28.405 1.00 29.27  ? 362  LEU A CA  1 
+ATOM   2675 C  C   . LEU A 1 343 ? 16.340  73.112 29.719 1.00 28.33  ? 362  LEU A C   1 
+ATOM   2676 O  O   . LEU A 1 343 ? 16.373  71.886 29.779 1.00 28.77  ? 362  LEU A O   1 
+ATOM   2677 C  CB  . LEU A 1 343 ? 15.404  72.839 27.425 1.00 31.20  ? 362  LEU A CB  1 
+ATOM   2678 C  CG  . LEU A 1 343 ? 15.114  73.511 26.091 1.00 37.57  ? 362  LEU A CG  1 
+ATOM   2679 C  CD1 . LEU A 1 343 ? 14.665  72.465 25.098 1.00 39.93  ? 362  LEU A CD1 1 
+ATOM   2680 C  CD2 . LEU A 1 343 ? 14.057  74.604 26.270 1.00 40.59  ? 362  LEU A CD2 1 
+ATOM   2681 N  N   . PRO A 1 344 ? 16.581  73.897 30.768 1.00 30.06  ? 363  PRO A N   1 
+ATOM   2682 C  CA  . PRO A 1 344 ? 17.049  73.387 32.069 1.00 30.46  ? 363  PRO A CA  1 
+ATOM   2683 C  C   . PRO A 1 344 ? 16.210  72.286 32.707 1.00 32.68  ? 363  PRO A C   1 
+ATOM   2684 O  O   . PRO A 1 344 ? 16.772  71.500 33.498 1.00 33.42  ? 363  PRO A O   1 
+ATOM   2685 C  CB  . PRO A 1 344 ? 16.998  74.628 32.940 1.00 32.09  ? 363  PRO A CB  1 
+ATOM   2686 C  CG  . PRO A 1 344 ? 17.178  75.751 32.005 1.00 28.66  ? 363  PRO A CG  1 
+ATOM   2687 C  CD  . PRO A 1 344 ? 16.443  75.365 30.788 1.00 28.38  ? 363  PRO A CD  1 
+ATOM   2688 N  N   . THR A 1 345 ? 14.908  72.268 32.385 1.00 33.31  ? 364  THR A N   1 
+ATOM   2689 C  CA  . THR A 1 345 ? 13.951  71.282 32.870 1.00 32.35  ? 364  THR A CA  1 
+ATOM   2690 C  C   . THR A 1 345 ? 13.175  70.693 31.705 1.00 35.43  ? 364  THR A C   1 
+ATOM   2691 O  O   . THR A 1 345 ? 11.974  70.489 31.780 1.00 45.83  ? 364  THR A O   1 
+ATOM   2692 C  CB  . THR A 1 345 ? 12.981  71.920 33.894 1.00 35.89  ? 364  THR A CB  1 
+ATOM   2693 O  OG1 . THR A 1 345 ? 12.129  72.909 33.269 1.00 33.88  ? 364  THR A OG1 1 
+ATOM   2694 C  CG2 . THR A 1 345 ? 13.764  72.683 34.963 1.00 36.02  ? 364  THR A CG2 1 
+ATOM   2695 N  N   . SER A 1 346 ? 13.908  70.337 30.664 1.00 35.48  ? 365  SER A N   1 
+ATOM   2696 C  CA  . SER A 1 346 ? 13.375  70.111 29.337 1.00 35.40  ? 365  SER A CA  1 
+ATOM   2697 C  C   . SER A 1 346 ? 11.943  70.613 29.202 1.00 34.98  ? 365  SER A C   1 
+ATOM   2698 O  O   . SER A 1 346 ? 11.719  71.799 29.304 1.00 28.74  ? 365  SER A O   1 
+ATOM   2699 C  CB  . SER A 1 346 ? 13.524  68.652 28.914 1.00 31.45  ? 365  SER A CB  1 
+ATOM   2700 O  OG  . SER A 1 346 ? 12.951  67.847 29.874 1.00 36.34  ? 365  SER A OG  1 
+ATOM   2701 N  N   . LEU A 1 347 ? 11.005  69.707 28.936 1.00 35.98  ? 366  LEU A N   1 
+ATOM   2702 C  CA  . LEU A 1 347 ? 9.594   70.009 28.897 1.00 36.81  ? 366  LEU A CA  1 
+ATOM   2703 C  C   . LEU A 1 347 ? 9.003   69.108 29.946 1.00 37.67  ? 366  LEU A C   1 
+ATOM   2704 O  O   . LEU A 1 347 ? 9.525   68.010 30.153 1.00 37.14  ? 366  LEU A O   1 
+ATOM   2705 C  CB  . LEU A 1 347 ? 8.989   69.683 27.519 1.00 36.92  ? 366  LEU A CB  1 
+ATOM   2706 C  CG  . LEU A 1 347 ? 8.621   70.863 26.596 1.00 36.76  ? 366  LEU A CG  1 
+ATOM   2707 C  CD1 . LEU A 1 347 ? 9.655   71.974 26.555 1.00 33.00  ? 366  LEU A CD1 1 
+ATOM   2708 C  CD2 . LEU A 1 347 ? 8.382   70.360 25.188 1.00 38.11  ? 366  LEU A CD2 1 
+ATOM   2709 N  N   . PRO A 1 348 ? 7.895   69.525 30.563 1.00 35.19  ? 367  PRO A N   1 
+ATOM   2710 C  CA  . PRO A 1 348 ? 7.395   68.836 31.733 1.00 34.65  ? 367  PRO A CA  1 
+ATOM   2711 C  C   . PRO A 1 348 ? 6.899   67.510 31.290 1.00 33.99  ? 367  PRO A C   1 
+ATOM   2712 O  O   . PRO A 1 348 ? 6.251   67.436 30.279 1.00 31.95  ? 367  PRO A O   1 
+ATOM   2713 C  CB  . PRO A 1 348 ? 6.244   69.709 32.198 1.00 38.85  ? 367  PRO A CB  1 
+ATOM   2714 C  CG  . PRO A 1 348 ? 6.330   70.950 31.423 1.00 38.94  ? 367  PRO A CG  1 
+ATOM   2715 C  CD  . PRO A 1 348 ? 6.992   70.602 30.155 1.00 36.89  ? 367  PRO A CD  1 
+ATOM   2716 N  N   . HIS A 1 349 ? 7.271   66.476 32.019 1.00 38.71  ? 368  HIS A N   1 
+ATOM   2717 C  CA  . HIS A 1 349 ? 6.802   65.127 31.796 1.00 41.26  ? 368  HIS A CA  1 
+ATOM   2718 C  C   . HIS A 1 349 ? 5.621   64.840 32.729 1.00 44.94  ? 368  HIS A C   1 
+ATOM   2719 O  O   . HIS A 1 349 ? 5.198   65.708 33.501 1.00 44.24  ? 368  HIS A O   1 
+ATOM   2720 C  CB  . HIS A 1 349 ? 7.954   64.167 32.077 1.00 41.76  ? 368  HIS A CB  1 
+ATOM   2721 C  CG  . HIS A 1 349 ? 8.858   63.966 30.910 1.00 38.54  ? 368  HIS A CG  1 
+ATOM   2722 N  ND1 . HIS A 1 349 ? 8.996   62.746 30.285 1.00 37.42  ? 368  HIS A ND1 1 
+ATOM   2723 C  CD2 . HIS A 1 349 ? 9.665   64.829 30.251 1.00 37.83  ? 368  HIS A CD2 1 
+ATOM   2724 C  CE1 . HIS A 1 349 ? 9.845   62.870 29.283 1.00 42.40  ? 368  HIS A CE1 1 
+ATOM   2725 N  NE2 . HIS A 1 349 ? 10.260  64.125 29.239 1.00 41.82  ? 368  HIS A NE2 1 
+ATOM   2726 N  N   . ALA A 1 350 ? 5.094   63.621 32.662 1.00 49.31  ? 369  ALA A N   1 
+ATOM   2727 C  CA  . ALA A 1 350 ? 3.971   63.215 33.515 1.00 50.92  ? 369  ALA A CA  1 
+ATOM   2728 C  C   . ALA A 1 350 ? 3.848   61.717 33.483 1.00 46.31  ? 369  ALA A C   1 
+ATOM   2729 O  O   . ALA A 1 350 ? 3.971   61.140 32.417 1.00 45.35  ? 369  ALA A O   1 
+ATOM   2730 C  CB  . ALA A 1 350 ? 2.681   63.851 33.016 1.00 54.32  ? 369  ALA A CB  1 
+ATOM   2731 N  N   . VAL A 1 351 ? 3.613   61.083 34.632 1.00 49.70  ? 370  VAL A N   1 
+ATOM   2732 C  CA  . VAL A 1 351 ? 3.582   59.608 34.679 1.00 51.76  ? 370  VAL A CA  1 
+ATOM   2733 C  C   . VAL A 1 351 ? 2.310   59.009 34.088 1.00 53.45  ? 370  VAL A C   1 
+ATOM   2734 O  O   . VAL A 1 351 ? 1.235   59.610 34.119 1.00 51.53  ? 370  VAL A O   1 
+ATOM   2735 C  CB  . VAL A 1 351 ? 3.823   59.023 36.090 1.00 52.59  ? 370  VAL A CB  1 
+ATOM   2736 C  CG1 . VAL A 1 351 ? 5.258   59.233 36.516 1.00 54.88  ? 370  VAL A CG1 1 
+ATOM   2737 C  CG2 . VAL A 1 351 ? 2.879   59.616 37.117 1.00 56.00  ? 370  VAL A CG2 1 
+ATOM   2738 N  N   . THR A 1 352 ? 2.465   57.801 33.570 1.00 58.06  ? 371  THR A N   1 
+ATOM   2739 C  CA  . THR A 1 352 ? 1.426   57.087 32.838 1.00 64.22  ? 371  THR A CA  1 
+ATOM   2740 C  C   . THR A 1 352 ? 0.451   56.328 33.753 1.00 68.39  ? 371  THR A C   1 
+ATOM   2741 O  O   . THR A 1 352 ? -0.672  56.033 33.357 1.00 70.16  ? 371  THR A O   1 
+ATOM   2742 C  CB  . THR A 1 352 ? 2.120   56.126 31.860 1.00 65.10  ? 371  THR A CB  1 
+ATOM   2743 O  OG1 . THR A 1 352 ? 2.632   56.887 30.755 1.00 64.52  ? 371  THR A OG1 1 
+ATOM   2744 C  CG2 . THR A 1 352 ? 1.140   55.111 31.240 1.00 66.78  ? 371  THR A CG2 1 
+ATOM   2745 N  N   . CYS A 1 353 ? 0.895   56.010 34.967 1.00 74.13  ? 372  CYS A N   1 
+ATOM   2746 C  CA  . CYS A 1 353 ? 0.059   55.348 35.975 1.00 78.39  ? 372  CYS A CA  1 
+ATOM   2747 C  C   . CYS A 1 353 ? 0.737   55.380 37.347 1.00 79.69  ? 372  CYS A C   1 
+ATOM   2748 O  O   . CYS A 1 353 ? 1.899   55.787 37.471 1.00 78.39  ? 372  CYS A O   1 
+ATOM   2749 C  CB  . CYS A 1 353 ? -0.203  53.906 35.577 1.00 79.75  ? 372  CYS A CB  1 
+ATOM   2750 S  SG  . CYS A 1 353 ? 1.329   53.138 35.073 1.00 86.75  ? 372  CYS A SG  1 
+ATOM   2751 N  N   . ASP A 1 354 ? 0.007   54.947 38.374 1.00 81.71  ? 373  ASP A N   1 
+ATOM   2752 C  CA  . ASP A 1 354 ? 0.540   54.946 39.737 1.00 83.09  ? 373  ASP A CA  1 
+ATOM   2753 C  C   . ASP A 1 354 ? 1.785   54.065 39.744 1.00 81.89  ? 373  ASP A C   1 
+ATOM   2754 O  O   . ASP A 1 354 ? 1.768   52.967 39.189 1.00 81.00  ? 373  ASP A O   1 
+ATOM   2755 C  CB  . ASP A 1 354 ? -0.494  54.433 40.746 1.00 84.64  ? 373  ASP A CB  1 
+ATOM   2756 C  CG  . ASP A 1 354 ? -1.775  55.261 40.750 1.00 85.86  ? 373  ASP A CG  1 
+ATOM   2757 O  OD1 . ASP A 1 354 ? -2.710  54.928 39.991 1.00 86.72  ? 373  ASP A OD1 1 
+ATOM   2758 O  OD2 . ASP A 1 354 ? -1.943  56.255 41.484 1.00 88.06  ? 373  ASP A OD2 1 
+ATOM   2759 N  N   . ILE A 1 355 ? 2.868   54.561 40.338 1.00 79.99  ? 374  ILE A N   1 
+ATOM   2760 C  CA  . ILE A 1 355 ? 4.151   53.869 40.268 1.00 79.85  ? 374  ILE A CA  1 
+ATOM   2761 C  C   . ILE A 1 355 ? 5.067   54.224 41.428 1.00 77.53  ? 374  ILE A C   1 
+ATOM   2762 O  O   . ILE A 1 355 ? 5.196   55.387 41.791 1.00 77.21  ? 374  ILE A O   1 
+ATOM   2763 C  CB  . ILE A 1 355 ? 4.865   54.166 38.912 1.00 81.61  ? 374  ILE A CB  1 
+ATOM   2764 C  CG1 . ILE A 1 355 ? 6.067   53.225 38.712 1.00 84.85  ? 374  ILE A CG1 1 
+ATOM   2765 C  CG2 . ILE A 1 355 ? 5.304   55.647 38.817 1.00 80.05  ? 374  ILE A CG2 1 
+ATOM   2766 C  CD1 . ILE A 1 355 ? 5.746   51.705 38.820 1.00 86.72  ? 374  ILE A CD1 1 
+ATOM   2767 N  N   . LYS A 1 356 ? 5.709   53.209 41.998 1.00 75.84  ? 375  LYS A N   1 
+ATOM   2768 C  CA  . LYS A 1 356 ? 6.678   53.424 43.059 1.00 74.75  ? 375  LYS A CA  1 
+ATOM   2769 C  C   . LYS A 1 356 ? 8.012   53.742 42.426 1.00 70.55  ? 375  LYS A C   1 
+ATOM   2770 O  O   . LYS A 1 356 ? 8.498   52.977 41.607 1.00 70.03  ? 375  LYS A O   1 
+ATOM   2771 C  CB  . LYS A 1 356 ? 6.800   52.181 43.937 1.00 78.00  ? 375  LYS A CB  1 
+ATOM   2772 C  CG  . LYS A 1 356 ? 7.562   52.434 45.237 1.00 81.14  ? 375  LYS A CG  1 
+ATOM   2773 C  CD  . LYS A 1 356 ? 7.379   51.303 46.251 1.00 83.19  ? 375  LYS A CD  1 
+ATOM   2774 C  CE  . LYS A 1 356 ? 8.342   50.148 45.992 1.00 82.95  ? 375  LYS A CE  1 
+ATOM   2775 N  NZ  . LYS A 1 356 ? 7.879   48.913 46.673 1.00 81.62  ? 375  LYS A NZ  1 
+ATOM   2776 N  N   . PHE A 1 357 ? 8.602   54.872 42.784 1.00 65.90  ? 376  PHE A N   1 
+ATOM   2777 C  CA  . PHE A 1 357 ? 9.883   55.242 42.208 1.00 63.55  ? 376  PHE A CA  1 
+ATOM   2778 C  C   . PHE A 1 357 ? 10.864  55.571 43.319 1.00 63.42  ? 376  PHE A C   1 
+ATOM   2779 O  O   . PHE A 1 357 ? 10.607  56.484 44.096 1.00 59.92  ? 376  PHE A O   1 
+ATOM   2780 C  CB  . PHE A 1 357 ? 9.735   56.433 41.255 1.00 62.64  ? 376  PHE A CB  1 
+ATOM   2781 C  CG  . PHE A 1 357 ? 11.034  56.860 40.630 1.00 61.84  ? 376  PHE A CG  1 
+ATOM   2782 C  CD1 . PHE A 1 357 ? 11.547  56.184 39.525 1.00 63.22  ? 376  PHE A CD1 1 
+ATOM   2783 C  CD2 . PHE A 1 357 ? 11.772  57.906 41.172 1.00 59.38  ? 376  PHE A CD2 1 
+ATOM   2784 C  CE1 . PHE A 1 357 ? 12.767  56.562 38.958 1.00 62.75  ? 376  PHE A CE1 1 
+ATOM   2785 C  CE2 . PHE A 1 357 ? 12.987  58.284 40.613 1.00 59.67  ? 376  PHE A CE2 1 
+ATOM   2786 C  CZ  . PHE A 1 357 ? 13.482  57.620 39.502 1.00 61.36  ? 376  PHE A CZ  1 
+ATOM   2787 N  N   . ARG A 1 358 ? 11.988  54.840 43.367 1.00 63.55  ? 377  ARG A N   1 
+ATOM   2788 C  CA  . ARG A 1 358 ? 12.946  54.899 44.479 1.00 64.90  ? 377  ARG A CA  1 
+ATOM   2789 C  C   . ARG A 1 358 ? 12.193  54.778 45.807 1.00 67.20  ? 377  ARG A C   1 
+ATOM   2790 O  O   . ARG A 1 358 ? 12.446  55.542 46.764 1.00 63.23  ? 377  ARG A O   1 
+ATOM   2791 C  CB  . ARG A 1 358 ? 13.787  56.190 44.455 1.00 65.78  ? 377  ARG A CB  1 
+ATOM   2792 C  CG  . ARG A 1 358 ? 14.558  56.448 43.159 1.00 66.64  ? 377  ARG A CG  1 
+ATOM   2793 C  CD  . ARG A 1 358 ? 16.023  56.050 43.180 1.00 65.06  ? 377  ARG A CD  1 
+ATOM   2794 N  NE  . ARG A 1 358 ? 16.903  57.221 43.243 1.00 64.64  ? 377  ARG A NE  1 
+ATOM   2795 C  CZ  . ARG A 1 358 ? 17.932  57.465 42.427 1.00 65.04  ? 377  ARG A CZ  1 
+ATOM   2796 N  NH1 . ARG A 1 358 ? 18.254  56.633 41.448 1.00 65.46  ? 377  ARG A NH1 1 
+ATOM   2797 N  NH2 . ARG A 1 358 ? 18.658  58.563 42.593 1.00 68.71  ? 377  ARG A NH2 1 
+ATOM   2798 N  N   . ASN A 1 359 ? 11.247  53.833 45.835 1.00 68.64  ? 378  ASN A N   1 
+ATOM   2799 C  CA  . ASN A 1 359 ? 10.378  53.615 46.979 1.00 71.70  ? 378  ASN A CA  1 
+ATOM   2800 C  C   . ASN A 1 359 ? 9.563   54.872 47.411 1.00 72.67  ? 378  ASN A C   1 
+ATOM   2801 O  O   . ASN A 1 359 ? 9.567   55.203 48.599 1.00 73.51  ? 378  ASN A O   1 
+ATOM   2802 C  CB  . ASN A 1 359 ? 11.249  53.079 48.130 1.00 74.51  ? 378  ASN A CB  1 
+ATOM   2803 C  CG  . ASN A 1 359 ? 10.442  52.595 49.317 1.00 79.16  ? 378  ASN A CG  1 
+ATOM   2804 O  OD1 . ASN A 1 359 ? 10.807  52.859 50.464 1.00 82.37  ? 378  ASN A OD1 1 
+ATOM   2805 N  ND2 . ASN A 1 359 ? 9.342   51.881 49.056 1.00 83.72  ? 378  ASN A ND2 1 
+ATOM   2806 N  N   . TYR A 1 360 ? 8.871   55.561 46.478 1.00 72.33  ? 379  TYR A N   1 
+ATOM   2807 C  CA  . TYR A 1 360 ? 8.138   56.813 46.820 1.00 72.28  ? 379  TYR A CA  1 
+ATOM   2808 C  C   . TYR A 1 360 ? 6.637   56.920 46.493 1.00 74.73  ? 379  TYR A C   1 
+ATOM   2809 O  O   . TYR A 1 360 ? 5.950   57.771 47.087 1.00 80.37  ? 379  TYR A O   1 
+ATOM   2810 C  CB  . TYR A 1 360 ? 8.849   58.062 46.265 1.00 70.80  ? 379  TYR A CB  1 
+ATOM   2811 C  CG  . TYR A 1 360 ? 9.936   58.580 47.178 1.00 69.60  ? 379  TYR A CG  1 
+ATOM   2812 C  CD1 . TYR A 1 360 ? 11.265  58.682 46.740 1.00 68.26  ? 379  TYR A CD1 1 
+ATOM   2813 C  CD2 . TYR A 1 360 ? 9.647   58.933 48.492 1.00 67.41  ? 379  TYR A CD2 1 
+ATOM   2814 C  CE1 . TYR A 1 360 ? 12.268  59.136 47.592 1.00 68.17  ? 379  TYR A CE1 1 
+ATOM   2815 C  CE2 . TYR A 1 360 ? 10.637  59.378 49.348 1.00 66.97  ? 379  TYR A CE2 1 
+ATOM   2816 C  CZ  . TYR A 1 360 ? 11.941  59.482 48.897 1.00 68.52  ? 379  TYR A CZ  1 
+ATOM   2817 O  OH  . TYR A 1 360 ? 12.910  59.933 49.758 1.00 68.54  ? 379  TYR A OH  1 
+ATOM   2818 N  N   . LEU A 1 361 ? 6.128   56.074 45.599 1.00 73.85  ? 380  LEU A N   1 
+ATOM   2819 C  CA  . LEU A 1 361 ? 4.720   56.131 45.144 1.00 74.67  ? 380  LEU A CA  1 
+ATOM   2820 C  C   . LEU A 1 361 ? 4.361   57.485 44.525 1.00 72.92  ? 380  LEU A C   1 
+ATOM   2821 O  O   . LEU A 1 361 ? 4.202   58.493 45.229 1.00 72.31  ? 380  LEU A O   1 
+ATOM   2822 C  CB  . LEU A 1 361 ? 3.705   55.770 46.259 1.00 75.96  ? 380  LEU A CB  1 
+ATOM   2823 C  CG  . LEU A 1 361 ? 2.211   56.098 45.998 1.00 76.68  ? 380  LEU A CG  1 
+ATOM   2824 C  CD1 . LEU A 1 361 ? 1.678   55.405 44.721 1.00 74.64  ? 380  LEU A CD1 1 
+ATOM   2825 C  CD2 . LEU A 1 361 ? 1.324   55.775 47.237 1.00 77.75  ? 380  LEU A CD2 1 
+ATOM   2826 N  N   . ILE A 1 362 ? 4.216   57.482 43.202 1.00 69.57  ? 381  ILE A N   1 
+ATOM   2827 C  CA  . ILE A 1 362 ? 3.912   58.682 42.440 1.00 65.88  ? 381  ILE A CA  1 
+ATOM   2828 C  C   . ILE A 1 362 ? 2.679   58.376 41.609 1.00 60.46  ? 381  ILE A C   1 
+ATOM   2829 O  O   . ILE A 1 362 ? 2.724   57.554 40.702 1.00 57.61  ? 381  ILE A O   1 
+ATOM   2830 C  CB  . ILE A 1 362 ? 5.102   59.087 41.539 1.00 66.32  ? 381  ILE A CB  1 
+ATOM   2831 C  CG1 . ILE A 1 362 ? 6.291   59.528 42.400 1.00 67.08  ? 381  ILE A CG1 1 
+ATOM   2832 C  CG2 . ILE A 1 362 ? 4.695   60.217 40.587 1.00 65.68  ? 381  ILE A CG2 1 
+ATOM   2833 C  CD1 . ILE A 1 362 ? 7.615   59.611 41.649 1.00 67.61  ? 381  ILE A CD1 1 
+ATOM   2834 N  N   . PRO A 1 363 ? 1.577   59.044 41.919 1.00 59.04  ? 382  PRO A N   1 
+ATOM   2835 C  CA  . PRO A 1 363 ? 0.291   58.728 41.280 1.00 59.48  ? 382  PRO A CA  1 
+ATOM   2836 C  C   . PRO A 1 363 ? 0.183   59.178 39.819 1.00 57.50  ? 382  PRO A C   1 
+ATOM   2837 O  O   . PRO A 1 363 ? 0.771   60.191 39.435 1.00 52.62  ? 382  PRO A O   1 
+ATOM   2838 C  CB  . PRO A 1 363 ? -0.740  59.454 42.165 1.00 57.06  ? 382  PRO A CB  1 
+ATOM   2839 C  CG  . PRO A 1 363 ? 0.018   60.513 42.894 1.00 57.04  ? 382  PRO A CG  1 
+ATOM   2840 C  CD  . PRO A 1 363 ? 1.464   60.147 42.891 1.00 58.04  ? 382  PRO A CD  1 
+ATOM   2841 N  N   . LYS A 1 364 ? -0.576  58.407 39.044 1.00 57.01  ? 383  LYS A N   1 
+ATOM   2842 C  CA  . LYS A 1 364 ? -0.850  58.672 37.624 1.00 58.31  ? 383  LYS A CA  1 
+ATOM   2843 C  C   . LYS A 1 364 ? -1.129  60.137 37.327 1.00 56.44  ? 383  LYS A C   1 
+ATOM   2844 O  O   . LYS A 1 364 ? -1.916  60.774 38.014 1.00 59.04  ? 383  LYS A O   1 
+ATOM   2845 C  CB  . LYS A 1 364 ? -2.065  57.856 37.162 1.00 60.06  ? 383  LYS A CB  1 
+ATOM   2846 C  CG  . LYS A 1 364 ? -2.364  57.923 35.663 1.00 63.41  ? 383  LYS A CG  1 
+ATOM   2847 C  CD  . LYS A 1 364 ? -3.314  56.789 35.219 1.00 64.44  ? 383  LYS A CD  1 
+ATOM   2848 C  CE  . LYS A 1 364 ? -3.776  56.971 33.776 1.00 64.20  ? 383  LYS A CE  1 
+ATOM   2849 N  NZ  . LYS A 1 364 ? -5.063  56.290 33.481 1.00 64.15  ? 383  LYS A NZ  1 
+ATOM   2850 N  N   . GLY A 1 365 ? -0.475  60.658 36.296 1.00 53.71  ? 384  GLY A N   1 
+ATOM   2851 C  CA  . GLY A 1 365 ? -0.707  62.005 35.829 1.00 50.94  ? 384  GLY A CA  1 
+ATOM   2852 C  C   . GLY A 1 365 ? -0.051  63.083 36.657 1.00 49.27  ? 384  GLY A C   1 
+ATOM   2853 O  O   . GLY A 1 365 ? -0.271  64.266 36.394 1.00 48.92  ? 384  GLY A O   1 
+ATOM   2854 N  N   . THR A 1 366 ? 0.743   62.690 37.651 1.00 48.30  ? 385  THR A N   1 
+ATOM   2855 C  CA  . THR A 1 366 ? 1.552   63.644 38.405 1.00 47.88  ? 385  THR A CA  1 
+ATOM   2856 C  C   . THR A 1 366 ? 2.619   64.199 37.510 1.00 46.80  ? 385  THR A C   1 
+ATOM   2857 O  O   . THR A 1 366 ? 3.356   63.448 36.886 1.00 50.00  ? 385  THR A O   1 
+ATOM   2858 C  CB  . THR A 1 366 ? 2.265   62.975 39.544 1.00 48.26  ? 385  THR A CB  1 
+ATOM   2859 O  OG1 . THR A 1 366 ? 1.309   62.502 40.499 1.00 55.82  ? 385  THR A OG1 1 
+ATOM   2860 C  CG2 . THR A 1 366 ? 3.133   63.982 40.298 1.00 46.09  ? 385  THR A CG2 1 
+ATOM   2861 N  N   . THR A 1 367 ? 2.714   65.512 37.469 1.00 44.57  ? 386  THR A N   1 
+ATOM   2862 C  CA  . THR A 1 367 ? 3.714   66.173 36.656 1.00 44.39  ? 386  THR A CA  1 
+ATOM   2863 C  C   . THR A 1 367 ? 5.138   65.986 37.205 1.00 43.69  ? 386  THR A C   1 
+ATOM   2864 O  O   . THR A 1 367 ? 5.372   66.091 38.415 1.00 44.01  ? 386  THR A O   1 
+ATOM   2865 C  CB  . THR A 1 367 ? 3.381   67.653 36.597 1.00 44.49  ? 386  THR A CB  1 
+ATOM   2866 O  OG1 . THR A 1 367 ? 2.143   67.841 35.901 1.00 42.09  ? 386  THR A OG1 1 
+ATOM   2867 C  CG2 . THR A 1 367 ? 4.423   68.413 35.796 1.00 44.50  ? 386  THR A CG2 1 
+ATOM   2868 N  N   . ILE A 1 368 ? 6.067   65.719 36.284 1.00 43.27  ? 387  ILE A N   1 
+ATOM   2869 C  CA  . ILE A 1 368 ? 7.492   65.486 36.556 1.00 40.10  ? 387  ILE A CA  1 
+ATOM   2870 C  C   . ILE A 1 368 ? 8.344   66.554 35.872 1.00 36.22  ? 387  ILE A C   1 
+ATOM   2871 O  O   . ILE A 1 368 ? 8.190   66.782 34.690 1.00 35.52  ? 387  ILE A O   1 
+ATOM   2872 C  CB  . ILE A 1 368 ? 7.954   64.107 35.995 1.00 39.64  ? 387  ILE A CB  1 
+ATOM   2873 C  CG1 . ILE A 1 368 ? 6.922   62.994 36.241 1.00 39.36  ? 387  ILE A CG1 1 
+ATOM   2874 C  CG2 . ILE A 1 368 ? 9.276   63.722 36.606 1.00 41.73  ? 387  ILE A CG2 1 
+ATOM   2875 C  CD1 . ILE A 1 368 ? 6.728   62.634 37.701 1.00 38.81  ? 387  ILE A CD1 1 
+ATOM   2876 N  N   . LEU A 1 369 ? 9.237   67.210 36.608 1.00 35.06  ? 388  LEU A N   1 
+ATOM   2877 C  CA  . LEU A 1 369 ? 10.279  68.019 35.994 1.00 34.37  ? 388  LEU A CA  1 
+ATOM   2878 C  C   . LEU A 1 369 ? 11.627  67.296 36.034 1.00 35.56  ? 388  LEU A C   1 
+ATOM   2879 O  O   . LEU A 1 369 ? 12.179  67.065 37.099 1.00 35.36  ? 388  LEU A O   1 
+ATOM   2880 C  CB  . LEU A 1 369 ? 10.406  69.341 36.696 1.00 34.27  ? 388  LEU A CB  1 
+ATOM   2881 C  CG  . LEU A 1 369 ? 9.242   70.277 36.433 1.00 38.78  ? 388  LEU A CG  1 
+ATOM   2882 C  CD1 . LEU A 1 369 ? 9.480   71.551 37.200 1.00 41.85  ? 388  LEU A CD1 1 
+ATOM   2883 C  CD2 . LEU A 1 369 ? 9.071   70.575 34.959 1.00 41.18  ? 388  LEU A CD2 1 
+ATOM   2884 N  N   . ILE A 1 370 ? 12.123  66.927 34.859 1.00 35.34  ? 389  ILE A N   1 
+ATOM   2885 C  CA  . ILE A 1 370 ? 13.467  66.407 34.672 1.00 35.40  ? 389  ILE A CA  1 
+ATOM   2886 C  C   . ILE A 1 370 ? 14.410  67.598 34.708 1.00 34.32  ? 389  ILE A C   1 
+ATOM   2887 O  O   . ILE A 1 370 ? 14.215  68.531 33.918 1.00 32.33  ? 389  ILE A O   1 
+ATOM   2888 C  CB  . ILE A 1 370 ? 13.567  65.772 33.269 1.00 39.52  ? 389  ILE A CB  1 
+ATOM   2889 C  CG1 . ILE A 1 370 ? 12.494  64.695 33.061 1.00 40.50  ? 389  ILE A CG1 1 
+ATOM   2890 C  CG2 . ILE A 1 370 ? 14.966  65.228 33.017 1.00 43.27  ? 389  ILE A CG2 1 
+ATOM   2891 C  CD1 . ILE A 1 370 ? 12.329  63.746 34.200 1.00 41.56  ? 389  ILE A CD1 1 
+ATOM   2892 N  N   . SER A 1 371 ? 15.415  67.590 35.591 1.00 30.58  ? 390  SER A N   1 
+ATOM   2893 C  CA  . SER A 1 371 ? 16.431  68.639 35.564 1.00 31.32  ? 390  SER A CA  1 
+ATOM   2894 C  C   . SER A 1 371 ? 17.532  68.273 34.590 1.00 32.00  ? 390  SER A C   1 
+ATOM   2895 O  O   . SER A 1 371 ? 18.491  67.635 34.965 1.00 32.15  ? 390  SER A O   1 
+ATOM   2896 C  CB  . SER A 1 371 ? 17.064  68.866 36.929 1.00 31.83  ? 390  SER A CB  1 
+ATOM   2897 O  OG  . SER A 1 371 ? 18.256  69.658 36.795 1.00 30.75  ? 390  SER A OG  1 
+ATOM   2898 N  N   . LEU A 1 372 ? 17.422  68.690 33.342 1.00 32.96  ? 391  LEU A N   1 
+ATOM   2899 C  CA  . LEU A 1 372 ? 18.541  68.500 32.423 1.00 34.90  ? 391  LEU A CA  1 
+ATOM   2900 C  C   . LEU A 1 372 ? 19.836  69.208 32.866 1.00 34.94  ? 391  LEU A C   1 
+ATOM   2901 O  O   . LEU A 1 372 ? 20.904  68.727 32.551 1.00 33.78  ? 391  LEU A O   1 
+ATOM   2902 C  CB  . LEU A 1 372 ? 18.177  68.953 31.009 1.00 32.49  ? 391  LEU A CB  1 
+ATOM   2903 C  CG  . LEU A 1 372 ? 17.068  68.168 30.316 1.00 27.67  ? 391  LEU A CG  1 
+ATOM   2904 C  CD1 . LEU A 1 372 ? 17.062  68.477 28.849 1.00 25.20  ? 391  LEU A CD1 1 
+ATOM   2905 C  CD2 . LEU A 1 372 ? 17.215  66.705 30.545 1.00 28.90  ? 391  LEU A CD2 1 
+ATOM   2906 N  N   . THR A 1 373 ? 19.745  70.333 33.581 1.00 36.31  ? 392  THR A N   1 
+ATOM   2907 C  CA  . THR A 1 373 ? 20.956  71.049 34.049 1.00 35.87  ? 392  THR A CA  1 
+ATOM   2908 C  C   . THR A 1 373 ? 21.849  70.154 34.901 1.00 36.28  ? 392  THR A C   1 
+ATOM   2909 O  O   . THR A 1 373 ? 23.053  70.234 34.850 1.00 29.00  ? 392  THR A O   1 
+ATOM   2910 C  CB  . THR A 1 373 ? 20.613  72.255 34.929 1.00 31.25  ? 392  THR A CB  1 
+ATOM   2911 O  OG1 . THR A 1 373 ? 19.680  73.093 34.266 1.00 33.17  ? 392  THR A OG1 1 
+ATOM   2912 C  CG2 . THR A 1 373 ? 21.847  73.133 35.119 1.00 32.50  ? 392  THR A CG2 1 
+ATOM   2913 N  N   . SER A 1 374 ? 21.222  69.343 35.726 1.00 36.45  ? 393  SER A N   1 
+ATOM   2914 C  CA  . SER A 1 374 ? 21.944  68.582 36.705 1.00 36.95  ? 393  SER A CA  1 
+ATOM   2915 C  C   . SER A 1 374 ? 22.797  67.529 36.021 1.00 38.25  ? 393  SER A C   1 
+ATOM   2916 O  O   . SER A 1 374 ? 23.839  67.133 36.555 1.00 39.77  ? 393  SER A O   1 
+ATOM   2917 C  CB  . SER A 1 374 ? 20.950  67.910 37.635 1.00 37.07  ? 393  SER A CB  1 
+ATOM   2918 O  OG  . SER A 1 374 ? 20.137  67.032 36.885 1.00 34.34  ? 393  SER A OG  1 
+ATOM   2919 N  N   . VAL A 1 375 ? 22.327  67.059 34.868 1.00 35.38  ? 394  VAL A N   1 
+ATOM   2920 C  CA  . VAL A 1 375 ? 23.051  66.099 34.048 1.00 35.66  ? 394  VAL A CA  1 
+ATOM   2921 C  C   . VAL A 1 375 ? 24.125  66.781 33.185 1.00 36.57  ? 394  VAL A C   1 
+ATOM   2922 O  O   . VAL A 1 375 ? 25.278  66.338 33.166 1.00 34.26  ? 394  VAL A O   1 
+ATOM   2923 C  CB  . VAL A 1 375 ? 22.085  65.354 33.139 1.00 35.63  ? 394  VAL A CB  1 
+ATOM   2924 C  CG1 . VAL A 1 375 ? 22.821  64.364 32.270 1.00 37.48  ? 394  VAL A CG1 1 
+ATOM   2925 C  CG2 . VAL A 1 375 ? 21.042  64.640 33.974 1.00 35.81  ? 394  VAL A CG2 1 
+ATOM   2926 N  N   . LEU A 1 376 ? 23.742  67.863 32.497 1.00 34.00  ? 395  LEU A N   1 
+ATOM   2927 C  CA  . LEU A 1 376 ? 24.644  68.620 31.608 1.00 30.95  ? 395  LEU A CA  1 
+ATOM   2928 C  C   . LEU A 1 376 ? 25.754  69.319 32.360 1.00 29.48  ? 395  LEU A C   1 
+ATOM   2929 O  O   . LEU A 1 376 ? 26.785  69.613 31.796 1.00 33.11  ? 395  LEU A O   1 
+ATOM   2930 C  CB  . LEU A 1 376 ? 23.885  69.674 30.777 1.00 30.78  ? 395  LEU A CB  1 
+ATOM   2931 C  CG  . LEU A 1 376 ? 23.238  69.233 29.450 1.00 33.56  ? 395  LEU A CG  1 
+ATOM   2932 C  CD1 . LEU A 1 376 ? 22.535  67.932 29.592 1.00 36.48  ? 395  LEU A CD1 1 
+ATOM   2933 C  CD2 . LEU A 1 376 ? 22.234  70.262 28.903 1.00 33.35  ? 395  LEU A CD2 1 
+ATOM   2934 N  N   . HIS A 1 377 ? 25.550  69.614 33.625 1.00 32.67  ? 396  HIS A N   1 
+ATOM   2935 C  CA  . HIS A 1 377 ? 26.524  70.388 34.398 1.00 33.53  ? 396  HIS A CA  1 
+ATOM   2936 C  C   . HIS A 1 377 ? 26.955  69.609 35.629 1.00 32.94  ? 396  HIS A C   1 
+ATOM   2937 O  O   . HIS A 1 377 ? 27.419  70.205 36.602 1.00 30.47  ? 396  HIS A O   1 
+ATOM   2938 C  CB  . HIS A 1 377 ? 25.940  71.740 34.818 1.00 33.63  ? 396  HIS A CB  1 
+ATOM   2939 C  CG  . HIS A 1 377 ? 25.898  72.746 33.722 1.00 36.91  ? 396  HIS A CG  1 
+ATOM   2940 N  ND1 . HIS A 1 377 ? 25.908  74.096 33.972 1.00 42.49  ? 396  HIS A ND1 1 
+ATOM   2941 C  CD2 . HIS A 1 377 ? 25.857  72.609 32.376 1.00 39.52  ? 396  HIS A CD2 1 
+ATOM   2942 C  CE1 . HIS A 1 377 ? 25.862  74.749 32.827 1.00 46.52  ? 396  HIS A CE1 1 
+ATOM   2943 N  NE2 . HIS A 1 377 ? 25.828  73.868 31.843 1.00 40.19  ? 396  HIS A NE2 1 
+ATOM   2944 N  N   . ASP A 1 378 ? 26.801  68.284 35.557 1.00 34.25  ? 397  ASP A N   1 
+ATOM   2945 C  CA  . ASP A 1 378 ? 27.365  67.354 36.535 1.00 36.99  ? 397  ASP A CA  1 
+ATOM   2946 C  C   . ASP A 1 378 ? 28.800  67.689 36.840 1.00 40.31  ? 397  ASP A C   1 
+ATOM   2947 O  O   . ASP A 1 378 ? 29.635  67.702 35.934 1.00 42.34  ? 397  ASP A O   1 
+ATOM   2948 C  CB  . ASP A 1 378 ? 27.322  65.926 35.998 1.00 38.31  ? 397  ASP A CB  1 
+ATOM   2949 C  CG  . ASP A 1 378 ? 27.641  64.917 37.053 1.00 41.12  ? 397  ASP A CG  1 
+ATOM   2950 O  OD1 . ASP A 1 378 ? 28.821  64.526 37.188 1.00 46.09  ? 397  ASP A OD1 1 
+ATOM   2951 O  OD2 . ASP A 1 378 ? 26.773  64.461 37.811 1.00 42.04  ? 397  ASP A OD2 1 
+ATOM   2952 N  N   . ASN A 1 379 ? 29.077  67.937 38.117 1.00 44.91  ? 398  ASN A N   1 
+ATOM   2953 C  CA  . ASN A 1 379 ? 30.399  68.355 38.580 1.00 46.66  ? 398  ASN A CA  1 
+ATOM   2954 C  C   . ASN A 1 379 ? 31.523  67.384 38.259 1.00 45.61  ? 398  ASN A C   1 
+ATOM   2955 O  O   . ASN A 1 379 ? 32.679  67.770 38.167 1.00 47.97  ? 398  ASN A O   1 
+ATOM   2956 C  CB  . ASN A 1 379 ? 30.393  68.573 40.096 1.00 49.60  ? 398  ASN A CB  1 
+ATOM   2957 C  CG  . ASN A 1 379 ? 31.017  69.872 40.458 1.00 57.55  ? 398  ASN A CG  1 
+ATOM   2958 O  OD1 . ASN A 1 379 ? 30.388  70.729 41.089 1.00 68.60  ? 398  ASN A OD1 1 
+ATOM   2959 N  ND2 . ASN A 1 379 ? 32.245  70.076 39.992 1.00 61.83  ? 398  ASN A ND2 1 
+ATOM   2960 N  N   . LYS A 1 380 ? 31.189  66.117 38.131 1.00 42.34  ? 399  LYS A N   1 
+ATOM   2961 C  CA  . LYS A 1 380 ? 32.204  65.101 38.093 1.00 41.32  ? 399  LYS A CA  1 
+ATOM   2962 C  C   . LYS A 1 380 ? 32.515  64.787 36.646 1.00 42.47  ? 399  LYS A C   1 
+ATOM   2963 O  O   . LYS A 1 380 ? 33.685  64.748 36.274 1.00 46.52  ? 399  LYS A O   1 
+ATOM   2964 C  CB  . LYS A 1 380 ? 31.724  63.869 38.861 1.00 42.59  ? 399  LYS A CB  1 
+ATOM   2965 C  CG  . LYS A 1 380 ? 32.682  62.722 38.871 1.00 48.12  ? 399  LYS A CG  1 
+ATOM   2966 C  CD  . LYS A 1 380 ? 32.170  61.597 39.762 1.00 54.03  ? 399  LYS A CD  1 
+ATOM   2967 C  CE  . LYS A 1 380 ? 33.121  60.404 39.770 1.00 53.46  ? 399  LYS A CE  1 
+ATOM   2968 N  NZ  . LYS A 1 380 ? 33.238  59.831 41.126 1.00 57.21  ? 399  LYS A NZ  1 
+ATOM   2969 N  N   . GLU A 1 381 ? 31.493  64.580 35.814 1.00 39.43  ? 400  GLU A N   1 
+ATOM   2970 C  CA  . GLU A 1 381 ? 31.749  64.293 34.404 1.00 39.50  ? 400  GLU A CA  1 
+ATOM   2971 C  C   . GLU A 1 381 ? 32.366  65.487 33.678 1.00 40.08  ? 400  GLU A C   1 
+ATOM   2972 O  O   . GLU A 1 381 ? 33.215  65.301 32.796 1.00 38.87  ? 400  GLU A O   1 
+ATOM   2973 C  CB  . GLU A 1 381 ? 30.490  63.847 33.676 1.00 40.82  ? 400  GLU A CB  1 
+ATOM   2974 C  CG  . GLU A 1 381 ? 30.745  63.417 32.233 1.00 40.89  ? 400  GLU A CG  1 
+ATOM   2975 C  CD  . GLU A 1 381 ? 31.004  61.938 32.075 1.00 41.16  ? 400  GLU A CD  1 
+ATOM   2976 O  OE1 . GLU A 1 381 ? 30.936  61.419 30.933 1.00 38.87  ? 400  GLU A OE1 1 
+ATOM   2977 O  OE2 . GLU A 1 381 ? 31.274  61.282 33.093 1.00 49.13  ? 400  GLU A OE2 1 
+ATOM   2978 N  N   . PHE A 1 382 ? 31.956  66.698 34.064 1.00 40.11  ? 401  PHE A N   1 
+ATOM   2979 C  CA  . PHE A 1 382 ? 32.443  67.933 33.447 1.00 38.76  ? 401  PHE A CA  1 
+ATOM   2980 C  C   . PHE A 1 382 ? 33.065  68.832 34.530 1.00 43.65  ? 401  PHE A C   1 
+ATOM   2981 O  O   . PHE A 1 382 ? 32.404  69.688 35.071 1.00 47.18  ? 401  PHE A O   1 
+ATOM   2982 C  CB  . PHE A 1 382 ? 31.302  68.647 32.677 1.00 36.25  ? 401  PHE A CB  1 
+ATOM   2983 C  CG  . PHE A 1 382 ? 30.501  67.727 31.733 1.00 31.77  ? 401  PHE A CG  1 
+ATOM   2984 C  CD1 . PHE A 1 382 ? 29.250  67.281 32.076 1.00 29.79  ? 401  PHE A CD1 1 
+ATOM   2985 C  CD2 . PHE A 1 382 ? 31.010  67.329 30.505 1.00 33.67  ? 401  PHE A CD2 1 
+ATOM   2986 C  CE1 . PHE A 1 382 ? 28.512  66.447 31.222 1.00 30.24  ? 401  PHE A CE1 1 
+ATOM   2987 C  CE2 . PHE A 1 382 ? 30.278  66.495 29.658 1.00 33.60  ? 401  PHE A CE2 1 
+ATOM   2988 C  CZ  . PHE A 1 382 ? 29.025  66.057 30.022 1.00 29.71  ? 401  PHE A CZ  1 
+ATOM   2989 N  N   . PRO A 1 383 ? 34.349  68.648 34.825 1.00 51.87  ? 402  PRO A N   1 
+ATOM   2990 C  CA  . PRO A 1 383 ? 34.995  69.266 35.987 1.00 53.71  ? 402  PRO A CA  1 
+ATOM   2991 C  C   . PRO A 1 383 ? 34.808  70.755 36.219 1.00 56.08  ? 402  PRO A C   1 
+ATOM   2992 O  O   . PRO A 1 383 ? 34.720  71.122 37.399 1.00 64.24  ? 402  PRO A O   1 
+ATOM   2993 C  CB  . PRO A 1 383 ? 36.457  68.961 35.754 1.00 53.08  ? 402  PRO A CB  1 
+ATOM   2994 C  CG  . PRO A 1 383 ? 36.410  67.687 35.090 1.00 54.91  ? 402  PRO A CG  1 
+ATOM   2995 C  CD  . PRO A 1 383 ? 35.303  67.802 34.094 1.00 54.31  ? 402  PRO A CD  1 
+ATOM   2996 N  N   . ASN A 1 384 ? 34.771  71.604 35.204 1.00 51.48  ? 403  ASN A N   1 
+ATOM   2997 C  CA  . ASN A 1 384 ? 34.413  72.997 35.483 1.00 51.00  ? 403  ASN A CA  1 
+ATOM   2998 C  C   . ASN A 1 384 ? 33.159  73.313 34.733 1.00 47.49  ? 403  ASN A C   1 
+ATOM   2999 O  O   . ASN A 1 384 ? 33.217  73.936 33.681 1.00 46.88  ? 403  ASN A O   1 
+ATOM   3000 C  CB  . ASN A 1 384 ? 35.524  73.933 35.076 1.00 54.92  ? 403  ASN A CB  1 
+ATOM   3001 C  CG  . ASN A 1 384 ? 36.816  73.609 35.764 1.00 59.63  ? 403  ASN A CG  1 
+ATOM   3002 O  OD1 . ASN A 1 384 ? 36.941  73.793 36.978 1.00 63.01  ? 403  ASN A OD1 1 
+ATOM   3003 N  ND2 . ASN A 1 384 ? 37.791  73.110 34.998 1.00 57.27  ? 403  ASN A ND2 1 
+ATOM   3004 N  N   . PRO A 1 385 ? 32.023  72.866 35.255 1.00 44.74  ? 404  PRO A N   1 
+ATOM   3005 C  CA  . PRO A 1 385 ? 30.831  72.701 34.426 1.00 43.70  ? 404  PRO A CA  1 
+ATOM   3006 C  C   . PRO A 1 385 ? 30.241  74.006 33.969 1.00 43.79  ? 404  PRO A C   1 
+ATOM   3007 O  O   . PRO A 1 385 ? 29.505  73.970 32.998 1.00 41.17  ? 404  PRO A O   1 
+ATOM   3008 C  CB  . PRO A 1 385 ? 29.841  71.973 35.342 1.00 45.99  ? 404  PRO A CB  1 
+ATOM   3009 C  CG  . PRO A 1 385 ? 30.552  71.683 36.617 1.00 45.62  ? 404  PRO A CG  1 
+ATOM   3010 C  CD  . PRO A 1 385 ? 31.755  72.541 36.662 1.00 45.54  ? 404  PRO A CD  1 
+ATOM   3011 N  N   . GLU A 1 386 ? 30.535  75.110 34.657 1.00 46.07  ? 405  GLU A N   1 
+ATOM   3012 C  CA  . GLU A 1 386 ? 29.961  76.422 34.324 1.00 49.59  ? 405  GLU A CA  1 
+ATOM   3013 C  C   . GLU A 1 386 ? 30.928  77.217 33.460 1.00 46.84  ? 405  GLU A C   1 
+ATOM   3014 O  O   . GLU A 1 386 ? 30.767  78.422 33.244 1.00 43.37  ? 405  GLU A O   1 
+ATOM   3015 C  CB  . GLU A 1 386 ? 29.570  77.196 35.594 1.00 52.86  ? 405  GLU A CB  1 
+ATOM   3016 C  CG  . GLU A 1 386 ? 28.387  76.581 36.369 1.00 60.24  ? 405  GLU A CG  1 
+ATOM   3017 C  CD  . GLU A 1 386 ? 27.416  77.611 36.977 1.00 67.52  ? 405  GLU A CD  1 
+ATOM   3018 O  OE1 . GLU A 1 386 ? 27.871  78.645 37.545 1.00 69.51  ? 405  GLU A OE1 1 
+ATOM   3019 O  OE2 . GLU A 1 386 ? 26.179  77.379 36.889 1.00 73.07  ? 405  GLU A OE2 1 
+ATOM   3020 N  N   . MET A 1 387 ? 31.923  76.490 32.955 1.00 46.95  ? 406  MET A N   1 
+ATOM   3021 C  CA  . MET A 1 387 ? 32.969  77.002 32.084 1.00 46.84  ? 406  MET A CA  1 
+ATOM   3022 C  C   . MET A 1 387 ? 32.887  76.331 30.713 1.00 42.91  ? 406  MET A C   1 
+ATOM   3023 O  O   . MET A 1 387 ? 32.641  75.113 30.597 1.00 43.98  ? 406  MET A O   1 
+ATOM   3024 C  CB  . MET A 1 387 ? 34.319  76.692 32.693 1.00 50.57  ? 406  MET A CB  1 
+ATOM   3025 C  CG  . MET A 1 387 ? 34.640  77.537 33.896 1.00 56.54  ? 406  MET A CG  1 
+ATOM   3026 S  SD  . MET A 1 387 ? 35.958  78.673 33.461 1.00 66.87  ? 406  MET A SD  1 
+ATOM   3027 C  CE  . MET A 1 387 ? 37.453  77.430 33.180 1.00 61.78  ? 406  MET A CE  1 
+ATOM   3028 N  N   . PHE A 1 388 ? 33.092  77.141 29.685 1.00 36.95  ? 407  PHE A N   1 
+ATOM   3029 C  CA  . PHE A 1 388 ? 33.052  76.679 28.299 1.00 38.01  ? 407  PHE A CA  1 
+ATOM   3030 C  C   . PHE A 1 388 ? 34.391  76.078 27.893 1.00 37.04  ? 407  PHE A C   1 
+ATOM   3031 O  O   . PHE A 1 388 ? 35.406  76.773 27.821 1.00 38.51  ? 407  PHE A O   1 
+ATOM   3032 C  CB  . PHE A 1 388 ? 32.722  77.844 27.360 1.00 36.42  ? 407  PHE A CB  1 
+ATOM   3033 C  CG  . PHE A 1 388 ? 32.740  77.467 25.914 1.00 33.00  ? 407  PHE A CG  1 
+ATOM   3034 C  CD1 . PHE A 1 388 ? 31.701  76.708 25.367 1.00 33.10  ? 407  PHE A CD1 1 
+ATOM   3035 C  CD2 . PHE A 1 388 ? 33.791  77.844 25.105 1.00 29.09  ? 407  PHE A CD2 1 
+ATOM   3036 C  CE1 . PHE A 1 388 ? 31.711  76.355 24.034 1.00 29.50  ? 407  PHE A CE1 1 
+ATOM   3037 C  CE2 . PHE A 1 388 ? 33.805  77.505 23.762 1.00 29.62  ? 407  PHE A CE2 1 
+ATOM   3038 C  CZ  . PHE A 1 388 ? 32.768  76.752 23.232 1.00 33.31  ? 407  PHE A CZ  1 
+ATOM   3039 N  N   . ASP A 1 389 ? 34.412  74.784 27.639 1.00 34.95  ? 408  ASP A N   1 
+ATOM   3040 C  CA  . ASP A 1 389 ? 35.675  74.153 27.294 1.00 36.36  ? 408  ASP A CA  1 
+ATOM   3041 C  C   . ASP A 1 389 ? 35.497  72.893 26.466 1.00 30.03  ? 408  ASP A C   1 
+ATOM   3042 O  O   . ASP A 1 389 ? 35.082  71.858 26.986 1.00 27.05  ? 408  ASP A O   1 
+ATOM   3043 C  CB  . ASP A 1 389 ? 36.471  73.840 28.549 1.00 39.24  ? 408  ASP A CB  1 
+ATOM   3044 C  CG  . ASP A 1 389 ? 37.788  73.174 28.233 1.00 41.88  ? 408  ASP A CG  1 
+ATOM   3045 O  OD1 . ASP A 1 389 ? 38.231  72.363 29.069 1.00 48.44  ? 408  ASP A OD1 1 
+ATOM   3046 O  OD2 . ASP A 1 389 ? 38.437  73.390 27.181 1.00 40.96  ? 408  ASP A OD2 1 
+ATOM   3047 N  N   . PRO A 1 390 ? 35.817  72.976 25.182 1.00 24.57  ? 409  PRO A N   1 
+ATOM   3048 C  CA  . PRO A 1 390 ? 35.654  71.834 24.276 1.00 27.47  ? 409  PRO A CA  1 
+ATOM   3049 C  C   . PRO A 1 390 ? 36.347  70.556 24.741 1.00 26.48  ? 409  PRO A C   1 
+ATOM   3050 O  O   . PRO A 1 390 ? 35.884  69.494 24.369 1.00 23.82  ? 409  PRO A O   1 
+ATOM   3051 C  CB  . PRO A 1 390 ? 36.260  72.327 22.965 1.00 29.98  ? 409  PRO A CB  1 
+ATOM   3052 C  CG  . PRO A 1 390 ? 36.189  73.818 23.048 1.00 30.73  ? 409  PRO A CG  1 
+ATOM   3053 C  CD  . PRO A 1 390 ? 36.330  74.165 24.488 1.00 27.49  ? 409  PRO A CD  1 
+ATOM   3054 N  N   . HIS A 1 391 ? 37.412  70.647 25.543 1.00 30.38  ? 410  HIS A N   1 
+ATOM   3055 C  CA  . HIS A 1 391 ? 38.074  69.439 26.065 1.00 29.76  ? 410  HIS A CA  1 
+ATOM   3056 C  C   . HIS A 1 391 ? 37.177  68.568 26.903 1.00 28.79  ? 410  HIS A C   1 
+ATOM   3057 O  O   . HIS A 1 391 ? 37.487  67.401 27.112 1.00 33.28  ? 410  HIS A O   1 
+ATOM   3058 C  CB  . HIS A 1 391 ? 39.403  69.769 26.759 1.00 29.24  ? 410  HIS A CB  1 
+ATOM   3059 C  CG  . HIS A 1 391 ? 40.382  70.366 25.810 1.00 32.24  ? 410  HIS A CG  1 
+ATOM   3060 N  ND1 . HIS A 1 391 ? 40.821  69.684 24.693 1.00 29.54  ? 410  HIS A ND1 1 
+ATOM   3061 C  CD2 . HIS A 1 391 ? 40.884  71.620 25.714 1.00 33.43  ? 410  HIS A CD2 1 
+ATOM   3062 C  CE1 . HIS A 1 391 ? 41.578  70.487 23.966 1.00 34.93  ? 410  HIS A CE1 1 
+ATOM   3063 N  NE2 . HIS A 1 391 ? 41.627  71.670 24.558 1.00 33.83  ? 410  HIS A NE2 1 
+ATOM   3064 N  N   . HIS A 1 392 ? 36.047  69.112 27.345 1.00 29.97  ? 411  HIS A N   1 
+ATOM   3065 C  CA  . HIS A 1 392 ? 34.991  68.305 27.940 1.00 28.38  ? 411  HIS A CA  1 
+ATOM   3066 C  C   . HIS A 1 392 ? 34.569  67.141 27.054 1.00 22.28  ? 411  HIS A C   1 
+ATOM   3067 O  O   . HIS A 1 392 ? 34.054  66.172 27.549 1.00 18.01  ? 411  HIS A O   1 
+ATOM   3068 C  CB  . HIS A 1 392 ? 33.761  69.171 28.239 1.00 35.00  ? 411  HIS A CB  1 
+ATOM   3069 C  CG  . HIS A 1 392 ? 33.890  70.024 29.470 1.00 36.98  ? 411  HIS A CG  1 
+ATOM   3070 N  ND1 . HIS A 1 392 ? 34.016  69.489 30.729 1.00 34.28  ? 411  HIS A ND1 1 
+ATOM   3071 C  CD2 . HIS A 1 392 ? 33.881  71.371 29.628 1.00 36.49  ? 411  HIS A CD2 1 
+ATOM   3072 C  CE1 . HIS A 1 392 ? 34.106  70.473 31.609 1.00 42.10  ? 411  HIS A CE1 1 
+ATOM   3073 N  NE2 . HIS A 1 392 ? 34.027  71.623 30.966 1.00 38.02  ? 411  HIS A NE2 1 
+ATOM   3074 N  N   . PHE A 1 393 ? 34.726  67.264 25.738 1.00 27.32  ? 412  PHE A N   1 
+ATOM   3075 C  CA  . PHE A 1 393 ? 34.381  66.189 24.810 1.00 29.86  ? 412  PHE A CA  1 
+ATOM   3076 C  C   . PHE A 1 393 ? 35.588  65.742 23.943 1.00 34.43  ? 412  PHE A C   1 
+ATOM   3077 O  O   . PHE A 1 393 ? 35.402  65.139 22.879 1.00 32.85  ? 412  PHE A O   1 
+ATOM   3078 C  CB  . PHE A 1 393 ? 33.201  66.617 23.934 1.00 32.60  ? 412  PHE A CB  1 
+ATOM   3079 C  CG  . PHE A 1 393 ? 31.917  66.820 24.695 1.00 32.56  ? 412  PHE A CG  1 
+ATOM   3080 C  CD1 . PHE A 1 393 ? 31.584  68.064 25.210 1.00 35.09  ? 412  PHE A CD1 1 
+ATOM   3081 C  CD2 . PHE A 1 393 ? 31.048  65.767 24.898 1.00 31.77  ? 412  PHE A CD2 1 
+ATOM   3082 C  CE1 . PHE A 1 393 ? 30.422  68.229 25.932 1.00 33.75  ? 412  PHE A CE1 1 
+ATOM   3083 C  CE2 . PHE A 1 393 ? 29.886  65.931 25.601 1.00 29.38  ? 412  PHE A CE2 1 
+ATOM   3084 C  CZ  . PHE A 1 393 ? 29.567  67.154 26.115 1.00 32.37  ? 412  PHE A CZ  1 
+ATOM   3085 N  N   . LEU A 1 394 ? 36.815  66.020 24.407 1.00 34.91  ? 413  LEU A N   1 
+ATOM   3086 C  CA  . LEU A 1 394 ? 38.041  65.468 23.800 1.00 35.09  ? 413  LEU A CA  1 
+ATOM   3087 C  C   . LEU A 1 394 ? 38.873  64.588 24.751 1.00 36.69  ? 413  LEU A C   1 
+ATOM   3088 O  O   . LEU A 1 394 ? 38.920  64.863 25.954 1.00 38.17  ? 413  LEU A O   1 
+ATOM   3089 C  CB  . LEU A 1 394 ? 38.906  66.612 23.307 1.00 33.81  ? 413  LEU A CB  1 
+ATOM   3090 C  CG  . LEU A 1 394 ? 38.275  67.399 22.168 1.00 32.70  ? 413  LEU A CG  1 
+ATOM   3091 C  CD1 . LEU A 1 394 ? 39.067  68.651 21.872 1.00 30.39  ? 413  LEU A CD1 1 
+ATOM   3092 C  CD2 . LEU A 1 394 ? 38.129  66.493 20.945 1.00 31.38  ? 413  LEU A CD2 1 
+ATOM   3093 N  N   . ASP A 1 395 ? 39.532  63.545 24.216 1.00 35.15  ? 414  ASP A N   1 
+ATOM   3094 C  CA  . ASP A 1 395 ? 40.549  62.792 24.980 1.00 30.66  ? 414  ASP A CA  1 
+ATOM   3095 C  C   . ASP A 1 395 ? 41.891  63.530 24.863 1.00 33.27  ? 414  ASP A C   1 
+ATOM   3096 O  O   . ASP A 1 395 ? 41.937  64.671 24.345 1.00 29.65  ? 414  ASP A O   1 
+ATOM   3097 C  CB  . ASP A 1 395 ? 40.625  61.286 24.621 1.00 24.52  ? 414  ASP A CB  1 
+ATOM   3098 C  CG  . ASP A 1 395 ? 40.991  61.011 23.170 1.00 32.47  ? 414  ASP A CG  1 
+ATOM   3099 O  OD1 . ASP A 1 395 ? 40.670  59.890 22.676 1.00 31.72  ? 414  ASP A OD1 1 
+ATOM   3100 O  OD2 . ASP A 1 395 ? 41.593  61.827 22.439 1.00 33.27  ? 414  ASP A OD2 1 
+ATOM   3101 N  N   . GLU A 1 396 ? 42.946  62.933 25.419 1.00 34.72  ? 415  GLU A N   1 
+ATOM   3102 C  CA  . GLU A 1 396 ? 44.280  63.549 25.429 1.00 37.95  ? 415  GLU A CA  1 
+ATOM   3103 C  C   . GLU A 1 396 ? 44.872  63.728 24.020 1.00 37.73  ? 415  GLU A C   1 
+ATOM   3104 O  O   . GLU A 1 396 ? 45.528  64.728 23.768 1.00 30.77  ? 415  GLU A O   1 
+ATOM   3105 C  CB  . GLU A 1 396 ? 45.239  62.771 26.331 1.00 40.90  ? 415  GLU A CB  1 
+ATOM   3106 C  CG  . GLU A 1 396 ? 45.776  61.478 25.734 1.00 42.52  ? 415  GLU A CG  1 
+ATOM   3107 C  CD  . GLU A 1 396 ? 44.719  60.414 25.559 1.00 44.47  ? 415  GLU A CD  1 
+ATOM   3108 O  OE1 . GLU A 1 396 ? 44.860  59.634 24.593 1.00 45.71  ? 415  GLU A OE1 1 
+ATOM   3109 O  OE2 . GLU A 1 396 ? 43.769  60.355 26.386 1.00 45.23  ? 415  GLU A OE2 1 
+ATOM   3110 N  N   . GLY A 1 397 ? 44.629  62.782 23.107 1.00 37.92  ? 416  GLY A N   1 
+ATOM   3111 C  CA  . GLY A 1 397 ? 44.871  63.031 21.688 1.00 42.84  ? 416  GLY A CA  1 
+ATOM   3112 C  C   . GLY A 1 397 ? 43.796  64.013 21.275 1.00 45.28  ? 416  GLY A C   1 
+ATOM   3113 O  O   . GLY A 1 397 ? 43.005  64.467 22.100 1.00 54.88  ? 416  GLY A O   1 
+ATOM   3114 N  N   . GLY A 1 398 ? 43.660  64.351 20.023 1.00 44.07  ? 417  GLY A N   1 
+ATOM   3115 C  CA  . GLY A 1 398 ? 42.496  65.194 19.733 1.00 43.80  ? 417  GLY A CA  1 
+ATOM   3116 C  C   . GLY A 1 398 ? 41.151  64.483 19.536 1.00 37.32  ? 417  GLY A C   1 
+ATOM   3117 O  O   . GLY A 1 398 ? 40.287  65.054 18.943 1.00 38.95  ? 417  GLY A O   1 
+ATOM   3118 N  N   . ASN A 1 399 ? 40.970  63.251 19.984 1.00 35.14  ? 418  ASN A N   1 
+ATOM   3119 C  CA  . ASN A 1 399 ? 39.800  62.466 19.575 1.00 34.88  ? 418  ASN A CA  1 
+ATOM   3120 C  C   . ASN A 1 399 ? 38.515  62.774 20.322 1.00 32.24  ? 418  ASN A C   1 
+ATOM   3121 O  O   . ASN A 1 399 ? 38.533  63.168 21.462 1.00 30.52  ? 418  ASN A O   1 
+ATOM   3122 C  CB  . ASN A 1 399 ? 40.092  60.966 19.670 1.00 38.57  ? 418  ASN A CB  1 
+ATOM   3123 C  CG  . ASN A 1 399 ? 41.423  60.591 19.030 1.00 44.68  ? 418  ASN A CG  1 
+ATOM   3124 O  OD1 . ASN A 1 399 ? 42.342  60.084 19.701 1.00 48.99  ? 418  ASN A OD1 1 
+ATOM   3125 N  ND2 . ASN A 1 399 ? 41.537  60.840 17.732 1.00 37.89  ? 418  ASN A ND2 1 
+ATOM   3126 N  N   . PHE A 1 400 ? 37.382  62.552 19.662 1.00 34.31  ? 419  PHE A N   1 
+ATOM   3127 C  CA  . PHE A 1 400 ? 36.084  62.918 20.201 1.00 28.12  ? 419  PHE A CA  1 
+ATOM   3128 C  C   . PHE A 1 400 ? 35.683  61.944 21.249 1.00 27.84  ? 419  PHE A C   1 
+ATOM   3129 O  O   . PHE A 1 400 ? 35.758  60.747 21.017 1.00 28.40  ? 419  PHE A O   1 
+ATOM   3130 C  CB  . PHE A 1 400 ? 34.994  62.934 19.125 1.00 28.67  ? 419  PHE A CB  1 
+ATOM   3131 C  CG  . PHE A 1 400 ? 33.634  63.260 19.675 1.00 28.79  ? 419  PHE A CG  1 
+ATOM   3132 C  CD1 . PHE A 1 400 ? 33.263  64.582 19.892 1.00 29.67  ? 419  PHE A CD1 1 
+ATOM   3133 C  CD2 . PHE A 1 400 ? 32.747  62.249 20.043 1.00 29.82  ? 419  PHE A CD2 1 
+ATOM   3134 C  CE1 . PHE A 1 400 ? 32.033  64.890 20.446 1.00 28.46  ? 419  PHE A CE1 1 
+ATOM   3135 C  CE2 . PHE A 1 400 ? 31.507  62.555 20.597 1.00 27.78  ? 419  PHE A CE2 1 
+ATOM   3136 C  CZ  . PHE A 1 400 ? 31.161  63.886 20.795 1.00 30.30  ? 419  PHE A CZ  1 
+ATOM   3137 N  N   . LYS A 1 401 ? 35.177  62.472 22.368 1.00 29.77  ? 420  LYS A N   1 
+ATOM   3138 C  CA  . LYS A 1 401 ? 34.848  61.690 23.560 1.00 31.11  ? 420  LYS A CA  1 
+ATOM   3139 C  C   . LYS A 1 401 ? 33.359  61.817 23.936 1.00 32.09  ? 420  LYS A C   1 
+ATOM   3140 O  O   . LYS A 1 401 ? 32.917  62.816 24.484 1.00 34.76  ? 420  LYS A O   1 
+ATOM   3141 C  CB  . LYS A 1 401 ? 35.742  62.145 24.720 1.00 29.46  ? 420  LYS A CB  1 
+ATOM   3142 C  CG  . LYS A 1 401 ? 35.498  61.367 26.028 1.00 31.46  ? 420  LYS A CG  1 
+ATOM   3143 C  CD  . LYS A 1 401 ? 36.494  61.729 27.177 1.00 35.20  ? 420  LYS A CD  1 
+ATOM   3144 C  CE  . LYS A 1 401 ? 36.609  63.241 27.404 1.00 31.92  ? 420  LYS A CE  1 
+ATOM   3145 N  NZ  . LYS A 1 401 ? 37.603  63.606 28.422 1.00 30.13  ? 420  LYS A NZ  1 
+ATOM   3146 N  N   . LYS A 1 402 ? 32.581  60.794 23.644 1.00 35.54  ? 421  LYS A N   1 
+ATOM   3147 C  CA  . LYS A 1 402 ? 31.154  60.841 23.915 1.00 37.83  ? 421  LYS A CA  1 
+ATOM   3148 C  C   . LYS A 1 402 ? 30.930  60.953 25.425 1.00 39.36  ? 421  LYS A C   1 
+ATOM   3149 O  O   . LYS A 1 402 ? 31.808  60.613 26.186 1.00 38.69  ? 421  LYS A O   1 
+ATOM   3150 C  CB  . LYS A 1 402 ? 30.432  59.617 23.306 1.00 38.33  ? 421  LYS A CB  1 
+ATOM   3151 C  CG  . LYS A 1 402 ? 30.841  58.243 23.859 1.00 41.07  ? 421  LYS A CG  1 
+ATOM   3152 C  CD  . LYS A 1 402 ? 30.128  57.101 23.111 1.00 42.68  ? 421  LYS A CD  1 
+ATOM   3153 C  CE  . LYS A 1 402 ? 30.794  55.751 23.366 1.00 44.81  ? 421  LYS A CE  1 
+ATOM   3154 N  NZ  . LYS A 1 402 ? 29.907  54.635 22.951 1.00 49.26  ? 421  LYS A NZ  1 
+ATOM   3155 N  N   . SER A 1 403 ? 29.784  61.497 25.843 1.00 41.86  ? 422  SER A N   1 
+ATOM   3156 C  CA  . SER A 1 403 ? 29.310  61.339 27.219 1.00 35.58  ? 422  SER A CA  1 
+ATOM   3157 C  C   . SER A 1 403 ? 27.839  60.957 27.323 1.00 36.61  ? 422  SER A C   1 
+ATOM   3158 O  O   . SER A 1 403 ? 26.994  61.517 26.641 1.00 31.10  ? 422  SER A O   1 
+ATOM   3159 C  CB  . SER A 1 403 ? 29.507  62.594 28.015 1.00 33.47  ? 422  SER A CB  1 
+ATOM   3160 O  OG  . SER A 1 403 ? 28.997  62.366 29.302 1.00 25.94  ? 422  SER A OG  1 
+ATOM   3161 N  N   . LYS A 1 404 ? 27.538  60.008 28.201 1.00 37.65  ? 423  LYS A N   1 
+ATOM   3162 C  CA  . LYS A 1 404 ? 26.158  59.655 28.458 1.00 38.41  ? 423  LYS A CA  1 
+ATOM   3163 C  C   . LYS A 1 404 ? 25.457  60.780 29.245 1.00 34.49  ? 423  LYS A C   1 
+ATOM   3164 O  O   . LYS A 1 404 ? 24.269  60.774 29.381 1.00 39.44  ? 423  LYS A O   1 
+ATOM   3165 C  CB  . LYS A 1 404 ? 26.076  58.288 29.143 1.00 40.86  ? 423  LYS A CB  1 
+ATOM   3166 C  CG  . LYS A 1 404 ? 26.582  58.247 30.585 1.00 49.09  ? 423  LYS A CG  1 
+ATOM   3167 C  CD  . LYS A 1 404 ? 26.963  56.790 31.028 1.00 53.42  ? 423  LYS A CD  1 
+ATOM   3168 C  CE  . LYS A 1 404 ? 27.462  56.717 32.490 1.00 50.63  ? 423  LYS A CE  1 
+ATOM   3169 N  NZ  . LYS A 1 404 ? 26.877  55.580 33.249 1.00 49.54  ? 423  LYS A NZ  1 
+ATOM   3170 N  N   . TYR A 1 405 ? 26.209  61.764 29.713 1.00 35.19  ? 424  TYR A N   1 
+ATOM   3171 C  CA  . TYR A 1 405 ? 25.676  62.957 30.360 1.00 34.02  ? 424  TYR A CA  1 
+ATOM   3172 C  C   . TYR A 1 405 ? 25.390  64.069 29.349 1.00 33.72  ? 424  TYR A C   1 
+ATOM   3173 O  O   . TYR A 1 405 ? 25.141  65.203 29.725 1.00 35.17  ? 424  TYR A O   1 
+ATOM   3174 C  CB  . TYR A 1 405 ? 26.689  63.522 31.396 1.00 35.13  ? 424  TYR A CB  1 
+ATOM   3175 C  CG  . TYR A 1 405 ? 26.903  62.690 32.657 1.00 39.36  ? 424  TYR A CG  1 
+ATOM   3176 C  CD1 . TYR A 1 405 ? 26.475  63.153 33.912 1.00 39.65  ? 424  TYR A CD1 1 
+ATOM   3177 C  CD2 . TYR A 1 405 ? 27.550  61.448 32.606 1.00 39.89  ? 424  TYR A CD2 1 
+ATOM   3178 C  CE1 . TYR A 1 405 ? 26.662  62.403 35.047 1.00 37.04  ? 424  TYR A CE1 1 
+ATOM   3179 C  CE2 . TYR A 1 405 ? 27.728  60.697 33.743 1.00 33.69  ? 424  TYR A CE2 1 
+ATOM   3180 C  CZ  . TYR A 1 405 ? 27.294  61.183 34.949 1.00 36.54  ? 424  TYR A CZ  1 
+ATOM   3181 O  OH  . TYR A 1 405 ? 27.504  60.442 36.066 1.00 40.47  ? 424  TYR A OH  1 
+ATOM   3182 N  N   . PHE A 1 406 ? 25.455  63.773 28.064 1.00 37.14  ? 425  PHE A N   1 
+ATOM   3183 C  CA  . PHE A 1 406 ? 25.080  64.742 27.033 1.00 33.22  ? 425  PHE A CA  1 
+ATOM   3184 C  C   . PHE A 1 406 ? 23.635  64.513 26.635 1.00 32.15  ? 425  PHE A C   1 
+ATOM   3185 O  O   . PHE A 1 406 ? 23.371  63.678 25.791 1.00 32.47  ? 425  PHE A O   1 
+ATOM   3186 C  CB  . PHE A 1 406 ? 25.962  64.572 25.824 1.00 31.84  ? 425  PHE A CB  1 
+ATOM   3187 C  CG  . PHE A 1 406 ? 25.710  65.572 24.750 1.00 28.43  ? 425  PHE A CG  1 
+ATOM   3188 C  CD1 . PHE A 1 406 ? 26.135  66.879 24.900 1.00 21.74  ? 425  PHE A CD1 1 
+ATOM   3189 C  CD2 . PHE A 1 406 ? 25.063  65.207 23.588 1.00 20.98  ? 425  PHE A CD2 1 
+ATOM   3190 C  CE1 . PHE A 1 406 ? 25.905  67.803 23.892 1.00 23.69  ? 425  PHE A CE1 1 
+ATOM   3191 C  CE2 . PHE A 1 406 ? 24.843  66.140 22.575 1.00 20.26  ? 425  PHE A CE2 1 
+ATOM   3192 C  CZ  . PHE A 1 406 ? 25.258  67.426 22.732 1.00 18.66  ? 425  PHE A CZ  1 
+ATOM   3193 N  N   . MET A 1 407 ? 22.737  65.284 27.258 1.00 34.25  ? 426  MET A N   1 
+ATOM   3194 C  CA  . MET A 1 407 ? 21.280  65.167 27.158 1.00 35.24  ? 426  MET A CA  1 
+ATOM   3195 C  C   . MET A 1 407 ? 20.561  66.488 26.863 1.00 33.80  ? 426  MET A C   1 
+ATOM   3196 O  O   . MET A 1 407 ? 19.505  66.724 27.412 1.00 33.82  ? 426  MET A O   1 
+ATOM   3197 C  CB  . MET A 1 407 ? 20.722  64.683 28.510 1.00 36.55  ? 426  MET A CB  1 
+ATOM   3198 C  CG  . MET A 1 407 ? 20.627  63.201 28.609 1.00 40.24  ? 426  MET A CG  1 
+ATOM   3199 S  SD  . MET A 1 407 ? 20.114  62.717 30.216 1.00 39.19  ? 426  MET A SD  1 
+ATOM   3200 C  CE  . MET A 1 407 ? 20.341  60.993 30.003 1.00 43.28  ? 426  MET A CE  1 
+ATOM   3201 N  N   . PRO A 1 408 ? 21.077  67.354 26.012 1.00 31.10  ? 427  PRO A N   1 
+ATOM   3202 C  CA  . PRO A 1 408 ? 20.392  68.627 25.787 1.00 29.75  ? 427  PRO A CA  1 
+ATOM   3203 C  C   . PRO A 1 408 ? 19.074  68.436 25.009 1.00 31.10  ? 427  PRO A C   1 
+ATOM   3204 O  O   . PRO A 1 408 ? 18.261  69.353 24.935 1.00 33.29  ? 427  PRO A O   1 
+ATOM   3205 C  CB  . PRO A 1 408 ? 21.415  69.427 24.991 1.00 29.66  ? 427  PRO A CB  1 
+ATOM   3206 C  CG  . PRO A 1 408 ? 22.199  68.378 24.267 1.00 30.92  ? 427  PRO A CG  1 
+ATOM   3207 C  CD  . PRO A 1 408 ? 22.271  67.199 25.161 1.00 30.58  ? 427  PRO A CD  1 
+ATOM   3208 N  N   . PHE A 1 409 ? 18.902  67.246 24.440 1.00 31.39  ? 428  PHE A N   1 
+ATOM   3209 C  CA  . PHE A 1 409 ? 17.708  66.836 23.709 1.00 32.83  ? 428  PHE A CA  1 
+ATOM   3210 C  C   . PHE A 1 409 ? 16.871  65.906 24.596 1.00 35.09  ? 428  PHE A C   1 
+ATOM   3211 O  O   . PHE A 1 409 ? 15.941  65.222 24.114 1.00 29.81  ? 428  PHE A O   1 
+ATOM   3212 C  CB  . PHE A 1 409 ? 18.093  66.067 22.413 1.00 27.16  ? 428  PHE A CB  1 
+ATOM   3213 C  CG  . PHE A 1 409 ? 18.851  66.877 21.419 1.00 25.33  ? 428  PHE A CG  1 
+ATOM   3214 C  CD1 . PHE A 1 409 ? 20.218  66.723 21.275 1.00 23.87  ? 428  PHE A CD1 1 
+ATOM   3215 C  CD2 . PHE A 1 409 ? 18.203  67.798 20.607 1.00 24.66  ? 428  PHE A CD2 1 
+ATOM   3216 C  CE1 . PHE A 1 409 ? 20.930  67.473 20.341 1.00 24.51  ? 428  PHE A CE1 1 
+ATOM   3217 C  CE2 . PHE A 1 409 ? 18.934  68.554 19.659 1.00 27.53  ? 428  PHE A CE2 1 
+ATOM   3218 C  CZ  . PHE A 1 409 ? 20.295  68.385 19.540 1.00 18.58  ? 428  PHE A CZ  1 
+ATOM   3219 N  N   . SER A 1 410 ? 17.223  65.866 25.880 1.00 36.16  ? 429  SER A N   1 
+ATOM   3220 C  CA  . SER A 1 410 ? 16.616  64.941 26.836 1.00 37.41  ? 429  SER A CA  1 
+ATOM   3221 C  C   . SER A 1 410 ? 16.943  63.476 26.491 1.00 38.31  ? 429  SER A C   1 
+ATOM   3222 O  O   . SER A 1 410 ? 17.994  63.193 25.908 1.00 39.02  ? 429  SER A O   1 
+ATOM   3223 C  CB  . SER A 1 410 ? 15.108  65.187 26.902 1.00 37.00  ? 429  SER A CB  1 
+ATOM   3224 O  OG  . SER A 1 410 ? 14.503  64.468 27.940 1.00 31.98  ? 429  SER A OG  1 
+ATOM   3225 N  N   . ALA A 1 411 ? 16.050  62.554 26.843 1.00 38.13  ? 430  ALA A N   1 
+ATOM   3226 C  CA  . ALA A 1 411 ? 16.367  61.139 26.779 1.00 40.62  ? 430  ALA A CA  1 
+ATOM   3227 C  C   . ALA A 1 411 ? 15.133  60.257 26.961 1.00 42.09  ? 430  ALA A C   1 
+ATOM   3228 O  O   . ALA A 1 411 ? 14.131  60.655 27.565 1.00 46.80  ? 430  ALA A O   1 
+ATOM   3229 C  CB  . ALA A 1 411 ? 17.406  60.795 27.835 1.00 41.45  ? 430  ALA A CB  1 
+ATOM   3230 N  N   . GLY A 1 412 ? 15.209  59.052 26.431 1.00 38.35  ? 431  GLY A N   1 
+ATOM   3231 C  CA  . GLY A 1 412 ? 14.106  58.141 26.544 1.00 40.00  ? 431  GLY A CA  1 
+ATOM   3232 C  C   . GLY A 1 412 ? 13.077  58.364 25.474 1.00 39.41  ? 431  GLY A C   1 
+ATOM   3233 O  O   . GLY A 1 412 ? 13.366  58.924 24.430 1.00 36.19  ? 431  GLY A O   1 
+ATOM   3234 N  N   . LYS A 1 413 ? 11.863  57.921 25.763 1.00 41.85  ? 432  LYS A N   1 
+ATOM   3235 C  CA  . LYS A 1 413 ? 10.774  57.894 24.783 1.00 45.85  ? 432  LYS A CA  1 
+ATOM   3236 C  C   . LYS A 1 413 ? 10.234  59.242 24.253 1.00 44.49  ? 432  LYS A C   1 
+ATOM   3237 O  O   . LYS A 1 413 ? 9.545   59.253 23.243 1.00 45.46  ? 432  LYS A O   1 
+ATOM   3238 C  CB  . LYS A 1 413 ? 9.631   57.038 25.335 1.00 46.86  ? 432  LYS A CB  1 
+ATOM   3239 C  CG  . LYS A 1 413 ? 10.070  55.577 25.555 1.00 50.87  ? 432  LYS A CG  1 
+ATOM   3240 C  CD  . LYS A 1 413 ? 8.908   54.602 25.531 1.00 55.57  ? 432  LYS A CD  1 
+ATOM   3241 C  CE  . LYS A 1 413 ? 9.376   53.154 25.566 1.00 55.94  ? 432  LYS A CE  1 
+ATOM   3242 N  NZ  . LYS A 1 413 ? 8.676   52.407 24.486 1.00 58.23  ? 432  LYS A NZ  1 
+ATOM   3243 N  N   . ARG A 1 414 ? 10.569  60.353 24.901 1.00 44.97  ? 433  ARG A N   1 
+ATOM   3244 C  CA  . ARG A 1 414 ? 10.121  61.683 24.481 1.00 45.26  ? 433  ARG A CA  1 
+ATOM   3245 C  C   . ARG A 1 414 ? 11.279  62.509 23.959 1.00 45.61  ? 433  ARG A C   1 
+ATOM   3246 O  O   . ARG A 1 414 ? 11.159  63.720 23.815 1.00 47.89  ? 433  ARG A O   1 
+ATOM   3247 C  CB  . ARG A 1 414 ? 9.511   62.436 25.670 1.00 48.71  ? 433  ARG A CB  1 
+ATOM   3248 C  CG  . ARG A 1 414 ? 8.052   62.144 25.932 1.00 51.05  ? 433  ARG A CG  1 
+ATOM   3249 C  CD  . ARG A 1 414 ? 7.070   63.211 25.400 1.00 52.16  ? 433  ARG A CD  1 
+ATOM   3250 N  NE  . ARG A 1 414 ? 5.714   62.712 25.557 1.00 48.84  ? 433  ARG A NE  1 
+ATOM   3251 C  CZ  . ARG A 1 414 ? 4.658   63.140 24.909 1.00 48.99  ? 433  ARG A CZ  1 
+ATOM   3252 N  NH1 . ARG A 1 414 ? 4.722   64.155 24.053 1.00 47.24  ? 433  ARG A NH1 1 
+ATOM   3253 N  NH2 . ARG A 1 414 ? 3.503   62.546 25.159 1.00 54.96  ? 433  ARG A NH2 1 
+ATOM   3254 N  N   . ILE A 1 415 ? 12.412  61.868 23.696 1.00 43.96  ? 434  ILE A N   1 
+ATOM   3255 C  CA  . ILE A 1 415 ? 13.587  62.579 23.211 1.00 41.08  ? 434  ILE A CA  1 
+ATOM   3256 C  C   . ILE A 1 415 ? 13.244  63.421 21.974 1.00 37.04  ? 434  ILE A C   1 
+ATOM   3257 O  O   . ILE A 1 415 ? 12.451  63.027 21.143 1.00 39.52  ? 434  ILE A O   1 
+ATOM   3258 C  CB  . ILE A 1 415 ? 14.751  61.574 22.937 1.00 44.08  ? 434  ILE A CB  1 
+ATOM   3259 C  CG1 . ILE A 1 415 ? 16.079  62.309 22.784 1.00 45.79  ? 434  ILE A CG1 1 
+ATOM   3260 C  CG2 . ILE A 1 415 ? 14.481  60.724 21.710 1.00 43.33  ? 434  ILE A CG2 1 
+ATOM   3261 C  CD1 . ILE A 1 415 ? 17.240  61.392 22.640 1.00 45.51  ? 434  ILE A CD1 1 
+ATOM   3262 N  N   . CYS A 1 416 ? 13.814  64.604 21.878 1.00 32.99  ? 435  CYS A N   1 
+ATOM   3263 C  CA  . CYS A 1 416 ? 13.581  65.469 20.732 1.00 33.44  ? 435  CYS A CA  1 
+ATOM   3264 C  C   . CYS A 1 416 ? 13.457  64.701 19.436 1.00 34.60  ? 435  CYS A C   1 
+ATOM   3265 O  O   . CYS A 1 416 ? 14.324  63.918 19.085 1.00 41.27  ? 435  CYS A O   1 
+ATOM   3266 C  CB  . CYS A 1 416 ? 14.727  66.446 20.598 1.00 33.70  ? 435  CYS A CB  1 
+ATOM   3267 S  SG  . CYS A 1 416 ? 14.569  67.657 19.289 1.00 33.40  ? 435  CYS A SG  1 
+ATOM   3268 N  N   . VAL A 1 417 ? 12.386  64.966 18.709 1.00 35.97  ? 436  VAL A N   1 
+ATOM   3269 C  CA  . VAL A 1 417 ? 12.113  64.313 17.440 1.00 35.15  ? 436  VAL A CA  1 
+ATOM   3270 C  C   . VAL A 1 417 ? 13.139  64.772 16.394 1.00 35.49  ? 436  VAL A C   1 
+ATOM   3271 O  O   . VAL A 1 417 ? 13.406  64.071 15.403 1.00 37.18  ? 436  VAL A O   1 
+ATOM   3272 C  CB  . VAL A 1 417 ? 10.628  64.596 17.053 1.00 36.18  ? 436  VAL A CB  1 
+ATOM   3273 C  CG1 . VAL A 1 417 ? 10.348  64.444 15.608 1.00 37.68  ? 436  VAL A CG1 1 
+ATOM   3274 C  CG2 . VAL A 1 417 ? 9.729   63.668 17.817 1.00 37.95  ? 436  VAL A CG2 1 
+ATOM   3275 N  N   . GLY A 1 418 ? 13.739  65.930 16.638 1.00 32.32  ? 437  GLY A N   1 
+ATOM   3276 C  CA  . GLY A 1 418 ? 14.695  66.493 15.714 1.00 32.02  ? 437  GLY A CA  1 
+ATOM   3277 C  C   . GLY A 1 418 ? 16.148  66.447 16.112 1.00 30.69  ? 437  GLY A C   1 
+ATOM   3278 O  O   . GLY A 1 418 ? 16.935  67.287 15.681 1.00 30.06  ? 437  GLY A O   1 
+ATOM   3279 N  N   . GLU A 1 419 ? 16.525  65.474 16.921 1.00 32.23  ? 438  GLU A N   1 
+ATOM   3280 C  CA  . GLU A 1 419 ? 17.906  65.366 17.373 1.00 30.35  ? 438  GLU A CA  1 
+ATOM   3281 C  C   . GLU A 1 419 ? 18.849  65.402 16.173 1.00 34.52  ? 438  GLU A C   1 
+ATOM   3282 O  O   . GLU A 1 419 ? 19.738  66.271 16.068 1.00 34.74  ? 438  GLU A O   1 
+ATOM   3283 C  CB  . GLU A 1 419 ? 18.086  64.069 18.147 1.00 33.34  ? 438  GLU A CB  1 
+ATOM   3284 C  CG  . GLU A 1 419 ? 19.327  64.011 19.018 1.00 37.16  ? 438  GLU A CG  1 
+ATOM   3285 C  CD  . GLU A 1 419 ? 19.497  62.667 19.724 1.00 41.67  ? 438  GLU A CD  1 
+ATOM   3286 O  OE1 . GLU A 1 419 ? 20.432  62.573 20.575 1.00 43.82  ? 438  GLU A OE1 1 
+ATOM   3287 O  OE2 . GLU A 1 419 ? 18.696  61.715 19.452 1.00 40.54  ? 438  GLU A OE2 1 
+ATOM   3288 N  N   . ALA A 1 420 ? 18.633  64.475 15.244 1.00 33.78  ? 439  ALA A N   1 
+ATOM   3289 C  CA  . ALA A 1 420 ? 19.488  64.380 14.065 1.00 30.60  ? 439  ALA A CA  1 
+ATOM   3290 C  C   . ALA A 1 420 ? 19.459  65.650 13.238 1.00 27.90  ? 439  ALA A C   1 
+ATOM   3291 O  O   . ALA A 1 420 ? 20.495  66.119 12.771 1.00 33.40  ? 439  ALA A O   1 
+ATOM   3292 C  CB  . ALA A 1 420 ? 19.092  63.202 13.227 1.00 29.59  ? 439  ALA A CB  1 
+ATOM   3293 N  N   . LEU A 1 421 ? 18.283  66.218 13.060 1.00 28.70  ? 440  LEU A N   1 
+ATOM   3294 C  CA  . LEU A 1 421 ? 18.141  67.378 12.185 1.00 31.96  ? 440  LEU A CA  1 
+ATOM   3295 C  C   . LEU A 1 421 ? 18.918  68.563 12.735 1.00 29.39  ? 440  LEU A C   1 
+ATOM   3296 O  O   . LEU A 1 421 ? 19.672  69.213 12.039 1.00 29.69  ? 440  LEU A O   1 
+ATOM   3297 C  CB  . LEU A 1 421 ? 16.667  67.735 12.036 1.00 35.75  ? 440  LEU A CB  1 
+ATOM   3298 C  CG  . LEU A 1 421 ? 16.360  69.006 11.242 1.00 38.50  ? 440  LEU A CG  1 
+ATOM   3299 C  CD1 . LEU A 1 421 ? 17.056  68.978 9.927  1.00 39.16  ? 440  LEU A CD1 1 
+ATOM   3300 C  CD2 . LEU A 1 421 ? 14.857  69.129 11.039 1.00 41.40  ? 440  LEU A CD2 1 
+ATOM   3301 N  N   . ALA A 1 422 ? 18.714  68.822 14.006 1.00 28.50  ? 441  ALA A N   1 
+ATOM   3302 C  CA  . ALA A 1 422 ? 19.480  69.806 14.737 1.00 29.61  ? 441  ALA A CA  1 
+ATOM   3303 C  C   . ALA A 1 422 ? 21.001  69.578 14.683 1.00 29.34  ? 441  ALA A C   1 
+ATOM   3304 O  O   . ALA A 1 422 ? 21.773  70.518 14.579 1.00 27.63  ? 441  ALA A O   1 
+ATOM   3305 C  CB  . ALA A 1 422 ? 19.004  69.807 16.192 1.00 31.64  ? 441  ALA A CB  1 
+ATOM   3306 N  N   . GLY A 1 423 ? 21.444  68.336 14.792 1.00 30.20  ? 442  GLY A N   1 
+ATOM   3307 C  CA  . GLY A 1 423 ? 22.863  68.049 14.654 1.00 30.81  ? 442  GLY A CA  1 
+ATOM   3308 C  C   . GLY A 1 423 ? 23.336  68.466 13.281 1.00 31.14  ? 442  GLY A C   1 
+ATOM   3309 O  O   . GLY A 1 423 ? 24.367  69.098 13.169 1.00 33.60  ? 442  GLY A O   1 
+ATOM   3310 N  N   . MET A 1 424 ? 22.569  68.143 12.241 1.00 31.76  ? 443  MET A N   1 
+ATOM   3311 C  CA  . MET A 1 424 ? 22.917  68.560 10.893 1.00 30.44  ? 443  MET A CA  1 
+ATOM   3312 C  C   . MET A 1 424 ? 22.953  70.058 10.778 1.00 31.49  ? 443  MET A C   1 
+ATOM   3313 O  O   . MET A 1 424 ? 23.846  70.601 10.153 1.00 31.80  ? 443  MET A O   1 
+ATOM   3314 C  CB  . MET A 1 424 ? 21.922  68.036 9.867  1.00 33.85  ? 443  MET A CB  1 
+ATOM   3315 C  CG  . MET A 1 424 ? 21.915  66.529 9.703  1.00 34.09  ? 443  MET A CG  1 
+ATOM   3316 S  SD  . MET A 1 424 ? 21.098  66.052 8.180  1.00 40.71  ? 443  MET A SD  1 
+ATOM   3317 C  CE  . MET A 1 424 ? 20.344  64.423 8.773  1.00 46.61  ? 443  MET A CE  1 
+ATOM   3318 N  N   . GLU A 1 425 ? 21.993  70.750 11.368 1.00 31.77  ? 444  GLU A N   1 
+ATOM   3319 C  CA  . GLU A 1 425 ? 21.927  72.189 11.159 1.00 31.06  ? 444  GLU A CA  1 
+ATOM   3320 C  C   . GLU A 1 425 ? 23.078  72.878 11.841 1.00 28.05  ? 444  GLU A C   1 
+ATOM   3321 O  O   . GLU A 1 425 ? 23.698  73.795 11.273 1.00 24.94  ? 444  GLU A O   1 
+ATOM   3322 C  CB  . GLU A 1 425 ? 20.628  72.768 11.665 1.00 32.92  ? 444  GLU A CB  1 
+ATOM   3323 C  CG  . GLU A 1 425 ? 19.418  72.292 10.901 1.00 37.84  ? 444  GLU A CG  1 
+ATOM   3324 C  CD  . GLU A 1 425 ? 18.180  73.031 11.338 1.00 42.20  ? 444  GLU A CD  1 
+ATOM   3325 O  OE1 . GLU A 1 425 ? 18.178  74.273 11.212 1.00 48.38  ? 444  GLU A OE1 1 
+ATOM   3326 O  OE2 . GLU A 1 425 ? 17.235  72.390 11.827 1.00 43.20  ? 444  GLU A OE2 1 
+ATOM   3327 N  N   . LEU A 1 426 ? 23.369  72.436 13.057 1.00 23.88  ? 445  LEU A N   1 
+ATOM   3328 C  CA  . LEU A 1 426 ? 24.407  73.082 13.851 1.00 23.07  ? 445  LEU A CA  1 
+ATOM   3329 C  C   . LEU A 1 426 ? 25.749  72.876 13.189 1.00 27.27  ? 445  LEU A C   1 
+ATOM   3330 O  O   . LEU A 1 426 ? 26.493  73.839 12.946 1.00 28.54  ? 445  LEU A O   1 
+ATOM   3331 C  CB  . LEU A 1 426 ? 24.433  72.502 15.251 1.00 21.11  ? 445  LEU A CB  1 
+ATOM   3332 C  CG  . LEU A 1 426 ? 23.211  72.946 16.039 1.00 21.47  ? 445  LEU A CG  1 
+ATOM   3333 C  CD1 . LEU A 1 426 ? 23.075  72.136 17.327 1.00 17.30  ? 445  LEU A CD1 1 
+ATOM   3334 C  CD2 . LEU A 1 426 ? 23.240  74.482 16.304 1.00 19.21  ? 445  LEU A CD2 1 
+ATOM   3335 N  N   . PHE A 1 427 ? 26.036  71.614 12.873 1.00 27.35  ? 446  PHE A N   1 
+ATOM   3336 C  CA  . PHE A 1 427 ? 27.298  71.239 12.241 1.00 32.64  ? 446  PHE A CA  1 
+ATOM   3337 C  C   . PHE A 1 427 ? 27.516  71.934 10.869 1.00 28.85  ? 446  PHE A C   1 
+ATOM   3338 O  O   . PHE A 1 427 ? 28.557  72.550 10.629 1.00 26.64  ? 446  PHE A O   1 
+ATOM   3339 C  CB  . PHE A 1 427 ? 27.399  69.713 12.098 1.00 33.69  ? 446  PHE A CB  1 
+ATOM   3340 C  CG  . PHE A 1 427 ? 28.665  69.276 11.454 1.00 38.12  ? 446  PHE A CG  1 
+ATOM   3341 C  CD1 . PHE A 1 427 ? 28.689  68.884 10.132 1.00 42.68  ? 446  PHE A CD1 1 
+ATOM   3342 C  CD2 . PHE A 1 427 ? 29.849  69.291 12.163 1.00 38.44  ? 446  PHE A CD2 1 
+ATOM   3343 C  CE1 . PHE A 1 427 ? 29.896  68.497 9.534  1.00 44.33  ? 446  PHE A CE1 1 
+ATOM   3344 C  CE2 . PHE A 1 427 ? 31.041  68.906 11.570 1.00 42.78  ? 446  PHE A CE2 1 
+ATOM   3345 C  CZ  . PHE A 1 427 ? 31.066  68.519 10.257 1.00 41.55  ? 446  PHE A CZ  1 
+ATOM   3346 N  N   . LEU A 1 428 ? 26.511  71.865 10.003 1.00 26.75  ? 447  LEU A N   1 
+ATOM   3347 C  CA  . LEU A 1 428 ? 26.618  72.404 8.646  1.00 25.60  ? 447  LEU A CA  1 
+ATOM   3348 C  C   . LEU A 1 428 ? 26.524  73.933 8.572  1.00 24.66  ? 447  LEU A C   1 
+ATOM   3349 O  O   . LEU A 1 428 ? 27.193  74.520 7.743  1.00 25.52  ? 447  LEU A O   1 
+ATOM   3350 C  CB  . LEU A 1 428 ? 25.588  71.750 7.718  1.00 24.02  ? 447  LEU A CB  1 
+ATOM   3351 C  CG  . LEU A 1 428 ? 25.711  70.229 7.637  1.00 29.23  ? 447  LEU A CG  1 
+ATOM   3352 C  CD1 . LEU A 1 428 ? 24.538  69.622 6.884  1.00 30.23  ? 447  LEU A CD1 1 
+ATOM   3353 C  CD2 . LEU A 1 428 ? 27.040  69.836 6.977  1.00 32.39  ? 447  LEU A CD2 1 
+ATOM   3354 N  N   . PHE A 1 429 ? 25.726  74.584 9.422  1.00 26.91  ? 448  PHE A N   1 
+ATOM   3355 C  CA  . PHE A 1 429 ? 25.689  76.057 9.415  1.00 29.36  ? 448  PHE A CA  1 
+ATOM   3356 C  C   . PHE A 1 429 ? 26.924  76.660 10.088 1.00 32.33  ? 448  PHE A C   1 
+ATOM   3357 O  O   . PHE A 1 429 ? 27.406  77.704 9.661  1.00 39.14  ? 448  PHE A O   1 
+ATOM   3358 C  CB  . PHE A 1 429 ? 24.458  76.637 10.128 1.00 30.61  ? 448  PHE A CB  1 
+ATOM   3359 C  CG  . PHE A 1 429 ? 23.129  76.250 9.533  1.00 26.90  ? 448  PHE A CG  1 
+ATOM   3360 C  CD1 . PHE A 1 429 ? 23.022  75.566 8.351  1.00 30.26  ? 448  PHE A CD1 1 
+ATOM   3361 C  CD2 . PHE A 1 429 ? 21.971  76.602 10.189 1.00 24.92  ? 448  PHE A CD2 1 
+ATOM   3362 C  CE1 . PHE A 1 429 ? 21.769  75.223 7.843  1.00 35.27  ? 448  PHE A CE1 1 
+ATOM   3363 C  CE2 . PHE A 1 429 ? 20.730  76.264 9.692  1.00 28.39  ? 448  PHE A CE2 1 
+ATOM   3364 C  CZ  . PHE A 1 429 ? 20.625  75.582 8.517  1.00 32.60  ? 448  PHE A CZ  1 
+ATOM   3365 N  N   . LEU A 1 430 ? 27.426  76.040 11.151 1.00 30.79  ? 449  LEU A N   1 
+ATOM   3366 C  CA  . LEU A 1 430 ? 28.588  76.595 11.837 1.00 30.90  ? 449  LEU A CA  1 
+ATOM   3367 C  C   . LEU A 1 430 ? 29.855  76.444 10.969 1.00 29.88  ? 449  LEU A C   1 
+ATOM   3368 O  O   . LEU A 1 430 ? 30.603  77.411 10.788 1.00 21.51  ? 449  LEU A O   1 
+ATOM   3369 C  CB  . LEU A 1 430 ? 28.768  75.961 13.229 1.00 31.56  ? 449  LEU A CB  1 
+ATOM   3370 C  CG  . LEU A 1 430 ? 27.741  76.394 14.285 1.00 35.96  ? 449  LEU A CG  1 
+ATOM   3371 C  CD1 . LEU A 1 430 ? 28.048  75.723 15.583 1.00 34.66  ? 449  LEU A CD1 1 
+ATOM   3372 C  CD2 . LEU A 1 430 ? 27.664  77.932 14.491 1.00 37.25  ? 449  LEU A CD2 1 
+ATOM   3373 N  N   . THR A 1 431 ? 30.076  75.244 10.420 1.00 29.18  ? 450  THR A N   1 
+ATOM   3374 C  CA  . THR A 1 431 ? 31.265  74.998 9.587  1.00 29.64  ? 450  THR A CA  1 
+ATOM   3375 C  C   . THR A 1 431 ? 31.195  75.850 8.355  1.00 28.81  ? 450  THR A C   1 
+ATOM   3376 O  O   . THR A 1 431 ? 32.200  76.429 7.964  1.00 32.21  ? 450  THR A O   1 
+ATOM   3377 C  CB  . THR A 1 431 ? 31.421  73.519 9.186  1.00 30.36  ? 450  THR A CB  1 
+ATOM   3378 O  OG1 . THR A 1 431 ? 30.180  72.986 8.699  1.00 34.16  ? 450  THR A OG1 1 
+ATOM   3379 C  CG2 . THR A 1 431 ? 31.726  72.655 10.413 1.00 31.55  ? 450  THR A CG2 1 
+ATOM   3380 N  N   . SER A 1 432 ? 29.999  75.959 7.771  1.00 28.40  ? 451  SER A N   1 
+ATOM   3381 C  CA  . SER A 1 432 ? 29.786  76.827 6.615  1.00 27.47  ? 451  SER A CA  1 
+ATOM   3382 C  C   . SER A 1 432 ? 30.124  78.281 6.937  1.00 29.16  ? 451  SER A C   1 
+ATOM   3383 O  O   . SER A 1 432 ? 30.802  78.935 6.157  1.00 32.94  ? 451  SER A O   1 
+ATOM   3384 C  CB  . SER A 1 432 ? 28.373  76.676 6.022  1.00 27.93  ? 451  SER A CB  1 
+ATOM   3385 O  OG  . SER A 1 432 ? 28.189  75.381 5.421  1.00 23.37  ? 451  SER A OG  1 
+ATOM   3386 N  N   . ILE A 1 433 ? 29.708  78.784 8.094  1.00 30.00  ? 452  ILE A N   1 
+ATOM   3387 C  CA  . ILE A 1 433 ? 30.029  80.152 8.459  1.00 29.35  ? 452  ILE A CA  1 
+ATOM   3388 C  C   . ILE A 1 433 ? 31.536  80.345 8.666  1.00 33.41  ? 452  ILE A C   1 
+ATOM   3389 O  O   . ILE A 1 433 ? 32.108  81.337 8.224  1.00 35.69  ? 452  ILE A O   1 
+ATOM   3390 C  CB  . ILE A 1 433 ? 29.287  80.566 9.734  1.00 32.21  ? 452  ILE A CB  1 
+ATOM   3391 C  CG1 . ILE A 1 433 ? 27.784  80.697 9.469  1.00 31.56  ? 452  ILE A CG1 1 
+ATOM   3392 C  CG2 . ILE A 1 433 ? 29.883  81.897 10.326 1.00 28.30  ? 452  ILE A CG2 1 
+ATOM   3393 C  CD1 . ILE A 1 433 ? 26.955  80.922 10.723 1.00 30.73  ? 452  ILE A CD1 1 
+ATOM   3394 N  N   . LEU A 1 434 ? 32.187  79.420 9.356  1.00 35.56  ? 453  LEU A N   1 
+ATOM   3395 C  CA  . LEU A 1 434 ? 33.603  79.614 9.690  1.00 35.66  ? 453  LEU A CA  1 
+ATOM   3396 C  C   . LEU A 1 434 ? 34.517  79.312 8.508  1.00 33.89  ? 453  LEU A C   1 
+ATOM   3397 O  O   . LEU A 1 434 ? 35.628  79.822 8.425  1.00 33.21  ? 453  LEU A O   1 
+ATOM   3398 C  CB  . LEU A 1 434 ? 33.990  78.786 10.902 1.00 34.89  ? 453  LEU A CB  1 
+ATOM   3399 C  CG  . LEU A 1 434 ? 33.335  79.311 12.170 1.00 36.20  ? 453  LEU A CG  1 
+ATOM   3400 C  CD1 . LEU A 1 434 ? 33.499  78.292 13.258 1.00 38.84  ? 453  LEU A CD1 1 
+ATOM   3401 C  CD2 . LEU A 1 434 ? 33.936  80.646 12.578 1.00 36.79  ? 453  LEU A CD2 1 
+ATOM   3402 N  N   . GLN A 1 435 ? 34.034  78.507 7.581  1.00 32.49  ? 454  GLN A N   1 
+ATOM   3403 C  CA  . GLN A 1 435 ? 34.745  78.313 6.326  1.00 35.68  ? 454  GLN A CA  1 
+ATOM   3404 C  C   . GLN A 1 435 ? 34.808  79.589 5.501  1.00 36.08  ? 454  GLN A C   1 
+ATOM   3405 O  O   . GLN A 1 435 ? 35.740  79.788 4.744  1.00 38.92  ? 454  GLN A O   1 
+ATOM   3406 C  CB  . GLN A 1 435 ? 34.046  77.252 5.501  1.00 35.01  ? 454  GLN A CB  1 
+ATOM   3407 C  CG  . GLN A 1 435 ? 34.571  77.127 4.103  1.00 33.32  ? 454  GLN A CG  1 
+ATOM   3408 C  CD  . GLN A 1 435 ? 33.744  76.183 3.287  1.00 34.79  ? 454  GLN A CD  1 
+ATOM   3409 O  OE1 . GLN A 1 435 ? 34.281  75.272 2.663  1.00 37.72  ? 454  GLN A OE1 1 
+ATOM   3410 N  NE2 . GLN A 1 435 ? 32.423  76.388 3.285  1.00 37.41  ? 454  GLN A NE2 1 
+ATOM   3411 N  N   . ASN A 1 436 ? 33.799  80.443 5.638  1.00 40.14  ? 455  ASN A N   1 
+ATOM   3412 C  CA  . ASN A 1 436 ? 33.636  81.577 4.745  1.00 36.76  ? 455  ASN A CA  1 
+ATOM   3413 C  C   . ASN A 1 436 ? 33.970  82.910 5.388  1.00 39.09  ? 455  ASN A C   1 
+ATOM   3414 O  O   . ASN A 1 436 ? 34.328  83.863 4.692  1.00 41.52  ? 455  ASN A O   1 
+ATOM   3415 C  CB  . ASN A 1 436 ? 32.214  81.569 4.193  1.00 36.92  ? 455  ASN A CB  1 
+ATOM   3416 C  CG  . ASN A 1 436 ? 32.004  80.487 3.126  1.00 32.82  ? 455  ASN A CG  1 
+ATOM   3417 O  OD1 . ASN A 1 436 ? 32.269  80.700 1.954  1.00 35.94  ? 455  ASN A OD1 1 
+ATOM   3418 N  ND2 . ASN A 1 436 ? 31.522  79.339 3.537  1.00 31.89  ? 455  ASN A ND2 1 
+ATOM   3419 N  N   . PHE A 1 437 ? 33.891  82.977 6.716  1.00 39.63  ? 456  PHE A N   1 
+ATOM   3420 C  CA  . PHE A 1 437 ? 34.128  84.224 7.439  1.00 38.25  ? 456  PHE A CA  1 
+ATOM   3421 C  C   . PHE A 1 437 ? 34.961  84.003 8.680  1.00 39.26  ? 456  PHE A C   1 
+ATOM   3422 O  O   . PHE A 1 437 ? 34.983  82.906 9.263  1.00 40.35  ? 456  PHE A O   1 
+ATOM   3423 C  CB  . PHE A 1 437 ? 32.800  84.868 7.899  1.00 40.01  ? 456  PHE A CB  1 
+ATOM   3424 C  CG  . PHE A 1 437 ? 31.754  84.956 6.829  1.00 42.03  ? 456  PHE A CG  1 
+ATOM   3425 C  CD1 . PHE A 1 437 ? 31.796  85.985 5.882  1.00 47.21  ? 456  PHE A CD1 1 
+ATOM   3426 C  CD2 . PHE A 1 437 ? 30.734  84.024 6.753  1.00 40.54  ? 456  PHE A CD2 1 
+ATOM   3427 C  CE1 . PHE A 1 437 ? 30.834  86.081 4.873  1.00 44.83  ? 456  PHE A CE1 1 
+ATOM   3428 C  CE2 . PHE A 1 437 ? 29.764  84.114 5.735  1.00 46.15  ? 456  PHE A CE2 1 
+ATOM   3429 C  CZ  . PHE A 1 437 ? 29.821  85.151 4.796  1.00 44.21  ? 456  PHE A CZ  1 
+ATOM   3430 N  N   . ASN A 1 438 ? 35.618  85.078 9.088  1.00 40.92  ? 457  ASN A N   1 
+ATOM   3431 C  CA  . ASN A 1 438 ? 36.161  85.231 10.417 1.00 42.55  ? 457  ASN A CA  1 
+ATOM   3432 C  C   . ASN A 1 438 ? 35.235  86.187 11.167 1.00 43.50  ? 457  ASN A C   1 
+ATOM   3433 O  O   . ASN A 1 438 ? 34.740  87.148 10.604 1.00 48.36  ? 457  ASN A O   1 
+ATOM   3434 C  CB  . ASN A 1 438 ? 37.598  85.768 10.346 1.00 42.31  ? 457  ASN A CB  1 
+ATOM   3435 C  CG  . ASN A 1 438 ? 38.534  84.836 9.581  1.00 43.03  ? 457  ASN A CG  1 
+ATOM   3436 O  OD1 . ASN A 1 438 ? 38.719  83.688 9.950  1.00 46.04  ? 457  ASN A OD1 1 
+ATOM   3437 N  ND2 . ASN A 1 438 ? 39.113  85.334 8.503  1.00 48.03  ? 457  ASN A ND2 1 
+ATOM   3438 N  N   . LEU A 1 439 ? 34.992  85.918 12.437 1.00 44.29  ? 458  LEU A N   1 
+ATOM   3439 C  CA  . LEU A 1 439 ? 34.040  86.692 13.210 1.00 45.69  ? 458  LEU A CA  1 
+ATOM   3440 C  C   . LEU A 1 439 ? 34.801  87.775 13.933 1.00 46.09  ? 458  LEU A C   1 
+ATOM   3441 O  O   . LEU A 1 439 ? 35.691  87.480 14.697 1.00 50.98  ? 458  LEU A O   1 
+ATOM   3442 C  CB  . LEU A 1 439 ? 33.314  85.778 14.205 1.00 45.14  ? 458  LEU A CB  1 
+ATOM   3443 C  CG  . LEU A 1 439 ? 32.880  84.427 13.622 1.00 45.29  ? 458  LEU A CG  1 
+ATOM   3444 C  CD1 . LEU A 1 439 ? 32.189  83.592 14.664 1.00 46.58  ? 458  LEU A CD1 1 
+ATOM   3445 C  CD2 . LEU A 1 439 ? 31.997  84.626 12.393 1.00 43.66  ? 458  LEU A CD2 1 
+ATOM   3446 N  N   . LYS A 1 440 ? 34.484  89.031 13.676 1.00 51.67  ? 459  LYS A N   1 
+ATOM   3447 C  CA  . LYS A 1 440 ? 35.117  90.110 14.407 1.00 55.62  ? 459  LYS A CA  1 
+ATOM   3448 C  C   . LYS A 1 440 ? 34.164  90.723 15.416 1.00 56.14  ? 459  LYS A C   1 
+ATOM   3449 O  O   . LYS A 1 440 ? 33.029  91.092 15.107 1.00 49.31  ? 459  LYS A O   1 
+ATOM   3450 C  CB  . LYS A 1 440 ? 35.668  91.178 13.477 1.00 60.15  ? 459  LYS A CB  1 
+ATOM   3451 C  CG  . LYS A 1 440 ? 36.506  92.218 14.223 1.00 67.14  ? 459  LYS A CG  1 
+ATOM   3452 C  CD  . LYS A 1 440 ? 37.433  93.010 13.293 1.00 73.38  ? 459  LYS A CD  1 
+ATOM   3453 C  CE  . LYS A 1 440 ? 37.681  94.449 13.797 1.00 74.99  ? 459  LYS A CE  1 
+ATOM   3454 N  NZ  . LYS A 1 440 ? 36.459  95.308 13.719 1.00 74.17  ? 459  LYS A NZ  1 
+ATOM   3455 N  N   . SER A 1 441 ? 34.658  90.794 16.644 1.00 61.96  ? 460  SER A N   1 
+ATOM   3456 C  CA  . SER A 1 441 ? 33.954  91.424 17.744 1.00 66.78  ? 460  SER A CA  1 
+ATOM   3457 C  C   . SER A 1 441 ? 34.212  92.903 17.633 1.00 69.99  ? 460  SER A C   1 
+ATOM   3458 O  O   . SER A 1 441 ? 35.223  93.317 17.059 1.00 69.84  ? 460  SER A O   1 
+ATOM   3459 C  CB  . SER A 1 441 ? 34.491  90.904 19.076 1.00 66.96  ? 460  SER A CB  1 
+ATOM   3460 O  OG  . SER A 1 441 ? 34.027  91.677 20.162 1.00 68.53  ? 460  SER A OG  1 
+ATOM   3461 N  N   . LEU A 1 442 ? 33.291  93.699 18.163 1.00 76.52  ? 461  LEU A N   1 
+ATOM   3462 C  CA  . LEU A 1 442 ? 33.501  95.146 18.259 1.00 79.14  ? 461  LEU A CA  1 
+ATOM   3463 C  C   . LEU A 1 442 ? 33.763  95.588 19.707 1.00 80.78  ? 461  LEU A C   1 
+ATOM   3464 O  O   . LEU A 1 442 ? 34.357  96.638 19.923 1.00 80.13  ? 461  LEU A O   1 
+ATOM   3465 C  CB  . LEU A 1 442 ? 32.351  95.950 17.612 1.00 79.38  ? 461  LEU A CB  1 
+ATOM   3466 C  CG  . LEU A 1 442 ? 30.937  95.377 17.443 1.00 78.91  ? 461  LEU A CG  1 
+ATOM   3467 C  CD1 . LEU A 1 442 ? 29.916  96.518 17.257 1.00 78.86  ? 461  LEU A CD1 1 
+ATOM   3468 C  CD2 . LEU A 1 442 ? 30.861  94.400 16.272 1.00 77.63  ? 461  LEU A CD2 1 
+ATOM   3469 N  N   . VAL A 1 443 ? 33.350  94.785 20.689 1.00 84.24  ? 462  VAL A N   1 
+ATOM   3470 C  CA  . VAL A 1 443 ? 33.566  95.114 22.107 1.00 86.40  ? 462  VAL A CA  1 
+ATOM   3471 C  C   . VAL A 1 443 ? 34.760  94.370 22.751 1.00 86.45  ? 462  VAL A C   1 
+ATOM   3472 O  O   . VAL A 1 443 ? 34.886  94.360 23.976 1.00 87.74  ? 462  VAL A O   1 
+ATOM   3473 C  CB  . VAL A 1 443 ? 32.233  94.937 22.948 1.00 86.21  ? 462  VAL A CB  1 
+ATOM   3474 C  CG1 . VAL A 1 443 ? 32.137  93.562 23.597 1.00 86.36  ? 462  VAL A CG1 1 
+ATOM   3475 C  CG2 . VAL A 1 443 ? 32.075  96.046 24.008 1.00 86.59  ? 462  VAL A CG2 1 
+ATOM   3476 N  N   . ASP A 1 444 ? 35.633  93.772 21.936 1.00 87.28  ? 463  ASP A N   1 
+ATOM   3477 C  CA  . ASP A 1 444 ? 36.879  93.152 22.419 1.00 89.60  ? 463  ASP A CA  1 
+ATOM   3478 C  C   . ASP A 1 444 ? 36.623  91.904 23.315 1.00 89.34  ? 463  ASP A C   1 
+ATOM   3479 O  O   . ASP A 1 444 ? 36.071  92.032 24.413 1.00 85.97  ? 463  ASP A O   1 
+ATOM   3480 C  CB  . ASP A 1 444 ? 37.767  94.232 23.103 1.00 92.06  ? 463  ASP A CB  1 
+ATOM   3481 C  CG  . ASP A 1 444 ? 38.848  93.655 24.041 1.00 96.29  ? 463  ASP A CG  1 
+ATOM   3482 O  OD1 . ASP A 1 444 ? 39.647  92.778 23.622 1.00 97.17  ? 463  ASP A OD1 1 
+ATOM   3483 O  OD2 . ASP A 1 444 ? 38.989  94.063 25.221 1.00 98.16  ? 463  ASP A OD2 1 
+ATOM   3484 N  N   . PRO A 1 445 ? 37.027  90.709 22.850 1.00 90.54  ? 464  PRO A N   1 
+ATOM   3485 C  CA  . PRO A 1 445 ? 36.751  89.443 23.562 1.00 90.71  ? 464  PRO A CA  1 
+ATOM   3486 C  C   . PRO A 1 445 ? 36.785  89.505 25.094 1.00 89.59  ? 464  PRO A C   1 
+ATOM   3487 O  O   . PRO A 1 445 ? 35.806  89.136 25.744 1.00 88.48  ? 464  PRO A O   1 
+ATOM   3488 C  CB  . PRO A 1 445 ? 37.867  88.492 23.064 1.00 91.07  ? 464  PRO A CB  1 
+ATOM   3489 C  CG  . PRO A 1 445 ? 38.455  89.130 21.815 1.00 90.77  ? 464  PRO A CG  1 
+ATOM   3490 C  CD  . PRO A 1 445 ? 37.782  90.467 21.604 1.00 90.56  ? 464  PRO A CD  1 
+ATOM   3491 N  N   . LYS A 1 446 ? 37.905  89.974 25.638 1.00 89.25  ? 465  LYS A N   1 
+ATOM   3492 C  CA  . LYS A 1 446 ? 38.188  89.929 27.077 1.00 89.10  ? 465  LYS A CA  1 
+ATOM   3493 C  C   . LYS A 1 446 ? 37.011  90.375 27.958 1.00 87.10  ? 465  LYS A C   1 
+ATOM   3494 O  O   . LYS A 1 446 ? 36.650  89.682 28.914 1.00 86.20  ? 465  LYS A O   1 
+ATOM   3495 C  CB  . LYS A 1 446 ? 39.446  90.770 27.394 1.00 89.70  ? 465  LYS A CB  1 
+ATOM   3496 C  CG  . LYS A 1 446 ? 40.711  89.939 27.622 1.00 90.21  ? 465  LYS A CG  1 
+ATOM   3497 C  CD  . LYS A 1 446 ? 40.675  89.220 28.986 1.00 91.31  ? 465  LYS A CD  1 
+ATOM   3498 C  CE  . LYS A 1 446 ? 41.765  89.718 29.951 1.00 91.65  ? 465  LYS A CE  1 
+ATOM   3499 N  NZ  . LYS A 1 446 ? 41.218  90.050 31.299 1.00 90.47  ? 465  LYS A NZ  1 
+ATOM   3500 N  N   . ASN A 1 447 ? 36.431  91.527 27.624 1.00 85.29  ? 466  ASN A N   1 
+ATOM   3501 C  CA  . ASN A 1 447 ? 35.319  92.108 28.389 1.00 85.85  ? 466  ASN A CA  1 
+ATOM   3502 C  C   . ASN A 1 447 ? 34.047  91.258 28.369 1.00 85.90  ? 466  ASN A C   1 
+ATOM   3503 O  O   . ASN A 1 447 ? 33.630  90.734 29.416 1.00 87.70  ? 466  ASN A O   1 
+ATOM   3504 C  CB  . ASN A 1 447 ? 34.956  93.508 27.859 1.00 85.58  ? 466  ASN A CB  1 
+ATOM   3505 C  CG  . ASN A 1 447 ? 35.709  94.619 28.569 1.00 86.77  ? 466  ASN A CG  1 
+ATOM   3506 O  OD1 . ASN A 1 447 ? 35.317  95.062 29.650 1.00 85.97  ? 466  ASN A OD1 1 
+ATOM   3507 N  ND2 . ASN A 1 447 ? 36.794  95.081 27.959 1.00 84.71  ? 466  ASN A ND2 1 
+ATOM   3508 N  N   . LEU A 1 448 ? 33.470  91.118 27.166 1.00 82.33  ? 467  LEU A N   1 
+ATOM   3509 C  CA  . LEU A 1 448 ? 32.081  90.685 26.960 1.00 77.52  ? 467  LEU A CA  1 
+ATOM   3510 C  C   . LEU A 1 448 ? 31.679  89.433 27.715 1.00 74.81  ? 467  LEU A C   1 
+ATOM   3511 O  O   . LEU A 1 448 ? 32.443  88.476 27.806 1.00 72.16  ? 467  LEU A O   1 
+ATOM   3512 C  CB  . LEU A 1 448 ? 31.784  90.505 25.471 1.00 78.17  ? 467  LEU A CB  1 
+ATOM   3513 C  CG  . LEU A 1 448 ? 32.472  89.369 24.708 1.00 77.97  ? 467  LEU A CG  1 
+ATOM   3514 C  CD1 . LEU A 1 448 ? 31.444  88.351 24.284 1.00 77.42  ? 467  LEU A CD1 1 
+ATOM   3515 C  CD2 . LEU A 1 448 ? 33.240  89.867 23.484 1.00 78.39  ? 467  LEU A CD2 1 
+ATOM   3516 N  N   . ASP A 1 449 ? 30.461  89.470 28.251 1.00 73.68  ? 468  ASP A N   1 
+ATOM   3517 C  CA  . ASP A 1 449 ? 29.962  88.464 29.191 1.00 71.69  ? 468  ASP A CA  1 
+ATOM   3518 C  C   . ASP A 1 449 ? 29.139  87.441 28.403 1.00 66.07  ? 468  ASP A C   1 
+ATOM   3519 O  O   . ASP A 1 449 ? 28.405  87.815 27.489 1.00 60.31  ? 468  ASP A O   1 
+ATOM   3520 C  CB  . ASP A 1 449 ? 29.144  89.167 30.303 1.00 74.84  ? 468  ASP A CB  1 
+ATOM   3521 C  CG  . ASP A 1 449 ? 28.040  88.289 30.896 1.00 79.92  ? 468  ASP A CG  1 
+ATOM   3522 O  OD1 . ASP A 1 449 ? 26.916  88.246 30.322 1.00 85.20  ? 468  ASP A OD1 1 
+ATOM   3523 O  OD2 . ASP A 1 449 ? 28.198  87.623 31.943 1.00 78.66  ? 468  ASP A OD2 1 
+ATOM   3524 N  N   . THR A 1 450 ? 29.286  86.156 28.723 1.00 60.15  ? 469  THR A N   1 
+ATOM   3525 C  CA  . THR A 1 450 ? 28.559  85.118 27.999 1.00 57.23  ? 469  THR A CA  1 
+ATOM   3526 C  C   . THR A 1 450 ? 27.609  84.349 28.896 1.00 57.92  ? 469  THR A C   1 
+ATOM   3527 O  O   . THR A 1 450 ? 27.100  83.288 28.523 1.00 55.49  ? 469  THR A O   1 
+ATOM   3528 C  CB  . THR A 1 450 ? 29.537  84.160 27.295 1.00 56.63  ? 469  THR A CB  1 
+ATOM   3529 O  OG1 . THR A 1 450 ? 30.201  83.308 28.247 1.00 58.20  ? 469  THR A OG1 1 
+ATOM   3530 C  CG2 . THR A 1 450 ? 30.635  84.932 26.619 1.00 54.10  ? 469  THR A CG2 1 
+ATOM   3531 N  N   . THR A 1 451 ? 27.348  84.904 30.071 1.00 61.06  ? 470  THR A N   1 
+ATOM   3532 C  CA  . THR A 1 451 ? 26.544  84.224 31.074 1.00 62.76  ? 470  THR A CA  1 
+ATOM   3533 C  C   . THR A 1 451 ? 25.094  84.292 30.641 1.00 60.54  ? 470  THR A C   1 
+ATOM   3534 O  O   . THR A 1 451 ? 24.593  85.367 30.317 1.00 58.76  ? 470  THR A O   1 
+ATOM   3535 C  CB  . THR A 1 451 ? 26.725  84.864 32.462 1.00 65.11  ? 470  THR A CB  1 
+ATOM   3536 O  OG1 . THR A 1 451 ? 28.113  85.178 32.667 1.00 64.29  ? 470  THR A OG1 1 
+ATOM   3537 C  CG2 . THR A 1 451 ? 26.373  83.852 33.581 1.00 65.42  ? 470  THR A CG2 1 
+ATOM   3538 N  N   . PRO A 1 452 ? 24.439  83.138 30.587 1.00 60.80  ? 471  PRO A N   1 
+ATOM   3539 C  CA  . PRO A 1 452 ? 23.038  83.075 30.177 1.00 60.54  ? 471  PRO A CA  1 
+ATOM   3540 C  C   . PRO A 1 452 ? 22.162  84.072 30.919 1.00 63.07  ? 471  PRO A C   1 
+ATOM   3541 O  O   . PRO A 1 452 ? 22.372  84.273 32.104 1.00 65.31  ? 471  PRO A O   1 
+ATOM   3542 C  CB  . PRO A 1 452 ? 22.638  81.637 30.532 1.00 61.06  ? 471  PRO A CB  1 
+ATOM   3543 C  CG  . PRO A 1 452 ? 23.917  80.839 30.480 1.00 61.03  ? 471  PRO A CG  1 
+ATOM   3544 C  CD  . PRO A 1 452 ? 25.006  81.798 30.845 1.00 60.75  ? 471  PRO A CD  1 
+ATOM   3545 N  N   . VAL A 1 453 ? 21.240  84.714 30.206 1.00 65.18  ? 472  VAL A N   1 
+ATOM   3546 C  CA  . VAL A 1 453 ? 20.078  85.388 30.791 1.00 66.96  ? 472  VAL A CA  1 
+ATOM   3547 C  C   . VAL A 1 453 ? 18.906  84.367 30.923 1.00 69.45  ? 472  VAL A C   1 
+ATOM   3548 O  O   . VAL A 1 453 ? 18.329  83.934 29.926 1.00 67.70  ? 472  VAL A O   1 
+ATOM   3549 C  CB  . VAL A 1 453 ? 19.671  86.626 29.922 1.00 67.05  ? 472  VAL A CB  1 
+ATOM   3550 C  CG1 . VAL A 1 453 ? 18.260  87.128 30.248 1.00 66.24  ? 472  VAL A CG1 1 
+ATOM   3551 C  CG2 . VAL A 1 453 ? 20.695  87.743 30.069 1.00 65.54  ? 472  VAL A CG2 1 
+ATOM   3552 N  N   . VAL A 1 454 ? 18.565  84.008 32.161 1.00 73.44  ? 473  VAL A N   1 
+ATOM   3553 C  CA  . VAL A 1 454 ? 17.591  82.949 32.451 1.00 76.49  ? 473  VAL A CA  1 
+ATOM   3554 C  C   . VAL A 1 454 ? 16.324  83.507 33.077 1.00 77.30  ? 473  VAL A C   1 
+ATOM   3555 O  O   . VAL A 1 454 ? 16.393  84.281 34.030 1.00 79.82  ? 473  VAL A O   1 
+ATOM   3556 C  CB  . VAL A 1 454 ? 18.159  81.919 33.470 1.00 77.80  ? 473  VAL A CB  1 
+ATOM   3557 C  CG1 . VAL A 1 454 ? 17.227  80.682 33.576 1.00 80.88  ? 473  VAL A CG1 1 
+ATOM   3558 C  CG2 . VAL A 1 454 ? 19.581  81.511 33.105 1.00 74.90  ? 473  VAL A CG2 1 
+ATOM   3559 N  N   . ASN A 1 455 ? 15.170  83.085 32.564 1.00 77.27  ? 474  ASN A N   1 
+ATOM   3560 C  CA  . ASN A 1 455 ? 13.875  83.483 33.126 1.00 75.32  ? 474  ASN A CA  1 
+ATOM   3561 C  C   . ASN A 1 455 ? 12.923  82.277 33.090 1.00 72.50  ? 474  ASN A C   1 
+ATOM   3562 O  O   . ASN A 1 455 ? 12.358  81.947 32.044 1.00 69.97  ? 474  ASN A O   1 
+ATOM   3563 C  CB  . ASN A 1 455 ? 13.293  84.693 32.368 1.00 76.46  ? 474  ASN A CB  1 
+ATOM   3564 C  CG  . ASN A 1 455 ? 14.032  86.015 32.677 1.00 77.44  ? 474  ASN A CG  1 
+ATOM   3565 O  OD1 . ASN A 1 455 ? 14.809  86.507 31.864 1.00 80.54  ? 474  ASN A OD1 1 
+ATOM   3566 N  ND2 . ASN A 1 455 ? 13.777  86.589 33.845 1.00 77.74  ? 474  ASN A ND2 1 
+ATOM   3567 N  N   . GLY A 1 456 ? 12.784  81.607 34.234 1.00 72.55  ? 475  GLY A N   1 
+ATOM   3568 C  CA  . GLY A 1 456 ? 11.969  80.403 34.348 1.00 72.40  ? 475  GLY A CA  1 
+ATOM   3569 C  C   . GLY A 1 456 ? 12.686  79.150 33.859 1.00 72.20  ? 475  GLY A C   1 
+ATOM   3570 O  O   . GLY A 1 456 ? 13.675  78.734 34.479 1.00 70.60  ? 475  GLY A O   1 
+ATOM   3571 N  N   . PHE A 1 457 ? 12.184  78.559 32.763 1.00 71.91  ? 476  PHE A N   1 
+ATOM   3572 C  CA  . PHE A 1 457 ? 12.829  77.423 32.084 1.00 71.98  ? 476  PHE A CA  1 
+ATOM   3573 C  C   . PHE A 1 457 ? 13.387  77.799 30.700 1.00 70.39  ? 476  PHE A C   1 
+ATOM   3574 O  O   . PHE A 1 457 ? 13.352  76.982 29.769 1.00 68.44  ? 476  PHE A O   1 
+ATOM   3575 C  CB  . PHE A 1 457 ? 11.850  76.258 31.865 1.00 73.64  ? 476  PHE A CB  1 
+ATOM   3576 C  CG  . PHE A 1 457 ? 10.934  75.968 33.021 1.00 75.92  ? 476  PHE A CG  1 
+ATOM   3577 C  CD1 . PHE A 1 457 ? 9.585   75.695 32.777 1.00 78.30  ? 476  PHE A CD1 1 
+ATOM   3578 C  CD2 . PHE A 1 457 ? 11.405  75.909 34.329 1.00 75.04  ? 476  PHE A CD2 1 
+ATOM   3579 C  CE1 . PHE A 1 457 ? 8.723   75.402 33.813 1.00 76.18  ? 476  PHE A CE1 1 
+ATOM   3580 C  CE2 . PHE A 1 457 ? 10.534  75.618 35.372 1.00 73.70  ? 476  PHE A CE2 1 
+ATOM   3581 C  CZ  . PHE A 1 457 ? 9.202   75.365 35.115 1.00 75.78  ? 476  PHE A CZ  1 
+ATOM   3582 N  N   . ALA A 1 458 ? 13.883  79.023 30.552 1.00 68.66  ? 477  ALA A N   1 
+ATOM   3583 C  CA  . ALA A 1 458 ? 14.383  79.489 29.260 1.00 67.01  ? 477  ALA A CA  1 
+ATOM   3584 C  C   . ALA A 1 458 ? 15.614  80.384 29.441 1.00 64.49  ? 477  ALA A C   1 
+ATOM   3585 O  O   . ALA A 1 458 ? 15.528  81.479 30.034 1.00 61.06  ? 477  ALA A O   1 
+ATOM   3586 C  CB  . ALA A 1 458 ? 13.284  80.229 28.508 1.00 69.69  ? 477  ALA A CB  1 
+ATOM   3587 N  N   . SER A 1 459 ? 16.756  79.888 28.956 1.00 57.72  ? 478  SER A N   1 
+ATOM   3588 C  CA  . SER A 1 459 ? 17.987  80.664 28.911 1.00 53.98  ? 478  SER A CA  1 
+ATOM   3589 C  C   . SER A 1 459 ? 18.125  81.225 27.521 1.00 47.16  ? 478  SER A C   1 
+ATOM   3590 O  O   . SER A 1 459 ? 17.633  80.637 26.560 1.00 46.55  ? 478  SER A O   1 
+ATOM   3591 C  CB  . SER A 1 459 ? 19.214  79.801 29.202 1.00 55.82  ? 478  SER A CB  1 
+ATOM   3592 O  OG  . SER A 1 459 ? 19.176  79.262 30.509 1.00 61.71  ? 478  SER A OG  1 
+ATOM   3593 N  N   . VAL A 1 460 ? 18.829  82.346 27.426 1.00 39.90  ? 479  VAL A N   1 
+ATOM   3594 C  CA  . VAL A 1 460 ? 19.137  82.988 26.153 1.00 37.43  ? 479  VAL A CA  1 
+ATOM   3595 C  C   . VAL A 1 460 ? 20.432  83.773 26.326 1.00 35.07  ? 479  VAL A C   1 
+ATOM   3596 O  O   . VAL A 1 460 ? 20.721  84.262 27.409 1.00 33.20  ? 479  VAL A O   1 
+ATOM   3597 C  CB  . VAL A 1 460 ? 18.004  83.978 25.673 1.00 37.69  ? 479  VAL A CB  1 
+ATOM   3598 C  CG1 . VAL A 1 460 ? 16.799  83.227 25.163 1.00 37.71  ? 479  VAL A CG1 1 
+ATOM   3599 C  CG2 . VAL A 1 460 ? 17.577  84.936 26.777 1.00 37.30  ? 479  VAL A CG2 1 
+ATOM   3600 N  N   . PRO A 1 461 ? 21.212  83.919 25.274 1.00 31.63  ? 480  PRO A N   1 
+ATOM   3601 C  CA  . PRO A 1 461 ? 22.431  84.715 25.383 1.00 35.67  ? 480  PRO A CA  1 
+ATOM   3602 C  C   . PRO A 1 461 ? 22.092  86.186 25.537 1.00 38.99  ? 480  PRO A C   1 
+ATOM   3603 O  O   . PRO A 1 461 ? 20.982  86.587 25.193 1.00 45.42  ? 480  PRO A O   1 
+ATOM   3604 C  CB  . PRO A 1 461 ? 23.145  84.478 24.050 1.00 34.43  ? 480  PRO A CB  1 
+ATOM   3605 C  CG  . PRO A 1 461 ? 22.089  84.013 23.128 1.00 33.00  ? 480  PRO A CG  1 
+ATOM   3606 C  CD  . PRO A 1 461 ? 21.010  83.370 23.930 1.00 29.68  ? 480  PRO A CD  1 
+ATOM   3607 N  N   . PRO A 1 462 ? 23.042  86.974 26.015 1.00 39.11  ? 481  PRO A N   1 
+ATOM   3608 C  CA  . PRO A 1 462 ? 22.892  88.413 26.050 1.00 39.33  ? 481  PRO A CA  1 
+ATOM   3609 C  C   . PRO A 1 462 ? 23.099  88.957 24.663 1.00 40.43  ? 481  PRO A C   1 
+ATOM   3610 O  O   . PRO A 1 462 ? 23.670  88.313 23.789 1.00 43.39  ? 481  PRO A O   1 
+ATOM   3611 C  CB  . PRO A 1 462 ? 24.056  88.852 26.938 1.00 38.55  ? 481  PRO A CB  1 
+ATOM   3612 C  CG  . PRO A 1 462 ? 25.109  87.886 26.628 1.00 40.31  ? 481  PRO A CG  1 
+ATOM   3613 C  CD  . PRO A 1 462 ? 24.366  86.568 26.513 1.00 41.67  ? 481  PRO A CD  1 
+ATOM   3614 N  N   . PHE A 1 463 ? 22.685  90.188 24.477 1.00 41.22  ? 482  PHE A N   1 
+ATOM   3615 C  CA  . PHE A 1 463 ? 22.738  90.776 23.166 1.00 41.31  ? 482  PHE A CA  1 
+ATOM   3616 C  C   . PHE A 1 463 ? 24.178  91.087 22.806 1.00 36.80  ? 482  PHE A C   1 
+ATOM   3617 O  O   . PHE A 1 463 ? 24.917  91.582 23.620 1.00 41.70  ? 482  PHE A O   1 
+ATOM   3618 C  CB  . PHE A 1 463 ? 21.894  92.056 23.148 1.00 41.83  ? 482  PHE A CB  1 
+ATOM   3619 C  CG  . PHE A 1 463 ? 22.201  92.946 21.989 1.00 44.01  ? 482  PHE A CG  1 
+ATOM   3620 C  CD1 . PHE A 1 463 ? 23.214  93.899 22.082 1.00 42.62  ? 482  PHE A CD1 1 
+ATOM   3621 C  CD2 . PHE A 1 463 ? 21.509  92.803 20.794 1.00 40.90  ? 482  PHE A CD2 1 
+ATOM   3622 C  CE1 . PHE A 1 463 ? 23.515  94.702 21.006 1.00 44.26  ? 482  PHE A CE1 1 
+ATOM   3623 C  CE2 . PHE A 1 463 ? 21.802  93.604 19.719 1.00 41.73  ? 482  PHE A CE2 1 
+ATOM   3624 C  CZ  . PHE A 1 463 ? 22.808  94.555 19.817 1.00 42.63  ? 482  PHE A CZ  1 
+ATOM   3625 N  N   . TYR A 1 464 ? 24.558  90.823 21.571 1.00 37.59  ? 483  TYR A N   1 
+ATOM   3626 C  CA  . TYR A 1 464 ? 25.864  91.230 21.058 1.00 37.31  ? 483  TYR A CA  1 
+ATOM   3627 C  C   . TYR A 1 464 ? 25.778  91.526 19.573 1.00 38.12  ? 483  TYR A C   1 
+ATOM   3628 O  O   . TYR A 1 464 ? 24.790  91.226 18.916 1.00 38.93  ? 483  TYR A O   1 
+ATOM   3629 C  CB  . TYR A 1 464 ? 26.912  90.126 21.266 1.00 34.16  ? 483  TYR A CB  1 
+ATOM   3630 C  CG  . TYR A 1 464 ? 26.655  88.890 20.412 1.00 33.32  ? 483  TYR A CG  1 
+ATOM   3631 C  CD1 . TYR A 1 464 ? 27.371  88.673 19.232 1.00 36.10  ? 483  TYR A CD1 1 
+ATOM   3632 C  CD2 . TYR A 1 464 ? 25.686  87.953 20.778 1.00 31.73  ? 483  TYR A CD2 1 
+ATOM   3633 C  CE1 . TYR A 1 464 ? 27.133  87.556 18.442 1.00 34.13  ? 483  TYR A CE1 1 
+ATOM   3634 C  CE2 . TYR A 1 464 ? 25.437  86.840 20.008 1.00 33.00  ? 483  TYR A CE2 1 
+ATOM   3635 C  CZ  . TYR A 1 464 ? 26.164  86.642 18.836 1.00 36.58  ? 483  TYR A CZ  1 
+ATOM   3636 O  OH  . TYR A 1 464 ? 25.911  85.546 18.047 1.00 28.98  ? 483  TYR A OH  1 
+ATOM   3637 N  N   . GLN A 1 465 ? 26.848  92.100 19.061 1.00 40.74  ? 484  GLN A N   1 
+ATOM   3638 C  CA  . GLN A 1 465 ? 27.018  92.311 17.647 1.00 45.85  ? 484  GLN A CA  1 
+ATOM   3639 C  C   . GLN A 1 465 ? 28.363  91.749 17.174 1.00 45.57  ? 484  GLN A C   1 
+ATOM   3640 O  O   . GLN A 1 465 ? 29.290  91.536 17.967 1.00 47.33  ? 484  GLN A O   1 
+ATOM   3641 C  CB  . GLN A 1 465 ? 26.981  93.807 17.350 1.00 49.47  ? 484  GLN A CB  1 
+ATOM   3642 C  CG  . GLN A 1 465 ? 25.690  94.536 17.778 1.00 54.98  ? 484  GLN A CG  1 
+ATOM   3643 C  CD  . GLN A 1 465 ? 25.597  95.938 17.166 1.00 54.65  ? 484  GLN A CD  1 
+ATOM   3644 O  OE1 . GLN A 1 465 ? 26.533  96.728 17.286 1.00 57.68  ? 484  GLN A OE1 1 
+ATOM   3645 N  NE2 . GLN A 1 465 ? 24.490  96.231 16.494 1.00 56.33  ? 484  GLN A NE2 1 
+ATOM   3646 N  N   . LEU A 1 466 ? 28.466  91.533 15.867 1.00 43.46  ? 485  LEU A N   1 
+ATOM   3647 C  CA  . LEU A 1 466 ? 29.708  91.082 15.249 1.00 45.53  ? 485  LEU A CA  1 
+ATOM   3648 C  C   . LEU A 1 466 ? 29.723  91.349 13.734 1.00 44.45  ? 485  LEU A C   1 
+ATOM   3649 O  O   . LEU A 1 466 ? 28.676  91.553 13.126 1.00 44.75  ? 485  LEU A O   1 
+ATOM   3650 C  CB  . LEU A 1 466 ? 29.923  89.590 15.542 1.00 45.57  ? 485  LEU A CB  1 
+ATOM   3651 C  CG  . LEU A 1 466 ? 29.087  88.564 14.767 1.00 45.06  ? 485  LEU A CG  1 
+ATOM   3652 C  CD1 . LEU A 1 466 ? 29.554  87.153 15.059 1.00 46.91  ? 485  LEU A CD1 1 
+ATOM   3653 C  CD2 . LEU A 1 466 ? 27.618  88.693 15.075 1.00 47.47  ? 485  LEU A CD2 1 
+ATOM   3654 N  N   . CYS A 1 467 ? 30.910  91.338 13.137 1.00 43.20  ? 486  CYS A N   1 
+ATOM   3655 C  CA  . CYS A 1 467 ? 31.054  91.508 11.701 1.00 44.90  ? 486  CYS A CA  1 
+ATOM   3656 C  C   . CYS A 1 467 ? 31.468  90.190 11.130 1.00 46.71  ? 486  CYS A C   1 
+ATOM   3657 O  O   . CYS A 1 467 ? 32.281  89.493 11.719 1.00 48.17  ? 486  CYS A O   1 
+ATOM   3658 C  CB  . CYS A 1 467 ? 32.148  92.526 11.370 1.00 47.18  ? 486  CYS A CB  1 
+ATOM   3659 S  SG  . CYS A 1 467 ? 32.067  94.053 12.323 1.00 52.37  ? 486  CYS A SG  1 
+ATOM   3660 N  N   . PHE A 1 468 ? 30.933  89.855 9.968  1.00 47.17  ? 487  PHE A N   1 
+ATOM   3661 C  CA  . PHE A 1 468 ? 31.341  88.652 9.273  1.00 45.68  ? 487  PHE A CA  1 
+ATOM   3662 C  C   . PHE A 1 468 ? 32.328  89.056 8.172  1.00 46.46  ? 487  PHE A C   1 
+ATOM   3663 O  O   . PHE A 1 468 ? 31.910  89.471 7.101  1.00 48.55  ? 487  PHE A O   1 
+ATOM   3664 C  CB  . PHE A 1 468 ? 30.098  87.931 8.716  1.00 45.57  ? 487  PHE A CB  1 
+ATOM   3665 C  CG  . PHE A 1 468 ? 29.172  87.413 9.790  1.00 43.37  ? 487  PHE A CG  1 
+ATOM   3666 C  CD1 . PHE A 1 468 ? 28.211  88.233 10.353 1.00 44.34  ? 487  PHE A CD1 1 
+ATOM   3667 C  CD2 . PHE A 1 468 ? 29.277  86.107 10.252 1.00 40.53  ? 487  PHE A CD2 1 
+ATOM   3668 C  CE1 . PHE A 1 468 ? 27.363  87.757 11.376 1.00 43.66  ? 487  PHE A CE1 1 
+ATOM   3669 C  CE2 . PHE A 1 468 ? 28.439  85.633 11.275 1.00 41.83  ? 487  PHE A CE2 1 
+ATOM   3670 C  CZ  . PHE A 1 468 ? 27.486  86.455 11.834 1.00 38.60  ? 487  PHE A CZ  1 
+ATOM   3671 N  N   . ILE A 1 469 ? 33.630  88.963 8.455  1.00 47.42  ? 488  ILE A N   1 
+ATOM   3672 C  CA  . ILE A 1 469 ? 34.682  89.303 7.482  1.00 49.52  ? 488  ILE A CA  1 
+ATOM   3673 C  C   . ILE A 1 469 ? 35.041  88.115 6.598  1.00 51.52  ? 488  ILE A C   1 
+ATOM   3674 O  O   . ILE A 1 469 ? 35.512  87.120 7.107  1.00 54.99  ? 488  ILE A O   1 
+ATOM   3675 C  CB  . ILE A 1 469 ? 35.985  89.773 8.184  1.00 46.95  ? 488  ILE A CB  1 
+ATOM   3676 C  CG1 . ILE A 1 469 ? 35.822  91.169 8.752  1.00 46.01  ? 488  ILE A CG1 1 
+ATOM   3677 C  CG2 . ILE A 1 469 ? 37.148  89.793 7.199  1.00 46.20  ? 488  ILE A CG2 1 
+ATOM   3678 C  CD1 . ILE A 1 469 ? 35.125  91.182 10.042 1.00 52.03  ? 488  ILE A CD1 1 
+ATOM   3679 N  N   . PRO A 1 470 ? 34.895  88.219 5.281  1.00 55.05  ? 489  PRO A N   1 
+ATOM   3680 C  CA  . PRO A 1 470 ? 35.207  87.077 4.410  1.00 56.93  ? 489  PRO A CA  1 
+ATOM   3681 C  C   . PRO A 1 470 ? 36.685  86.728 4.419  1.00 55.92  ? 489  PRO A C   1 
+ATOM   3682 O  O   . PRO A 1 470 ? 37.503  87.616 4.589  1.00 62.07  ? 489  PRO A O   1 
+ATOM   3683 C  CB  . PRO A 1 470 ? 34.751  87.552 3.025  1.00 57.54  ? 489  PRO A CB  1 
+ATOM   3684 C  CG  . PRO A 1 470 ? 33.824  88.692 3.307  1.00 56.71  ? 489  PRO A CG  1 
+ATOM   3685 C  CD  . PRO A 1 470 ? 34.417  89.373 4.506  1.00 54.56  ? 489  PRO A CD  1 
+ATOM   3686 N  N   . VAL A 1 471 ? 37.007  85.457 4.230  1.00 55.87  ? 490  VAL A N   1 
+ATOM   3687 C  CA  . VAL A 1 471 ? 38.375  84.956 4.378  1.00 57.14  ? 490  VAL A CA  1 
+ATOM   3688 C  C   . VAL A 1 471 ? 39.286  85.243 3.154  1.00 61.04  ? 490  VAL A C   1 
+ATOM   3689 O  O   . VAL A 1 471 ? 38.798  85.177 2.017  1.00 62.59  ? 490  VAL A O   1 
+ATOM   3690 C  CB  . VAL A 1 471 ? 38.364  83.434 4.663  1.00 56.13  ? 490  VAL A CB  1 
+ATOM   3691 C  CG1 . VAL A 1 471 ? 37.644  83.142 5.959  1.00 55.78  ? 490  VAL A CG1 1 
+ATOM   3692 C  CG2 . VAL A 1 471 ? 37.730  82.645 3.510  1.00 54.84  ? 490  VAL A CG2 1 
+ATOM   3693 N  N   . HIS A 1 472 ? 40.514  85.528 3.240  1.00 57.05  ? 491  HIS A N   1 
+ATOM   3694 N  N   . PRO B 1 11  ? 57.425  70.240 57.617 1.00 54.43  ? 30   PRO B N   1 
+ATOM   3695 C  CA  . PRO B 1 11  ? 56.507  69.110 57.849 1.00 56.73  ? 30   PRO B CA  1 
+ATOM   3696 C  C   . PRO B 1 11  ? 57.165  68.075 58.721 1.00 58.10  ? 30   PRO B C   1 
+ATOM   3697 O  O   . PRO B 1 11  ? 58.388  68.101 58.819 1.00 62.13  ? 30   PRO B O   1 
+ATOM   3698 C  CB  . PRO B 1 11  ? 56.271  68.528 56.436 1.00 53.60  ? 30   PRO B CB  1 
+ATOM   3699 C  CG  . PRO B 1 11  ? 56.624  69.568 55.503 1.00 50.78  ? 30   PRO B CG  1 
+ATOM   3700 C  CD  . PRO B 1 11  ? 57.682  70.411 56.180 1.00 56.04  ? 30   PRO B CD  1 
+ATOM   3701 N  N   . PRO B 1 12  ? 56.374  67.174 59.307 1.00 58.74  ? 31   PRO B N   1 
+ATOM   3702 C  CA  . PRO B 1 12  ? 56.878  66.171 60.250 1.00 59.47  ? 31   PRO B CA  1 
+ATOM   3703 C  C   . PRO B 1 12  ? 57.637  65.126 59.486 1.00 61.31  ? 31   PRO B C   1 
+ATOM   3704 O  O   . PRO B 1 12  ? 57.806  65.343 58.301 1.00 64.88  ? 31   PRO B O   1 
+ATOM   3705 C  CB  . PRO B 1 12  ? 55.598  65.572 60.850 1.00 60.00  ? 31   PRO B CB  1 
+ATOM   3706 C  CG  . PRO B 1 12  ? 54.565  65.744 59.789 1.00 59.27  ? 31   PRO B CG  1 
+ATOM   3707 C  CD  . PRO B 1 12  ? 54.922  67.034 59.084 1.00 59.30  ? 31   PRO B CD  1 
+ATOM   3708 N  N   . GLY B 1 13  ? 58.064  64.040 60.131 1.00 64.11  ? 32   GLY B N   1 
+ATOM   3709 C  CA  . GLY B 1 13  ? 58.800  62.960 59.474 1.00 63.30  ? 32   GLY B CA  1 
+ATOM   3710 C  C   . GLY B 1 13  ? 59.794  62.275 60.400 1.00 61.87  ? 32   GLY B C   1 
+ATOM   3711 O  O   . GLY B 1 13  ? 60.103  62.805 61.465 1.00 61.56  ? 32   GLY B O   1 
+ATOM   3712 N  N   . PRO B 1 14  ? 60.351  61.136 59.993 1.00 61.48  ? 33   PRO B N   1 
+ATOM   3713 C  CA  . PRO B 1 14  ? 61.204  60.368 60.905 1.00 62.51  ? 33   PRO B CA  1 
+ATOM   3714 C  C   . PRO B 1 14  ? 62.485  61.129 61.194 1.00 63.89  ? 33   PRO B C   1 
+ATOM   3715 O  O   . PRO B 1 14  ? 62.873  62.013 60.415 1.00 65.39  ? 33   PRO B O   1 
+ATOM   3716 C  CB  . PRO B 1 14  ? 61.495  59.058 60.154 1.00 58.71  ? 33   PRO B CB  1 
+ATOM   3717 C  CG  . PRO B 1 14  ? 60.693  59.106 58.933 1.00 61.28  ? 33   PRO B CG  1 
+ATOM   3718 C  CD  . PRO B 1 14  ? 60.324  60.542 58.651 1.00 61.30  ? 33   PRO B CD  1 
+ATOM   3719 N  N   . THR B 1 15  ? 63.101  60.801 62.324 1.00 64.96  ? 34   THR B N   1 
+ATOM   3720 C  CA  . THR B 1 15  ? 64.306  61.479 62.771 1.00 64.37  ? 34   THR B CA  1 
+ATOM   3721 C  C   . THR B 1 15  ? 65.479  60.896 61.992 1.00 62.59  ? 34   THR B C   1 
+ATOM   3722 O  O   . THR B 1 15  ? 65.677  59.677 62.005 1.00 61.17  ? 34   THR B O   1 
+ATOM   3723 C  CB  . THR B 1 15  ? 64.462  61.328 64.309 1.00 64.76  ? 34   THR B CB  1 
+ATOM   3724 O  OG1 . THR B 1 15  ? 63.852  62.459 64.937 1.00 64.88  ? 34   THR B OG1 1 
+ATOM   3725 C  CG2 . THR B 1 15  ? 65.944  61.370 64.790 1.00 65.45  ? 34   THR B CG2 1 
+ATOM   3726 N  N   . PRO B 1 16  ? 66.207  61.753 61.273 1.00 61.95  ? 35   PRO B N   1 
+ATOM   3727 C  CA  . PRO B 1 16  ? 67.376  61.313 60.515 1.00 62.44  ? 35   PRO B CA  1 
+ATOM   3728 C  C   . PRO B 1 16  ? 68.598  61.154 61.408 1.00 64.13  ? 35   PRO B C   1 
+ATOM   3729 O  O   . PRO B 1 16  ? 68.954  62.068 62.153 1.00 59.59  ? 35   PRO B O   1 
+ATOM   3730 C  CB  . PRO B 1 16  ? 67.590  62.447 59.503 1.00 62.98  ? 35   PRO B CB  1 
+ATOM   3731 C  CG  . PRO B 1 16  ? 67.081  63.668 60.188 1.00 62.89  ? 35   PRO B CG  1 
+ATOM   3732 C  CD  . PRO B 1 16  ? 65.962  63.201 61.100 1.00 63.02  ? 35   PRO B CD  1 
+ATOM   3733 N  N   . LEU B 1 17  ? 69.212  59.977 61.319 1.00 66.86  ? 36   LEU B N   1 
+ATOM   3734 C  CA  . LEU B 1 17  ? 70.513  59.706 61.908 1.00 68.73  ? 36   LEU B CA  1 
+ATOM   3735 C  C   . LEU B 1 17  ? 71.624  60.574 61.269 1.00 71.80  ? 36   LEU B C   1 
+ATOM   3736 O  O   . LEU B 1 17  ? 71.449  61.086 60.156 1.00 72.79  ? 36   LEU B O   1 
+ATOM   3737 C  CB  . LEU B 1 17  ? 70.813  58.211 61.770 1.00 68.51  ? 36   LEU B CB  1 
+ATOM   3738 C  CG  . LEU B 1 17  ? 69.980  57.289 62.688 1.00 68.44  ? 36   LEU B CG  1 
+ATOM   3739 C  CD1 . LEU B 1 17  ? 70.343  55.858 62.373 1.00 66.02  ? 36   LEU B CD1 1 
+ATOM   3740 C  CD2 . LEU B 1 17  ? 70.142  57.552 64.205 1.00 66.36  ? 36   LEU B CD2 1 
+ATOM   3741 N  N   . PRO B 1 18  ? 72.751  60.750 61.974 1.00 74.33  ? 37   PRO B N   1 
+ATOM   3742 C  CA  . PRO B 1 18  ? 73.766  61.752 61.611 1.00 74.39  ? 37   PRO B CA  1 
+ATOM   3743 C  C   . PRO B 1 18  ? 74.079  61.938 60.118 1.00 72.91  ? 37   PRO B C   1 
+ATOM   3744 O  O   . PRO B 1 18  ? 73.912  63.056 59.616 1.00 74.58  ? 37   PRO B O   1 
+ATOM   3745 C  CB  . PRO B 1 18  ? 75.021  61.271 62.371 1.00 75.81  ? 37   PRO B CB  1 
+ATOM   3746 C  CG  . PRO B 1 18  ? 74.509  60.548 63.587 1.00 75.55  ? 37   PRO B CG  1 
+ATOM   3747 C  CD  . PRO B 1 18  ? 73.142  60.024 63.204 1.00 75.72  ? 37   PRO B CD  1 
+ATOM   3748 N  N   . VAL B 1 19  ? 74.544  60.892 59.440 1.00 70.18  ? 38   VAL B N   1 
+ATOM   3749 C  CA  . VAL B 1 19  ? 74.979  61.022 58.041 1.00 70.53  ? 38   VAL B CA  1 
+ATOM   3750 C  C   . VAL B 1 19  ? 74.215  60.113 57.062 1.00 67.69  ? 38   VAL B C   1 
+ATOM   3751 O  O   . VAL B 1 19  ? 74.041  60.454 55.888 1.00 66.86  ? 38   VAL B O   1 
+ATOM   3752 C  CB  . VAL B 1 19  ? 76.506  60.779 57.906 1.00 72.77  ? 38   VAL B CB  1 
+ATOM   3753 C  CG1 . VAL B 1 19  ? 76.860  59.290 58.170 1.00 74.43  ? 38   VAL B CG1 1 
+ATOM   3754 C  CG2 . VAL B 1 19  ? 77.024  61.268 56.523 1.00 73.14  ? 38   VAL B CG2 1 
+ATOM   3755 N  N   . ILE B 1 20  ? 73.774  58.958 57.548 1.00 65.10  ? 39   ILE B N   1 
+ATOM   3756 C  CA  . ILE B 1 20  ? 72.951  58.044 56.760 1.00 63.34  ? 39   ILE B CA  1 
+ATOM   3757 C  C   . ILE B 1 20  ? 71.491  58.527 56.548 1.00 60.94  ? 39   ILE B C   1 
+ATOM   3758 O  O   . ILE B 1 20  ? 70.756  57.940 55.759 1.00 59.84  ? 39   ILE B O   1 
+ATOM   3759 C  CB  . ILE B 1 20  ? 72.975  56.598 57.376 1.00 64.80  ? 39   ILE B CB  1 
+ATOM   3760 C  CG1 . ILE B 1 20  ? 72.644  56.599 58.874 1.00 63.61  ? 39   ILE B CG1 1 
+ATOM   3761 C  CG2 . ILE B 1 20  ? 74.328  55.916 57.140 1.00 65.92  ? 39   ILE B CG2 1 
+ATOM   3762 C  CD1 . ILE B 1 20  ? 72.515  55.196 59.439 1.00 63.21  ? 39   ILE B CD1 1 
+ATOM   3763 N  N   . GLY B 1 21  ? 71.073  59.585 57.239 1.00 56.80  ? 40   GLY B N   1 
+ATOM   3764 C  CA  . GLY B 1 21  ? 69.717  60.090 57.103 1.00 53.11  ? 40   GLY B CA  1 
+ATOM   3765 C  C   . GLY B 1 21  ? 68.676  59.047 57.467 1.00 50.59  ? 40   GLY B C   1 
+ATOM   3766 O  O   . GLY B 1 21  ? 68.791  58.396 58.510 1.00 52.88  ? 40   GLY B O   1 
+ATOM   3767 N  N   . ASN B 1 22  ? 67.669  58.877 56.605 1.00 48.30  ? 41   ASN B N   1 
+ATOM   3768 C  CA  . ASN B 1 22  ? 66.564  57.938 56.853 1.00 46.68  ? 41   ASN B CA  1 
+ATOM   3769 C  C   . ASN B 1 22  ? 66.720  56.624 56.106 1.00 45.74  ? 41   ASN B C   1 
+ATOM   3770 O  O   . ASN B 1 22  ? 65.818  55.799 56.116 1.00 41.06  ? 41   ASN B O   1 
+ATOM   3771 C  CB  . ASN B 1 22  ? 65.214  58.567 56.490 1.00 45.30  ? 41   ASN B CB  1 
+ATOM   3772 C  CG  . ASN B 1 22  ? 64.778  59.627 57.472 1.00 46.24  ? 41   ASN B CG  1 
+ATOM   3773 O  OD1 . ASN B 1 22  ? 64.641  59.370 58.680 1.00 46.21  ? 41   ASN B OD1 1 
+ATOM   3774 N  ND2 . ASN B 1 22  ? 64.538  60.829 56.963 1.00 38.07  ? 41   ASN B ND2 1 
+ATOM   3775 N  N   . ILE B 1 23  ? 67.868  56.424 55.469 1.00 48.21  ? 42   ILE B N   1 
+ATOM   3776 C  CA  . ILE B 1 23  ? 68.187  55.148 54.824 1.00 51.94  ? 42   ILE B CA  1 
+ATOM   3777 C  C   . ILE B 1 23  ? 67.859  53.905 55.676 1.00 52.96  ? 42   ILE B C   1 
+ATOM   3778 O  O   . ILE B 1 23  ? 67.677  52.823 55.134 1.00 56.00  ? 42   ILE B O   1 
+ATOM   3779 C  CB  . ILE B 1 23  ? 69.678  55.104 54.399 1.00 50.69  ? 42   ILE B CB  1 
+ATOM   3780 C  CG1 . ILE B 1 23  ? 69.851  54.324 53.100 1.00 51.62  ? 42   ILE B CG1 1 
+ATOM   3781 C  CG2 . ILE B 1 23  ? 70.537  54.450 55.471 1.00 50.95  ? 42   ILE B CG2 1 
+ATOM   3782 C  CD1 . ILE B 1 23  ? 71.292  54.312 52.588 1.00 50.59  ? 42   ILE B CD1 1 
+ATOM   3783 N  N   . LEU B 1 24  ? 67.797  54.043 56.994 1.00 55.68  ? 43   LEU B N   1 
+ATOM   3784 C  CA  . LEU B 1 24  ? 67.536  52.877 57.834 1.00 60.16  ? 43   LEU B CA  1 
+ATOM   3785 C  C   . LEU B 1 24  ? 66.101  52.338 57.723 1.00 60.99  ? 43   LEU B C   1 
+ATOM   3786 O  O   . LEU B 1 24  ? 65.886  51.123 57.707 1.00 57.98  ? 43   LEU B O   1 
+ATOM   3787 C  CB  . LEU B 1 24  ? 67.896  53.179 59.281 1.00 60.52  ? 43   LEU B CB  1 
+ATOM   3788 C  CG  . LEU B 1 24  ? 69.086  52.368 59.814 1.00 64.39  ? 43   LEU B CG  1 
+ATOM   3789 C  CD1 . LEU B 1 24  ? 70.076  51.811 58.755 1.00 64.31  ? 43   LEU B CD1 1 
+ATOM   3790 C  CD2 . LEU B 1 24  ? 69.834  53.210 60.815 1.00 66.13  ? 43   LEU B CD2 1 
+ATOM   3791 N  N   . GLN B 1 25  ? 65.149  53.259 57.632 1.00 61.79  ? 44   GLN B N   1 
+ATOM   3792 C  CA  . GLN B 1 25  ? 63.735  52.940 57.457 1.00 64.99  ? 44   GLN B CA  1 
+ATOM   3793 C  C   . GLN B 1 25  ? 63.293  52.799 55.971 1.00 63.93  ? 44   GLN B C   1 
+ATOM   3794 O  O   . GLN B 1 25  ? 62.682  51.775 55.609 1.00 62.76  ? 44   GLN B O   1 
+ATOM   3795 C  CB  . GLN B 1 25  ? 62.834  53.943 58.234 1.00 68.02  ? 44   GLN B CB  1 
+ATOM   3796 C  CG  . GLN B 1 25  ? 63.256  55.441 58.215 1.00 72.27  ? 44   GLN B CG  1 
+ATOM   3797 C  CD  . GLN B 1 25  ? 63.912  55.929 59.534 1.00 76.63  ? 44   GLN B CD  1 
+ATOM   3798 O  OE1 . GLN B 1 25  ? 63.206  56.252 60.490 1.00 82.52  ? 44   GLN B OE1 1 
+ATOM   3799 N  NE2 . GLN B 1 25  ? 65.245  55.998 59.570 1.00 72.60  ? 44   GLN B NE2 1 
+ATOM   3800 N  N   . ILE B 1 26  ? 63.581  53.785 55.116 1.00 60.42  ? 45   ILE B N   1 
+ATOM   3801 C  CA  . ILE B 1 26  ? 63.172  53.682 53.699 1.00 61.83  ? 45   ILE B CA  1 
+ATOM   3802 C  C   . ILE B 1 26  ? 63.878  52.548 52.956 1.00 60.69  ? 45   ILE B C   1 
+ATOM   3803 O  O   . ILE B 1 26  ? 63.288  51.905 52.098 1.00 59.79  ? 45   ILE B O   1 
+ATOM   3804 C  CB  . ILE B 1 26  ? 63.344  55.006 52.908 1.00 61.71  ? 45   ILE B CB  1 
+ATOM   3805 C  CG1 . ILE B 1 26  ? 64.814  55.325 52.670 1.00 62.20  ? 45   ILE B CG1 1 
+ATOM   3806 C  CG2 . ILE B 1 26  ? 62.636  56.143 53.624 1.00 65.65  ? 45   ILE B CG2 1 
+ATOM   3807 C  CD1 . ILE B 1 26  ? 65.086  56.757 52.240 1.00 63.33  ? 45   ILE B CD1 1 
+ATOM   3808 N  N   . GLY B 1 27  ? 65.132  52.302 53.298 1.00 61.09  ? 46   GLY B N   1 
+ATOM   3809 C  CA  . GLY B 1 27  ? 65.915  51.305 52.608 1.00 61.35  ? 46   GLY B CA  1 
+ATOM   3810 C  C   . GLY B 1 27  ? 66.397  51.861 51.287 1.00 63.36  ? 46   GLY B C   1 
+ATOM   3811 O  O   . GLY B 1 27  ? 66.672  53.047 51.163 1.00 59.52  ? 46   GLY B O   1 
+ATOM   3812 N  N   . ILE B 1 28  ? 66.430  50.998 50.279 1.00 68.04  ? 47   ILE B N   1 
+ATOM   3813 C  CA  . ILE B 1 28  ? 67.234  51.221 49.077 1.00 68.43  ? 47   ILE B CA  1 
+ATOM   3814 C  C   . ILE B 1 28  ? 66.689  50.414 47.882 1.00 70.85  ? 47   ILE B C   1 
+ATOM   3815 O  O   . ILE B 1 28  ? 66.852  50.823 46.729 1.00 67.62  ? 47   ILE B O   1 
+ATOM   3816 C  CB  . ILE B 1 28  ? 68.689  50.833 49.415 1.00 68.91  ? 47   ILE B CB  1 
+ATOM   3817 C  CG1 . ILE B 1 28  ? 69.619  50.994 48.207 1.00 69.77  ? 47   ILE B CG1 1 
+ATOM   3818 C  CG2 . ILE B 1 28  ? 68.729  49.401 50.013 1.00 70.92  ? 47   ILE B CG2 1 
+ATOM   3819 C  CD1 . ILE B 1 28  ? 71.000  50.340 48.379 1.00 68.99  ? 47   ILE B CD1 1 
+ATOM   3820 N  N   . LYS B 1 29  ? 66.065  49.267 48.167 1.00 74.69  ? 48   LYS B N   1 
+ATOM   3821 C  CA  . LYS B 1 29  ? 65.306  48.515 47.165 1.00 78.41  ? 48   LYS B CA  1 
+ATOM   3822 C  C   . LYS B 1 29  ? 63.979  49.244 46.801 1.00 78.58  ? 48   LYS B C   1 
+ATOM   3823 O  O   . LYS B 1 29  ? 64.008  50.164 45.984 1.00 77.76  ? 48   LYS B O   1 
+ATOM   3824 C  CB  . LYS B 1 29  ? 65.091  47.034 47.586 1.00 81.26  ? 48   LYS B CB  1 
+ATOM   3825 C  CG  . LYS B 1 29  ? 64.759  46.747 49.089 1.00 84.00  ? 48   LYS B CG  1 
+ATOM   3826 C  CD  . LYS B 1 29  ? 64.566  45.233 49.360 1.00 84.78  ? 48   LYS B CD  1 
+ATOM   3827 C  CE  . LYS B 1 29  ? 64.152  44.935 50.815 1.00 84.61  ? 48   LYS B CE  1 
+ATOM   3828 N  NZ  . LYS B 1 29  ? 65.308  44.899 51.759 1.00 80.92  ? 48   LYS B NZ  1 
+ATOM   3829 N  N   . ASP B 1 30  ? 62.849  48.855 47.406 1.00 78.47  ? 49   ASP B N   1 
+ATOM   3830 C  CA  . ASP B 1 30  ? 61.511  49.396 47.071 1.00 80.27  ? 49   ASP B CA  1 
+ATOM   3831 C  C   . ASP B 1 30  ? 61.161  50.597 47.953 1.00 76.85  ? 49   ASP B C   1 
+ATOM   3832 O  O   . ASP B 1 30  ? 60.349  50.476 48.877 1.00 76.75  ? 49   ASP B O   1 
+ATOM   3833 C  CB  . ASP B 1 30  ? 60.424  48.284 47.234 1.00 84.46  ? 49   ASP B CB  1 
+ATOM   3834 C  CG  . ASP B 1 30  ? 59.032  48.651 46.598 1.00 88.36  ? 49   ASP B CG  1 
+ATOM   3835 O  OD1 . ASP B 1 30  ? 58.115  47.788 46.626 1.00 87.53  ? 49   ASP B OD1 1 
+ATOM   3836 O  OD2 . ASP B 1 30  ? 58.749  49.743 46.052 1.00 92.27  ? 49   ASP B OD2 1 
+ATOM   3837 N  N   . ILE B 1 31  ? 61.748  51.759 47.669 1.00 73.15  ? 50   ILE B N   1 
+ATOM   3838 C  CA  . ILE B 1 31  ? 61.466  52.944 48.484 1.00 72.13  ? 50   ILE B CA  1 
+ATOM   3839 C  C   . ILE B 1 31  ? 59.956  53.311 48.473 1.00 71.34  ? 50   ILE B C   1 
+ATOM   3840 O  O   . ILE B 1 31  ? 59.446  53.836 49.453 1.00 71.26  ? 50   ILE B O   1 
+ATOM   3841 C  CB  . ILE B 1 31  ? 62.368  54.160 48.102 1.00 71.66  ? 50   ILE B CB  1 
+ATOM   3842 C  CG1 . ILE B 1 31  ? 61.953  54.768 46.761 1.00 76.38  ? 50   ILE B CG1 1 
+ATOM   3843 C  CG2 . ILE B 1 31  ? 63.851  53.767 48.064 1.00 71.11  ? 50   ILE B CG2 1 
+ATOM   3844 C  CD1 . ILE B 1 31  ? 61.691  56.269 46.818 1.00 77.55  ? 50   ILE B CD1 1 
+ATOM   3845 N  N   . SER B 1 32  ? 59.246  52.995 47.390 1.00 69.88  ? 51   SER B N   1 
+ATOM   3846 C  CA  . SER B 1 32  ? 57.794  53.237 47.301 1.00 70.37  ? 51   SER B CA  1 
+ATOM   3847 C  C   . SER B 1 32  ? 56.941  52.483 48.348 1.00 68.31  ? 51   SER B C   1 
+ATOM   3848 O  O   . SER B 1 32  ? 55.968  53.037 48.870 1.00 58.23  ? 51   SER B O   1 
+ATOM   3849 C  CB  . SER B 1 32  ? 57.245  52.939 45.874 1.00 73.12  ? 51   SER B CB  1 
+ATOM   3850 O  OG  . SER B 1 32  ? 58.067  52.050 45.106 1.00 73.89  ? 51   SER B OG  1 
+ATOM   3851 N  N   . LYS B 1 33  ? 57.291  51.227 48.643 1.00 70.45  ? 52   LYS B N   1 
+ATOM   3852 C  CA  . LYS B 1 33  ? 56.501  50.414 49.588 1.00 71.98  ? 52   LYS B CA  1 
+ATOM   3853 C  C   . LYS B 1 33  ? 56.554  50.991 50.995 1.00 67.60  ? 52   LYS B C   1 
+ATOM   3854 O  O   . LYS B 1 33  ? 55.539  51.006 51.709 1.00 69.43  ? 52   LYS B O   1 
+ATOM   3855 C  CB  . LYS B 1 33  ? 56.950  48.945 49.616 1.00 76.11  ? 52   LYS B CB  1 
+ATOM   3856 C  CG  . LYS B 1 33  ? 55.805  47.958 49.974 1.00 81.92  ? 52   LYS B CG  1 
+ATOM   3857 C  CD  . LYS B 1 33  ? 54.949  47.565 48.739 1.00 85.82  ? 52   LYS B CD  1 
+ATOM   3858 C  CE  . LYS B 1 33  ? 53.521  48.152 48.778 1.00 86.39  ? 52   LYS B CE  1 
+ATOM   3859 N  NZ  . LYS B 1 33  ? 52.931  48.286 47.403 1.00 87.07  ? 52   LYS B NZ  1 
+ATOM   3860 N  N   . SER B 1 34  ? 57.732  51.480 51.377 1.00 59.69  ? 53   SER B N   1 
+ATOM   3861 C  CA  . SER B 1 34  ? 57.903  52.093 52.685 1.00 55.82  ? 53   SER B CA  1 
+ATOM   3862 C  C   . SER B 1 34  ? 57.347  53.522 52.801 1.00 55.39  ? 53   SER B C   1 
+ATOM   3863 O  O   . SER B 1 34  ? 57.180  54.020 53.906 1.00 54.81  ? 53   SER B O   1 
+ATOM   3864 C  CB  . SER B 1 34  ? 59.369  52.033 53.114 1.00 52.93  ? 53   SER B CB  1 
+ATOM   3865 O  OG  . SER B 1 34  ? 60.181  52.734 52.226 1.00 51.20  ? 53   SER B OG  1 
+ATOM   3866 N  N   . LEU B 1 35  ? 57.064  54.181 51.676 1.00 55.84  ? 54   LEU B N   1 
+ATOM   3867 C  CA  . LEU B 1 35  ? 56.466  55.520 51.679 1.00 50.19  ? 54   LEU B CA  1 
+ATOM   3868 C  C   . LEU B 1 35  ? 54.975  55.465 52.035 1.00 51.35  ? 54   LEU B C   1 
+ATOM   3869 O  O   . LEU B 1 35  ? 54.453  56.358 52.711 1.00 51.60  ? 54   LEU B O   1 
+ATOM   3870 C  CB  . LEU B 1 35  ? 56.617  56.173 50.317 1.00 49.20  ? 54   LEU B CB  1 
+ATOM   3871 C  CG  . LEU B 1 35  ? 57.981  56.749 49.978 1.00 53.14  ? 54   LEU B CG  1 
+ATOM   3872 C  CD1 . LEU B 1 35  ? 57.983  57.236 48.533 1.00 58.13  ? 54   LEU B CD1 1 
+ATOM   3873 C  CD2 . LEU B 1 35  ? 58.365  57.879 50.878 1.00 52.49  ? 54   LEU B CD2 1 
+ATOM   3874 N  N   . THR B 1 36  ? 54.279  54.432 51.579 1.00 47.22  ? 55   THR B N   1 
+ATOM   3875 C  CA  . THR B 1 36  ? 52.901  54.239 52.008 1.00 49.08  ? 55   THR B CA  1 
+ATOM   3876 C  C   . THR B 1 36  ? 52.820  53.829 53.488 1.00 49.09  ? 55   THR B C   1 
+ATOM   3877 O  O   . THR B 1 36  ? 51.864  54.152 54.173 1.00 50.67  ? 55   THR B O   1 
+ATOM   3878 C  CB  . THR B 1 36  ? 52.213  53.204 51.117 1.00 48.57  ? 55   THR B CB  1 
+ATOM   3879 O  OG1 . THR B 1 36  ? 52.004  53.778 49.822 1.00 53.30  ? 55   THR B OG1 1 
+ATOM   3880 C  CG2 . THR B 1 36  ? 50.806  52.882 51.613 1.00 47.10  ? 55   THR B CG2 1 
+ATOM   3881 N  N   . ASN B 1 37  ? 53.808  53.096 53.978 1.00 50.90  ? 56   ASN B N   1 
+ATOM   3882 C  CA  . ASN B 1 37  ? 53.879  52.821 55.409 1.00 48.33  ? 56   ASN B CA  1 
+ATOM   3883 C  C   . ASN B 1 37  ? 54.104  54.091 56.209 1.00 47.97  ? 56   ASN B C   1 
+ATOM   3884 O  O   . ASN B 1 37  ? 53.444  54.299 57.230 1.00 52.67  ? 56   ASN B O   1 
+ATOM   3885 C  CB  . ASN B 1 37  ? 54.956  51.795 55.724 1.00 44.50  ? 56   ASN B CB  1 
+ATOM   3886 C  CG  . ASN B 1 37  ? 54.505  50.392 55.428 1.00 43.30  ? 56   ASN B CG  1 
+ATOM   3887 O  OD1 . ASN B 1 37  ? 53.353  50.146 55.082 1.00 39.24  ? 56   ASN B OD1 1 
+ATOM   3888 N  ND2 . ASN B 1 37  ? 55.419  49.458 55.559 1.00 46.07  ? 56   ASN B ND2 1 
+ATOM   3889 N  N   . LEU B 1 38  ? 54.984  54.965 55.744 1.00 43.86  ? 57   LEU B N   1 
+ATOM   3890 C  CA  . LEU B 1 38  ? 55.243  56.197 56.484 1.00 47.09  ? 57   LEU B CA  1 
+ATOM   3891 C  C   . LEU B 1 38  ? 54.046  57.168 56.476 1.00 49.03  ? 57   LEU B C   1 
+ATOM   3892 O  O   . LEU B 1 38  ? 53.927  57.993 57.374 1.00 51.53  ? 57   LEU B O   1 
+ATOM   3893 C  CB  . LEU B 1 38  ? 56.520  56.894 55.994 1.00 46.41  ? 57   LEU B CB  1 
+ATOM   3894 C  CG  . LEU B 1 38  ? 57.828  56.132 56.292 1.00 50.59  ? 57   LEU B CG  1 
+ATOM   3895 C  CD1 . LEU B 1 38  ? 58.981  56.643 55.466 1.00 51.68  ? 57   LEU B CD1 1 
+ATOM   3896 C  CD2 . LEU B 1 38  ? 58.212  56.168 57.769 1.00 53.01  ? 57   LEU B CD2 1 
+ATOM   3897 N  N   . SER B 1 39  ? 53.156  57.075 55.489 1.00 49.86  ? 58   SER B N   1 
+ATOM   3898 C  CA  . SER B 1 39  ? 52.042  58.021 55.408 1.00 48.26  ? 58   SER B CA  1 
+ATOM   3899 C  C   . SER B 1 39  ? 51.045  57.683 56.502 1.00 46.79  ? 58   SER B C   1 
+ATOM   3900 O  O   . SER B 1 39  ? 50.378  58.564 57.035 1.00 48.29  ? 58   SER B O   1 
+ATOM   3901 C  CB  . SER B 1 39  ? 51.368  58.009 54.022 1.00 46.64  ? 58   SER B CB  1 
+ATOM   3902 O  OG  . SER B 1 39  ? 50.574  56.843 53.842 1.00 44.98  ? 58   SER B OG  1 
+ATOM   3903 N  N   . LYS B 1 40  ? 50.970  56.398 56.822 1.00 43.76  ? 59   LYS B N   1 
+ATOM   3904 C  CA  . LYS B 1 40  ? 50.092  55.874 57.848 1.00 44.17  ? 59   LYS B CA  1 
+ATOM   3905 C  C   . LYS B 1 40  ? 50.439  56.434 59.230 1.00 46.11  ? 59   LYS B C   1 
+ATOM   3906 O  O   . LYS B 1 40  ? 49.602  56.404 60.135 1.00 45.35  ? 59   LYS B O   1 
+ATOM   3907 C  CB  . LYS B 1 40  ? 50.205  54.346 57.869 1.00 46.56  ? 59   LYS B CB  1 
+ATOM   3908 C  CG  . LYS B 1 40  ? 49.086  53.591 57.191 1.00 49.93  ? 59   LYS B CG  1 
+ATOM   3909 C  CD  . LYS B 1 40  ? 48.767  54.084 55.764 1.00 53.96  ? 59   LYS B CD  1 
+ATOM   3910 C  CE  . LYS B 1 40  ? 47.701  53.200 55.116 1.00 54.10  ? 59   LYS B CE  1 
+ATOM   3911 N  NZ  . LYS B 1 40  ? 47.763  51.792 55.664 1.00 57.02  ? 59   LYS B NZ  1 
+ATOM   3912 N  N   . VAL B 1 41  ? 51.666  56.933 59.396 1.00 45.72  ? 60   VAL B N   1 
+ATOM   3913 C  CA  . VAL B 1 41  ? 52.062  57.538 60.654 1.00 43.72  ? 60   VAL B CA  1 
+ATOM   3914 C  C   . VAL B 1 41  ? 52.328  59.026 60.588 1.00 44.24  ? 60   VAL B C   1 
+ATOM   3915 O  O   . VAL B 1 41  ? 52.103  59.695 61.578 1.00 47.49  ? 60   VAL B O   1 
+ATOM   3916 C  CB  . VAL B 1 41  ? 53.236  56.763 61.392 1.00 45.18  ? 60   VAL B CB  1 
+ATOM   3917 C  CG1 . VAL B 1 41  ? 53.701  55.516 60.632 1.00 43.71  ? 60   VAL B CG1 1 
+ATOM   3918 C  CG2 . VAL B 1 41  ? 54.413  57.678 61.745 1.00 46.50  ? 60   VAL B CG2 1 
+ATOM   3919 N  N   . TYR B 1 42  ? 52.774  59.592 59.477 1.00 42.00  ? 61   TYR B N   1 
+ATOM   3920 C  CA  . TYR B 1 42  ? 53.073  61.040 59.505 1.00 45.60  ? 61   TYR B CA  1 
+ATOM   3921 C  C   . TYR B 1 42  ? 52.068  61.895 58.704 1.00 47.89  ? 61   TYR B C   1 
+ATOM   3922 O  O   . TYR B 1 42  ? 52.189  63.130 58.620 1.00 46.50  ? 61   TYR B O   1 
+ATOM   3923 C  CB  . TYR B 1 42  ? 54.521  61.325 59.066 1.00 46.36  ? 61   TYR B CB  1 
+ATOM   3924 C  CG  . TYR B 1 42  ? 55.591  60.726 59.980 1.00 52.77  ? 61   TYR B CG  1 
+ATOM   3925 C  CD1 . TYR B 1 42  ? 56.005  61.389 61.154 1.00 55.20  ? 61   TYR B CD1 1 
+ATOM   3926 C  CD2 . TYR B 1 42  ? 56.198  59.506 59.668 1.00 50.50  ? 61   TYR B CD2 1 
+ATOM   3927 C  CE1 . TYR B 1 42  ? 56.982  60.835 61.990 1.00 52.62  ? 61   TYR B CE1 1 
+ATOM   3928 C  CE2 . TYR B 1 42  ? 57.163  58.957 60.490 1.00 53.00  ? 61   TYR B CE2 1 
+ATOM   3929 C  CZ  . TYR B 1 42  ? 57.553  59.622 61.648 1.00 53.46  ? 61   TYR B CZ  1 
+ATOM   3930 O  OH  . TYR B 1 42  ? 58.505  59.051 62.453 1.00 51.41  ? 61   TYR B OH  1 
+ATOM   3931 N  N   . GLY B 1 43  ? 51.055  61.244 58.141 1.00 49.06  ? 62   GLY B N   1 
+ATOM   3932 C  CA  . GLY B 1 43  ? 50.054  61.940 57.354 1.00 48.86  ? 62   GLY B CA  1 
+ATOM   3933 C  C   . GLY B 1 43  ? 50.388  61.945 55.877 1.00 50.05  ? 62   GLY B C   1 
+ATOM   3934 O  O   . GLY B 1 43  ? 51.244  61.189 55.423 1.00 50.41  ? 62   GLY B O   1 
+ATOM   3935 N  N   . PRO B 1 44  ? 49.694  62.789 55.116 1.00 48.49  ? 63   PRO B N   1 
+ATOM   3936 C  CA  . PRO B 1 44  ? 49.854  62.831 53.666 1.00 45.87  ? 63   PRO B CA  1 
+ATOM   3937 C  C   . PRO B 1 44  ? 50.986  63.747 53.238 1.00 43.35  ? 63   PRO B C   1 
+ATOM   3938 O  O   . PRO B 1 44  ? 51.274  63.807 52.066 1.00 46.42  ? 63   PRO B O   1 
+ATOM   3939 C  CB  . PRO B 1 44  ? 48.520  63.415 53.212 1.00 46.26  ? 63   PRO B CB  1 
+ATOM   3940 C  CG  . PRO B 1 44  ? 48.159  64.352 54.283 1.00 43.56  ? 63   PRO B CG  1 
+ATOM   3941 C  CD  . PRO B 1 44  ? 48.703  63.780 55.565 1.00 45.22  ? 63   PRO B CD  1 
+ATOM   3942 N  N   . VAL B 1 45  ? 51.604  64.467 54.159 1.00 43.05  ? 64   VAL B N   1 
+ATOM   3943 C  CA  . VAL B 1 45  ? 52.666  65.392 53.802 1.00 43.45  ? 64   VAL B CA  1 
+ATOM   3944 C  C   . VAL B 1 45  ? 53.802  65.301 54.798 1.00 45.21  ? 64   VAL B C   1 
+ATOM   3945 O  O   . VAL B 1 45  ? 53.799  66.003 55.801 1.00 44.95  ? 64   VAL B O   1 
+ATOM   3946 C  CB  . VAL B 1 45  ? 52.162  66.842 53.752 1.00 42.30  ? 64   VAL B CB  1 
+ATOM   3947 C  CG1 . VAL B 1 45  ? 53.295  67.792 53.416 1.00 37.68  ? 64   VAL B CG1 1 
+ATOM   3948 C  CG2 . VAL B 1 45  ? 51.055  66.983 52.727 1.00 46.81  ? 64   VAL B CG2 1 
+ATOM   3949 N  N   . PHE B 1 46  ? 54.783  64.452 54.505 1.00 47.54  ? 65   PHE B N   1 
+ATOM   3950 C  CA  . PHE B 1 46  ? 55.916  64.266 55.412 1.00 48.77  ? 65   PHE B CA  1 
+ATOM   3951 C  C   . PHE B 1 46  ? 57.305  64.461 54.823 1.00 47.75  ? 65   PHE B C   1 
+ATOM   3952 O  O   . PHE B 1 46  ? 57.505  64.238 53.643 1.00 46.86  ? 65   PHE B O   1 
+ATOM   3953 C  CB  . PHE B 1 46  ? 55.841  62.890 56.048 1.00 50.24  ? 65   PHE B CB  1 
+ATOM   3954 C  CG  . PHE B 1 46  ? 55.805  61.745 55.081 1.00 47.32  ? 65   PHE B CG  1 
+ATOM   3955 C  CD1 . PHE B 1 46  ? 54.588  61.166 54.715 1.00 49.90  ? 65   PHE B CD1 1 
+ATOM   3956 C  CD2 . PHE B 1 46  ? 56.975  61.194 54.605 1.00 43.60  ? 65   PHE B CD2 1 
+ATOM   3957 C  CE1 . PHE B 1 46  ? 54.544  60.059 53.857 1.00 45.43  ? 65   PHE B CE1 1 
+ATOM   3958 C  CE2 . PHE B 1 46  ? 56.943  60.104 53.753 1.00 42.93  ? 65   PHE B CE2 1 
+ATOM   3959 C  CZ  . PHE B 1 46  ? 55.724  59.532 53.377 1.00 44.94  ? 65   PHE B CZ  1 
+ATOM   3960 N  N   . THR B 1 47  ? 58.248  64.866 55.682 1.00 48.23  ? 66   THR B N   1 
+ATOM   3961 C  CA  . THR B 1 47  ? 59.646  65.121 55.322 1.00 49.54  ? 66   THR B CA  1 
+ATOM   3962 C  C   . THR B 1 47  ? 60.513  63.860 55.433 1.00 51.62  ? 66   THR B C   1 
+ATOM   3963 O  O   . THR B 1 47  ? 60.282  62.992 56.278 1.00 53.03  ? 66   THR B O   1 
+ATOM   3964 C  CB  . THR B 1 47  ? 60.245  66.246 56.188 1.00 50.95  ? 66   THR B CB  1 
+ATOM   3965 O  OG1 . THR B 1 47  ? 59.555  67.489 55.952 1.00 53.54  ? 66   THR B OG1 1 
+ATOM   3966 C  CG2 . THR B 1 47  ? 61.697  66.553 55.772 1.00 51.12  ? 66   THR B CG2 1 
+ATOM   3967 N  N   . LEU B 1 48  ? 61.510  63.774 54.558 1.00 53.01  ? 67   LEU B N   1 
+ATOM   3968 C  CA  . LEU B 1 48  ? 62.397  62.622 54.486 1.00 53.33  ? 67   LEU B CA  1 
+ATOM   3969 C  C   . LEU B 1 48  ? 63.830  63.016 54.205 1.00 53.29  ? 67   LEU B C   1 
+ATOM   3970 O  O   . LEU B 1 48  ? 64.105  64.097 53.701 1.00 48.63  ? 67   LEU B O   1 
+ATOM   3971 C  CB  . LEU B 1 48  ? 61.928  61.667 53.405 1.00 53.41  ? 67   LEU B CB  1 
+ATOM   3972 C  CG  . LEU B 1 48  ? 61.969  60.214 53.835 1.00 56.72  ? 67   LEU B CG  1 
+ATOM   3973 C  CD1 . LEU B 1 48  ? 61.064  60.010 55.042 1.00 59.62  ? 67   LEU B CD1 1 
+ATOM   3974 C  CD2 . LEU B 1 48  ? 61.548  59.331 52.684 1.00 59.51  ? 67   LEU B CD2 1 
+ATOM   3975 N  N   . TYR B 1 49  ? 64.749  62.105 54.501 1.00 57.56  ? 68   TYR B N   1 
+ATOM   3976 C  CA  . TYR B 1 49  ? 66.174  62.406 54.370 1.00 58.88  ? 68   TYR B CA  1 
+ATOM   3977 C  C   . TYR B 1 49  ? 66.919  61.372 53.554 1.00 56.90  ? 68   TYR B C   1 
+ATOM   3978 O  O   . TYR B 1 49  ? 67.018  60.200 53.926 1.00 52.83  ? 68   TYR B O   1 
+ATOM   3979 C  CB  . TYR B 1 49  ? 66.828  62.619 55.744 1.00 59.94  ? 68   TYR B CB  1 
+ATOM   3980 C  CG  . TYR B 1 49  ? 66.547  64.004 56.293 1.00 59.91  ? 68   TYR B CG  1 
+ATOM   3981 C  CD1 . TYR B 1 49  ? 65.481  64.230 57.165 1.00 57.34  ? 68   TYR B CD1 1 
+ATOM   3982 C  CD2 . TYR B 1 49  ? 67.331  65.100 55.904 1.00 58.00  ? 68   TYR B CD2 1 
+ATOM   3983 C  CE1 . TYR B 1 49  ? 65.216  65.512 57.651 1.00 59.65  ? 68   TYR B CE1 1 
+ATOM   3984 C  CE2 . TYR B 1 49  ? 67.077  66.372 56.387 1.00 56.10  ? 68   TYR B CE2 1 
+ATOM   3985 C  CZ  . TYR B 1 49  ? 66.022  66.571 57.253 1.00 57.40  ? 68   TYR B CZ  1 
+ATOM   3986 O  OH  . TYR B 1 49  ? 65.763  67.828 57.712 1.00 58.80  ? 68   TYR B OH  1 
+ATOM   3987 N  N   . PHE B 1 50  ? 67.386  61.828 52.399 1.00 59.37  ? 69   PHE B N   1 
+ATOM   3988 C  CA  . PHE B 1 50  ? 68.369  61.104 51.620 1.00 62.15  ? 69   PHE B CA  1 
+ATOM   3989 C  C   . PHE B 1 50  ? 69.700  61.728 51.985 1.00 60.37  ? 69   PHE B C   1 
+ATOM   3990 O  O   . PHE B 1 50  ? 70.103  62.755 51.431 1.00 58.76  ? 69   PHE B O   1 
+ATOM   3991 C  CB  . PHE B 1 50  ? 68.054  61.199 50.127 1.00 66.18  ? 69   PHE B CB  1 
+ATOM   3992 C  CG  . PHE B 1 50  ? 66.860  60.394 49.731 1.00 68.48  ? 69   PHE B CG  1 
+ATOM   3993 C  CD1 . PHE B 1 50  ? 66.962  59.027 49.575 1.00 72.74  ? 69   PHE B CD1 1 
+ATOM   3994 C  CD2 . PHE B 1 50  ? 65.631  60.988 49.574 1.00 71.75  ? 69   PHE B CD2 1 
+ATOM   3995 C  CE1 . PHE B 1 50  ? 65.866  58.277 49.234 1.00 73.87  ? 69   PHE B CE1 1 
+ATOM   3996 C  CE2 . PHE B 1 50  ? 64.528  60.237 49.239 1.00 73.28  ? 69   PHE B CE2 1 
+ATOM   3997 C  CZ  . PHE B 1 50  ? 64.648  58.886 49.068 1.00 73.18  ? 69   PHE B CZ  1 
+ATOM   3998 N  N   . GLY B 1 51  ? 70.355  61.113 52.965 1.00 59.60  ? 70   GLY B N   1 
+ATOM   3999 C  CA  . GLY B 1 51  ? 71.523  61.695 53.588 1.00 59.13  ? 70   GLY B CA  1 
+ATOM   4000 C  C   . GLY B 1 51  ? 71.170  63.017 54.231 1.00 56.62  ? 70   GLY B C   1 
+ATOM   4001 O  O   . GLY B 1 51  ? 70.475  63.053 55.237 1.00 56.39  ? 70   GLY B O   1 
+ATOM   4002 N  N   . LEU B 1 52  ? 71.643  64.099 53.627 1.00 58.18  ? 71   LEU B N   1 
+ATOM   4003 C  CA  . LEU B 1 52  ? 71.464  65.450 54.158 1.00 60.50  ? 71   LEU B CA  1 
+ATOM   4004 C  C   . LEU B 1 52  ? 70.405  66.231 53.374 1.00 64.26  ? 71   LEU B C   1 
+ATOM   4005 O  O   . LEU B 1 52  ? 70.039  67.349 53.765 1.00 64.74  ? 71   LEU B O   1 
+ATOM   4006 C  CB  . LEU B 1 52  ? 72.803  66.211 54.126 1.00 60.58  ? 71   LEU B CB  1 
+ATOM   4007 C  CG  . LEU B 1 52  ? 74.002  65.595 54.881 1.00 56.51  ? 71   LEU B CG  1 
+ATOM   4008 C  CD1 . LEU B 1 52  ? 75.258  66.400 54.640 1.00 53.41  ? 71   LEU B CD1 1 
+ATOM   4009 C  CD2 . LEU B 1 52  ? 73.705  65.474 56.385 1.00 52.28  ? 71   LEU B CD2 1 
+ATOM   4010 N  N   . LYS B 1 53  ? 69.932  65.647 52.265 1.00 64.57  ? 72   LYS B N   1 
+ATOM   4011 C  CA  . LYS B 1 53  ? 68.899  66.248 51.435 1.00 62.31  ? 72   LYS B CA  1 
+ATOM   4012 C  C   . LYS B 1 53  ? 67.520  66.018 52.081 1.00 61.67  ? 72   LYS B C   1 
+ATOM   4013 O  O   . LYS B 1 53  ? 67.118  64.874 52.328 1.00 55.55  ? 72   LYS B O   1 
+ATOM   4014 C  CB  . LYS B 1 53  ? 68.945  65.659 50.018 1.00 64.58  ? 72   LYS B CB  1 
+ATOM   4015 C  CG  . LYS B 1 53  ? 68.407  66.591 48.898 1.00 65.46  ? 72   LYS B CG  1 
+ATOM   4016 C  CD  . LYS B 1 53  ? 69.138  66.381 47.553 1.00 66.10  ? 72   LYS B CD  1 
+ATOM   4017 C  CE  . LYS B 1 53  ? 68.198  66.505 46.353 1.00 66.80  ? 72   LYS B CE  1 
+ATOM   4018 N  NZ  . LYS B 1 53  ? 67.453  67.793 46.361 1.00 67.18  ? 72   LYS B NZ  1 
+ATOM   4019 N  N   . PRO B 1 54  ? 66.832  67.113 52.405 1.00 61.12  ? 73   PRO B N   1 
+ATOM   4020 C  CA  . PRO B 1 54  ? 65.439  67.063 52.867 1.00 60.60  ? 73   PRO B CA  1 
+ATOM   4021 C  C   . PRO B 1 54  ? 64.424  66.972 51.718 1.00 60.73  ? 73   PRO B C   1 
+ATOM   4022 O  O   . PRO B 1 54  ? 64.461  67.815 50.811 1.00 62.12  ? 73   PRO B O   1 
+ATOM   4023 C  CB  . PRO B 1 54  ? 65.288  68.391 53.611 1.00 60.05  ? 73   PRO B CB  1 
+ATOM   4024 C  CG  . PRO B 1 54  ? 66.207  69.319 52.903 1.00 59.35  ? 73   PRO B CG  1 
+ATOM   4025 C  CD  . PRO B 1 54  ? 67.353  68.494 52.416 1.00 60.56  ? 73   PRO B CD  1 
+ATOM   4026 N  N   . ILE B 1 55  ? 63.528  65.980 51.783 1.00 60.24  ? 74   ILE B N   1 
+ATOM   4027 C  CA  . ILE B 1 55  ? 62.546  65.683 50.728 1.00 57.67  ? 74   ILE B CA  1 
+ATOM   4028 C  C   . ILE B 1 55  ? 61.123  65.620 51.303 1.00 54.66  ? 74   ILE B C   1 
+ATOM   4029 O  O   . ILE B 1 55  ? 60.806  64.736 52.105 1.00 51.14  ? 74   ILE B O   1 
+ATOM   4030 C  CB  . ILE B 1 55  ? 62.911  64.327 50.037 1.00 58.41  ? 74   ILE B CB  1 
+ATOM   4031 C  CG1 . ILE B 1 55  ? 63.731  64.574 48.779 1.00 61.62  ? 74   ILE B CG1 1 
+ATOM   4032 C  CG2 . ILE B 1 55  ? 61.684  63.524 49.619 1.00 56.66  ? 74   ILE B CG2 1 
+ATOM   4033 C  CD1 . ILE B 1 55  ? 65.089  65.134 49.033 1.00 63.47  ? 74   ILE B CD1 1 
+ATOM   4034 N  N   . VAL B 1 56  ? 60.264  66.541 50.876 1.00 49.32  ? 75   VAL B N   1 
+ATOM   4035 C  CA  . VAL B 1 56  ? 58.846  66.452 51.189 1.00 47.24  ? 75   VAL B CA  1 
+ATOM   4036 C  C   . VAL B 1 56  ? 58.171  65.468 50.238 1.00 45.28  ? 75   VAL B C   1 
+ATOM   4037 O  O   . VAL B 1 56  ? 58.214  65.645 49.029 1.00 46.01  ? 75   VAL B O   1 
+ATOM   4038 C  CB  . VAL B 1 56  ? 58.164  67.817 51.075 1.00 48.31  ? 75   VAL B CB  1 
+ATOM   4039 C  CG1 . VAL B 1 56  ? 56.670  67.695 51.339 1.00 51.13  ? 75   VAL B CG1 1 
+ATOM   4040 C  CG2 . VAL B 1 56  ? 58.784  68.815 52.037 1.00 47.75  ? 75   VAL B CG2 1 
+ATOM   4041 N  N   . VAL B 1 57  ? 57.567  64.428 50.801 1.00 44.39  ? 76   VAL B N   1 
+ATOM   4042 C  CA  . VAL B 1 57  ? 56.705  63.475 50.084 1.00 41.92  ? 76   VAL B CA  1 
+ATOM   4043 C  C   . VAL B 1 57  ? 55.225  63.863 50.196 1.00 41.32  ? 76   VAL B C   1 
+ATOM   4044 O  O   . VAL B 1 57  ? 54.803  64.384 51.219 1.00 44.48  ? 76   VAL B O   1 
+ATOM   4045 C  CB  . VAL B 1 57  ? 56.867  62.041 50.673 1.00 40.90  ? 76   VAL B CB  1 
+ATOM   4046 C  CG1 . VAL B 1 57  ? 55.926  61.047 50.004 1.00 41.02  ? 76   VAL B CG1 1 
+ATOM   4047 C  CG2 . VAL B 1 57  ? 58.315  61.563 50.548 1.00 40.28  ? 76   VAL B CG2 1 
+ATOM   4048 N  N   . LEU B 1 58  ? 54.448  63.602 49.145 1.00 41.22  ? 77   LEU B N   1 
+ATOM   4049 C  CA  . LEU B 1 58  ? 53.000  63.814 49.126 1.00 38.54  ? 77   LEU B CA  1 
+ATOM   4050 C  C   . LEU B 1 58  ? 52.278  62.491 48.855 1.00 40.89  ? 77   LEU B C   1 
+ATOM   4051 O  O   . LEU B 1 58  ? 52.599  61.810 47.897 1.00 42.81  ? 77   LEU B O   1 
+ATOM   4052 C  CB  . LEU B 1 58  ? 52.661  64.788 48.018 1.00 37.52  ? 77   LEU B CB  1 
+ATOM   4053 C  CG  . LEU B 1 58  ? 53.454  66.086 47.974 1.00 39.76  ? 77   LEU B CG  1 
+ATOM   4054 C  CD1 . LEU B 1 58  ? 52.864  67.038 46.930 1.00 39.07  ? 77   LEU B CD1 1 
+ATOM   4055 C  CD2 . LEU B 1 58  ? 53.492  66.763 49.346 1.00 43.97  ? 77   LEU B CD2 1 
+ATOM   4056 N  N   . HIS B 1 59  ? 51.290  62.119 49.656 1.00 41.87  ? 78   HIS B N   1 
+ATOM   4057 C  CA  . HIS B 1 59  ? 50.747  60.772 49.533 1.00 43.43  ? 78   HIS B CA  1 
+ATOM   4058 C  C   . HIS B 1 59  ? 49.239  60.698 49.179 1.00 49.50  ? 78   HIS B C   1 
+ATOM   4059 O  O   . HIS B 1 59  ? 48.837  59.935 48.292 1.00 50.06  ? 78   HIS B O   1 
+ATOM   4060 C  CB  . HIS B 1 59  ? 51.090  59.954 50.771 1.00 39.94  ? 78   HIS B CB  1 
+ATOM   4061 C  CG  . HIS B 1 59  ? 50.870  58.494 50.594 1.00 34.21  ? 78   HIS B CG  1 
+ATOM   4062 N  ND1 . HIS B 1 59  ? 49.827  57.824 51.199 1.00 39.96  ? 78   HIS B ND1 1 
+ATOM   4063 C  CD2 . HIS B 1 59  ? 51.536  57.573 49.857 1.00 35.66  ? 78   HIS B CD2 1 
+ATOM   4064 C  CE1 . HIS B 1 59  ? 49.857  56.550 50.840 1.00 37.49  ? 78   HIS B CE1 1 
+ATOM   4065 N  NE2 . HIS B 1 59  ? 50.892  56.369 50.035 1.00 38.17  ? 78   HIS B NE2 1 
+ATOM   4066 N  N   . GLY B 1 60  ? 48.383  61.482 49.810 1.00 52.24  ? 79   GLY B N   1 
+ATOM   4067 C  CA  . GLY B 1 60  ? 46.986  61.451 49.366 1.00 55.16  ? 79   GLY B CA  1 
+ATOM   4068 C  C   . GLY B 1 60  ? 46.750  61.780 47.874 1.00 51.62  ? 79   GLY B C   1 
+ATOM   4069 O  O   . GLY B 1 60  ? 47.556  62.494 47.265 1.00 52.73  ? 79   GLY B O   1 
+ATOM   4070 N  N   . TYR B 1 61  ? 45.650  61.298 47.282 1.00 45.31  ? 80   TYR B N   1 
+ATOM   4071 C  CA  . TYR B 1 61  ? 45.121  61.963 46.079 1.00 45.27  ? 80   TYR B CA  1 
+ATOM   4072 C  C   . TYR B 1 61  ? 44.844  63.449 46.354 1.00 43.35  ? 80   TYR B C   1 
+ATOM   4073 O  O   . TYR B 1 61  ? 45.136  64.297 45.519 1.00 36.53  ? 80   TYR B O   1 
+ATOM   4074 C  CB  . TYR B 1 61  ? 43.817  61.325 45.534 1.00 47.61  ? 80   TYR B CB  1 
+ATOM   4075 C  CG  . TYR B 1 61  ? 43.112  62.261 44.536 1.00 49.92  ? 80   TYR B CG  1 
+ATOM   4076 C  CD1 . TYR B 1 61  ? 43.477  62.278 43.186 1.00 50.04  ? 80   TYR B CD1 1 
+ATOM   4077 C  CD2 . TYR B 1 61  ? 42.140  63.188 44.955 1.00 49.17  ? 80   TYR B CD2 1 
+ATOM   4078 C  CE1 . TYR B 1 61  ? 42.870  63.155 42.270 1.00 43.21  ? 80   TYR B CE1 1 
+ATOM   4079 C  CE2 . TYR B 1 61  ? 41.540  64.065 44.049 1.00 46.47  ? 80   TYR B CE2 1 
+ATOM   4080 C  CZ  . TYR B 1 61  ? 41.916  64.043 42.708 1.00 44.61  ? 80   TYR B CZ  1 
+ATOM   4081 O  OH  . TYR B 1 61  ? 41.337  64.897 41.801 1.00 39.29  ? 80   TYR B OH  1 
+ATOM   4082 N  N   . GLU B 1 62  ? 44.236  63.751 47.504 1.00 43.44  ? 81   GLU B N   1 
+ATOM   4083 C  CA  . GLU B 1 62  ? 43.877  65.126 47.835 1.00 46.28  ? 81   GLU B CA  1 
+ATOM   4084 C  C   . GLU B 1 62  ? 45.124  66.004 47.904 1.00 45.86  ? 81   GLU B C   1 
+ATOM   4085 O  O   . GLU B 1 62  ? 45.123  67.112 47.387 1.00 43.46  ? 81   GLU B O   1 
+ATOM   4086 C  CB  . GLU B 1 62  ? 43.038  65.219 49.128 1.00 48.63  ? 81   GLU B CB  1 
+ATOM   4087 C  CG  . GLU B 1 62  ? 41.583  64.700 49.042 1.00 54.17  ? 81   GLU B CG  1 
+ATOM   4088 C  CD  . GLU B 1 62  ? 40.690  65.388 47.970 1.00 59.24  ? 81   GLU B CD  1 
+ATOM   4089 O  OE1 . GLU B 1 62  ? 39.750  64.723 47.448 1.00 54.16  ? 81   GLU B OE1 1 
+ATOM   4090 O  OE2 . GLU B 1 62  ? 40.906  66.590 47.637 1.00 59.01  ? 81   GLU B OE2 1 
+ATOM   4091 N  N   . ALA B 1 63  ? 46.199  65.490 48.496 1.00 49.51  ? 82   ALA B N   1 
+ATOM   4092 C  CA  . ALA B 1 63  ? 47.467  66.244 48.606 1.00 48.70  ? 82   ALA B CA  1 
+ATOM   4093 C  C   . ALA B 1 63  ? 48.210  66.392 47.257 1.00 48.64  ? 82   ALA B C   1 
+ATOM   4094 O  O   . ALA B 1 63  ? 48.783  67.446 46.953 1.00 41.19  ? 82   ALA B O   1 
+ATOM   4095 C  CB  . ALA B 1 63  ? 48.371  65.588 49.638 1.00 48.45  ? 82   ALA B CB  1 
+ATOM   4096 N  N   . VAL B 1 64  ? 48.184  65.341 46.446 1.00 47.33  ? 83   VAL B N   1 
+ATOM   4097 C  CA  . VAL B 1 64  ? 48.800  65.401 45.132 1.00 48.02  ? 83   VAL B CA  1 
+ATOM   4098 C  C   . VAL B 1 64  ? 48.020  66.375 44.256 1.00 46.38  ? 83   VAL B C   1 
+ATOM   4099 O  O   . VAL B 1 64  ? 48.621  67.175 43.559 1.00 46.10  ? 83   VAL B O   1 
+ATOM   4100 C  CB  . VAL B 1 64  ? 48.851  64.014 44.471 1.00 50.42  ? 83   VAL B CB  1 
+ATOM   4101 C  CG1 . VAL B 1 64  ? 49.353  64.113 43.057 1.00 50.55  ? 83   VAL B CG1 1 
+ATOM   4102 C  CG2 . VAL B 1 64  ? 49.752  63.074 45.262 1.00 51.79  ? 83   VAL B CG2 1 
+ATOM   4103 N  N   . LYS B 1 65  ? 46.691  66.316 44.320 1.00 46.25  ? 84   LYS B N   1 
+ATOM   4104 C  CA  . LYS B 1 65  ? 45.810  67.185 43.520 1.00 49.65  ? 84   LYS B CA  1 
+ATOM   4105 C  C   . LYS B 1 65  ? 45.980  68.628 43.921 1.00 47.57  ? 84   LYS B C   1 
+ATOM   4106 O  O   . LYS B 1 65  ? 46.148  69.499 43.085 1.00 54.13  ? 84   LYS B O   1 
+ATOM   4107 C  CB  . LYS B 1 65  ? 44.320  66.731 43.627 1.00 54.96  ? 84   LYS B CB  1 
+ATOM   4108 C  CG  . LYS B 1 65  ? 43.208  67.812 43.748 1.00 56.68  ? 84   LYS B CG  1 
+ATOM   4109 C  CD  . LYS B 1 65  ? 42.840  68.424 42.404 1.00 61.56  ? 84   LYS B CD  1 
+ATOM   4110 C  CE  . LYS B 1 65  ? 41.537  69.251 42.474 1.00 64.54  ? 84   LYS B CE  1 
+ATOM   4111 N  NZ  . LYS B 1 65  ? 41.552  70.262 43.577 1.00 62.32  ? 84   LYS B NZ  1 
+ATOM   4112 N  N   . GLU B 1 66  ? 45.975  68.880 45.212 1.00 47.57  ? 85   GLU B N   1 
+ATOM   4113 C  CA  . GLU B 1 66  ? 46.139  70.229 45.706 1.00 48.70  ? 85   GLU B CA  1 
+ATOM   4114 C  C   . GLU B 1 66  ? 47.478  70.813 45.299 1.00 48.76  ? 85   GLU B C   1 
+ATOM   4115 O  O   . GLU B 1 66  ? 47.590  72.004 45.037 1.00 54.33  ? 85   GLU B O   1 
+ATOM   4116 C  CB  . GLU B 1 66  ? 46.006  70.248 47.220 1.00 51.82  ? 85   GLU B CB  1 
+ATOM   4117 C  CG  . GLU B 1 66  ? 45.873  71.641 47.813 1.00 58.25  ? 85   GLU B CG  1 
+ATOM   4118 C  CD  . GLU B 1 66  ? 45.554  71.607 49.297 1.00 64.65  ? 85   GLU B CD  1 
+ATOM   4119 O  OE1 . GLU B 1 66  ? 44.759  70.720 49.724 1.00 61.60  ? 85   GLU B OE1 1 
+ATOM   4120 O  OE2 . GLU B 1 66  ? 46.103  72.475 50.023 1.00 70.15  ? 85   GLU B OE2 1 
+ATOM   4121 N  N   . ALA B 1 67  ? 48.512  69.993 45.254 1.00 48.14  ? 86   ALA B N   1 
+ATOM   4122 C  CA  . ALA B 1 67  ? 49.834  70.527 44.971 1.00 49.19  ? 86   ALA B CA  1 
+ATOM   4123 C  C   . ALA B 1 67  ? 50.022  70.716 43.473 1.00 46.53  ? 86   ALA B C   1 
+ATOM   4124 O  O   . ALA B 1 67  ? 50.439  71.768 43.034 1.00 44.32  ? 86   ALA B O   1 
+ATOM   4125 C  CB  . ALA B 1 67  ? 50.904  69.614 45.527 1.00 50.74  ? 86   ALA B CB  1 
+ATOM   4126 N  N   . LEU B 1 68  ? 49.693  69.694 42.697 1.00 46.16  ? 87   LEU B N   1 
+ATOM   4127 C  CA  . LEU B 1 68  ? 50.053  69.655 41.281 1.00 46.76  ? 87   LEU B CA  1 
+ATOM   4128 C  C   . LEU B 1 68  ? 49.097  70.511 40.430 1.00 45.37  ? 87   LEU B C   1 
+ATOM   4129 O  O   . LEU B 1 68  ? 49.460  71.035 39.382 1.00 43.94  ? 87   LEU B O   1 
+ATOM   4130 C  CB  . LEU B 1 68  ? 50.064  68.197 40.782 1.00 44.90  ? 87   LEU B CB  1 
+ATOM   4131 C  CG  . LEU B 1 68  ? 51.378  67.392 40.650 1.00 45.66  ? 87   LEU B CG  1 
+ATOM   4132 C  CD1 . LEU B 1 68  ? 52.579  67.999 41.355 1.00 46.69  ? 87   LEU B CD1 1 
+ATOM   4133 C  CD2 . LEU B 1 68  ? 51.174  66.000 41.156 1.00 42.65  ? 87   LEU B CD2 1 
+ATOM   4134 N  N   . ILE B 1 69  ? 47.867  70.637 40.888 1.00 46.03  ? 88   ILE B N   1 
+ATOM   4135 C  CA  . ILE B 1 69  ? 46.881  71.387 40.155 1.00 45.64  ? 88   ILE B CA  1 
+ATOM   4136 C  C   . ILE B 1 69  ? 46.637  72.731 40.854 1.00 47.91  ? 88   ILE B C   1 
+ATOM   4137 O  O   . ILE B 1 69  ? 46.984  73.767 40.291 1.00 45.87  ? 88   ILE B O   1 
+ATOM   4138 C  CB  . ILE B 1 69  ? 45.617  70.530 39.945 1.00 42.78  ? 88   ILE B CB  1 
+ATOM   4139 C  CG1 . ILE B 1 69  ? 45.905  69.454 38.886 1.00 43.32  ? 88   ILE B CG1 1 
+ATOM   4140 C  CG2 . ILE B 1 69  ? 44.463  71.393 39.480 1.00 44.42  ? 88   ILE B CG2 1 
+ATOM   4141 C  CD1 . ILE B 1 69  ? 45.542  68.055 39.332 1.00 44.53  ? 88   ILE B CD1 1 
+ATOM   4142 N  N   . ASP B 1 70  ? 46.107  72.714 42.082 1.00 51.20  ? 89   ASP B N   1 
+ATOM   4143 C  CA  . ASP B 1 70  ? 45.730  73.958 42.778 1.00 53.92  ? 89   ASP B CA  1 
+ATOM   4144 C  C   . ASP B 1 70  ? 46.920  74.892 42.980 1.00 54.53  ? 89   ASP B C   1 
+ATOM   4145 O  O   . ASP B 1 70  ? 46.800  76.104 42.776 1.00 55.68  ? 89   ASP B O   1 
+ATOM   4146 C  CB  . ASP B 1 70  ? 45.054  73.687 44.136 1.00 54.81  ? 89   ASP B CB  1 
+ATOM   4147 C  CG  . ASP B 1 70  ? 43.737  72.897 44.013 1.00 57.24  ? 89   ASP B CG  1 
+ATOM   4148 O  OD1 . ASP B 1 70  ? 43.052  72.753 45.054 1.00 57.05  ? 89   ASP B OD1 1 
+ATOM   4149 O  OD2 . ASP B 1 70  ? 43.318  72.374 42.949 1.00 55.42  ? 89   ASP B OD2 1 
+ATOM   4150 N  N   . LEU B 1 71  ? 48.062  74.326 43.364 1.00 54.14  ? 90   LEU B N   1 
+ATOM   4151 C  CA  . LEU B 1 71  ? 49.300  75.087 43.513 1.00 54.97  ? 90   LEU B CA  1 
+ATOM   4152 C  C   . LEU B 1 71  ? 50.238  74.726 42.359 1.00 53.04  ? 90   LEU B C   1 
+ATOM   4153 O  O   . LEU B 1 71  ? 51.432  74.578 42.541 1.00 50.74  ? 90   LEU B O   1 
+ATOM   4154 C  CB  . LEU B 1 71  ? 49.951  74.772 44.869 1.00 58.33  ? 90   LEU B CB  1 
+ATOM   4155 C  CG  . LEU B 1 71  ? 49.509  75.514 46.150 1.00 59.62  ? 90   LEU B CG  1 
+ATOM   4156 C  CD1 . LEU B 1 71  ? 49.262  76.994 45.894 1.00 61.01  ? 90   LEU B CD1 1 
+ATOM   4157 C  CD2 . LEU B 1 71  ? 48.286  74.890 46.790 1.00 60.33  ? 90   LEU B CD2 1 
+ATOM   4158 N  N   . GLY B 1 72  ? 49.684  74.623 41.158 1.00 53.90  ? 91   GLY B N   1 
+ATOM   4159 C  CA  . GLY B 1 72  ? 50.375  74.043 40.025 1.00 53.51  ? 91   GLY B CA  1 
+ATOM   4160 C  C   . GLY B 1 72  ? 51.678  74.708 39.673 1.00 53.73  ? 91   GLY B C   1 
+ATOM   4161 O  O   . GLY B 1 72  ? 52.683  74.033 39.512 1.00 52.79  ? 91   GLY B O   1 
+ATOM   4162 N  N   . GLU B 1 73  ? 51.674  76.029 39.546 1.00 56.50  ? 92   GLU B N   1 
+ATOM   4163 C  CA  . GLU B 1 73  ? 52.903  76.743 39.159 1.00 61.29  ? 92   GLU B CA  1 
+ATOM   4164 C  C   . GLU B 1 73  ? 53.972  76.660 40.253 1.00 59.86  ? 92   GLU B C   1 
+ATOM   4165 O  O   . GLU B 1 73  ? 55.180  76.646 39.970 1.00 60.66  ? 92   GLU B O   1 
+ATOM   4166 C  CB  . GLU B 1 73  ? 52.634  78.218 38.780 1.00 62.15  ? 92   GLU B CB  1 
+ATOM   4167 C  CG  . GLU B 1 73  ? 52.621  78.466 37.271 1.00 67.25  ? 92   GLU B CG  1 
+ATOM   4168 C  CD  . GLU B 1 73  ? 54.011  78.389 36.647 1.00 70.58  ? 92   GLU B CD  1 
+ATOM   4169 O  OE1 . GLU B 1 73  ? 54.879  79.159 37.094 1.00 65.54  ? 92   GLU B OE1 1 
+ATOM   4170 O  OE2 . GLU B 1 73  ? 54.244  77.560 35.722 1.00 74.60  ? 92   GLU B OE2 1 
+ATOM   4171 N  N   . GLU B 1 74  ? 53.520  76.589 41.495 1.00 55.16  ? 93   GLU B N   1 
+ATOM   4172 C  CA  . GLU B 1 74  ? 54.425  76.556 42.626 1.00 55.01  ? 93   GLU B CA  1 
+ATOM   4173 C  C   . GLU B 1 74  ? 55.206  75.224 42.657 1.00 51.10  ? 93   GLU B C   1 
+ATOM   4174 O  O   . GLU B 1 74  ? 56.395  75.203 42.976 1.00 44.98  ? 93   GLU B O   1 
+ATOM   4175 C  CB  . GLU B 1 74  ? 53.646  76.840 43.925 1.00 58.26  ? 93   GLU B CB  1 
+ATOM   4176 C  CG  . GLU B 1 74  ? 53.183  78.302 44.075 1.00 60.47  ? 93   GLU B CG  1 
+ATOM   4177 C  CD  . GLU B 1 74  ? 51.903  78.682 43.296 1.00 64.17  ? 93   GLU B CD  1 
+ATOM   4178 O  OE1 . GLU B 1 74  ? 50.967  77.855 43.094 1.00 64.16  ? 93   GLU B OE1 1 
+ATOM   4179 O  OE2 . GLU B 1 74  ? 51.825  79.857 42.884 1.00 66.30  ? 93   GLU B OE2 1 
+ATOM   4180 N  N   . PHE B 1 75  ? 54.542  74.137 42.261 1.00 46.92  ? 94   PHE B N   1 
+ATOM   4181 C  CA  . PHE B 1 75  ? 55.160  72.809 42.197 1.00 47.80  ? 94   PHE B CA  1 
+ATOM   4182 C  C   . PHE B 1 75  ? 55.610  72.377 40.789 1.00 45.27  ? 94   PHE B C   1 
+ATOM   4183 O  O   . PHE B 1 75  ? 55.824  71.195 40.520 1.00 42.31  ? 94   PHE B O   1 
+ATOM   4184 C  CB  . PHE B 1 75  ? 54.178  71.765 42.715 1.00 47.70  ? 94   PHE B CB  1 
+ATOM   4185 C  CG  . PHE B 1 75  ? 53.935  71.834 44.183 1.00 51.30  ? 94   PHE B CG  1 
+ATOM   4186 C  CD1 . PHE B 1 75  ? 54.666  71.047 45.050 1.00 53.19  ? 94   PHE B CD1 1 
+ATOM   4187 C  CD2 . PHE B 1 75  ? 52.948  72.657 44.697 1.00 56.32  ? 94   PHE B CD2 1 
+ATOM   4188 C  CE1 . PHE B 1 75  ? 54.433  71.084 46.408 1.00 54.93  ? 94   PHE B CE1 1 
+ATOM   4189 C  CE2 . PHE B 1 75  ? 52.707  72.705 46.049 1.00 57.87  ? 94   PHE B CE2 1 
+ATOM   4190 C  CZ  . PHE B 1 75  ? 53.456  71.912 46.914 1.00 57.50  ? 94   PHE B CZ  1 
+ATOM   4191 N  N   . SER B 1 76  ? 55.772  73.327 39.890 1.00 47.16  ? 95   SER B N   1 
+ATOM   4192 C  CA  . SER B 1 76  ? 56.136  72.998 38.517 1.00 48.16  ? 95   SER B CA  1 
+ATOM   4193 C  C   . SER B 1 76  ? 57.648  72.811 38.351 1.00 46.91  ? 95   SER B C   1 
+ATOM   4194 O  O   . SER B 1 76  ? 58.125  72.590 37.250 1.00 48.84  ? 95   SER B O   1 
+ATOM   4195 C  CB  . SER B 1 76  ? 55.608  74.071 37.556 1.00 46.93  ? 95   SER B CB  1 
+ATOM   4196 O  OG  . SER B 1 76  ? 56.395  75.235 37.621 1.00 46.97  ? 95   SER B OG  1 
+ATOM   4197 N  N   . GLY B 1 77  ? 58.402  72.892 39.437 1.00 46.94  ? 96   GLY B N   1 
+ATOM   4198 C  CA  . GLY B 1 77  ? 59.840  72.765 39.336 1.00 45.76  ? 96   GLY B CA  1 
+ATOM   4199 C  C   . GLY B 1 77  ? 60.233  71.317 39.149 1.00 45.62  ? 96   GLY B C   1 
+ATOM   4200 O  O   . GLY B 1 77  ? 59.479  70.400 39.510 1.00 43.64  ? 96   GLY B O   1 
+ATOM   4201 N  N   . ARG B 1 78  ? 61.413  71.124 38.557 1.00 44.75  ? 97   ARG B N   1 
+ATOM   4202 C  CA  . ARG B 1 78  ? 62.025  69.814 38.399 1.00 41.03  ? 97   ARG B CA  1 
+ATOM   4203 C  C   . ARG B 1 78  ? 63.132  69.726 39.416 1.00 45.75  ? 97   ARG B C   1 
+ATOM   4204 O  O   . ARG B 1 78  ? 64.007  70.603 39.464 1.00 45.52  ? 97   ARG B O   1 
+ATOM   4205 C  CB  . ARG B 1 78  ? 62.625  69.651 37.007 1.00 38.25  ? 97   ARG B CB  1 
+ATOM   4206 C  CG  . ARG B 1 78  ? 63.325  68.311 36.760 1.00 37.54  ? 97   ARG B CG  1 
+ATOM   4207 C  CD  . ARG B 1 78  ? 62.439  67.065 36.945 1.00 40.45  ? 97   ARG B CD  1 
+ATOM   4208 N  NE  . ARG B 1 78  ? 61.468  66.832 35.856 1.00 40.19  ? 97   ARG B NE  1 
+ATOM   4209 C  CZ  . ARG B 1 78  ? 60.263  66.256 36.008 1.00 40.84  ? 97   ARG B CZ  1 
+ATOM   4210 N  NH1 . ARG B 1 78  ? 59.487  66.090 34.950 1.00 40.40  ? 97   ARG B NH1 1 
+ATOM   4211 N  NH2 . ARG B 1 78  ? 59.804  65.881 37.201 1.00 40.05  ? 97   ARG B NH2 1 
+ATOM   4212 N  N   . GLY B 1 79  ? 63.089  68.674 40.225 1.00 45.93  ? 98   GLY B N   1 
+ATOM   4213 C  CA  . GLY B 1 79  ? 64.120  68.416 41.200 1.00 47.49  ? 98   GLY B CA  1 
+ATOM   4214 C  C   . GLY B 1 79  ? 65.141  67.443 40.657 1.00 50.68  ? 98   GLY B C   1 
+ATOM   4215 O  O   . GLY B 1 79  ? 64.787  66.450 40.006 1.00 52.96  ? 98   GLY B O   1 
+ATOM   4216 N  N   . ILE B 1 80  ? 66.410  67.708 40.957 1.00 54.08  ? 99   ILE B N   1 
+ATOM   4217 C  CA  . ILE B 1 80  ? 67.511  66.914 40.431 1.00 55.14  ? 99   ILE B CA  1 
+ATOM   4218 C  C   . ILE B 1 80  ? 68.255  66.282 41.562 1.00 54.19  ? 99   ILE B C   1 
+ATOM   4219 O  O   . ILE B 1 80  ? 68.785  66.971 42.408 1.00 53.97  ? 99   ILE B O   1 
+ATOM   4220 C  CB  . ILE B 1 80  ? 68.506  67.781 39.655 1.00 56.46  ? 99   ILE B CB  1 
+ATOM   4221 C  CG1 . ILE B 1 80  ? 67.822  69.017 39.028 1.00 58.53  ? 99   ILE B CG1 1 
+ATOM   4222 C  CG2 . ILE B 1 80  ? 69.248  66.905 38.637 1.00 55.96  ? 99   ILE B CG2 1 
+ATOM   4223 C  CD1 . ILE B 1 80  ? 67.389  68.865 37.579 1.00 59.75  ? 99   ILE B CD1 1 
+ATOM   4224 N  N   . PHE B 1 81  ? 68.306  64.965 41.571 1.00 56.69  ? 100  PHE B N   1 
+ATOM   4225 C  CA  . PHE B 1 81  ? 69.102  64.260 42.558 1.00 58.73  ? 100  PHE B CA  1 
+ATOM   4226 C  C   . PHE B 1 81  ? 70.570  64.250 42.135 1.00 58.27  ? 100  PHE B C   1 
+ATOM   4227 O  O   . PHE B 1 81  ? 70.885  64.507 40.971 1.00 57.57  ? 100  PHE B O   1 
+ATOM   4228 C  CB  . PHE B 1 81  ? 68.574  62.839 42.734 1.00 62.63  ? 100  PHE B CB  1 
+ATOM   4229 C  CG  . PHE B 1 81  ? 67.387  62.758 43.633 1.00 61.73  ? 100  PHE B CG  1 
+ATOM   4230 C  CD1 . PHE B 1 81  ? 66.142  62.452 43.129 1.00 59.70  ? 100  PHE B CD1 1 
+ATOM   4231 C  CD2 . PHE B 1 81  ? 67.522  62.997 44.989 1.00 63.59  ? 100  PHE B CD2 1 
+ATOM   4232 C  CE1 . PHE B 1 81  ? 65.048  62.391 43.962 1.00 59.99  ? 100  PHE B CE1 1 
+ATOM   4233 C  CE2 . PHE B 1 81  ? 66.425  62.932 45.827 1.00 64.94  ? 100  PHE B CE2 1 
+ATOM   4234 C  CZ  . PHE B 1 81  ? 65.183  62.631 45.306 1.00 60.44  ? 100  PHE B CZ  1 
+ATOM   4235 N  N   . PRO B 1 82  ? 71.470  63.969 43.075 1.00 58.08  ? 101  PRO B N   1 
+ATOM   4236 C  CA  . PRO B 1 82  ? 72.906  64.042 42.797 1.00 57.74  ? 101  PRO B CA  1 
+ATOM   4237 C  C   . PRO B 1 82  ? 73.357  63.313 41.529 1.00 56.41  ? 101  PRO B C   1 
+ATOM   4238 O  O   . PRO B 1 82  ? 74.055  63.916 40.729 1.00 57.23  ? 101  PRO B O   1 
+ATOM   4239 C  CB  . PRO B 1 82  ? 73.523  63.403 44.039 1.00 58.55  ? 101  PRO B CB  1 
+ATOM   4240 C  CG  . PRO B 1 82  ? 72.547  63.694 45.124 1.00 58.42  ? 101  PRO B CG  1 
+ATOM   4241 C  CD  . PRO B 1 82  ? 71.210  63.589 44.478 1.00 58.62  ? 101  PRO B CD  1 
+ATOM   4242 N  N   . LEU B 1 83  ? 72.958  62.056 41.354 1.00 57.46  ? 102  LEU B N   1 
+ATOM   4243 C  CA  . LEU B 1 83  ? 73.439  61.224 40.246 1.00 55.62  ? 102  LEU B CA  1 
+ATOM   4244 C  C   . LEU B 1 83  ? 72.992  61.795 38.921 1.00 58.35  ? 102  LEU B C   1 
+ATOM   4245 O  O   . LEU B 1 83  ? 73.799  61.961 38.020 1.00 59.23  ? 102  LEU B O   1 
+ATOM   4246 C  CB  . LEU B 1 83  ? 72.934  59.783 40.393 1.00 54.66  ? 102  LEU B CB  1 
+ATOM   4247 C  CG  . LEU B 1 83  ? 73.523  58.645 39.539 1.00 57.35  ? 102  LEU B CG  1 
+ATOM   4248 C  CD1 . LEU B 1 83  ? 72.615  58.244 38.381 1.00 57.77  ? 102  LEU B CD1 1 
+ATOM   4249 C  CD2 . LEU B 1 83  ? 74.907  58.948 38.996 1.00 59.61  ? 102  LEU B CD2 1 
+ATOM   4250 N  N   . ALA B 1 84  ? 71.699  62.091 38.803 1.00 62.72  ? 103  ALA B N   1 
+ATOM   4251 C  CA  . ALA B 1 84  ? 71.165  62.762 37.617 1.00 64.41  ? 103  ALA B CA  1 
+ATOM   4252 C  C   . ALA B 1 84  ? 71.954  64.060 37.315 1.00 65.51  ? 103  ALA B C   1 
+ATOM   4253 O  O   . ALA B 1 84  ? 72.328  64.312 36.166 1.00 63.99  ? 103  ALA B O   1 
+ATOM   4254 C  CB  . ALA B 1 84  ? 69.649  63.065 37.792 1.00 63.09  ? 103  ALA B CB  1 
+ATOM   4255 N  N   . GLU B 1 85  ? 72.233  64.848 38.357 1.00 65.17  ? 104  GLU B N   1 
+ATOM   4256 C  CA  . GLU B 1 85  ? 72.877  66.157 38.212 1.00 65.86  ? 104  GLU B CA  1 
+ATOM   4257 C  C   . GLU B 1 85  ? 74.270  66.066 37.624 1.00 63.94  ? 104  GLU B C   1 
+ATOM   4258 O  O   . GLU B 1 85  ? 74.684  66.955 36.893 1.00 62.72  ? 104  GLU B O   1 
+ATOM   4259 C  CB  . GLU B 1 85  ? 72.939  66.864 39.566 1.00 67.87  ? 104  GLU B CB  1 
+ATOM   4260 C  CG  . GLU B 1 85  ? 73.712  68.173 39.600 1.00 71.21  ? 104  GLU B CG  1 
+ATOM   4261 C  CD  . GLU B 1 85  ? 73.544  68.870 40.941 1.00 77.43  ? 104  GLU B CD  1 
+ATOM   4262 O  OE1 . GLU B 1 85  ? 74.206  68.468 41.930 1.00 79.71  ? 104  GLU B OE1 1 
+ATOM   4263 O  OE2 . GLU B 1 85  ? 72.723  69.809 41.017 1.00 82.66  ? 104  GLU B OE2 1 
+ATOM   4264 N  N   . ARG B 1 86  ? 74.981  64.987 37.939 1.00 63.58  ? 105  ARG B N   1 
+ATOM   4265 C  CA  . ARG B 1 86  ? 76.357  64.785 37.481 1.00 62.76  ? 105  ARG B CA  1 
+ATOM   4266 C  C   . ARG B 1 86  ? 76.451  64.049 36.144 1.00 58.19  ? 105  ARG B C   1 
+ATOM   4267 O  O   . ARG B 1 86  ? 77.475  64.107 35.471 1.00 54.97  ? 105  ARG B O   1 
+ATOM   4268 C  CB  . ARG B 1 86  ? 77.146  64.067 38.576 1.00 64.17  ? 105  ARG B CB  1 
+ATOM   4269 C  CG  . ARG B 1 86  ? 77.170  64.896 39.889 1.00 70.50  ? 105  ARG B CG  1 
+ATOM   4270 C  CD  . ARG B 1 86  ? 78.514  64.969 40.638 1.00 74.07  ? 105  ARG B CD  1 
+ATOM   4271 N  NE  . ARG B 1 86  ? 79.687  64.875 39.758 1.00 74.42  ? 105  ARG B NE  1 
+ATOM   4272 C  CZ  . ARG B 1 86  ? 80.899  64.480 40.144 1.00 73.12  ? 105  ARG B CZ  1 
+ATOM   4273 N  NH1 . ARG B 1 86  ? 81.879  64.427 39.249 1.00 75.69  ? 105  ARG B NH1 1 
+ATOM   4274 N  NH2 . ARG B 1 86  ? 81.146  64.139 41.404 1.00 71.98  ? 105  ARG B NH2 1 
+ATOM   4275 N  N   . ALA B 1 87  ? 75.364  63.385 35.762 1.00 58.38  ? 106  ALA B N   1 
+ATOM   4276 C  CA  . ALA B 1 87  ? 75.288  62.608 34.523 1.00 58.27  ? 106  ALA B CA  1 
+ATOM   4277 C  C   . ALA B 1 87  ? 74.693  63.405 33.358 1.00 59.71  ? 106  ALA B C   1 
+ATOM   4278 O  O   . ALA B 1 87  ? 74.612  62.899 32.245 1.00 57.15  ? 106  ALA B O   1 
+ATOM   4279 C  CB  . ALA B 1 87  ? 74.478  61.343 34.755 1.00 55.28  ? 106  ALA B CB  1 
+ATOM   4280 N  N   . ASN B 1 88  ? 74.285  64.648 33.617 1.00 63.18  ? 107  ASN B N   1 
+ATOM   4281 C  CA  . ASN B 1 88  ? 73.696  65.498 32.593 1.00 64.73  ? 107  ASN B CA  1 
+ATOM   4282 C  C   . ASN B 1 88  ? 74.565  66.734 32.329 1.00 65.58  ? 107  ASN B C   1 
+ATOM   4283 O  O   . ASN B 1 88  ? 74.914  67.473 33.250 1.00 61.76  ? 107  ASN B O   1 
+ATOM   4284 C  CB  . ASN B 1 88  ? 72.267  65.919 32.993 1.00 64.90  ? 107  ASN B CB  1 
+ATOM   4285 C  CG  . ASN B 1 88  ? 71.229  64.802 32.790 1.00 63.80  ? 107  ASN B CG  1 
+ATOM   4286 O  OD1 . ASN B 1 88  ? 70.340  64.624 33.612 1.00 66.57  ? 107  ASN B OD1 1 
+ATOM   4287 N  ND2 . ASN B 1 88  ? 71.345  64.058 31.700 1.00 60.76  ? 107  ASN B ND2 1 
+ATOM   4288 N  N   . ARG B 1 89  ? 74.924  66.922 31.062 1.00 66.73  ? 108  ARG B N   1 
+ATOM   4289 C  CA  . ARG B 1 89  ? 75.513  68.169 30.583 1.00 67.03  ? 108  ARG B CA  1 
+ATOM   4290 C  C   . ARG B 1 89  ? 74.492  68.766 29.631 1.00 64.70  ? 108  ARG B C   1 
+ATOM   4291 O  O   . ARG B 1 89  ? 74.184  68.186 28.583 1.00 62.61  ? 108  ARG B O   1 
+ATOM   4292 C  CB  . ARG B 1 89  ? 76.836  67.913 29.849 1.00 69.19  ? 108  ARG B CB  1 
+ATOM   4293 C  CG  . ARG B 1 89  ? 78.040  68.638 30.456 1.00 72.03  ? 108  ARG B CG  1 
+ATOM   4294 C  CD  . ARG B 1 89  ? 78.524  68.012 31.772 1.00 74.54  ? 108  ARG B CD  1 
+ATOM   4295 N  NE  . ARG B 1 89  ? 79.923  67.553 31.828 1.00 72.76  ? 108  ARG B NE  1 
+ATOM   4296 C  CZ  . ARG B 1 89  ? 80.543  66.761 30.946 1.00 68.20  ? 108  ARG B CZ  1 
+ATOM   4297 N  NH1 . ARG B 1 89  ? 79.951  66.320 29.841 1.00 67.27  ? 108  ARG B NH1 1 
+ATOM   4298 N  NH2 . ARG B 1 89  ? 81.802  66.424 31.169 1.00 65.54  ? 108  ARG B NH2 1 
+ATOM   4299 N  N   . GLY B 1 90  ? 73.944  69.911 30.013 1.00 62.78  ? 109  GLY B N   1 
+ATOM   4300 C  CA  . GLY B 1 90  ? 72.911  70.552 29.234 1.00 61.07  ? 109  GLY B CA  1 
+ATOM   4301 C  C   . GLY B 1 90  ? 71.542  69.951 29.517 1.00 62.54  ? 109  GLY B C   1 
+ATOM   4302 O  O   . GLY B 1 90  ? 71.376  68.736 29.609 1.00 61.64  ? 109  GLY B O   1 
+ATOM   4303 N  N   . PHE B 1 91  ? 70.555  70.829 29.643 1.00 61.97  ? 110  PHE B N   1 
+ATOM   4304 C  CA  . PHE B 1 91  ? 69.193  70.441 29.928 1.00 60.68  ? 110  PHE B CA  1 
+ATOM   4305 C  C   . PHE B 1 91  ? 68.334  70.716 28.705 1.00 58.49  ? 110  PHE B C   1 
+ATOM   4306 O  O   . PHE B 1 91  ? 68.559  71.692 27.999 1.00 57.85  ? 110  PHE B O   1 
+ATOM   4307 C  CB  . PHE B 1 91  ? 68.698  71.231 31.142 1.00 63.85  ? 110  PHE B CB  1 
+ATOM   4308 C  CG  . PHE B 1 91  ? 69.535  71.018 32.381 1.00 68.27  ? 110  PHE B CG  1 
+ATOM   4309 C  CD1 . PHE B 1 91  ? 69.763  69.727 32.868 1.00 70.46  ? 110  PHE B CD1 1 
+ATOM   4310 C  CD2 . PHE B 1 91  ? 70.108  72.097 33.048 1.00 71.31  ? 110  PHE B CD2 1 
+ATOM   4311 C  CE1 . PHE B 1 91  ? 70.527  69.506 34.010 1.00 71.79  ? 110  PHE B CE1 1 
+ATOM   4312 C  CE2 . PHE B 1 91  ? 70.878  71.891 34.197 1.00 74.45  ? 110  PHE B CE2 1 
+ATOM   4313 C  CZ  . PHE B 1 91  ? 71.084  70.588 34.683 1.00 74.70  ? 110  PHE B CZ  1 
+ATOM   4314 N  N   . GLY B 1 92  ? 67.367  69.837 28.441 1.00 56.69  ? 111  GLY B N   1 
+ATOM   4315 C  CA  . GLY B 1 92  ? 66.439  70.020 27.337 1.00 55.45  ? 111  GLY B CA  1 
+ATOM   4316 C  C   . GLY B 1 92  ? 65.038  70.358 27.829 1.00 54.30  ? 111  GLY B C   1 
+ATOM   4317 O  O   . GLY B 1 92  ? 64.614  71.513 27.893 1.00 52.87  ? 111  GLY B O   1 
+ATOM   4318 N  N   . ILE B 1 93  ? 64.308  69.324 28.188 1.00 51.77  ? 112  ILE B N   1 
+ATOM   4319 C  CA  . ILE B 1 93  ? 62.982  69.500 28.715 1.00 51.52  ? 112  ILE B CA  1 
+ATOM   4320 C  C   . ILE B 1 93  ? 62.860  68.809 30.070 1.00 49.06  ? 112  ILE B C   1 
+ATOM   4321 O  O   . ILE B 1 93  ? 62.379  69.421 31.020 1.00 50.28  ? 112  ILE B O   1 
+ATOM   4322 C  CB  . ILE B 1 93  ? 61.965  69.007 27.668 1.00 55.24  ? 112  ILE B CB  1 
+ATOM   4323 C  CG1 . ILE B 1 93  ? 60.541  69.295 28.082 1.00 54.56  ? 112  ILE B CG1 1 
+ATOM   4324 C  CG2 . ILE B 1 93  ? 62.116  67.524 27.364 1.00 60.06  ? 112  ILE B CG2 1 
+ATOM   4325 C  CD1 . ILE B 1 93  ? 59.607  69.195 26.874 1.00 58.31  ? 112  ILE B CD1 1 
+ATOM   4326 N  N   . VAL B 1 94  ? 63.348  67.572 30.182 1.00 42.56  ? 113  VAL B N   1 
+ATOM   4327 C  CA  . VAL B 1 94  ? 63.112  66.770 31.375 1.00 40.55  ? 113  VAL B CA  1 
+ATOM   4328 C  C   . VAL B 1 94  ? 63.718  67.411 32.597 1.00 40.56  ? 113  VAL B C   1 
+ATOM   4329 O  O   . VAL B 1 94  ? 63.111  67.405 33.656 1.00 45.64  ? 113  VAL B O   1 
+ATOM   4330 C  CB  . VAL B 1 94  ? 63.647  65.324 31.226 1.00 42.39  ? 113  VAL B CB  1 
+ATOM   4331 C  CG1 . VAL B 1 94  ? 63.648  64.567 32.568 1.00 43.22  ? 113  VAL B CG1 1 
+ATOM   4332 C  CG2 . VAL B 1 94  ? 62.823  64.555 30.220 1.00 42.30  ? 113  VAL B CG2 1 
+ATOM   4333 N  N   . PHE B 1 95  ? 64.903  67.982 32.450 1.00 42.92  ? 114  PHE B N   1 
+ATOM   4334 C  CA  . PHE B 1 95  ? 65.674  68.447 33.597 1.00 40.37  ? 114  PHE B CA  1 
+ATOM   4335 C  C   . PHE B 1 95  ? 65.810  69.966 33.616 1.00 41.28  ? 114  PHE B C   1 
+ATOM   4336 O  O   . PHE B 1 95  ? 66.559  70.527 34.418 1.00 44.34  ? 114  PHE B O   1 
+ATOM   4337 C  CB  . PHE B 1 95  ? 67.042  67.764 33.569 1.00 40.85  ? 114  PHE B CB  1 
+ATOM   4338 C  CG  . PHE B 1 95  ? 67.001  66.291 33.921 1.00 41.83  ? 114  PHE B CG  1 
+ATOM   4339 C  CD1 . PHE B 1 95  ? 67.352  65.325 32.987 1.00 42.17  ? 114  PHE B CD1 1 
+ATOM   4340 C  CD2 . PHE B 1 95  ? 66.611  65.872 35.192 1.00 41.61  ? 114  PHE B CD2 1 
+ATOM   4341 C  CE1 . PHE B 1 95  ? 67.320  63.964 33.317 1.00 43.01  ? 114  PHE B CE1 1 
+ATOM   4342 C  CE2 . PHE B 1 95  ? 66.559  64.517 35.517 1.00 42.95  ? 114  PHE B CE2 1 
+ATOM   4343 C  CZ  . PHE B 1 95  ? 66.926  63.565 34.585 1.00 41.74  ? 114  PHE B CZ  1 
+ATOM   4344 N  N   . SER B 1 96  ? 65.082  70.633 32.727 1.00 41.51  ? 115  SER B N   1 
+ATOM   4345 C  CA  . SER B 1 96  ? 65.098  72.086 32.642 1.00 39.59  ? 115  SER B CA  1 
+ATOM   4346 C  C   . SER B 1 96  ? 64.208  72.680 33.691 1.00 37.55  ? 115  SER B C   1 
+ATOM   4347 O  O   . SER B 1 96  ? 63.420  71.976 34.284 1.00 41.64  ? 115  SER B O   1 
+ATOM   4348 C  CB  . SER B 1 96  ? 64.607  72.546 31.283 1.00 40.58  ? 115  SER B CB  1 
+ATOM   4349 O  OG  . SER B 1 96  ? 65.690  72.568 30.391 1.00 48.52  ? 115  SER B OG  1 
+ATOM   4350 N  N   . ASN B 1 97  ? 64.340  73.985 33.896 1.00 38.91  ? 116  ASN B N   1 
+ATOM   4351 C  CA  . ASN B 1 97  ? 63.526  74.750 34.839 1.00 40.50  ? 116  ASN B CA  1 
+ATOM   4352 C  C   . ASN B 1 97  ? 63.388  76.205 34.365 1.00 46.53  ? 116  ASN B C   1 
+ATOM   4353 O  O   . ASN B 1 97  ? 64.140  76.645 33.487 1.00 52.32  ? 116  ASN B O   1 
+ATOM   4354 C  CB  . ASN B 1 97  ? 64.173  74.718 36.205 1.00 39.49  ? 116  ASN B CB  1 
+ATOM   4355 C  CG  . ASN B 1 97  ? 63.625  73.640 37.069 1.00 37.22  ? 116  ASN B CG  1 
+ATOM   4356 O  OD1 . ASN B 1 97  ? 62.490  73.730 37.529 1.00 45.10  ? 116  ASN B OD1 1 
+ATOM   4357 N  ND2 . ASN B 1 97  ? 64.418  72.613 37.318 1.00 33.20  ? 116  ASN B ND2 1 
+ATOM   4358 N  N   . GLY B 1 98  ? 62.427  76.946 34.917 1.00 49.45  ? 117  GLY B N   1 
+ATOM   4359 C  CA  . GLY B 1 98  ? 62.234  78.349 34.544 1.00 51.32  ? 117  GLY B CA  1 
+ATOM   4360 C  C   . GLY B 1 98  ? 61.792  78.611 33.108 1.00 53.22  ? 117  GLY B C   1 
+ATOM   4361 O  O   . GLY B 1 98  ? 61.069  77.805 32.539 1.00 52.14  ? 117  GLY B O   1 
+ATOM   4362 N  N   . LYS B 1 99  ? 62.217  79.748 32.537 1.00 57.12  ? 118  LYS B N   1 
+ATOM   4363 C  CA  . LYS B 1 99  ? 61.888  80.128 31.144 1.00 59.62  ? 118  LYS B CA  1 
+ATOM   4364 C  C   . LYS B 1 99  ? 62.410  79.142 30.094 1.00 56.60  ? 118  LYS B C   1 
+ATOM   4365 O  O   . LYS B 1 99  ? 61.814  79.004 29.021 1.00 56.26  ? 118  LYS B O   1 
+ATOM   4366 C  CB  . LYS B 1 99  ? 62.366  81.560 30.756 1.00 63.73  ? 118  LYS B CB  1 
+ATOM   4367 C  CG  . LYS B 1 99  ? 63.593  82.152 31.508 1.00 72.99  ? 118  LYS B CG  1 
+ATOM   4368 C  CD  . LYS B 1 99  ? 64.932  81.346 31.342 1.00 78.11  ? 118  LYS B CD  1 
+ATOM   4369 C  CE  . LYS B 1 99  ? 65.407  80.560 32.627 1.00 77.59  ? 118  LYS B CE  1 
+ATOM   4370 N  NZ  . LYS B 1 99  ? 65.130  81.220 33.944 1.00 72.75  ? 118  LYS B NZ  1 
+ATOM   4371 N  N   . LYS B 1 100 ? 63.532  78.489 30.378 1.00 52.76  ? 119  LYS B N   1 
+ATOM   4372 C  CA  . LYS B 1 100 ? 64.122  77.569 29.417 1.00 52.42  ? 119  LYS B CA  1 
+ATOM   4373 C  C   . LYS B 1 100 ? 63.242  76.316 29.264 1.00 50.10  ? 119  LYS B C   1 
+ATOM   4374 O  O   . LYS B 1 100 ? 63.103  75.779 28.161 1.00 48.06  ? 119  LYS B O   1 
+ATOM   4375 C  CB  . LYS B 1 100 ? 65.567  77.200 29.797 1.00 53.23  ? 119  LYS B CB  1 
+ATOM   4376 C  CG  . LYS B 1 100 ? 66.051  75.948 29.087 1.00 54.28  ? 119  LYS B CG  1 
+ATOM   4377 C  CD  . LYS B 1 100 ? 67.534  75.783 29.096 1.00 56.75  ? 119  LYS B CD  1 
+ATOM   4378 C  CE  . LYS B 1 100 ? 67.914  74.765 28.029 1.00 59.92  ? 119  LYS B CE  1 
+ATOM   4379 N  NZ  . LYS B 1 100 ? 69.264  74.171 28.219 1.00 62.76  ? 119  LYS B NZ  1 
+ATOM   4380 N  N   . TRP B 1 101 ? 62.665  75.862 30.375 1.00 46.72  ? 120  TRP B N   1 
+ATOM   4381 C  CA  . TRP B 1 101 ? 61.673  74.790 30.357 1.00 46.48  ? 120  TRP B CA  1 
+ATOM   4382 C  C   . TRP B 1 101 ? 60.343  75.257 29.750 1.00 46.65  ? 120  TRP B C   1 
+ATOM   4383 O  O   . TRP B 1 101 ? 59.860  74.650 28.809 1.00 47.47  ? 120  TRP B O   1 
+ATOM   4384 C  CB  . TRP B 1 101 ? 61.460  74.254 31.777 1.00 47.22  ? 120  TRP B CB  1 
+ATOM   4385 C  CG  . TRP B 1 101 ? 60.293  73.360 31.920 1.00 44.36  ? 120  TRP B CG  1 
+ATOM   4386 C  CD1 . TRP B 1 101 ? 60.155  72.117 31.410 1.00 43.28  ? 120  TRP B CD1 1 
+ATOM   4387 C  CD2 . TRP B 1 101 ? 59.089  73.646 32.616 1.00 41.85  ? 120  TRP B CD2 1 
+ATOM   4388 N  NE1 . TRP B 1 101 ? 58.930  71.600 31.745 1.00 40.45  ? 120  TRP B NE1 1 
+ATOM   4389 C  CE2 . TRP B 1 101 ? 58.256  72.523 32.493 1.00 40.32  ? 120  TRP B CE2 1 
+ATOM   4390 C  CE3 . TRP B 1 101 ? 58.628  74.743 33.344 1.00 42.93  ? 120  TRP B CE3 1 
+ATOM   4391 C  CZ2 . TRP B 1 101 ? 56.990  72.464 33.049 1.00 43.44  ? 120  TRP B CZ2 1 
+ATOM   4392 C  CZ3 . TRP B 1 101 ? 57.383  74.683 33.902 1.00 44.52  ? 120  TRP B CZ3 1 
+ATOM   4393 C  CH2 . TRP B 1 101 ? 56.568  73.545 33.750 1.00 41.64  ? 120  TRP B CH2 1 
+ATOM   4394 N  N   . LYS B 1 102 ? 59.763  76.329 30.293 1.00 49.24  ? 121  LYS B N   1 
+ATOM   4395 C  CA  . LYS B 1 102 ? 58.526  76.942 29.768 1.00 52.35  ? 121  LYS B CA  1 
+ATOM   4396 C  C   . LYS B 1 102 ? 58.490  76.964 28.227 1.00 50.42  ? 121  LYS B C   1 
+ATOM   4397 O  O   . LYS B 1 102 ? 57.565  76.415 27.588 1.00 45.74  ? 121  LYS B O   1 
+ATOM   4398 C  CB  . LYS B 1 102 ? 58.348  78.377 30.318 1.00 55.49  ? 121  LYS B CB  1 
+ATOM   4399 C  CG  . LYS B 1 102 ? 57.561  78.483 31.646 1.00 62.55  ? 121  LYS B CG  1 
+ATOM   4400 C  CD  . LYS B 1 102 ? 56.032  78.588 31.409 1.00 70.98  ? 121  LYS B CD  1 
+ATOM   4401 C  CE  . LYS B 1 102 ? 55.185  78.145 32.644 1.00 75.31  ? 121  LYS B CE  1 
+ATOM   4402 N  NZ  . LYS B 1 102 ? 54.013  77.253 32.288 1.00 74.75  ? 121  LYS B NZ  1 
+ATOM   4403 N  N   . GLU B 1 103 ? 59.517  77.575 27.643 1.00 48.10  ? 122  GLU B N   1 
+ATOM   4404 C  CA  . GLU B 1 103 ? 59.577  77.768 26.205 1.00 48.69  ? 122  GLU B CA  1 
+ATOM   4405 C  C   . GLU B 1 103 ? 59.761  76.450 25.472 1.00 46.75  ? 122  GLU B C   1 
+ATOM   4406 O  O   . GLU B 1 103 ? 59.007  76.156 24.560 1.00 52.66  ? 122  GLU B O   1 
+ATOM   4407 C  CB  . GLU B 1 103 ? 60.670  78.772 25.822 1.00 50.68  ? 122  GLU B CB  1 
+ATOM   4408 C  CG  . GLU B 1 103 ? 60.248  80.233 25.985 1.00 56.86  ? 122  GLU B CG  1 
+ATOM   4409 C  CD  . GLU B 1 103 ? 61.359  81.221 25.639 1.00 60.05  ? 122  GLU B CD  1 
+ATOM   4410 O  OE1 . GLU B 1 103 ? 62.083  81.659 26.559 1.00 65.69  ? 122  GLU B OE1 1 
+ATOM   4411 O  OE2 . GLU B 1 103 ? 61.514  81.564 24.449 1.00 61.06  ? 122  GLU B OE2 1 
+ATOM   4412 N  N   . ILE B 1 104 ? 60.734  75.640 25.866 1.00 43.11  ? 123  ILE B N   1 
+ATOM   4413 C  CA  . ILE B 1 104 ? 61.042  74.438 25.089 1.00 41.56  ? 123  ILE B CA  1 
+ATOM   4414 C  C   . ILE B 1 104 ? 59.916  73.422 25.179 1.00 39.63  ? 123  ILE B C   1 
+ATOM   4415 O  O   . ILE B 1 104 ? 59.692  72.646 24.237 1.00 37.21  ? 123  ILE B O   1 
+ATOM   4416 C  CB  . ILE B 1 104 ? 62.398  73.809 25.506 1.00 41.11  ? 123  ILE B CB  1 
+ATOM   4417 C  CG1 . ILE B 1 104 ? 63.540  74.673 24.992 1.00 46.46  ? 123  ILE B CG1 1 
+ATOM   4418 C  CG2 . ILE B 1 104 ? 62.577  72.421 24.903 1.00 40.76  ? 123  ILE B CG2 1 
+ATOM   4419 C  CD1 . ILE B 1 104 ? 64.865  74.426 25.706 1.00 53.40  ? 123  ILE B CD1 1 
+ATOM   4420 N  N   . ARG B 1 105 ? 59.212  73.422 26.306 1.00 38.83  ? 124  ARG B N   1 
+ATOM   4421 C  CA  . ARG B 1 105 ? 58.109  72.494 26.501 1.00 40.70  ? 124  ARG B CA  1 
+ATOM   4422 C  C   . ARG B 1 105 ? 56.922  72.873 25.644 1.00 43.40  ? 124  ARG B C   1 
+ATOM   4423 O  O   . ARG B 1 105 ? 56.217  71.998 25.131 1.00 45.30  ? 124  ARG B O   1 
+ATOM   4424 C  CB  . ARG B 1 105 ? 57.662  72.461 27.953 1.00 38.62  ? 124  ARG B CB  1 
+ATOM   4425 C  CG  . ARG B 1 105 ? 56.449  71.533 28.199 1.00 38.42  ? 124  ARG B CG  1 
+ATOM   4426 C  CD  . ARG B 1 105 ? 55.950  71.586 29.606 1.00 38.68  ? 124  ARG B CD  1 
+ATOM   4427 N  NE  . ARG B 1 105 ? 54.680  70.892 29.764 1.00 39.77  ? 124  ARG B NE  1 
+ATOM   4428 C  CZ  . ARG B 1 105 ? 54.535  69.633 30.170 1.00 38.95  ? 124  ARG B CZ  1 
+ATOM   4429 N  NH1 . ARG B 1 105 ? 55.573  68.855 30.442 1.00 44.62  ? 124  ARG B NH1 1 
+ATOM   4430 N  NH2 . ARG B 1 105 ? 53.326  69.144 30.311 1.00 41.88  ? 124  ARG B NH2 1 
+ATOM   4431 N  N   . ARG B 1 106 ? 56.697  74.178 25.535 1.00 46.57  ? 125  ARG B N   1 
+ATOM   4432 C  CA  . ARG B 1 106 ? 55.582  74.713 24.788 1.00 50.71  ? 125  ARG B CA  1 
+ATOM   4433 C  C   . ARG B 1 106 ? 55.802  74.324 23.356 1.00 48.44  ? 125  ARG B C   1 
+ATOM   4434 O  O   . ARG B 1 106 ? 54.927  73.718 22.727 1.00 50.75  ? 125  ARG B O   1 
+ATOM   4435 C  CB  . ARG B 1 106 ? 55.551  76.227 24.926 1.00 56.64  ? 125  ARG B CB  1 
+ATOM   4436 C  CG  . ARG B 1 106 ? 54.250  76.870 24.558 1.00 64.63  ? 125  ARG B CG  1 
+ATOM   4437 C  CD  . ARG B 1 106 ? 54.283  78.366 24.757 1.00 72.84  ? 125  ARG B CD  1 
+ATOM   4438 N  NE  . ARG B 1 106 ? 54.148  79.052 23.475 1.00 82.96  ? 125  ARG B NE  1 
+ATOM   4439 C  CZ  . ARG B 1 106 ? 53.349  80.094 23.241 1.00 92.12  ? 125  ARG B CZ  1 
+ATOM   4440 N  NH1 . ARG B 1 106 ? 52.586  80.624 24.206 1.00 95.40  ? 125  ARG B NH1 1 
+ATOM   4441 N  NH2 . ARG B 1 106 ? 53.314  80.621 22.020 1.00 93.51  ? 125  ARG B NH2 1 
+ATOM   4442 N  N   . PHE B 1 107 ? 57.002  74.624 22.866 1.00 44.24  ? 126  PHE B N   1 
+ATOM   4443 C  CA  . PHE B 1 107 ? 57.382  74.297 21.503 1.00 43.51  ? 126  PHE B CA  1 
+ATOM   4444 C  C   . PHE B 1 107 ? 57.208  72.831 21.187 1.00 41.69  ? 126  PHE B C   1 
+ATOM   4445 O  O   . PHE B 1 107 ? 56.738  72.480 20.116 1.00 44.77  ? 126  PHE B O   1 
+ATOM   4446 C  CB  . PHE B 1 107 ? 58.837  74.655 21.216 1.00 44.54  ? 126  PHE B CB  1 
+ATOM   4447 C  CG  . PHE B 1 107 ? 59.280  74.192 19.876 1.00 47.90  ? 126  PHE B CG  1 
+ATOM   4448 C  CD1 . PHE B 1 107 ? 60.006  73.024 19.741 1.00 53.22  ? 126  PHE B CD1 1 
+ATOM   4449 C  CD2 . PHE B 1 107 ? 58.888  74.879 18.738 1.00 49.75  ? 126  PHE B CD2 1 
+ATOM   4450 C  CE1 . PHE B 1 107 ? 60.377  72.562 18.497 1.00 56.26  ? 126  PHE B CE1 1 
+ATOM   4451 C  CE2 . PHE B 1 107 ? 59.242  74.431 17.496 1.00 53.77  ? 126  PHE B CE2 1 
+ATOM   4452 C  CZ  . PHE B 1 107 ? 59.995  73.264 17.369 1.00 57.50  ? 126  PHE B CZ  1 
+ATOM   4453 N  N   . SER B 1 108 ? 57.605  71.979 22.121 1.00 40.26  ? 127  SER B N   1 
+ATOM   4454 C  CA  . SER B 1 108 ? 57.544  70.550 21.920 1.00 38.43  ? 127  SER B CA  1 
+ATOM   4455 C  C   . SER B 1 108 ? 56.117  70.078 21.867 1.00 36.47  ? 127  SER B C   1 
+ATOM   4456 O  O   . SER B 1 108 ? 55.764  69.282 20.994 1.00 38.41  ? 127  SER B O   1 
+ATOM   4457 C  CB  . SER B 1 108 ? 58.275  69.829 23.037 1.00 40.79  ? 127  SER B CB  1 
+ATOM   4458 O  OG  . SER B 1 108 ? 59.659  70.095 22.961 1.00 41.98  ? 127  SER B OG  1 
+ATOM   4459 N  N   . LEU B 1 109 ? 55.288  70.568 22.782 1.00 35.63  ? 128  LEU B N   1 
+ATOM   4460 C  CA  . LEU B 1 109 ? 53.877  70.179 22.792 1.00 37.68  ? 128  LEU B CA  1 
+ATOM   4461 C  C   . LEU B 1 109 ? 53.249  70.587 21.472 1.00 40.45  ? 128  LEU B C   1 
+ATOM   4462 O  O   . LEU B 1 109 ? 52.429  69.860 20.923 1.00 39.55  ? 128  LEU B O   1 
+ATOM   4463 C  CB  . LEU B 1 109 ? 53.122  70.797 23.961 1.00 35.74  ? 128  LEU B CB  1 
+ATOM   4464 C  CG  . LEU B 1 109 ? 53.235  70.052 25.294 1.00 38.96  ? 128  LEU B CG  1 
+ATOM   4465 C  CD1 . LEU B 1 109 ? 52.569  70.837 26.404 1.00 36.77  ? 128  LEU B CD1 1 
+ATOM   4466 C  CD2 . LEU B 1 109 ? 52.623  68.626 25.218 1.00 40.42  ? 128  LEU B CD2 1 
+ATOM   4467 N  N   . MET B 1 110 ? 53.686  71.721 20.935 1.00 45.07  ? 129  MET B N   1 
+ATOM   4468 C  CA  . MET B 1 110 ? 53.198  72.188 19.639 1.00 51.61  ? 129  MET B CA  1 
+ATOM   4469 C  C   . MET B 1 110 ? 53.504  71.188 18.527 1.00 50.01  ? 129  MET B C   1 
+ATOM   4470 O  O   . MET B 1 110 ? 52.593  70.751 17.808 1.00 49.00  ? 129  MET B O   1 
+ATOM   4471 C  CB  . MET B 1 110 ? 53.807  73.552 19.279 1.00 59.46  ? 129  MET B CB  1 
+ATOM   4472 C  CG  . MET B 1 110 ? 52.770  74.606 18.892 1.00 65.11  ? 129  MET B CG  1 
+ATOM   4473 S  SD  . MET B 1 110 ? 51.915  75.240 20.362 1.00 76.35  ? 129  MET B SD  1 
+ATOM   4474 C  CE  . MET B 1 110 ? 52.952  76.840 20.807 1.00 70.67  ? 129  MET B CE  1 
+ATOM   4475 N  N   . THR B 1 111 ? 54.780  70.818 18.392 1.00 46.61  ? 130  THR B N   1 
+ATOM   4476 C  CA  . THR B 1 111 ? 55.182  69.838 17.385 1.00 43.27  ? 130  THR B CA  1 
+ATOM   4477 C  C   . THR B 1 111 ? 54.558  68.484 17.608 1.00 37.32  ? 130  THR B C   1 
+ATOM   4478 O  O   . THR B 1 111 ? 54.405  67.740 16.662 1.00 38.81  ? 130  THR B O   1 
+ATOM   4479 C  CB  . THR B 1 111 ? 56.696  69.633 17.356 1.00 46.01  ? 130  THR B CB  1 
+ATOM   4480 O  OG1 . THR B 1 111 ? 57.115  69.028 18.595 1.00 49.65  ? 130  THR B OG1 1 
+ATOM   4481 C  CG2 . THR B 1 111 ? 57.430  70.965 17.254 1.00 46.00  ? 130  THR B CG2 1 
+ATOM   4482 N  N   . LEU B 1 112 ? 54.221  68.138 18.843 1.00 36.65  ? 131  LEU B N   1 
+ATOM   4483 C  CA  . LEU B 1 112 ? 53.692  66.792 19.110 1.00 38.27  ? 131  LEU B CA  1 
+ATOM   4484 C  C   . LEU B 1 112 ? 52.187  66.626 18.840 1.00 37.66  ? 131  LEU B C   1 
+ATOM   4485 O  O   . LEU B 1 112 ? 51.654  65.538 19.020 1.00 36.27  ? 131  LEU B O   1 
+ATOM   4486 C  CB  . LEU B 1 112 ? 54.035  66.334 20.542 1.00 36.09  ? 131  LEU B CB  1 
+ATOM   4487 C  CG  . LEU B 1 112 ? 55.504  65.921 20.744 1.00 41.85  ? 131  LEU B CG  1 
+ATOM   4488 C  CD1 . LEU B 1 112 ? 55.716  65.331 22.115 1.00 43.81  ? 131  LEU B CD1 1 
+ATOM   4489 C  CD2 . LEU B 1 112 ? 56.000  64.933 19.675 1.00 42.73  ? 131  LEU B CD2 1 
+ATOM   4490 N  N   . ARG B 1 113 ? 51.504  67.696 18.432 1.00 36.65  ? 132  ARG B N   1 
+ATOM   4491 C  CA  . ARG B 1 113 ? 50.092  67.598 18.101 1.00 37.82  ? 132  ARG B CA  1 
+ATOM   4492 C  C   . ARG B 1 113 ? 49.932  66.732 16.873 1.00 36.75  ? 132  ARG B C   1 
+ATOM   4493 O  O   . ARG B 1 113 ? 50.802  66.721 15.994 1.00 31.55  ? 132  ARG B O   1 
+ATOM   4494 C  CB  . ARG B 1 113 ? 49.513  68.951 17.729 1.00 41.54  ? 132  ARG B CB  1 
+ATOM   4495 C  CG  . ARG B 1 113 ? 49.523  70.018 18.778 1.00 43.31  ? 132  ARG B CG  1 
+ATOM   4496 C  CD  . ARG B 1 113 ? 49.158  71.367 18.199 1.00 48.60  ? 132  ARG B CD  1 
+ATOM   4497 N  NE  . ARG B 1 113 ? 50.094  71.771 17.145 1.00 56.22  ? 132  ARG B NE  1 
+ATOM   4498 C  CZ  . ARG B 1 113 ? 50.108  72.960 16.546 1.00 61.15  ? 132  ARG B CZ  1 
+ATOM   4499 N  NH1 . ARG B 1 113 ? 49.210  73.881 16.869 1.00 65.15  ? 132  ARG B NH1 1 
+ATOM   4500 N  NH2 . ARG B 1 113 ? 51.027  73.226 15.611 1.00 59.62  ? 132  ARG B NH2 1 
+ATOM   4501 N  N   . ASN B 1 114 ? 48.793  66.057 16.766 1.00 35.11  ? 133  ASN B N   1 
+ATOM   4502 C  CA  . ASN B 1 114 ? 48.615  65.107 15.676 1.00 35.81  ? 133  ASN B CA  1 
+ATOM   4503 C  C   . ASN B 1 114 ? 48.972  65.706 14.307 1.00 36.60  ? 133  ASN B C   1 
+ATOM   4504 O  O   . ASN B 1 114 ? 49.702  65.088 13.550 1.00 40.28  ? 133  ASN B O   1 
+ATOM   4505 C  CB  . ASN B 1 114 ? 47.222  64.496 15.691 1.00 33.41  ? 133  ASN B CB  1 
+ATOM   4506 C  CG  . ASN B 1 114 ? 47.131  63.251 14.864 1.00 35.85  ? 133  ASN B CG  1 
+ATOM   4507 O  OD1 . ASN B 1 114 ? 46.077  62.921 14.325 1.00 44.99  ? 133  ASN B OD1 1 
+ATOM   4508 N  ND2 . ASN B 1 114 ? 48.223  62.541 14.758 1.00 34.81  ? 133  ASN B ND2 1 
+ATOM   4509 N  N   . PHE B 1 115 ? 48.515  66.920 14.011 1.00 39.70  ? 134  PHE B N   1 
+ATOM   4510 C  CA  . PHE B 1 115 ? 48.876  67.599 12.752 1.00 38.87  ? 134  PHE B CA  1 
+ATOM   4511 C  C   . PHE B 1 115 ? 49.826  68.792 12.994 1.00 39.63  ? 134  PHE B C   1 
+ATOM   4512 O  O   . PHE B 1 115 ? 49.881  69.745 12.238 1.00 37.42  ? 134  PHE B O   1 
+ATOM   4513 C  CB  . PHE B 1 115 ? 47.604  67.999 12.007 1.00 36.18  ? 134  PHE B CB  1 
+ATOM   4514 C  CG  . PHE B 1 115 ? 46.716  66.834 11.685 1.00 32.78  ? 134  PHE B CG  1 
+ATOM   4515 C  CD1 . PHE B 1 115 ? 46.855  66.143 10.482 1.00 35.23  ? 134  PHE B CD1 1 
+ATOM   4516 C  CD2 . PHE B 1 115 ? 45.763  66.396 12.589 1.00 34.40  ? 134  PHE B CD2 1 
+ATOM   4517 C  CE1 . PHE B 1 115 ? 46.041  65.035 10.172 1.00 24.27  ? 134  PHE B CE1 1 
+ATOM   4518 C  CE2 . PHE B 1 115 ? 44.939  65.293 12.283 1.00 31.60  ? 134  PHE B CE2 1 
+ATOM   4519 C  CZ  . PHE B 1 115 ? 45.101  64.613 11.071 1.00 27.34  ? 134  PHE B CZ  1 
+ATOM   4520 N  N   . GLY B 1 116 ? 50.631  68.685 14.037 1.00 45.75  ? 135  GLY B N   1 
+ATOM   4521 C  CA  . GLY B 1 116 ? 51.556  69.733 14.418 1.00 50.63  ? 135  GLY B CA  1 
+ATOM   4522 C  C   . GLY B 1 116 ? 52.778  69.939 13.527 1.00 56.02  ? 135  GLY B C   1 
+ATOM   4523 O  O   . GLY B 1 116 ? 53.551  70.868 13.806 1.00 57.17  ? 135  GLY B O   1 
+ATOM   4524 N  N   . MET B 1 117 ? 52.974  69.120 12.482 1.00 58.49  ? 136  MET B N   1 
+ATOM   4525 C  CA  . MET B 1 117 ? 54.105  69.347 11.568 1.00 60.41  ? 136  MET B CA  1 
+ATOM   4526 C  C   . MET B 1 117 ? 54.053  68.648 10.196 1.00 61.95  ? 136  MET B C   1 
+ATOM   4527 O  O   . MET B 1 117 ? 54.353  67.443 10.053 1.00 61.82  ? 136  MET B O   1 
+ATOM   4528 C  CB  . MET B 1 117 ? 55.441  69.034 12.264 1.00 60.51  ? 136  MET B CB  1 
+ATOM   4529 C  CG  . MET B 1 117 ? 55.650  67.600 12.605 1.00 59.61  ? 136  MET B CG  1 
+ATOM   4530 S  SD  . MET B 1 117 ? 56.773  67.371 13.979 1.00 57.19  ? 136  MET B SD  1 
+ATOM   4531 C  CE  . MET B 1 117 ? 56.223  65.671 14.396 1.00 50.87  ? 136  MET B CE  1 
+ATOM   4532 N  N   . GLY B 1 118 ? 53.719  69.448 9.186  1.00 60.97  ? 137  GLY B N   1 
+ATOM   4533 C  CA  . GLY B 1 118 ? 53.718  68.997 7.815  1.00 62.18  ? 137  GLY B CA  1 
+ATOM   4534 C  C   . GLY B 1 118 ? 52.461  68.208 7.535  1.00 63.45  ? 137  GLY B C   1 
+ATOM   4535 O  O   . GLY B 1 118 ? 51.559  68.144 8.362  1.00 61.89  ? 137  GLY B O   1 
+ATOM   4536 N  N   . LYS B 1 119 ? 52.446  67.569 6.373  1.00 66.57  ? 138  LYS B N   1 
+ATOM   4537 C  CA  . LYS B 1 119 ? 51.267  66.885 5.849  1.00 68.31  ? 138  LYS B CA  1 
+ATOM   4538 C  C   . LYS B 1 119 ? 51.114  65.454 6.385  1.00 65.87  ? 138  LYS B C   1 
+ATOM   4539 O  O   . LYS B 1 119 ? 50.130  64.784 6.064  1.00 65.95  ? 138  LYS B O   1 
+ATOM   4540 C  CB  . LYS B 1 119 ? 51.313  66.867 4.302  1.00 71.90  ? 138  LYS B CB  1 
+ATOM   4541 C  CG  . LYS B 1 119 ? 51.938  68.144 3.641  1.00 74.45  ? 138  LYS B CG  1 
+ATOM   4542 C  CD  . LYS B 1 119 ? 51.345  68.485 2.250  1.00 76.05  ? 138  LYS B CD  1 
+ATOM   4543 C  CE  . LYS B 1 119 ? 52.037  67.736 1.095  1.00 75.07  ? 138  LYS B CE  1 
+ATOM   4544 N  NZ  . LYS B 1 119 ? 51.378  67.865 -0.242 1.00 71.94  ? 138  LYS B NZ  1 
+ATOM   4545 N  N   . ARG B 1 120 ? 52.091  64.986 7.171  1.00 61.46  ? 139  ARG B N   1 
+ATOM   4546 C  CA  . ARG B 1 120 ? 52.019  63.676 7.834  1.00 56.16  ? 139  ARG B CA  1 
+ATOM   4547 C  C   . ARG B 1 120 ? 51.644  63.809 9.319  1.00 48.50  ? 139  ARG B C   1 
+ATOM   4548 O  O   . ARG B 1 120 ? 52.277  64.546 10.071 1.00 43.84  ? 139  ARG B O   1 
+ATOM   4549 C  CB  . ARG B 1 120 ? 53.358  62.957 7.696  1.00 58.39  ? 139  ARG B CB  1 
+ATOM   4550 C  CG  . ARG B 1 120 ? 53.275  61.435 7.623  1.00 61.82  ? 139  ARG B CG  1 
+ATOM   4551 C  CD  . ARG B 1 120 ? 54.441  60.800 6.841  1.00 65.46  ? 139  ARG B CD  1 
+ATOM   4552 N  NE  . ARG B 1 120 ? 54.924  59.555 7.450  1.00 66.19  ? 139  ARG B NE  1 
+ATOM   4553 C  CZ  . ARG B 1 120 ? 54.296  58.380 7.386  1.00 64.84  ? 139  ARG B CZ  1 
+ATOM   4554 N  NH1 . ARG B 1 120 ? 54.840  57.321 7.974  1.00 57.44  ? 139  ARG B NH1 1 
+ATOM   4555 N  NH2 . ARG B 1 120 ? 53.125  58.252 6.744  1.00 68.37  ? 139  ARG B NH2 1 
+ATOM   4556 N  N   . SER B 1 121 ? 50.603  63.093 9.733  1.00 43.76  ? 140  SER B N   1 
+ATOM   4557 C  CA  . SER B 1 121 ? 50.152  63.127 11.126 1.00 37.92  ? 140  SER B CA  1 
+ATOM   4558 C  C   . SER B 1 121 ? 51.008  62.214 12.026 1.00 36.30  ? 140  SER B C   1 
+ATOM   4559 O  O   . SER B 1 121 ? 51.664  61.296 11.544 1.00 32.38  ? 140  SER B O   1 
+ATOM   4560 C  CB  . SER B 1 121 ? 48.636  62.777 11.223 1.00 36.86  ? 140  SER B CB  1 
+ATOM   4561 O  OG  . SER B 1 121 ? 48.323  61.417 10.940 1.00 28.74  ? 140  SER B OG  1 
+ATOM   4562 N  N   . ILE B 1 122 ? 51.019  62.464 13.331 1.00 35.12  ? 141  ILE B N   1 
+ATOM   4563 C  CA  . ILE B 1 122 ? 51.642  61.514 14.254 1.00 36.72  ? 141  ILE B CA  1 
+ATOM   4564 C  C   . ILE B 1 122 ? 50.929  60.155 14.110 1.00 35.13  ? 141  ILE B C   1 
+ATOM   4565 O  O   . ILE B 1 122 ? 51.550  59.111 14.160 1.00 40.71  ? 141  ILE B O   1 
+ATOM   4566 C  CB  . ILE B 1 122 ? 51.526  61.963 15.739 1.00 37.75  ? 141  ILE B CB  1 
+ATOM   4567 C  CG1 . ILE B 1 122 ? 52.106  63.359 15.987 1.00 37.41  ? 141  ILE B CG1 1 
+ATOM   4568 C  CG2 . ILE B 1 122 ? 52.159  60.906 16.662 1.00 36.17  ? 141  ILE B CG2 1 
+ATOM   4569 C  CD1 . ILE B 1 122 ? 53.544  63.477 15.678 1.00 40.53  ? 141  ILE B CD1 1 
+ATOM   4570 N  N   . GLU B 1 123 ? 49.624  60.169 13.924 1.00 32.27  ? 142  GLU B N   1 
+ATOM   4571 C  CA  . GLU B 1 123 ? 48.877  58.933 13.922 1.00 34.57  ? 142  GLU B CA  1 
+ATOM   4572 C  C   . GLU B 1 123 ? 49.256  58.090 12.728 1.00 33.02  ? 142  GLU B C   1 
+ATOM   4573 O  O   . GLU B 1 123 ? 49.160  56.878 12.799 1.00 34.43  ? 142  GLU B O   1 
+ATOM   4574 C  CB  . GLU B 1 123 ? 47.354  59.189 13.998 1.00 34.97  ? 142  GLU B CB  1 
+ATOM   4575 C  CG  . GLU B 1 123 ? 46.497  57.945 13.749 1.00 36.94  ? 142  GLU B CG  1 
+ATOM   4576 C  CD  . GLU B 1 123 ? 45.025  58.093 14.105 1.00 39.85  ? 142  GLU B CD  1 
+ATOM   4577 O  OE1 . GLU B 1 123 ? 44.546  59.226 14.352 1.00 44.43  ? 142  GLU B OE1 1 
+ATOM   4578 O  OE2 . GLU B 1 123 ? 44.332  57.053 14.135 1.00 43.56  ? 142  GLU B OE2 1 
+ATOM   4579 N  N   . ASP B 1 124 ? 49.698  58.710 11.641 1.00 37.22  ? 143  ASP B N   1 
+ATOM   4580 C  CA  . ASP B 1 124 ? 50.132  57.948 10.468 1.00 42.00  ? 143  ASP B CA  1 
+ATOM   4581 C  C   . ASP B 1 124 ? 51.407  57.235 10.817 1.00 38.42  ? 143  ASP B C   1 
+ATOM   4582 O  O   . ASP B 1 124 ? 51.504  56.013 10.673 1.00 40.11  ? 143  ASP B O   1 
+ATOM   4583 C  CB  . ASP B 1 124 ? 50.384  58.845 9.250  1.00 46.83  ? 143  ASP B CB  1 
+ATOM   4584 C  CG  . ASP B 1 124 ? 49.094  59.207 8.509  1.00 57.73  ? 143  ASP B CG  1 
+ATOM   4585 O  OD1 . ASP B 1 124 ? 48.346  58.277 8.101  1.00 60.37  ? 143  ASP B OD1 1 
+ATOM   4586 O  OD2 . ASP B 1 124 ? 48.749  60.400 8.282  1.00 67.82  ? 143  ASP B OD2 1 
+ATOM   4587 N  N   . ARG B 1 125 ? 52.376  58.023 11.285 1.00 33.53  ? 144  ARG B N   1 
+ATOM   4588 C  CA  . ARG B 1 125 ? 53.658  57.525 11.778 1.00 28.97  ? 144  ARG B CA  1 
+ATOM   4589 C  C   . ARG B 1 125 ? 53.485  56.317 12.701 1.00 30.36  ? 144  ARG B C   1 
+ATOM   4590 O  O   . ARG B 1 125 ? 54.121  55.299 12.505 1.00 29.10  ? 144  ARG B O   1 
+ATOM   4591 C  CB  . ARG B 1 125 ? 54.382  58.627 12.510 1.00 28.17  ? 144  ARG B CB  1 
+ATOM   4592 C  CG  . ARG B 1 125 ? 54.954  59.730 11.624 1.00 25.88  ? 144  ARG B CG  1 
+ATOM   4593 C  CD  . ARG B 1 125 ? 55.770  60.707 12.452 1.00 30.70  ? 144  ARG B CD  1 
+ATOM   4594 N  NE  . ARG B 1 125 ? 55.701  62.084 11.984 1.00 36.88  ? 144  ARG B NE  1 
+ATOM   4595 C  CZ  . ARG B 1 125 ? 56.326  62.534 10.918 1.00 39.36  ? 144  ARG B CZ  1 
+ATOM   4596 N  NH1 . ARG B 1 125 ? 57.059  61.703 10.192 1.00 42.29  ? 144  ARG B NH1 1 
+ATOM   4597 N  NH2 . ARG B 1 125 ? 56.211  63.805 10.567 1.00 39.49  ? 144  ARG B NH2 1 
+ATOM   4598 N  N   . VAL B 1 126 ? 52.574  56.416 13.665 1.00 28.03  ? 145  VAL B N   1 
+ATOM   4599 C  CA  . VAL B 1 126 ? 52.345  55.340 14.593 1.00 24.69  ? 145  VAL B CA  1 
+ATOM   4600 C  C   . VAL B 1 126 ? 51.618  54.206 13.936 1.00 29.04  ? 145  VAL B C   1 
+ATOM   4601 O  O   . VAL B 1 126 ? 51.844  53.043 14.290 1.00 32.30  ? 145  VAL B O   1 
+ATOM   4602 C  CB  . VAL B 1 126 ? 51.604  55.819 15.837 1.00 23.14  ? 145  VAL B CB  1 
+ATOM   4603 C  CG1 . VAL B 1 126 ? 51.306  54.676 16.760 1.00 20.62  ? 145  VAL B CG1 1 
+ATOM   4604 C  CG2 . VAL B 1 126 ? 52.429  56.839 16.559 1.00 24.00  ? 145  VAL B CG2 1 
+ATOM   4605 N  N   . GLN B 1 127 ? 50.744  54.508 12.982 1.00 33.11  ? 146  GLN B N   1 
+ATOM   4606 C  CA  . GLN B 1 127 ? 50.059  53.435 12.230 1.00 32.04  ? 146  GLN B CA  1 
+ATOM   4607 C  C   . GLN B 1 127 ? 51.023  52.655 11.357 1.00 32.36  ? 146  GLN B C   1 
+ATOM   4608 O  O   . GLN B 1 127 ? 50.849  51.452 11.194 1.00 33.03  ? 146  GLN B O   1 
+ATOM   4609 C  CB  . GLN B 1 127 ? 48.923  53.975 11.384 1.00 31.48  ? 146  GLN B CB  1 
+ATOM   4610 C  CG  . GLN B 1 127 ? 47.680  54.253 12.209 1.00 37.50  ? 146  GLN B CG  1 
+ATOM   4611 C  CD  . GLN B 1 127 ? 46.565  54.834 11.394 1.00 38.80  ? 146  GLN B CD  1 
+ATOM   4612 O  OE1 . GLN B 1 127 ? 45.550  54.177 11.201 1.00 43.89  ? 146  GLN B OE1 1 
+ATOM   4613 N  NE2 . GLN B 1 127 ? 46.754  56.049 10.883 1.00 36.94  ? 146  GLN B NE2 1 
+ATOM   4614 N  N   . GLU B 1 128 ? 52.051  53.325 10.830 1.00 33.23  ? 147  GLU B N   1 
+ATOM   4615 C  CA  . GLU B 1 128 ? 53.032  52.657 9.981  1.00 36.76  ? 147  GLU B CA  1 
+ATOM   4616 C  C   . GLU B 1 128 ? 53.870  51.704 10.835 1.00 35.60  ? 147  GLU B C   1 
+ATOM   4617 O  O   . GLU B 1 128 ? 54.036  50.527 10.489 1.00 31.38  ? 147  GLU B O   1 
+ATOM   4618 C  CB  . GLU B 1 128 ? 53.937  53.654 9.235  1.00 38.53  ? 147  GLU B CB  1 
+ATOM   4619 C  CG  . GLU B 1 128 ? 54.961  52.968 8.318  1.00 41.39  ? 147  GLU B CG  1 
+ATOM   4620 C  CD  . GLU B 1 128 ? 56.071  53.895 7.797  1.00 45.64  ? 147  GLU B CD  1 
+ATOM   4621 O  OE1 . GLU B 1 128 ? 56.244  55.016 8.326  1.00 46.78  ? 147  GLU B OE1 1 
+ATOM   4622 O  OE2 . GLU B 1 128 ? 56.797  53.491 6.851  1.00 48.95  ? 147  GLU B OE2 1 
+ATOM   4623 N  N   . GLU B 1 129 ? 54.372  52.222 11.953 1.00 30.23  ? 148  GLU B N   1 
+ATOM   4624 C  CA  . GLU B 1 129 ? 55.138  51.422 12.894 1.00 31.41  ? 148  GLU B CA  1 
+ATOM   4625 C  C   . GLU B 1 129 ? 54.339  50.223 13.382 1.00 30.12  ? 148  GLU B C   1 
+ATOM   4626 O  O   . GLU B 1 129 ? 54.854  49.132 13.544 1.00 28.18  ? 148  GLU B O   1 
+ATOM   4627 C  CB  . GLU B 1 129 ? 55.559  52.268 14.095 1.00 32.38  ? 148  GLU B CB  1 
+ATOM   4628 C  CG  . GLU B 1 129 ? 56.753  51.699 14.832 1.00 33.68  ? 148  GLU B CG  1 
+ATOM   4629 C  CD  . GLU B 1 129 ? 57.947  51.495 13.918 1.00 38.00  ? 148  GLU B CD  1 
+ATOM   4630 O  OE1 . GLU B 1 129 ? 58.277  52.453 13.156 1.00 37.51  ? 148  GLU B OE1 1 
+ATOM   4631 O  OE2 . GLU B 1 129 ? 58.540  50.388 13.963 1.00 33.06  ? 148  GLU B OE2 1 
+ATOM   4632 N  N   . ALA B 1 130 ? 53.059  50.434 13.593 1.00 33.45  ? 149  ALA B N   1 
+ATOM   4633 C  CA  . ALA B 1 130 ? 52.183  49.372 14.035 1.00 34.62  ? 149  ALA B CA  1 
+ATOM   4634 C  C   . ALA B 1 130 ? 52.168  48.181 13.066 1.00 36.19  ? 149  ALA B C   1 
+ATOM   4635 O  O   . ALA B 1 130 ? 52.093  47.028 13.501 1.00 30.78  ? 149  ALA B O   1 
+ATOM   4636 C  CB  . ALA B 1 130 ? 50.792  49.919 14.228 1.00 34.50  ? 149  ALA B CB  1 
+ATOM   4637 N  N   . ARG B 1 131 ? 52.231  48.429 11.759 1.00 39.61  ? 150  ARG B N   1 
+ATOM   4638 C  CA  . ARG B 1 131 ? 52.189  47.287 10.843 1.00 44.05  ? 150  ARG B CA  1 
+ATOM   4639 C  C   . ARG B 1 131 ? 53.569  46.657 10.624 1.00 44.70  ? 150  ARG B C   1 
+ATOM   4640 O  O   . ARG B 1 131 ? 53.671  45.455 10.409 1.00 47.87  ? 150  ARG B O   1 
+ATOM   4641 C  CB  . ARG B 1 131 ? 51.397  47.558 9.545  1.00 45.45  ? 150  ARG B CB  1 
+ATOM   4642 C  CG  . ARG B 1 131 ? 51.954  48.548 8.566  1.00 50.36  ? 150  ARG B CG  1 
+ATOM   4643 C  CD  . ARG B 1 131 ? 51.516  48.303 7.102  1.00 52.98  ? 150  ARG B CD  1 
+ATOM   4644 N  NE  . ARG B 1 131 ? 52.660  48.453 6.199  1.00 56.92  ? 150  ARG B NE  1 
+ATOM   4645 C  CZ  . ARG B 1 131 ? 53.187  49.625 5.834  1.00 60.47  ? 150  ARG B CZ  1 
+ATOM   4646 N  NH1 . ARG B 1 131 ? 54.241  49.656 5.023  1.00 62.22  ? 150  ARG B NH1 1 
+ATOM   4647 N  NH2 . ARG B 1 131 ? 52.665  50.775 6.267  1.00 61.13  ? 150  ARG B NH2 1 
+ATOM   4648 N  N   . CYS B 1 132 ? 54.623  47.455 10.755 1.00 41.78  ? 151  CYS B N   1 
+ATOM   4649 C  CA  . CYS B 1 132 ? 55.972  46.934 10.741 1.00 40.86  ? 151  CYS B CA  1 
+ATOM   4650 C  C   . CYS B 1 132 ? 56.265  46.083 11.943 1.00 43.60  ? 151  CYS B C   1 
+ATOM   4651 O  O   . CYS B 1 132 ? 57.156  45.248 11.886 1.00 50.81  ? 151  CYS B O   1 
+ATOM   4652 C  CB  . CYS B 1 132 ? 56.976  48.064 10.770 1.00 41.98  ? 151  CYS B CB  1 
+ATOM   4653 S  SG  . CYS B 1 132 ? 56.862  49.090 9.324  1.00 47.07  ? 151  CYS B SG  1 
+ATOM   4654 N  N   . LEU B 1 133 ? 55.578  46.353 13.047 1.00 43.76  ? 152  LEU B N   1 
+ATOM   4655 C  CA  . LEU B 1 133 ? 55.758  45.625 14.285 1.00 44.36  ? 152  LEU B CA  1 
+ATOM   4656 C  C   . LEU B 1 133 ? 55.122  44.255 14.105 1.00 43.27  ? 152  LEU B C   1 
+ATOM   4657 O  O   . LEU B 1 133 ? 55.663  43.246 14.525 1.00 35.31  ? 152  LEU B O   1 
+ATOM   4658 C  CB  . LEU B 1 133 ? 55.073  46.383 15.422 1.00 46.67  ? 152  LEU B CB  1 
+ATOM   4659 C  CG  . LEU B 1 133 ? 55.385  45.957 16.857 1.00 50.64  ? 152  LEU B CG  1 
+ATOM   4660 C  CD1 . LEU B 1 133 ? 54.762  46.954 17.825 1.00 54.44  ? 152  LEU B CD1 1 
+ATOM   4661 C  CD2 . LEU B 1 133 ? 54.876  44.576 17.166 1.00 50.97  ? 152  LEU B CD2 1 
+ATOM   4662 N  N   . VAL B 1 134 ? 53.957  44.247 13.467 1.00 46.77  ? 153  VAL B N   1 
+ATOM   4663 C  CA  . VAL B 1 134 ? 53.224  43.019 13.182 1.00 48.40  ? 153  VAL B CA  1 
+ATOM   4664 C  C   . VAL B 1 134 ? 54.010  42.175 12.189 1.00 51.42  ? 153  VAL B C   1 
+ATOM   4665 O  O   . VAL B 1 134 ? 54.082  40.974 12.324 1.00 52.52  ? 153  VAL B O   1 
+ATOM   4666 C  CB  . VAL B 1 134 ? 51.830  43.329 12.576 1.00 46.17  ? 153  VAL B CB  1 
+ATOM   4667 C  CG1 . VAL B 1 134 ? 51.182  42.074 12.024 1.00 43.13  ? 153  VAL B CG1 1 
+ATOM   4668 C  CG2 . VAL B 1 134 ? 50.926  43.969 13.610 1.00 45.13  ? 153  VAL B CG2 1 
+ATOM   4669 N  N   . GLU B 1 135 ? 54.589  42.823 11.184 1.00 57.00  ? 154  GLU B N   1 
+ATOM   4670 C  CA  . GLU B 1 135 ? 55.427  42.148 10.202 1.00 58.60  ? 154  GLU B CA  1 
+ATOM   4671 C  C   . GLU B 1 135 ? 56.607  41.481 10.929 1.00 55.96  ? 154  GLU B C   1 
+ATOM   4672 O  O   . GLU B 1 135 ? 56.989  40.379 10.578 1.00 60.56  ? 154  GLU B O   1 
+ATOM   4673 C  CB  . GLU B 1 135 ? 55.874  43.122 9.067  1.00 62.55  ? 154  GLU B CB  1 
+ATOM   4674 C  CG  . GLU B 1 135 ? 54.859  43.259 7.906  1.00 66.72  ? 154  GLU B CG  1 
+ATOM   4675 C  CD  . GLU B 1 135 ? 54.905  44.602 7.135  1.00 72.72  ? 154  GLU B CD  1 
+ATOM   4676 O  OE1 . GLU B 1 135 ? 53.896  44.959 6.468  1.00 76.67  ? 154  GLU B OE1 1 
+ATOM   4677 O  OE2 . GLU B 1 135 ? 55.935  45.315 7.166  1.00 71.91  ? 154  GLU B OE2 1 
+ATOM   4678 N  N   . GLU B 1 136 ? 57.133  42.108 11.978 1.00 53.69  ? 155  GLU B N   1 
+ATOM   4679 C  CA  . GLU B 1 136 ? 58.260  41.543 12.732 1.00 53.73  ? 155  GLU B CA  1 
+ATOM   4680 C  C   . GLU B 1 136 ? 57.901  40.441 13.731 1.00 52.03  ? 155  GLU B C   1 
+ATOM   4681 O  O   . GLU B 1 136 ? 58.744  39.608 14.071 1.00 52.47  ? 155  GLU B O   1 
+ATOM   4682 C  CB  . GLU B 1 136 ? 59.065  42.645 13.420 1.00 51.29  ? 155  GLU B CB  1 
+ATOM   4683 C  CG  . GLU B 1 136 ? 60.148  43.155 12.486 1.00 58.97  ? 155  GLU B CG  1 
+ATOM   4684 C  CD  . GLU B 1 136 ? 61.487  42.407 12.597 1.00 62.29  ? 155  GLU B CD  1 
+ATOM   4685 O  OE1 . GLU B 1 136 ? 62.014  42.030 11.534 1.00 63.39  ? 155  GLU B OE1 1 
+ATOM   4686 O  OE2 . GLU B 1 136 ? 62.029  42.212 13.716 1.00 64.60  ? 155  GLU B OE2 1 
+ATOM   4687 N  N   . LEU B 1 137 ? 56.665  40.430 14.203 1.00 50.66  ? 156  LEU B N   1 
+ATOM   4688 C  CA  . LEU B 1 137 ? 56.225  39.358 15.072 1.00 50.62  ? 156  LEU B CA  1 
+ATOM   4689 C  C   . LEU B 1 137 ? 55.972  38.155 14.184 1.00 49.95  ? 156  LEU B C   1 
+ATOM   4690 O  O   . LEU B 1 137 ? 56.234  37.021 14.568 1.00 49.39  ? 156  LEU B O   1 
+ATOM   4691 C  CB  . LEU B 1 137 ? 54.974  39.756 15.874 1.00 49.09  ? 156  LEU B CB  1 
+ATOM   4692 C  CG  . LEU B 1 137 ? 55.118  40.984 16.785 1.00 48.78  ? 156  LEU B CG  1 
+ATOM   4693 C  CD1 . LEU B 1 137 ? 53.795  41.305 17.454 1.00 49.37  ? 156  LEU B CD1 1 
+ATOM   4694 C  CD2 . LEU B 1 137 ? 56.196  40.839 17.846 1.00 49.61  ? 156  LEU B CD2 1 
+ATOM   4695 N  N   . ARG B 1 138 ? 55.500  38.418 12.974 1.00 51.43  ? 157  ARG B N   1 
+ATOM   4696 C  CA  . ARG B 1 138 ? 55.271  37.370 11.989 1.00 53.04  ? 157  ARG B CA  1 
+ATOM   4697 C  C   . ARG B 1 138 ? 56.551  36.561 11.723 1.00 55.90  ? 157  ARG B C   1 
+ATOM   4698 O  O   . ARG B 1 138 ? 56.510  35.342 11.591 1.00 56.09  ? 157  ARG B O   1 
+ATOM   4699 C  CB  . ARG B 1 138 ? 54.772  37.984 10.690 1.00 50.62  ? 157  ARG B CB  1 
+ATOM   4700 C  CG  . ARG B 1 138 ? 53.512  37.371 10.166 1.00 50.34  ? 157  ARG B CG  1 
+ATOM   4701 C  CD  . ARG B 1 138 ? 53.020  38.074 8.903  1.00 54.97  ? 157  ARG B CD  1 
+ATOM   4702 N  NE  . ARG B 1 138 ? 51.922  39.012 9.144  1.00 54.25  ? 157  ARG B NE  1 
+ATOM   4703 C  CZ  . ARG B 1 138 ? 50.688  38.642 9.503  1.00 53.55  ? 157  ARG B CZ  1 
+ATOM   4704 N  NH1 . ARG B 1 138 ? 50.381  37.356 9.707  1.00 53.02  ? 157  ARG B NH1 1 
+ATOM   4705 N  NH2 . ARG B 1 138 ? 49.763  39.567 9.700  1.00 50.07  ? 157  ARG B NH2 1 
+ATOM   4706 N  N   . LYS B 1 139 ? 57.681  37.259 11.670 1.00 59.26  ? 158  LYS B N   1 
+ATOM   4707 C  CA  . LYS B 1 139 ? 58.986  36.653 11.411 1.00 60.18  ? 158  LYS B CA  1 
+ATOM   4708 C  C   . LYS B 1 139 ? 59.532  35.797 12.558 1.00 61.17  ? 158  LYS B C   1 
+ATOM   4709 O  O   . LYS B 1 139 ? 60.516  35.094 12.366 1.00 65.39  ? 158  LYS B O   1 
+ATOM   4710 C  CB  . LYS B 1 139 ? 60.008  37.742 11.055 1.00 60.07  ? 158  LYS B CB  1 
+ATOM   4711 C  CG  . LYS B 1 139 ? 59.794  38.310 9.669  1.00 60.96  ? 158  LYS B CG  1 
+ATOM   4712 C  CD  . LYS B 1 139 ? 60.481  39.648 9.470  1.00 64.67  ? 158  LYS B CD  1 
+ATOM   4713 C  CE  . LYS B 1 139 ? 60.075  40.267 8.121  1.00 67.18  ? 158  LYS B CE  1 
+ATOM   4714 N  NZ  . LYS B 1 139 ? 60.945  41.423 7.766  1.00 67.52  ? 158  LYS B NZ  1 
+ATOM   4715 N  N   . THR B 1 140 ? 58.924  35.845 13.741 1.00 59.80  ? 159  THR B N   1 
+ATOM   4716 C  CA  . THR B 1 140 ? 59.310  34.917 14.807 1.00 57.38  ? 159  THR B CA  1 
+ATOM   4717 C  C   . THR B 1 140 ? 58.718  33.548 14.547 1.00 57.78  ? 159  THR B C   1 
+ATOM   4718 O  O   . THR B 1 140 ? 58.907  32.640 15.346 1.00 56.78  ? 159  THR B O   1 
+ATOM   4719 C  CB  . THR B 1 140 ? 58.875  35.409 16.206 1.00 57.65  ? 159  THR B CB  1 
+ATOM   4720 O  OG1 . THR B 1 140 ? 57.446  35.516 16.276 1.00 56.26  ? 159  THR B OG1 1 
+ATOM   4721 C  CG2 . THR B 1 140 ? 59.399  36.810 16.485 1.00 55.57  ? 159  THR B CG2 1 
+ATOM   4722 N  N   . LYS B 1 141 ? 57.976  33.423 13.449 1.00 58.54  ? 160  LYS B N   1 
+ATOM   4723 C  CA  . LYS B 1 141 ? 57.531  32.137 12.917 1.00 61.50  ? 160  LYS B CA  1 
+ATOM   4724 C  C   . LYS B 1 141 ? 56.663  31.318 13.896 1.00 60.43  ? 160  LYS B C   1 
+ATOM   4725 O  O   . LYS B 1 141 ? 56.540  30.105 13.766 1.00 61.44  ? 160  LYS B O   1 
+ATOM   4726 C  CB  . LYS B 1 141 ? 58.751  31.333 12.433 1.00 65.46  ? 160  LYS B CB  1 
+ATOM   4727 C  CG  . LYS B 1 141 ? 59.220  31.689 11.014 1.00 69.73  ? 160  LYS B CG  1 
+ATOM   4728 C  CD  . LYS B 1 141 ? 60.637  31.145 10.710 1.00 72.41  ? 160  LYS B CD  1 
+ATOM   4729 C  CE  . LYS B 1 141 ? 60.639  29.664 10.292 1.00 73.83  ? 160  LYS B CE  1 
+ATOM   4730 N  NZ  . LYS B 1 141 ? 62.017  29.122 9.981  1.00 74.41  ? 160  LYS B NZ  1 
+ATOM   4731 N  N   . ALA B 1 142 ? 56.039  32.000 14.858 1.00 60.02  ? 161  ALA B N   1 
+ATOM   4732 C  CA  . ALA B 1 142 ? 55.159  31.374 15.854 1.00 55.48  ? 161  ALA B CA  1 
+ATOM   4733 C  C   . ALA B 1 142 ? 55.920  30.542 16.870 1.00 55.99  ? 161  ALA B C   1 
+ATOM   4734 O  O   . ALA B 1 142 ? 55.332  29.741 17.575 1.00 58.27  ? 161  ALA B O   1 
+ATOM   4735 C  CB  . ALA B 1 142 ? 54.086  30.547 15.190 1.00 53.11  ? 161  ALA B CB  1 
+ATOM   4736 N  N   . SER B 1 143 ? 57.226  30.763 16.960 1.00 58.85  ? 162  SER B N   1 
+ATOM   4737 C  CA  . SER B 1 143 ? 58.090  30.086 17.922 1.00 58.89  ? 162  SER B CA  1 
+ATOM   4738 C  C   . SER B 1 143 ? 58.248  30.959 19.158 1.00 54.99  ? 162  SER B C   1 
+ATOM   4739 O  O   . SER B 1 143 ? 58.069  32.162 19.074 1.00 56.86  ? 162  SER B O   1 
+ATOM   4740 C  CB  . SER B 1 143 ? 59.477  29.840 17.309 1.00 60.03  ? 162  SER B CB  1 
+ATOM   4741 O  OG  . SER B 1 143 ? 60.297  30.997 17.449 1.00 62.56  ? 162  SER B OG  1 
+ATOM   4742 N  N   . PRO B 1 144 ? 58.640  30.364 20.286 1.00 54.45  ? 163  PRO B N   1 
+ATOM   4743 C  CA  . PRO B 1 144 ? 58.812  31.102 21.533 1.00 52.00  ? 163  PRO B CA  1 
+ATOM   4744 C  C   . PRO B 1 144 ? 59.761  32.235 21.335 1.00 51.37  ? 163  PRO B C   1 
+ATOM   4745 O  O   . PRO B 1 144 ? 60.692  32.131 20.548 1.00 53.81  ? 163  PRO B O   1 
+ATOM   4746 C  CB  . PRO B 1 144 ? 59.467  30.079 22.456 1.00 54.27  ? 163  PRO B CB  1 
+ATOM   4747 C  CG  . PRO B 1 144 ? 59.035  28.786 21.952 1.00 53.17  ? 163  PRO B CG  1 
+ATOM   4748 C  CD  . PRO B 1 144 ? 58.980  28.941 20.464 1.00 54.83  ? 163  PRO B CD  1 
+ATOM   4749 N  N   . CYS B 1 145 ? 59.533  33.314 22.060 1.00 53.15  ? 164  CYS B N   1 
+ATOM   4750 C  CA  . CYS B 1 145 ? 60.316  34.513 21.872 1.00 50.95  ? 164  CYS B CA  1 
+ATOM   4751 C  C   . CYS B 1 145 ? 60.211  35.421 23.090 1.00 47.26  ? 164  CYS B C   1 
+ATOM   4752 O  O   . CYS B 1 145 ? 59.233  35.366 23.818 1.00 43.94  ? 164  CYS B O   1 
+ATOM   4753 C  CB  . CYS B 1 145 ? 59.871  35.216 20.588 1.00 52.39  ? 164  CYS B CB  1 
+ATOM   4754 S  SG  . CYS B 1 145 ? 58.919  36.701 20.857 1.00 44.47  ? 164  CYS B SG  1 
+ATOM   4755 N  N   . ASP B 1 146 ? 61.271  36.192 23.313 1.00 44.11  ? 165  ASP B N   1 
+ATOM   4756 C  CA  . ASP B 1 146 ? 61.343  37.196 24.349 1.00 42.83  ? 165  ASP B CA  1 
+ATOM   4757 C  C   . ASP B 1 146 ? 61.056  38.531 23.651 1.00 47.24  ? 165  ASP B C   1 
+ATOM   4758 O  O   . ASP B 1 146 ? 61.902  39.072 22.885 1.00 45.76  ? 165  ASP B O   1 
+ATOM   4759 C  CB  . ASP B 1 146 ? 62.719  37.235 24.996 1.00 40.07  ? 165  ASP B CB  1 
+ATOM   4760 C  CG  . ASP B 1 146 ? 62.869  38.383 25.988 1.00 44.60  ? 165  ASP B CG  1 
+ATOM   4761 O  OD1 . ASP B 1 146 ? 63.987  38.557 26.541 1.00 38.75  ? 165  ASP B OD1 1 
+ATOM   4762 O  OD2 . ASP B 1 146 ? 61.921  39.159 26.298 1.00 46.40  ? 165  ASP B OD2 1 
+ATOM   4763 N  N   . PRO B 1 147 ? 59.867  39.074 23.924 1.00 45.75  ? 166  PRO B N   1 
+ATOM   4764 C  CA  . PRO B 1 147 ? 59.384  40.258 23.211 1.00 40.43  ? 166  PRO B CA  1 
+ATOM   4765 C  C   . PRO B 1 147 ? 60.161  41.523 23.533 1.00 32.47  ? 166  PRO B C   1 
+ATOM   4766 O  O   . PRO B 1 147 ? 60.002  42.504 22.837 1.00 32.76  ? 166  PRO B O   1 
+ATOM   4767 C  CB  . PRO B 1 147 ? 57.945  40.376 23.697 1.00 42.06  ? 166  PRO B CB  1 
+ATOM   4768 C  CG  . PRO B 1 147 ? 57.956  39.791 25.037 1.00 42.71  ? 166  PRO B CG  1 
+ATOM   4769 C  CD  . PRO B 1 147 ? 58.898  38.622 24.944 1.00 44.55  ? 166  PRO B CD  1 
+ATOM   4770 N  N   . THR B 1 148 ? 61.006  41.512 24.546 1.00 30.17  ? 167  THR B N   1 
+ATOM   4771 C  CA  . THR B 1 148 ? 61.677  42.755 24.977 1.00 30.91  ? 167  THR B CA  1 
+ATOM   4772 C  C   . THR B 1 148 ? 62.233  43.615 23.867 1.00 32.69  ? 167  THR B C   1 
+ATOM   4773 O  O   . THR B 1 148 ? 62.137  44.828 23.921 1.00 39.39  ? 167  THR B O   1 
+ATOM   4774 C  CB  . THR B 1 148 ? 62.843  42.448 25.902 1.00 27.98  ? 167  THR B CB  1 
+ATOM   4775 O  OG1 . THR B 1 148 ? 62.401  41.644 27.003 1.00 31.52  ? 167  THR B OG1 1 
+ATOM   4776 C  CG2 . THR B 1 148 ? 63.372  43.721 26.539 1.00 29.26  ? 167  THR B CG2 1 
+ATOM   4777 N  N   . PHE B 1 149 ? 62.851  42.985 22.880 1.00 36.43  ? 168  PHE B N   1 
+ATOM   4778 C  CA  . PHE B 1 149 ? 63.642  43.706 21.913 1.00 35.88  ? 168  PHE B CA  1 
+ATOM   4779 C  C   . PHE B 1 149 ? 62.758  44.323 20.840 1.00 34.83  ? 168  PHE B C   1 
+ATOM   4780 O  O   . PHE B 1 149 ? 62.877  45.510 20.548 1.00 32.07  ? 168  PHE B O   1 
+ATOM   4781 C  CB  . PHE B 1 149 ? 64.681  42.785 21.253 1.00 38.23  ? 168  PHE B CB  1 
+ATOM   4782 C  CG  . PHE B 1 149 ? 65.364  43.420 20.074 1.00 34.51  ? 168  PHE B CG  1 
+ATOM   4783 C  CD1 . PHE B 1 149 ? 65.065  43.020 18.780 1.00 37.06  ? 168  PHE B CD1 1 
+ATOM   4784 C  CD2 . PHE B 1 149 ? 66.262  44.458 20.271 1.00 31.85  ? 168  PHE B CD2 1 
+ATOM   4785 C  CE1 . PHE B 1 149 ? 65.674  43.643 17.695 1.00 38.50  ? 168  PHE B CE1 1 
+ATOM   4786 C  CE2 . PHE B 1 149 ? 66.881  45.068 19.209 1.00 32.99  ? 168  PHE B CE2 1 
+ATOM   4787 C  CZ  . PHE B 1 149 ? 66.590  44.666 17.920 1.00 37.97  ? 168  PHE B CZ  1 
+ATOM   4788 N  N   . ILE B 1 150 ? 61.930  43.476 20.230 1.00 32.19  ? 169  ILE B N   1 
+ATOM   4789 C  CA  . ILE B 1 150 ? 60.978  43.876 19.205 1.00 32.87  ? 169  ILE B CA  1 
+ATOM   4790 C  C   . ILE B 1 150 ? 60.034  44.979 19.716 1.00 32.65  ? 169  ILE B C   1 
+ATOM   4791 O  O   . ILE B 1 150 ? 59.821  45.990 19.064 1.00 31.29  ? 169  ILE B O   1 
+ATOM   4792 C  CB  . ILE B 1 150 ? 60.151  42.657 18.794 1.00 33.57  ? 169  ILE B CB  1 
+ATOM   4793 C  CG1 . ILE B 1 150 ? 60.920  41.786 17.799 1.00 37.06  ? 169  ILE B CG1 1 
+ATOM   4794 C  CG2 . ILE B 1 150 ? 58.866  43.088 18.163 1.00 37.91  ? 169  ILE B CG2 1 
+ATOM   4795 C  CD1 . ILE B 1 150 ? 60.219  40.434 17.439 1.00 36.02  ? 169  ILE B CD1 1 
+ATOM   4796 N  N   . LEU B 1 151 ? 59.459  44.754 20.885 1.00 33.03  ? 170  LEU B N   1 
+ATOM   4797 C  CA  . LEU B 1 151 ? 58.642  45.749 21.553 1.00 32.36  ? 170  LEU B CA  1 
+ATOM   4798 C  C   . LEU B 1 151 ? 59.406  46.991 21.985 1.00 31.49  ? 170  LEU B C   1 
+ATOM   4799 O  O   . LEU B 1 151 ? 58.800  47.984 22.276 1.00 39.89  ? 170  LEU B O   1 
+ATOM   4800 C  CB  . LEU B 1 151 ? 57.998  45.126 22.777 1.00 33.67  ? 170  LEU B CB  1 
+ATOM   4801 C  CG  . LEU B 1 151 ? 56.534  44.747 22.712 1.00 36.61  ? 170  LEU B CG  1 
+ATOM   4802 C  CD1 . LEU B 1 151 ? 56.067  44.385 21.322 1.00 38.24  ? 170  LEU B CD1 1 
+ATOM   4803 C  CD2 . LEU B 1 151 ? 56.306  43.599 23.663 1.00 38.59  ? 170  LEU B CD2 1 
+ATOM   4804 N  N   . GLY B 1 152 ? 60.717  46.944 22.092 1.00 32.67  ? 171  GLY B N   1 
+ATOM   4805 C  CA  . GLY B 1 152 ? 61.472  48.155 22.353 1.00 32.89  ? 171  GLY B CA  1 
+ATOM   4806 C  C   . GLY B 1 152 ? 61.707  48.921 21.061 1.00 34.33  ? 171  GLY B C   1 
+ATOM   4807 O  O   . GLY B 1 152 ? 61.864  50.148 21.035 1.00 30.48  ? 171  GLY B O   1 
+ATOM   4808 N  N   . CYS B 1 153 ? 61.766  48.177 19.971 1.00 35.93  ? 172  CYS B N   1 
+ATOM   4809 C  CA  . CYS B 1 153 ? 62.158  48.756 18.696 1.00 40.19  ? 172  CYS B CA  1 
+ATOM   4810 C  C   . CYS B 1 153 ? 61.084  49.735 18.254 1.00 38.35  ? 172  CYS B C   1 
+ATOM   4811 O  O   . CYS B 1 153 ? 61.396  50.811 17.796 1.00 33.84  ? 172  CYS B O   1 
+ATOM   4812 C  CB  . CYS B 1 153 ? 62.360  47.654 17.635 1.00 43.64  ? 172  CYS B CB  1 
+ATOM   4813 S  SG  . CYS B 1 153 ? 63.928  46.762 17.773 1.00 45.69  ? 172  CYS B SG  1 
+ATOM   4814 N  N   . ALA B 1 154 ? 59.820  49.352 18.456 1.00 34.64  ? 173  ALA B N   1 
+ATOM   4815 C  CA  . ALA B 1 154 ? 58.686  50.073 17.926 1.00 31.50  ? 173  ALA B CA  1 
+ATOM   4816 C  C   . ALA B 1 154 ? 58.530  51.497 18.472 1.00 31.08  ? 173  ALA B C   1 
+ATOM   4817 O  O   . ALA B 1 154 ? 58.388  52.435 17.695 1.00 27.21  ? 173  ALA B O   1 
+ATOM   4818 C  CB  . ALA B 1 154 ? 57.421  49.263 18.133 1.00 33.46  ? 173  ALA B CB  1 
+ATOM   4819 N  N   . PRO B 1 155 ? 58.545  51.673 19.788 1.00 28.92  ? 174  PRO B N   1 
+ATOM   4820 C  CA  . PRO B 1 155 ? 58.459  53.011 20.354 1.00 27.83  ? 174  PRO B CA  1 
+ATOM   4821 C  C   . PRO B 1 155 ? 59.678  53.875 20.006 1.00 29.92  ? 174  PRO B C   1 
+ATOM   4822 O  O   . PRO B 1 155 ? 59.578  55.081 19.797 1.00 30.02  ? 174  PRO B O   1 
+ATOM   4823 C  CB  . PRO B 1 155 ? 58.371  52.755 21.864 1.00 28.29  ? 174  PRO B CB  1 
+ATOM   4824 C  CG  . PRO B 1 155 ? 58.131  51.327 22.043 1.00 28.37  ? 174  PRO B CG  1 
+ATOM   4825 C  CD  . PRO B 1 155 ? 58.611  50.640 20.827 1.00 28.79  ? 174  PRO B CD  1 
+ATOM   4826 N  N   . CYS B 1 156 ? 60.840  53.269 19.950 1.00 32.90  ? 175  CYS B N   1 
+ATOM   4827 C  CA  . CYS B 1 156 ? 62.029  54.030 19.602 1.00 38.05  ? 175  CYS B CA  1 
+ATOM   4828 C  C   . CYS B 1 156 ? 61.949  54.611 18.191 1.00 37.12  ? 175  CYS B C   1 
+ATOM   4829 O  O   . CYS B 1 156 ? 62.344  55.769 17.936 1.00 36.00  ? 175  CYS B O   1 
+ATOM   4830 C  CB  . CYS B 1 156 ? 63.251  53.143 19.677 1.00 39.99  ? 175  CYS B CB  1 
+ATOM   4831 S  SG  . CYS B 1 156 ? 64.745  54.093 19.469 1.00 43.27  ? 175  CYS B SG  1 
+ATOM   4832 N  N   . ASN B 1 157 ? 61.459  53.779 17.284 1.00 33.45  ? 176  ASN B N   1 
+ATOM   4833 C  CA  . ASN B 1 157 ? 61.269  54.146 15.888 1.00 34.90  ? 176  ASN B CA  1 
+ATOM   4834 C  C   . ASN B 1 157 ? 60.191  55.227 15.709 1.00 32.54  ? 176  ASN B C   1 
+ATOM   4835 O  O   . ASN B 1 157 ? 60.283  56.061 14.802 1.00 30.28  ? 176  ASN B O   1 
+ATOM   4836 C  CB  . ASN B 1 157 ? 60.894  52.893 15.077 1.00 37.22  ? 176  ASN B CB  1 
+ATOM   4837 C  CG  . ASN B 1 157 ? 61.768  52.685 13.845 1.00 37.79  ? 176  ASN B CG  1 
+ATOM   4838 O  OD1 . ASN B 1 157 ? 62.683  53.463 13.570 1.00 38.53  ? 176  ASN B OD1 1 
+ATOM   4839 N  ND2 . ASN B 1 157 ? 61.457  51.636 13.081 1.00 32.25  ? 176  ASN B ND2 1 
+ATOM   4840 N  N   . VAL B 1 158 ? 59.175  55.220 16.572 1.00 32.48  ? 177  VAL B N   1 
+ATOM   4841 C  CA  . VAL B 1 158 ? 58.142  56.249 16.511 1.00 29.47  ? 177  VAL B CA  1 
+ATOM   4842 C  C   . VAL B 1 158 ? 58.818  57.571 16.773 1.00 29.44  ? 177  VAL B C   1 
+ATOM   4843 O  O   . VAL B 1 158 ? 58.583  58.522 16.041 1.00 27.49  ? 177  VAL B O   1 
+ATOM   4844 C  CB  . VAL B 1 158 ? 56.965  56.018 17.489 1.00 27.20  ? 177  VAL B CB  1 
+ATOM   4845 C  CG1 . VAL B 1 158 ? 56.062  57.236 17.560 1.00 32.51  ? 177  VAL B CG1 1 
+ATOM   4846 C  CG2 . VAL B 1 158 ? 56.128  54.862 17.046 1.00 25.70  ? 177  VAL B CG2 1 
+ATOM   4847 N  N   . ILE B 1 159 ? 59.683  57.625 17.789 1.00 33.14  ? 178  ILE B N   1 
+ATOM   4848 C  CA  . ILE B 1 159 ? 60.422  58.858 18.080 1.00 32.91  ? 178  ILE B CA  1 
+ATOM   4849 C  C   . ILE B 1 159 ? 61.335  59.228 16.905 1.00 29.84  ? 178  ILE B C   1 
+ATOM   4850 O  O   . ILE B 1 159 ? 61.436  60.388 16.557 1.00 29.31  ? 178  ILE B O   1 
+ATOM   4851 C  CB  . ILE B 1 159 ? 61.193  58.805 19.431 1.00 33.73  ? 178  ILE B CB  1 
+ATOM   4852 C  CG1 . ILE B 1 159 ? 60.278  59.113 20.603 1.00 37.05  ? 178  ILE B CG1 1 
+ATOM   4853 C  CG2 . ILE B 1 159 ? 62.246  59.899 19.482 1.00 35.49  ? 178  ILE B CG2 1 
+ATOM   4854 C  CD1 . ILE B 1 159 ? 59.409  57.987 20.969 1.00 48.50  ? 178  ILE B CD1 1 
+ATOM   4855 N  N   . CYS B 1 160 ? 61.955  58.241 16.266 1.00 34.56  ? 179  CYS B N   1 
+ATOM   4856 C  CA  . CYS B 1 160 ? 62.827  58.488 15.097 1.00 35.27  ? 179  CYS B CA  1 
+ATOM   4857 C  C   . CYS B 1 160 ? 62.082  59.177 13.963 1.00 31.48  ? 179  CYS B C   1 
+ATOM   4858 O  O   . CYS B 1 160 ? 62.599  60.115 13.341 1.00 29.79  ? 179  CYS B O   1 
+ATOM   4859 C  CB  . CYS B 1 160 ? 63.419  57.180 14.555 1.00 36.73  ? 179  CYS B CB  1 
+ATOM   4860 S  SG  . CYS B 1 160 ? 64.699  56.413 15.579 1.00 43.67  ? 179  CYS B SG  1 
+ATOM   4861 N  N   . SER B 1 161 ? 60.864  58.707 13.708 1.00 30.22  ? 180  SER B N   1 
+ATOM   4862 C  CA  . SER B 1 161 ? 60.041  59.258 12.656 1.00 29.06  ? 180  SER B CA  1 
+ATOM   4863 C  C   . SER B 1 161 ? 59.729  60.692 12.993 1.00 34.26  ? 180  SER B C   1 
+ATOM   4864 O  O   . SER B 1 161 ? 59.990  61.588 12.190 1.00 38.73  ? 180  SER B O   1 
+ATOM   4865 C  CB  . SER B 1 161 ? 58.774  58.457 12.486 1.00 30.56  ? 180  SER B CB  1 
+ATOM   4866 O  OG  . SER B 1 161 ? 58.241  58.698 11.204 1.00 33.62  ? 180  SER B OG  1 
+ATOM   4867 N  N   . ILE B 1 162 ? 59.239  60.930 14.210 1.00 35.30  ? 181  ILE B N   1 
+ATOM   4868 C  CA  . ILE B 1 162 ? 58.930  62.287 14.663 1.00 32.27  ? 181  ILE B CA  1 
+ATOM   4869 C  C   . ILE B 1 162 ? 60.125  63.235 14.595 1.00 34.08  ? 181  ILE B C   1 
+ATOM   4870 O  O   . ILE B 1 162 ? 59.940  64.413 14.287 1.00 34.63  ? 181  ILE B O   1 
+ATOM   4871 C  CB  . ILE B 1 162 ? 58.380  62.272 16.097 1.00 33.41  ? 181  ILE B CB  1 
+ATOM   4872 C  CG1 . ILE B 1 162 ? 56.951  61.724 16.123 1.00 35.78  ? 181  ILE B CG1 1 
+ATOM   4873 C  CG2 . ILE B 1 162 ? 58.413  63.665 16.712 1.00 32.36  ? 181  ILE B CG2 1 
+ATOM   4874 C  CD1 . ILE B 1 162 ? 56.555  61.116 17.490 1.00 34.35  ? 181  ILE B CD1 1 
+ATOM   4875 N  N   . ILE B 1 163 ? 61.336  62.766 14.895 1.00 35.33  ? 182  ILE B N   1 
+ATOM   4876 C  CA  . ILE B 1 163 ? 62.491  63.686 14.918 1.00 37.31  ? 182  ILE B CA  1 
+ATOM   4877 C  C   . ILE B 1 163 ? 63.148  63.822 13.542 1.00 38.37  ? 182  ILE B C   1 
+ATOM   4878 O  O   . ILE B 1 163 ? 63.472  64.938 13.138 1.00 37.64  ? 182  ILE B O   1 
+ATOM   4879 C  CB  . ILE B 1 163 ? 63.571  63.282 15.949 1.00 38.28  ? 182  ILE B CB  1 
+ATOM   4880 C  CG1 . ILE B 1 163 ? 62.958  62.906 17.321 1.00 38.37  ? 182  ILE B CG1 1 
+ATOM   4881 C  CG2 . ILE B 1 163 ? 64.614  64.386 16.022 1.00 34.11  ? 182  ILE B CG2 1 
+ATOM   4882 C  CD1 . ILE B 1 163 ? 63.119  63.900 18.383 1.00 38.80  ? 182  ILE B CD1 1 
+ATOM   4883 N  N   . PHE B 1 164 ? 63.314  62.695 12.839 1.00 38.93  ? 183  PHE B N   1 
+ATOM   4884 C  CA  . PHE B 1 164 ? 64.051  62.616 11.556 1.00 42.19  ? 183  PHE B CA  1 
+ATOM   4885 C  C   . PHE B 1 164 ? 63.219  62.584 10.242 1.00 43.73  ? 183  PHE B C   1 
+ATOM   4886 O  O   . PHE B 1 164 ? 63.783  62.623 9.162  1.00 44.42  ? 183  PHE B O   1 
+ATOM   4887 C  CB  . PHE B 1 164 ? 64.936  61.351 11.561 1.00 42.12  ? 183  PHE B CB  1 
+ATOM   4888 C  CG  . PHE B 1 164 ? 65.813  61.213 12.772 1.00 38.57  ? 183  PHE B CG  1 
+ATOM   4889 C  CD1 . PHE B 1 164 ? 66.123  59.956 13.262 1.00 37.36  ? 183  PHE B CD1 1 
+ATOM   4890 C  CD2 . PHE B 1 164 ? 66.339  62.331 13.411 1.00 38.17  ? 183  PHE B CD2 1 
+ATOM   4891 C  CE1 . PHE B 1 164 ? 66.921  59.803 14.385 1.00 40.00  ? 183  PHE B CE1 1 
+ATOM   4892 C  CE2 . PHE B 1 164 ? 67.155  62.190 14.532 1.00 40.54  ? 183  PHE B CE2 1 
+ATOM   4893 C  CZ  . PHE B 1 164 ? 67.442  60.920 15.024 1.00 39.73  ? 183  PHE B CZ  1 
+ATOM   4894 N  N   . HIS B 1 165 ? 61.898  62.540 10.361 1.00 49.53  ? 184  HIS B N   1 
+ATOM   4895 C  CA  . HIS B 1 165 ? 60.893  62.295 9.284  1.00 55.63  ? 184  HIS B CA  1 
+ATOM   4896 C  C   . HIS B 1 165 ? 60.727  60.856 8.853  1.00 57.03  ? 184  HIS B C   1 
+ATOM   4897 O  O   . HIS B 1 165 ? 59.665  60.481 8.366  1.00 62.81  ? 184  HIS B O   1 
+ATOM   4898 C  CB  . HIS B 1 165 ? 60.946  63.195 8.002  1.00 60.11  ? 184  HIS B CB  1 
+ATOM   4899 C  CG  . HIS B 1 165 ? 59.620  63.225 7.254  1.00 66.64  ? 184  HIS B CG  1 
+ATOM   4900 N  ND1 . HIS B 1 165 ? 59.418  63.879 6.037  1.00 69.03  ? 184  HIS B ND1 1 
+ATOM   4901 C  CD2 . HIS B 1 165 ? 58.417  62.658 7.575  1.00 72.12  ? 184  HIS B CD2 1 
+ATOM   4902 C  CE1 . HIS B 1 165 ? 58.152  63.697 5.640  1.00 75.03  ? 184  HIS B CE1 1 
+ATOM   4903 N  NE2 . HIS B 1 165 ? 57.528  62.952 6.557  1.00 76.75  ? 184  HIS B NE2 1 
+ATOM   4904 N  N   . LYS B 1 166 ? 61.729  60.025 9.005  1.00 56.92  ? 185  LYS B N   1 
+ATOM   4905 C  CA  . LYS B 1 166 ? 61.490  58.655 8.626  1.00 57.43  ? 185  LYS B CA  1 
+ATOM   4906 C  C   . LYS B 1 166 ? 61.963  57.668 9.683  1.00 51.61  ? 185  LYS B C   1 
+ATOM   4907 O  O   . LYS B 1 166 ? 62.976  57.869 10.350 1.00 50.70  ? 185  LYS B O   1 
+ATOM   4908 C  CB  . LYS B 1 166 ? 62.073  58.360 7.223  1.00 62.75  ? 185  LYS B CB  1 
+ATOM   4909 C  CG  . LYS B 1 166 ? 63.294  59.205 6.756  1.00 63.80  ? 185  LYS B CG  1 
+ATOM   4910 C  CD  . LYS B 1 166 ? 63.518  59.052 5.219  1.00 65.84  ? 185  LYS B CD  1 
+ATOM   4911 C  CE  . LYS B 1 166 ? 64.924  58.577 4.826  1.00 67.35  ? 185  LYS B CE  1 
+ATOM   4912 N  NZ  . LYS B 1 166 ? 65.374  57.359 5.570  1.00 69.31  ? 185  LYS B NZ  1 
+ATOM   4913 N  N   . ARG B 1 167 ? 61.185  56.608 9.838  1.00 45.00  ? 186  ARG B N   1 
+ATOM   4914 C  CA  . ARG B 1 167 ? 61.606  55.445 10.612 1.00 42.59  ? 186  ARG B CA  1 
+ATOM   4915 C  C   . ARG B 1 167 ? 62.773  54.700 9.971  1.00 44.47  ? 186  ARG B C   1 
+ATOM   4916 O  O   . ARG B 1 167 ? 63.054  54.871 8.798  1.00 46.44  ? 186  ARG B O   1 
+ATOM   4917 C  CB  . ARG B 1 167 ? 60.452  54.471 10.731 1.00 39.06  ? 186  ARG B CB  1 
+ATOM   4918 C  CG  . ARG B 1 167 ? 60.016  53.898 9.420  1.00 33.68  ? 186  ARG B CG  1 
+ATOM   4919 C  CD  . ARG B 1 167 ? 58.869  52.985 9.523  1.00 33.15  ? 186  ARG B CD  1 
+ATOM   4920 N  NE  . ARG B 1 167 ? 59.086  51.916 10.488 1.00 39.50  ? 186  ARG B NE  1 
+ATOM   4921 C  CZ  . ARG B 1 167 ? 59.765  50.788 10.248 1.00 45.27  ? 186  ARG B CZ  1 
+ATOM   4922 N  NH1 . ARG B 1 167 ? 60.303  50.548 9.058  1.00 44.16  ? 186  ARG B NH1 1 
+ATOM   4923 N  NH2 . ARG B 1 167 ? 59.888  49.873 11.213 1.00 47.73  ? 186  ARG B NH2 1 
+ATOM   4924 N  N   . PHE B 1 168 ? 63.428  53.854 10.754 1.00 46.47  ? 187  PHE B N   1 
+ATOM   4925 C  CA  . PHE B 1 168 ? 64.520  53.012 10.285 1.00 46.93  ? 187  PHE B CA  1 
+ATOM   4926 C  C   . PHE B 1 168 ? 63.998  51.611 10.136 1.00 49.10  ? 187  PHE B C   1 
+ATOM   4927 O  O   . PHE B 1 168 ? 62.934  51.299 10.624 1.00 54.23  ? 187  PHE B O   1 
+ATOM   4928 C  CB  . PHE B 1 168 ? 65.669  52.993 11.296 1.00 47.51  ? 187  PHE B CB  1 
+ATOM   4929 C  CG  . PHE B 1 168 ? 66.362  54.328 11.469 1.00 44.36  ? 187  PHE B CG  1 
+ATOM   4930 C  CD1 . PHE B 1 168 ? 66.129  55.112 12.598 1.00 40.73  ? 187  PHE B CD1 1 
+ATOM   4931 C  CD2 . PHE B 1 168 ? 67.260  54.775 10.524 1.00 43.78  ? 187  PHE B CD2 1 
+ATOM   4932 C  CE1 . PHE B 1 168 ? 66.771  56.341 12.776 1.00 43.91  ? 187  PHE B CE1 1 
+ATOM   4933 C  CE2 . PHE B 1 168 ? 67.906  56.008 10.684 1.00 49.14  ? 187  PHE B CE2 1 
+ATOM   4934 C  CZ  . PHE B 1 168 ? 67.659  56.793 11.823 1.00 47.64  ? 187  PHE B CZ  1 
+ATOM   4935 N  N   . ASP B 1 169 ? 64.749  50.765 9.454  1.00 52.94  ? 188  ASP B N   1 
+ATOM   4936 C  CA  . ASP B 1 169 ? 64.465  49.338 9.417  1.00 53.84  ? 188  ASP B CA  1 
+ATOM   4937 C  C   . ASP B 1 169 ? 64.988  48.775 10.727 1.00 52.84  ? 188  ASP B C   1 
+ATOM   4938 O  O   . ASP B 1 169 ? 66.010  49.250 11.222 1.00 51.71  ? 188  ASP B O   1 
+ATOM   4939 C  CB  . ASP B 1 169 ? 65.182  48.691 8.220  1.00 55.99  ? 188  ASP B CB  1 
+ATOM   4940 C  CG  . ASP B 1 169 ? 64.720  47.273 7.958  1.00 57.31  ? 188  ASP B CG  1 
+ATOM   4941 O  OD1 . ASP B 1 169 ? 65.232  46.365 8.636  1.00 59.11  ? 188  ASP B OD1 1 
+ATOM   4942 O  OD2 . ASP B 1 169 ? 63.851  46.965 7.106  1.00 60.31  ? 188  ASP B OD2 1 
+ATOM   4943 N  N   . TYR B 1 170 ? 64.318  47.768 11.289 1.00 52.32  ? 189  TYR B N   1 
+ATOM   4944 C  CA  . TYR B 1 170 ? 64.717  47.228 12.599 1.00 53.81  ? 189  TYR B CA  1 
+ATOM   4945 C  C   . TYR B 1 170 ? 66.159  46.681 12.625 1.00 56.45  ? 189  TYR B C   1 
+ATOM   4946 O  O   . TYR B 1 170 ? 66.689  46.388 13.702 1.00 58.81  ? 189  TYR B O   1 
+ATOM   4947 C  CB  . TYR B 1 170 ? 63.734  46.133 13.093 1.00 54.82  ? 189  TYR B CB  1 
+ATOM   4948 C  CG  . TYR B 1 170 ? 62.330  46.584 13.551 1.00 55.56  ? 189  TYR B CG  1 
+ATOM   4949 C  CD1 . TYR B 1 170 ? 61.404  45.662 14.015 1.00 57.32  ? 189  TYR B CD1 1 
+ATOM   4950 C  CD2 . TYR B 1 170 ? 61.940  47.911 13.534 1.00 55.63  ? 189  TYR B CD2 1 
+ATOM   4951 C  CE1 . TYR B 1 170 ? 60.122  46.054 14.425 1.00 54.67  ? 189  TYR B CE1 1 
+ATOM   4952 C  CE2 . TYR B 1 170 ? 60.679  48.303 13.944 1.00 51.65  ? 189  TYR B CE2 1 
+ATOM   4953 C  CZ  . TYR B 1 170 ? 59.771  47.383 14.386 1.00 52.16  ? 189  TYR B CZ  1 
+ATOM   4954 O  OH  . TYR B 1 170 ? 58.512  47.810 14.784 1.00 46.92  ? 189  TYR B OH  1 
+ATOM   4955 N  N   . LYS B 1 171 ? 66.794  46.555 11.456 1.00 62.37  ? 190  LYS B N   1 
+ATOM   4956 C  CA  . LYS B 1 171 ? 68.153  45.990 11.334 1.00 63.41  ? 190  LYS B CA  1 
+ATOM   4957 C  C   . LYS B 1 171 ? 69.243  47.008 10.953 1.00 58.78  ? 190  LYS B C   1 
+ATOM   4958 O  O   . LYS B 1 171 ? 70.419  46.747 11.169 1.00 59.14  ? 190  LYS B O   1 
+ATOM   4959 C  CB  . LYS B 1 171 ? 68.138  44.823 10.340 1.00 65.36  ? 190  LYS B CB  1 
+ATOM   4960 C  CG  . LYS B 1 171 ? 67.416  43.567 10.878 1.00 69.62  ? 190  LYS B CG  1 
+ATOM   4961 C  CD  . LYS B 1 171 ? 67.528  42.369 9.925  1.00 73.42  ? 190  LYS B CD  1 
+ATOM   4962 C  CE  . LYS B 1 171 ? 66.737  42.573 8.608  1.00 77.24  ? 190  LYS B CE  1 
+ATOM   4963 N  NZ  . LYS B 1 171 ? 67.232  43.697 7.716  1.00 78.73  ? 190  LYS B NZ  1 
+ATOM   4964 N  N   . ASP B 1 172 ? 68.851  48.146 10.384 1.00 55.84  ? 191  ASP B N   1 
+ATOM   4965 C  CA  . ASP B 1 172 ? 69.743  49.300 10.158 1.00 54.65  ? 191  ASP B CA  1 
+ATOM   4966 C  C   . ASP B 1 172 ? 70.721  49.560 11.299 1.00 56.28  ? 191  ASP B C   1 
+ATOM   4967 O  O   . ASP B 1 172 ? 70.339  49.539 12.456 1.00 61.03  ? 191  ASP B O   1 
+ATOM   4968 C  CB  . ASP B 1 172 ? 68.904  50.544 9.965  1.00 55.00  ? 191  ASP B CB  1 
+ATOM   4969 C  CG  . ASP B 1 172 ? 69.604  51.589 9.167  1.00 59.30  ? 191  ASP B CG  1 
+ATOM   4970 O  OD1 . ASP B 1 172 ? 69.228  51.741 7.989  1.00 60.80  ? 191  ASP B OD1 1 
+ATOM   4971 O  OD2 . ASP B 1 172 ? 70.523  52.312 9.624  1.00 63.08  ? 191  ASP B OD2 1 
+ATOM   4972 N  N   . GLN B 1 173 ? 71.987  49.806 10.981 1.00 57.64  ? 192  GLN B N   1 
+ATOM   4973 C  CA  . GLN B 1 173 ? 73.036  49.808 12.009 1.00 53.38  ? 192  GLN B CA  1 
+ATOM   4974 C  C   . GLN B 1 173 ? 73.001  51.073 12.849 1.00 50.21  ? 192  GLN B C   1 
+ATOM   4975 O  O   . GLN B 1 173 ? 73.327  51.026 14.028 1.00 48.50  ? 192  GLN B O   1 
+ATOM   4976 C  CB  . GLN B 1 173 ? 74.435  49.614 11.388 1.00 52.50  ? 192  GLN B CB  1 
+ATOM   4977 C  CG  . GLN B 1 173 ? 75.549  49.314 12.399 1.00 51.83  ? 192  GLN B CG  1 
+ATOM   4978 C  CD  . GLN B 1 173 ? 75.289  48.046 13.227 1.00 52.20  ? 192  GLN B CD  1 
+ATOM   4979 O  OE1 . GLN B 1 173 ? 75.073  46.966 12.671 1.00 47.17  ? 192  GLN B OE1 1 
+ATOM   4980 N  NE2 . GLN B 1 173 ? 75.302  48.187 14.556 1.00 49.48  ? 192  GLN B NE2 1 
+ATOM   4981 N  N   . GLN B 1 174 ? 72.635  52.195 12.230 1.00 48.66  ? 193  GLN B N   1 
+ATOM   4982 C  CA  . GLN B 1 174 ? 72.377  53.448 12.950 1.00 49.35  ? 193  GLN B CA  1 
+ATOM   4983 C  C   . GLN B 1 174 ? 71.363  53.239 14.080 1.00 47.76  ? 193  GLN B C   1 
+ATOM   4984 O  O   . GLN B 1 174 ? 71.487  53.811 15.172 1.00 46.05  ? 193  GLN B O   1 
+ATOM   4985 C  CB  . GLN B 1 174 ? 71.736  54.484 12.031 1.00 51.02  ? 193  GLN B CB  1 
+ATOM   4986 C  CG  . GLN B 1 174 ? 72.527  54.981 10.860 1.00 55.29  ? 193  GLN B CG  1 
+ATOM   4987 C  CD  . GLN B 1 174 ? 71.647  55.868 9.985  1.00 58.72  ? 193  GLN B CD  1 
+ATOM   4988 O  OE1 . GLN B 1 174 ? 71.407  57.047 10.307 1.00 53.68  ? 193  GLN B OE1 1 
+ATOM   4989 N  NE2 . GLN B 1 174 ? 71.114  55.286 8.912  1.00 61.93  ? 193  GLN B NE2 1 
+ATOM   4990 N  N   . PHE B 1 175 ? 70.337  52.448 13.764 1.00 42.69  ? 194  PHE B N   1 
+ATOM   4991 C  CA  . PHE B 1 175 ? 69.189  52.250 14.615 1.00 40.17  ? 194  PHE B CA  1 
+ATOM   4992 C  C   . PHE B 1 175 ? 69.565  51.419 15.800 1.00 40.37  ? 194  PHE B C   1 
+ATOM   4993 O  O   . PHE B 1 175 ? 69.329  51.822 16.935 1.00 43.30  ? 194  PHE B O   1 
+ATOM   4994 C  CB  . PHE B 1 175 ? 68.069  51.577 13.831 1.00 40.70  ? 194  PHE B CB  1 
+ATOM   4995 C  CG  . PHE B 1 175 ? 66.850  51.315 14.635 1.00 38.62  ? 194  PHE B CG  1 
+ATOM   4996 C  CD1 . PHE B 1 175 ? 66.351  50.034 14.754 1.00 37.53  ? 194  PHE B CD1 1 
+ATOM   4997 C  CD2 . PHE B 1 175 ? 66.209  52.355 15.302 1.00 37.41  ? 194  PHE B CD2 1 
+ATOM   4998 C  CE1 . PHE B 1 175 ? 65.211  49.792 15.517 1.00 42.49  ? 194  PHE B CE1 1 
+ATOM   4999 C  CE2 . PHE B 1 175 ? 65.082  52.118 16.078 1.00 35.46  ? 194  PHE B CE2 1 
+ATOM   5000 C  CZ  . PHE B 1 175 ? 64.580  50.841 16.181 1.00 38.94  ? 194  PHE B CZ  1 
+ATOM   5001 N  N   . LEU B 1 176 ? 70.161  50.265 15.531 1.00 46.26  ? 195  LEU B N   1 
+ATOM   5002 C  CA  . LEU B 1 176 ? 70.672  49.365 16.572 1.00 46.33  ? 195  LEU B CA  1 
+ATOM   5003 C  C   . LEU B 1 176 ? 71.672  50.021 17.521 1.00 45.71  ? 195  LEU B C   1 
+ATOM   5004 O  O   . LEU B 1 176 ? 71.667  49.688 18.704 1.00 42.41  ? 195  LEU B O   1 
+ATOM   5005 C  CB  . LEU B 1 176 ? 71.290  48.111 15.955 1.00 47.65  ? 195  LEU B CB  1 
+ATOM   5006 C  CG  . LEU B 1 176 ? 70.283  47.159 15.297 1.00 50.96  ? 195  LEU B CG  1 
+ATOM   5007 C  CD1 . LEU B 1 176 ? 70.909  46.347 14.183 1.00 50.06  ? 195  LEU B CD1 1 
+ATOM   5008 C  CD2 . LEU B 1 176 ? 69.691  46.225 16.336 1.00 54.71  ? 195  LEU B CD2 1 
+ATOM   5009 N  N   . ASN B 1 177 ? 72.505  50.955 17.037 1.00 43.68  ? 196  ASN B N   1 
+ATOM   5010 C  CA  . ASN B 1 177 ? 73.424  51.666 17.943 1.00 43.95  ? 196  ASN B CA  1 
+ATOM   5011 C  C   . ASN B 1 177 ? 72.658  52.537 18.915 1.00 42.72  ? 196  ASN B C   1 
+ATOM   5012 O  O   . ASN B 1 177 ? 72.872  52.447 20.101 1.00 47.81  ? 196  ASN B O   1 
+ATOM   5013 C  CB  . ASN B 1 177 ? 74.460  52.542 17.226 1.00 43.81  ? 196  ASN B CB  1 
+ATOM   5014 C  CG  . ASN B 1 177 ? 75.335  51.766 16.271 1.00 43.09  ? 196  ASN B CG  1 
+ATOM   5015 O  OD1 . ASN B 1 177 ? 75.754  52.331 15.265 1.00 39.57  ? 196  ASN B OD1 1 
+ATOM   5016 N  ND2 . ASN B 1 177 ? 75.596  50.465 16.555 1.00 35.53  ? 196  ASN B ND2 1 
+ATOM   5017 N  N   . LEU B 1 178 ? 71.772  53.385 18.406 1.00 44.70  ? 197  LEU B N   1 
+ATOM   5018 C  CA  . LEU B 1 178 ? 70.851  54.170 19.241 1.00 42.28  ? 197  LEU B CA  1 
+ATOM   5019 C  C   . LEU B 1 178 ? 70.082  53.304 20.252 1.00 42.14  ? 197  LEU B C   1 
+ATOM   5020 O  O   . LEU B 1 178 ? 69.944  53.629 21.419 1.00 37.66  ? 197  LEU B O   1 
+ATOM   5021 C  CB  . LEU B 1 178 ? 69.856  54.874 18.333 1.00 44.60  ? 197  LEU B CB  1 
+ATOM   5022 C  CG  . LEU B 1 178 ? 68.889  55.870 18.962 1.00 46.86  ? 197  LEU B CG  1 
+ATOM   5023 C  CD1 . LEU B 1 178 ? 69.632  56.766 19.936 1.00 49.87  ? 197  LEU B CD1 1 
+ATOM   5024 C  CD2 . LEU B 1 178 ? 68.175  56.690 17.855 1.00 47.16  ? 197  LEU B CD2 1 
+ATOM   5025 N  N   . MET B 1 179 ? 69.586  52.183 19.783 1.00 43.62  ? 198  MET B N   1 
+ATOM   5026 C  CA  . MET B 1 179 ? 68.851  51.249 20.617 1.00 46.98  ? 198  MET B CA  1 
+ATOM   5027 C  C   . MET B 1 179 ? 69.729  50.722 21.757 1.00 48.28  ? 198  MET B C   1 
+ATOM   5028 O  O   . MET B 1 179 ? 69.292  50.585 22.907 1.00 45.96  ? 198  MET B O   1 
+ATOM   5029 C  CB  . MET B 1 179 ? 68.424  50.097 19.720 1.00 50.65  ? 198  MET B CB  1 
+ATOM   5030 C  CG  . MET B 1 179 ? 67.266  49.325 20.175 1.00 55.77  ? 198  MET B CG  1 
+ATOM   5031 S  SD  . MET B 1 179 ? 65.834  50.289 19.990 1.00 57.78  ? 198  MET B SD  1 
+ATOM   5032 C  CE  . MET B 1 179 ? 65.287  50.356 21.797 1.00 59.60  ? 198  MET B CE  1 
+ATOM   5033 N  N   . GLU B 1 180 ? 70.981  50.432 21.401 1.00 52.28  ? 199  GLU B N   1 
+ATOM   5034 C  CA  . GLU B 1 180 ? 72.011  49.906 22.302 1.00 51.61  ? 199  GLU B CA  1 
+ATOM   5035 C  C   . GLU B 1 180 ? 72.312  50.877 23.452 1.00 47.98  ? 199  GLU B C   1 
+ATOM   5036 O  O   . GLU B 1 180 ? 72.321  50.481 24.613 1.00 49.86  ? 199  GLU B O   1 
+ATOM   5037 C  CB  . GLU B 1 180 ? 73.286  49.637 21.478 1.00 54.69  ? 199  GLU B CB  1 
+ATOM   5038 C  CG  . GLU B 1 180 ? 74.449  48.933 22.167 1.00 58.54  ? 199  GLU B CG  1 
+ATOM   5039 C  CD  . GLU B 1 180 ? 75.654  48.820 21.236 1.00 62.89  ? 199  GLU B CD  1 
+ATOM   5040 O  OE1 . GLU B 1 180 ? 75.563  48.093 20.208 1.00 61.77  ? 199  GLU B OE1 1 
+ATOM   5041 O  OE2 . GLU B 1 180 ? 76.684  49.479 21.521 1.00 64.92  ? 199  GLU B OE2 1 
+ATOM   5042 N  N   . LYS B 1 181 ? 72.538  52.143 23.120 1.00 40.25  ? 200  LYS B N   1 
+ATOM   5043 C  CA  . LYS B 1 181 ? 72.943  53.146 24.093 1.00 40.34  ? 200  LYS B CA  1 
+ATOM   5044 C  C   . LYS B 1 181 ? 71.790  53.524 25.037 1.00 40.17  ? 200  LYS B C   1 
+ATOM   5045 O  O   . LYS B 1 181 ? 72.007  53.836 26.212 1.00 38.41  ? 200  LYS B O   1 
+ATOM   5046 C  CB  . LYS B 1 181 ? 73.470  54.390 23.360 1.00 40.87  ? 200  LYS B CB  1 
+ATOM   5047 C  CG  . LYS B 1 181 ? 74.723  54.152 22.509 1.00 42.79  ? 200  LYS B CG  1 
+ATOM   5048 C  CD  . LYS B 1 181 ? 76.033  54.168 23.349 1.00 47.37  ? 200  LYS B CD  1 
+ATOM   5049 C  CE  . LYS B 1 181 ? 77.213  53.410 22.702 1.00 47.87  ? 200  LYS B CE  1 
+ATOM   5050 N  NZ  . LYS B 1 181 ? 76.789  52.543 21.552 1.00 52.55  ? 200  LYS B NZ  1 
+ATOM   5051 N  N   . LEU B 1 182 ? 70.566  53.514 24.505 1.00 39.59  ? 201  LEU B N   1 
+ATOM   5052 C  CA  . LEU B 1 182 ? 69.377  53.738 25.301 1.00 36.90  ? 201  LEU B CA  1 
+ATOM   5053 C  C   . LEU B 1 182 ? 69.190  52.590 26.282 1.00 36.70  ? 201  LEU B C   1 
+ATOM   5054 O  O   . LEU B 1 182 ? 68.923  52.830 27.438 1.00 29.07  ? 201  LEU B O   1 
+ATOM   5055 C  CB  . LEU B 1 182 ? 68.140  53.864 24.416 1.00 38.45  ? 201  LEU B CB  1 
+ATOM   5056 C  CG  . LEU B 1 182 ? 68.016  55.155 23.595 1.00 42.57  ? 201  LEU B CG  1 
+ATOM   5057 C  CD1 . LEU B 1 182 ? 66.815  55.081 22.692 1.00 41.52  ? 201  LEU B CD1 1 
+ATOM   5058 C  CD2 . LEU B 1 182 ? 67.896  56.412 24.451 1.00 45.63  ? 201  LEU B CD2 1 
+ATOM   5059 N  N   . ASN B 1 183 ? 69.343  51.345 25.826 1.00 40.44  ? 202  ASN B N   1 
+ATOM   5060 C  CA  . ASN B 1 183 ? 69.159  50.179 26.703 1.00 41.25  ? 202  ASN B CA  1 
+ATOM   5061 C  C   . ASN B 1 183 ? 70.241  50.044 27.741 1.00 43.58  ? 202  ASN B C   1 
+ATOM   5062 O  O   . ASN B 1 183 ? 69.984  49.579 28.842 1.00 47.35  ? 202  ASN B O   1 
+ATOM   5063 C  CB  . ASN B 1 183 ? 69.150  48.886 25.920 1.00 42.42  ? 202  ASN B CB  1 
+ATOM   5064 C  CG  . ASN B 1 183 ? 67.922  48.706 25.108 1.00 43.17  ? 202  ASN B CG  1 
+ATOM   5065 O  OD1 . ASN B 1 183 ? 67.921  47.881 24.206 1.00 42.47  ? 202  ASN B OD1 1 
+ATOM   5066 N  ND2 . ASN B 1 183 ? 66.860  49.460 25.401 1.00 42.86  ? 202  ASN B ND2 1 
+ATOM   5067 N  N   . GLU B 1 184 ? 71.454  50.431 27.371 1.00 45.15  ? 203  GLU B N   1 
+ATOM   5068 C  CA  . GLU B 1 184 ? 72.591  50.431 28.276 1.00 45.79  ? 203  GLU B CA  1 
+ATOM   5069 C  C   . GLU B 1 184 ? 72.384  51.437 29.420 1.00 43.96  ? 203  GLU B C   1 
+ATOM   5070 O  O   . GLU B 1 184 ? 72.615  51.120 30.590 1.00 41.33  ? 203  GLU B O   1 
+ATOM   5071 C  CB  . GLU B 1 184 ? 73.864  50.765 27.488 1.00 47.53  ? 203  GLU B CB  1 
+ATOM   5072 C  CG  . GLU B 1 184 ? 75.124  50.209 28.110 1.00 54.03  ? 203  GLU B CG  1 
+ATOM   5073 C  CD  . GLU B 1 184 ? 76.364  50.928 27.644 1.00 59.01  ? 203  GLU B CD  1 
+ATOM   5074 O  OE1 . GLU B 1 184 ? 76.563  51.037 26.402 1.00 60.90  ? 203  GLU B OE1 1 
+ATOM   5075 O  OE2 . GLU B 1 184 ? 77.122  51.386 28.534 1.00 63.18  ? 203  GLU B OE2 1 
+ATOM   5076 N  N   . ASN B 1 185 ? 71.967  52.650 29.064 1.00 43.40  ? 204  ASN B N   1 
+ATOM   5077 C  CA  . ASN B 1 185 ? 71.531  53.647 30.032 1.00 45.38  ? 204  ASN B CA  1 
+ATOM   5078 C  C   . ASN B 1 185 ? 70.436  53.152 30.999 1.00 45.83  ? 204  ASN B C   1 
+ATOM   5079 O  O   . ASN B 1 185 ? 70.446  53.514 32.160 1.00 48.06  ? 204  ASN B O   1 
+ATOM   5080 C  CB  . ASN B 1 185 ? 71.043  54.892 29.300 1.00 46.44  ? 204  ASN B CB  1 
+ATOM   5081 C  CG  . ASN B 1 185 ? 72.172  55.817 28.899 1.00 51.55  ? 204  ASN B CG  1 
+ATOM   5082 O  OD1 . ASN B 1 185 ? 71.936  56.855 28.273 1.00 56.95  ? 204  ASN B OD1 1 
+ATOM   5083 N  ND2 . ASN B 1 185 ? 73.405  55.454 29.259 1.00 52.70  ? 204  ASN B ND2 1 
+ATOM   5084 N  N   . ILE B 1 186 ? 69.514  52.316 30.536 1.00 46.24  ? 205  ILE B N   1 
+ATOM   5085 C  CA  . ILE B 1 186 ? 68.417  51.846 31.377 1.00 50.12  ? 205  ILE B CA  1 
+ATOM   5086 C  C   . ILE B 1 186 ? 68.939  50.852 32.378 1.00 51.01  ? 205  ILE B C   1 
+ATOM   5087 O  O   . ILE B 1 186 ? 68.519  50.860 33.541 1.00 55.71  ? 205  ILE B O   1 
+ATOM   5088 C  CB  . ILE B 1 186 ? 67.303  51.182 30.515 1.00 51.81  ? 205  ILE B CB  1 
+ATOM   5089 C  CG1 . ILE B 1 186 ? 66.580  52.230 29.679 1.00 52.14  ? 205  ILE B CG1 1 
+ATOM   5090 C  CG2 . ILE B 1 186 ? 66.292  50.405 31.366 1.00 50.47  ? 205  ILE B CG2 1 
+ATOM   5091 C  CD1 . ILE B 1 186 ? 65.984  51.635 28.354 1.00 55.32  ? 205  ILE B CD1 1 
+ATOM   5092 N  N   . GLU B 1 187 ? 69.822  49.975 31.900 1.00 53.47  ? 206  GLU B N   1 
+ATOM   5093 C  CA  . GLU B 1 187 ? 70.490  48.955 32.716 1.00 52.39  ? 206  GLU B CA  1 
+ATOM   5094 C  C   . GLU B 1 187 ? 71.301  49.636 33.832 1.00 51.22  ? 206  GLU B C   1 
+ATOM   5095 O  O   . GLU B 1 187 ? 71.132  49.319 35.010 1.00 50.97  ? 206  GLU B O   1 
+ATOM   5096 C  CB  . GLU B 1 187 ? 71.381  48.074 31.833 1.00 53.14  ? 206  GLU B CB  1 
+ATOM   5097 C  CG  . GLU B 1 187 ? 71.646  46.669 32.359 1.00 62.06  ? 206  GLU B CG  1 
+ATOM   5098 C  CD  . GLU B 1 187 ? 73.115  46.240 32.249 1.00 69.80  ? 206  GLU B CD  1 
+ATOM   5099 O  OE1 . GLU B 1 187 ? 73.636  45.570 33.186 1.00 74.82  ? 206  GLU B OE1 1 
+ATOM   5100 O  OE2 . GLU B 1 187 ? 73.755  46.572 31.225 1.00 73.65  ? 206  GLU B OE2 1 
+ATOM   5101 N  N   . ILE B 1 188 ? 72.149  50.596 33.471 1.00 47.59  ? 207  ILE B N   1 
+ATOM   5102 C  CA  . ILE B 1 188 ? 72.909  51.334 34.472 1.00 48.00  ? 207  ILE B CA  1 
+ATOM   5103 C  C   . ILE B 1 188 ? 71.969  51.904 35.527 1.00 46.15  ? 207  ILE B C   1 
+ATOM   5104 O  O   . ILE B 1 188 ? 72.186  51.722 36.715 1.00 46.51  ? 207  ILE B O   1 
+ATOM   5105 C  CB  . ILE B 1 188 ? 73.736  52.475 33.818 1.00 49.34  ? 207  ILE B CB  1 
+ATOM   5106 C  CG1 . ILE B 1 188 ? 74.943  51.896 33.079 1.00 49.48  ? 207  ILE B CG1 1 
+ATOM   5107 C  CG2 . ILE B 1 188 ? 74.209  53.505 34.864 1.00 49.11  ? 207  ILE B CG2 1 
+ATOM   5108 C  CD1 . ILE B 1 188 ? 75.423  52.774 31.929 1.00 50.36  ? 207  ILE B CD1 1 
+ATOM   5109 N  N   . LEU B 1 189 ? 70.914  52.574 35.079 1.00 44.85  ? 208  LEU B N   1 
+ATOM   5110 C  CA  . LEU B 1 189 ? 70.060  53.365 35.962 1.00 42.26  ? 208  LEU B CA  1 
+ATOM   5111 C  C   . LEU B 1 189 ? 69.123  52.532 36.836 1.00 45.78  ? 208  LEU B C   1 
+ATOM   5112 O  O   . LEU B 1 189 ? 68.516  53.072 37.760 1.00 47.74  ? 208  LEU B O   1 
+ATOM   5113 C  CB  . LEU B 1 189 ? 69.237  54.342 35.143 1.00 38.63  ? 208  LEU B CB  1 
+ATOM   5114 C  CG  . LEU B 1 189 ? 70.026  55.543 34.652 1.00 43.79  ? 208  LEU B CG  1 
+ATOM   5115 C  CD1 . LEU B 1 189 ? 69.201  56.364 33.672 1.00 43.55  ? 208  LEU B CD1 1 
+ATOM   5116 C  CD2 . LEU B 1 189 ? 70.521  56.404 35.828 1.00 46.49  ? 208  LEU B CD2 1 
+ATOM   5117 N  N   . SER B 1 190 ? 69.018  51.232 36.551 1.00 45.69  ? 209  SER B N   1 
+ATOM   5118 C  CA  . SER B 1 190 ? 68.174  50.323 37.313 1.00 47.63  ? 209  SER B CA  1 
+ATOM   5119 C  C   . SER B 1 190 ? 68.941  49.472 38.355 1.00 53.01  ? 209  SER B C   1 
+ATOM   5120 O  O   . SER B 1 190 ? 68.404  48.502 38.899 1.00 54.21  ? 209  SER B O   1 
+ATOM   5121 C  CB  . SER B 1 190 ? 67.412  49.428 36.348 1.00 47.36  ? 209  SER B CB  1 
+ATOM   5122 O  OG  . SER B 1 190 ? 68.300  48.744 35.499 1.00 46.14  ? 209  SER B OG  1 
+ATOM   5123 N  N   . SER B 1 191 ? 70.182  49.850 38.644 1.00 56.37  ? 210  SER B N   1 
+ATOM   5124 C  CA  . SER B 1 191 ? 70.974  49.210 39.688 1.00 59.99  ? 210  SER B CA  1 
+ATOM   5125 C  C   . SER B 1 191 ? 70.543  49.769 41.006 1.00 58.76  ? 210  SER B C   1 
+ATOM   5126 O  O   . SER B 1 191 ? 70.505  50.973 41.154 1.00 60.95  ? 210  SER B O   1 
+ATOM   5127 C  CB  . SER B 1 191 ? 72.461  49.531 39.527 1.00 61.68  ? 210  SER B CB  1 
+ATOM   5128 O  OG  . SER B 1 191 ? 72.973  48.897 38.368 1.00 69.94  ? 210  SER B OG  1 
+ATOM   5129 N  N   . PRO B 1 192 ? 70.201  48.920 41.965 1.00 59.65  ? 211  PRO B N   1 
+ATOM   5130 C  CA  . PRO B 1 192 ? 70.000  49.382 43.344 1.00 60.13  ? 211  PRO B CA  1 
+ATOM   5131 C  C   . PRO B 1 192 ? 71.170  50.207 43.877 1.00 61.83  ? 211  PRO B C   1 
+ATOM   5132 O  O   . PRO B 1 192 ? 71.003  51.093 44.691 1.00 62.83  ? 211  PRO B O   1 
+ATOM   5133 C  CB  . PRO B 1 192 ? 69.853  48.078 44.105 1.00 61.60  ? 211  PRO B CB  1 
+ATOM   5134 C  CG  . PRO B 1 192 ? 69.218  47.176 43.104 1.00 60.26  ? 211  PRO B CG  1 
+ATOM   5135 C  CD  . PRO B 1 192 ? 69.904  47.483 41.815 1.00 57.83  ? 211  PRO B CD  1 
+ATOM   5136 N  N   . TRP B 1 193 ? 72.355  49.897 43.397 1.00 66.81  ? 212  TRP B N   1 
+ATOM   5137 C  CA  . TRP B 1 193 ? 73.558  50.694 43.617 1.00 70.92  ? 212  TRP B CA  1 
+ATOM   5138 C  C   . TRP B 1 193 ? 73.293  52.229 43.449 1.00 67.83  ? 212  TRP B C   1 
+ATOM   5139 O  O   . TRP B 1 193 ? 73.817  53.025 44.209 1.00 69.50  ? 212  TRP B O   1 
+ATOM   5140 C  CB  . TRP B 1 193 ? 74.625  50.110 42.645 1.00 77.32  ? 212  TRP B CB  1 
+ATOM   5141 C  CG  . TRP B 1 193 ? 76.090  50.481 42.755 1.00 84.41  ? 212  TRP B CG  1 
+ATOM   5142 C  CD1 . TRP B 1 193 ? 76.940  50.726 41.699 1.00 87.03  ? 212  TRP B CD1 1 
+ATOM   5143 C  CD2 . TRP B 1 193 ? 76.896  50.581 43.942 1.00 90.85  ? 212  TRP B CD2 1 
+ATOM   5144 N  NE1 . TRP B 1 193 ? 78.205  51.007 42.158 1.00 90.55  ? 212  TRP B NE1 1 
+ATOM   5145 C  CE2 . TRP B 1 193 ? 78.215  50.922 43.527 1.00 93.47  ? 212  TRP B CE2 1 
+ATOM   5146 C  CE3 . TRP B 1 193 ? 76.642  50.436 45.320 1.00 92.62  ? 212  TRP B CE3 1 
+ATOM   5147 C  CZ2 . TRP B 1 193 ? 79.278  51.115 44.443 1.00 95.21  ? 212  TRP B CZ2 1 
+ATOM   5148 C  CZ3 . TRP B 1 193 ? 77.706  50.633 46.236 1.00 94.00  ? 212  TRP B CZ3 1 
+ATOM   5149 C  CH2 . TRP B 1 193 ? 79.004  50.969 45.785 1.00 93.78  ? 212  TRP B CH2 1 
+ATOM   5150 N  N   . ILE B 1 194 ? 72.450  52.641 42.501 1.00 65.11  ? 213  ILE B N   1 
+ATOM   5151 C  CA  . ILE B 1 194 ? 72.208  54.077 42.209 1.00 63.23  ? 213  ILE B CA  1 
+ATOM   5152 C  C   . ILE B 1 194 ? 71.651  54.903 43.369 1.00 64.00  ? 213  ILE B C   1 
+ATOM   5153 O  O   . ILE B 1 194 ? 71.807  56.127 43.413 1.00 65.32  ? 213  ILE B O   1 
+ATOM   5154 C  CB  . ILE B 1 194 ? 71.216  54.238 40.998 1.00 62.76  ? 213  ILE B CB  1 
+ATOM   5155 C  CG1 . ILE B 1 194 ? 71.853  53.796 39.685 1.00 62.26  ? 213  ILE B CG1 1 
+ATOM   5156 C  CG2 . ILE B 1 194 ? 70.711  55.694 40.832 1.00 63.74  ? 213  ILE B CG2 1 
+ATOM   5157 C  CD1 . ILE B 1 194 ? 73.077  54.570 39.292 1.00 61.63  ? 213  ILE B CD1 1 
+ATOM   5158 N  N   . GLN B 1 195 ? 70.939  54.246 44.269 1.00 63.90  ? 214  GLN B N   1 
+ATOM   5159 C  CA  . GLN B 1 195 ? 70.255  54.931 45.353 1.00 61.39  ? 214  GLN B CA  1 
+ATOM   5160 C  C   . GLN B 1 195 ? 71.242  55.273 46.487 1.00 56.84  ? 214  GLN B C   1 
+ATOM   5161 O  O   . GLN B 1 195 ? 71.066  56.247 47.227 1.00 52.38  ? 214  GLN B O   1 
+ATOM   5162 C  CB  . GLN B 1 195 ? 69.078  54.060 45.830 1.00 64.68  ? 214  GLN B CB  1 
+ATOM   5163 C  CG  . GLN B 1 195 ? 67.963  54.805 46.553 1.00 68.59  ? 214  GLN B CG  1 
+ATOM   5164 C  CD  . GLN B 1 195 ? 67.571  56.083 45.849 1.00 72.73  ? 214  GLN B CD  1 
+ATOM   5165 O  OE1 . GLN B 1 195 ? 67.398  56.099 44.620 1.00 73.27  ? 214  GLN B OE1 1 
+ATOM   5166 N  NE2 . GLN B 1 195 ? 67.448  57.166 46.617 1.00 73.67  ? 214  GLN B NE2 1 
+ATOM   5167 N  N   . VAL B 1 196 ? 72.291  54.475 46.608 1.00 52.81  ? 215  VAL B N   1 
+ATOM   5168 C  CA  . VAL B 1 196 ? 73.413  54.827 47.468 1.00 54.76  ? 215  VAL B CA  1 
+ATOM   5169 C  C   . VAL B 1 196 ? 73.927  56.242 47.132 1.00 51.94  ? 215  VAL B C   1 
+ATOM   5170 O  O   . VAL B 1 196 ? 74.163  57.045 48.019 1.00 54.70  ? 215  VAL B O   1 
+ATOM   5171 C  CB  . VAL B 1 196 ? 74.589  53.805 47.357 1.00 56.71  ? 215  VAL B CB  1 
+ATOM   5172 C  CG1 . VAL B 1 196 ? 75.540  53.964 48.518 1.00 56.32  ? 215  VAL B CG1 1 
+ATOM   5173 C  CG2 . VAL B 1 196 ? 74.084  52.347 47.303 1.00 59.54  ? 215  VAL B CG2 1 
+ATOM   5174 N  N   . TYR B 1 197 ? 74.073  56.548 45.850 1.00 51.81  ? 216  TYR B N   1 
+ATOM   5175 C  CA  . TYR B 1 197 ? 74.582  57.847 45.420 1.00 50.46  ? 216  TYR B CA  1 
+ATOM   5176 C  C   . TYR B 1 197 ? 73.701  59.010 45.873 1.00 53.08  ? 216  TYR B C   1 
+ATOM   5177 O  O   . TYR B 1 197 ? 74.212  60.086 46.220 1.00 54.12  ? 216  TYR B O   1 
+ATOM   5178 C  CB  . TYR B 1 197 ? 74.699  57.895 43.905 1.00 50.98  ? 216  TYR B CB  1 
+ATOM   5179 C  CG  . TYR B 1 197 ? 75.822  57.077 43.279 1.00 54.98  ? 216  TYR B CG  1 
+ATOM   5180 C  CD1 . TYR B 1 197 ? 77.147  57.255 43.662 1.00 57.50  ? 216  TYR B CD1 1 
+ATOM   5181 C  CD2 . TYR B 1 197 ? 75.558  56.162 42.262 1.00 55.22  ? 216  TYR B CD2 1 
+ATOM   5182 C  CE1 . TYR B 1 197 ? 78.170  56.523 43.067 1.00 59.09  ? 216  TYR B CE1 1 
+ATOM   5183 C  CE2 . TYR B 1 197 ? 76.576  55.428 41.663 1.00 55.37  ? 216  TYR B CE2 1 
+ATOM   5184 C  CZ  . TYR B 1 197 ? 77.876  55.612 42.067 1.00 57.97  ? 216  TYR B CZ  1 
+ATOM   5185 O  OH  . TYR B 1 197 ? 78.893  54.893 41.476 1.00 64.50  ? 216  TYR B OH  1 
+ATOM   5186 N  N   . ASN B 1 198 ? 72.383  58.807 45.853 1.00 53.38  ? 217  ASN B N   1 
+ATOM   5187 C  CA  . ASN B 1 198 ? 71.442  59.861 46.228 1.00 52.92  ? 217  ASN B CA  1 
+ATOM   5188 C  C   . ASN B 1 198 ? 71.504  60.180 47.725 1.00 53.30  ? 217  ASN B C   1 
+ATOM   5189 O  O   . ASN B 1 198 ? 71.291  61.316 48.137 1.00 48.98  ? 217  ASN B O   1 
+ATOM   5190 C  CB  . ASN B 1 198 ? 70.010  59.478 45.829 1.00 54.95  ? 217  ASN B CB  1 
+ATOM   5191 C  CG  . ASN B 1 198 ? 69.819  59.339 44.310 1.00 53.08  ? 217  ASN B CG  1 
+ATOM   5192 O  OD1 . ASN B 1 198 ? 70.490  59.997 43.503 1.00 44.58  ? 217  ASN B OD1 1 
+ATOM   5193 N  ND2 . ASN B 1 198 ? 68.877  58.478 43.926 1.00 52.79  ? 217  ASN B ND2 1 
+ATOM   5194 N  N   . ASN B 1 199 ? 71.804  59.172 48.535 1.00 54.69  ? 218  ASN B N   1 
+ATOM   5195 C  CA  . ASN B 1 199 ? 72.018  59.383 49.962 1.00 58.06  ? 218  ASN B CA  1 
+ATOM   5196 C  C   . ASN B 1 199 ? 73.408  60.001 50.220 1.00 59.56  ? 218  ASN B C   1 
+ATOM   5197 O  O   . ASN B 1 199 ? 73.551  60.958 51.009 1.00 56.87  ? 218  ASN B O   1 
+ATOM   5198 C  CB  . ASN B 1 199 ? 71.865  58.061 50.748 1.00 60.78  ? 218  ASN B CB  1 
+ATOM   5199 C  CG  . ASN B 1 199 ? 70.424  57.537 50.761 1.00 60.18  ? 218  ASN B CG  1 
+ATOM   5200 O  OD1 . ASN B 1 199 ? 69.562  58.069 51.459 1.00 58.81  ? 218  ASN B OD1 1 
+ATOM   5201 N  ND2 . ASN B 1 199 ? 70.172  56.480 49.992 1.00 56.34  ? 218  ASN B ND2 1 
+ATOM   5202 N  N   . PHE B 1 200 ? 74.424  59.455 49.544 1.00 56.84  ? 219  PHE B N   1 
+ATOM   5203 C  CA  . PHE B 1 200 ? 75.806  59.846 49.767 1.00 55.69  ? 219  PHE B CA  1 
+ATOM   5204 C  C   . PHE B 1 200 ? 76.486  60.415 48.507 1.00 53.80  ? 219  PHE B C   1 
+ATOM   5205 O  O   . PHE B 1 200 ? 77.369  59.772 47.954 1.00 54.09  ? 219  PHE B O   1 
+ATOM   5206 C  CB  . PHE B 1 200 ? 76.601  58.638 50.267 1.00 59.63  ? 219  PHE B CB  1 
+ATOM   5207 C  CG  . PHE B 1 200 ? 75.905  57.820 51.337 1.00 63.47  ? 219  PHE B CG  1 
+ATOM   5208 C  CD1 . PHE B 1 200 ? 76.066  56.430 51.367 1.00 67.09  ? 219  PHE B CD1 1 
+ATOM   5209 C  CD2 . PHE B 1 200 ? 75.134  58.420 52.320 1.00 65.65  ? 219  PHE B CD2 1 
+ATOM   5210 C  CE1 . PHE B 1 200 ? 75.458  55.655 52.342 1.00 67.91  ? 219  PHE B CE1 1 
+ATOM   5211 C  CE2 . PHE B 1 200 ? 74.515  57.651 53.299 1.00 69.17  ? 219  PHE B CE2 1 
+ATOM   5212 C  CZ  . PHE B 1 200 ? 74.682  56.264 53.313 1.00 69.07  ? 219  PHE B CZ  1 
+ATOM   5213 N  N   . PRO B 1 201 ? 76.125  61.624 48.074 1.00 51.90  ? 220  PRO B N   1 
+ATOM   5214 C  CA  . PRO B 1 201 ? 76.702  62.218 46.855 1.00 52.59  ? 220  PRO B CA  1 
+ATOM   5215 C  C   . PRO B 1 201 ? 78.241  62.242 46.782 1.00 55.14  ? 220  PRO B C   1 
+ATOM   5216 O  O   . PRO B 1 201 ? 78.791  62.381 45.694 1.00 59.99  ? 220  PRO B O   1 
+ATOM   5217 C  CB  . PRO B 1 201 ? 76.158  63.669 46.864 1.00 52.60  ? 220  PRO B CB  1 
+ATOM   5218 C  CG  . PRO B 1 201 ? 75.550  63.896 48.215 1.00 50.50  ? 220  PRO B CG  1 
+ATOM   5219 C  CD  . PRO B 1 201 ? 75.163  62.538 48.717 1.00 52.92  ? 220  PRO B CD  1 
+ATOM   5220 N  N   . ALA B 1 202 ? 78.924  62.146 47.916 1.00 54.63  ? 221  ALA B N   1 
+ATOM   5221 C  CA  . ALA B 1 202 ? 80.374  62.138 47.923 1.00 54.62  ? 221  ALA B CA  1 
+ATOM   5222 C  C   . ALA B 1 202 ? 80.907  60.877 47.237 1.00 55.55  ? 221  ALA B C   1 
+ATOM   5223 O  O   . ALA B 1 202 ? 81.995  60.887 46.683 1.00 60.34  ? 221  ALA B O   1 
+ATOM   5224 C  CB  . ALA B 1 202 ? 80.893  62.229 49.353 1.00 55.17  ? 221  ALA B CB  1 
+ATOM   5225 N  N   . LEU B 1 203 ? 80.137  59.796 47.264 1.00 53.48  ? 222  LEU B N   1 
+ATOM   5226 C  CA  . LEU B 1 203 ? 80.545  58.548 46.640 1.00 52.48  ? 222  LEU B CA  1 
+ATOM   5227 C  C   . LEU B 1 203 ? 80.604  58.623 45.120 1.00 53.37  ? 222  LEU B C   1 
+ATOM   5228 O  O   . LEU B 1 203 ? 81.034  57.671 44.462 1.00 48.59  ? 222  LEU B O   1 
+ATOM   5229 C  CB  . LEU B 1 203 ? 79.595  57.416 47.042 1.00 54.77  ? 222  LEU B CB  1 
+ATOM   5230 C  CG  . LEU B 1 203 ? 79.582  56.957 48.504 1.00 57.01  ? 222  LEU B CG  1 
+ATOM   5231 C  CD1 . LEU B 1 203 ? 78.834  55.636 48.595 1.00 55.16  ? 222  LEU B CD1 1 
+ATOM   5232 C  CD2 . LEU B 1 203 ? 80.999  56.829 49.119 1.00 57.95  ? 222  LEU B CD2 1 
+ATOM   5233 N  N   . LEU B 1 204 ? 80.146  59.732 44.553 1.00 56.15  ? 223  LEU B N   1 
+ATOM   5234 C  CA  . LEU B 1 204 ? 80.226  59.932 43.107 1.00 57.48  ? 223  LEU B CA  1 
+ATOM   5235 C  C   . LEU B 1 204 ? 81.673  60.175 42.704 1.00 60.66  ? 223  LEU B C   1 
+ATOM   5236 O  O   . LEU B 1 204 ? 82.135  59.638 41.689 1.00 57.55  ? 223  LEU B O   1 
+ATOM   5237 C  CB  . LEU B 1 204 ? 79.343  61.108 42.684 1.00 57.30  ? 223  LEU B CB  1 
+ATOM   5238 C  CG  . LEU B 1 204 ? 77.836  60.838 42.772 1.00 52.63  ? 223  LEU B CG  1 
+ATOM   5239 C  CD1 . LEU B 1 204 ? 77.006  62.114 42.851 1.00 49.43  ? 223  LEU B CD1 1 
+ATOM   5240 C  CD2 . LEU B 1 204 ? 77.428  60.026 41.595 1.00 51.32  ? 223  LEU B CD2 1 
+ATOM   5241 N  N   . ASP B 1 205 ? 82.367  60.980 43.521 1.00 65.61  ? 224  ASP B N   1 
+ATOM   5242 C  CA  . ASP B 1 205 ? 83.822  61.172 43.432 1.00 69.52  ? 224  ASP B CA  1 
+ATOM   5243 C  C   . ASP B 1 205 ? 84.599  59.849 43.506 1.00 70.95  ? 224  ASP B C   1 
+ATOM   5244 O  O   . ASP B 1 205 ? 85.487  59.624 42.693 1.00 73.77  ? 224  ASP B O   1 
+ATOM   5245 C  CB  . ASP B 1 205 ? 84.332  62.114 44.539 1.00 71.02  ? 224  ASP B CB  1 
+ATOM   5246 C  CG  . ASP B 1 205 ? 83.711  63.513 44.474 1.00 73.65  ? 224  ASP B CG  1 
+ATOM   5247 O  OD1 . ASP B 1 205 ? 83.600  64.074 43.365 1.00 71.92  ? 224  ASP B OD1 1 
+ATOM   5248 O  OD2 . ASP B 1 205 ? 83.314  64.139 45.490 1.00 78.42  ? 224  ASP B OD2 1 
+ATOM   5249 N  N   . TYR B 1 206 ? 84.246  58.979 44.458 1.00 72.95  ? 225  TYR B N   1 
+ATOM   5250 C  CA  . TYR B 1 206 ? 85.016  57.750 44.747 1.00 74.26  ? 225  TYR B CA  1 
+ATOM   5251 C  C   . TYR B 1 206 ? 84.656  56.569 43.844 1.00 74.03  ? 225  TYR B C   1 
+ATOM   5252 O  O   . TYR B 1 206 ? 85.327  55.538 43.882 1.00 77.38  ? 225  TYR B O   1 
+ATOM   5253 C  CB  . TYR B 1 206 ? 84.871  57.332 46.236 1.00 74.17  ? 225  TYR B CB  1 
+ATOM   5254 C  CG  . TYR B 1 206 ? 85.550  58.278 47.224 1.00 76.24  ? 225  TYR B CG  1 
+ATOM   5255 C  CD1 . TYR B 1 206 ? 84.986  59.518 47.533 1.00 78.93  ? 225  TYR B CD1 1 
+ATOM   5256 C  CD2 . TYR B 1 206 ? 86.748  57.941 47.841 1.00 76.90  ? 225  TYR B CD2 1 
+ATOM   5257 C  CE1 . TYR B 1 206 ? 85.593  60.397 48.427 1.00 80.70  ? 225  TYR B CE1 1 
+ATOM   5258 C  CE2 . TYR B 1 206 ? 87.368  58.816 48.739 1.00 79.68  ? 225  TYR B CE2 1 
+ATOM   5259 C  CZ  . TYR B 1 206 ? 86.786  60.046 49.030 1.00 81.28  ? 225  TYR B CZ  1 
+ATOM   5260 O  OH  . TYR B 1 206 ? 87.386  60.927 49.915 1.00 78.71  ? 225  TYR B OH  1 
+ATOM   5261 N  N   . PHE B 1 207 ? 83.601  56.718 43.048 1.00 74.89  ? 226  PHE B N   1 
+ATOM   5262 C  CA  . PHE B 1 207 ? 83.112  55.665 42.145 1.00 74.78  ? 226  PHE B CA  1 
+ATOM   5263 C  C   . PHE B 1 207 ? 82.468  56.354 40.948 1.00 71.46  ? 226  PHE B C   1 
+ATOM   5264 O  O   . PHE B 1 207 ? 81.242  56.426 40.851 1.00 72.22  ? 226  PHE B O   1 
+ATOM   5265 C  CB  . PHE B 1 207 ? 82.044  54.796 42.818 1.00 77.17  ? 226  PHE B CB  1 
+ATOM   5266 C  CG  . PHE B 1 207 ? 82.567  53.875 43.884 1.00 81.39  ? 226  PHE B CG  1 
+ATOM   5267 C  CD1 . PHE B 1 207 ? 82.559  54.264 45.223 1.00 81.72  ? 226  PHE B CD1 1 
+ATOM   5268 C  CD2 . PHE B 1 207 ? 83.020  52.597 43.554 1.00 85.56  ? 226  PHE B CD2 1 
+ATOM   5269 C  CE1 . PHE B 1 207 ? 83.014  53.417 46.208 1.00 80.66  ? 226  PHE B CE1 1 
+ATOM   5270 C  CE2 . PHE B 1 207 ? 83.480  51.736 44.537 1.00 85.65  ? 226  PHE B CE2 1 
+ATOM   5271 C  CZ  . PHE B 1 207 ? 83.478  52.149 45.869 1.00 84.79  ? 226  PHE B CZ  1 
+ATOM   5272 N  N   . PRO B 1 208 ? 83.276  56.878 40.041 1.00 66.83  ? 227  PRO B N   1 
+ATOM   5273 C  CA  . PRO B 1 208 ? 82.740  57.700 38.959 1.00 62.98  ? 227  PRO B CA  1 
+ATOM   5274 C  C   . PRO B 1 208 ? 82.387  56.868 37.732 1.00 57.33  ? 227  PRO B C   1 
+ATOM   5275 O  O   . PRO B 1 208 ? 81.920  57.435 36.774 1.00 49.96  ? 227  PRO B O   1 
+ATOM   5276 C  CB  . PRO B 1 208 ? 83.890  58.657 38.657 1.00 65.04  ? 227  PRO B CB  1 
+ATOM   5277 C  CG  . PRO B 1 208 ? 85.155  57.868 39.033 1.00 68.03  ? 227  PRO B CG  1 
+ATOM   5278 C  CD  . PRO B 1 208 ? 84.734  56.710 39.927 1.00 68.18  ? 227  PRO B CD  1 
+ATOM   5279 N  N   . GLY B 1 209 ? 82.594  55.558 37.761 1.00 55.62  ? 228  GLY B N   1 
+ATOM   5280 C  CA  . GLY B 1 209 ? 82.304  54.724 36.611 1.00 57.53  ? 228  GLY B CA  1 
+ATOM   5281 C  C   . GLY B 1 209 ? 80.885  54.887 36.087 1.00 57.79  ? 228  GLY B C   1 
+ATOM   5282 O  O   . GLY B 1 209 ? 80.674  54.984 34.883 1.00 59.27  ? 228  GLY B O   1 
+ATOM   5283 N  N   . THR B 1 210 ? 79.915  54.900 36.997 1.00 57.34  ? 229  THR B N   1 
+ATOM   5284 C  CA  . THR B 1 210 ? 78.528  55.215 36.672 1.00 53.88  ? 229  THR B CA  1 
+ATOM   5285 C  C   . THR B 1 210 ? 78.439  56.711 36.574 1.00 52.58  ? 229  THR B C   1 
+ATOM   5286 O  O   . THR B 1 210 ? 78.776  57.390 37.542 1.00 59.75  ? 229  THR B O   1 
+ATOM   5287 C  CB  . THR B 1 210 ? 77.620  54.770 37.818 1.00 52.45  ? 229  THR B CB  1 
+ATOM   5288 O  OG1 . THR B 1 210 ? 77.559  53.343 37.858 1.00 57.85  ? 229  THR B OG1 1 
+ATOM   5289 C  CG2 . THR B 1 210 ? 76.187  55.207 37.574 1.00 52.09  ? 229  THR B CG2 1 
+ATOM   5290 N  N   . HIS B 1 211 ? 77.982  57.225 35.445 1.00 47.74  ? 230  HIS B N   1 
+ATOM   5291 C  CA  . HIS B 1 211 ? 77.919  58.672 35.195 1.00 51.53  ? 230  HIS B CA  1 
+ATOM   5292 C  C   . HIS B 1 211 ? 78.962  59.100 34.196 1.00 54.60  ? 230  HIS B C   1 
+ATOM   5293 O  O   . HIS B 1 211 ? 78.782  60.086 33.475 1.00 53.87  ? 230  HIS B O   1 
+ATOM   5294 C  CB  . HIS B 1 211 ? 77.867  59.564 36.469 1.00 52.04  ? 230  HIS B CB  1 
+ATOM   5295 C  CG  . HIS B 1 211 ? 79.136  60.285 36.839 1.00 57.17  ? 230  HIS B CG  1 
+ATOM   5296 N  ND1 . HIS B 1 211 ? 79.155  61.210 37.861 1.00 63.61  ? 230  HIS B ND1 1 
+ATOM   5297 C  CD2 . HIS B 1 211 ? 80.417  60.210 36.387 1.00 62.32  ? 230  HIS B CD2 1 
+ATOM   5298 C  CE1 . HIS B 1 211 ? 80.379  61.688 38.011 1.00 63.23  ? 230  HIS B CE1 1 
+ATOM   5299 N  NE2 . HIS B 1 211 ? 81.168  61.095 37.129 1.00 62.17  ? 230  HIS B NE2 1 
+ATOM   5300 N  N   . ASN B 1 212 ? 80.054  58.350 34.148 1.00 55.43  ? 231  ASN B N   1 
+ATOM   5301 C  CA  . ASN B 1 212 ? 81.006  58.495 33.079 1.00 52.75  ? 231  ASN B CA  1 
+ATOM   5302 C  C   . ASN B 1 212 ? 80.412  57.712 31.920 1.00 51.00  ? 231  ASN B C   1 
+ATOM   5303 O  O   . ASN B 1 212 ? 80.431  58.185 30.796 1.00 49.67  ? 231  ASN B O   1 
+ATOM   5304 C  CB  . ASN B 1 212 ? 82.407  58.000 33.494 1.00 53.15  ? 231  ASN B CB  1 
+ATOM   5305 C  CG  . ASN B 1 212 ? 83.191  59.042 34.323 1.00 53.79  ? 231  ASN B CG  1 
+ATOM   5306 O  OD1 . ASN B 1 212 ? 82.779  60.196 34.462 1.00 53.39  ? 231  ASN B OD1 1 
+ATOM   5307 N  ND2 . ASN B 1 212 ? 84.329  58.621 34.879 1.00 52.99  ? 231  ASN B ND2 1 
+ATOM   5308 N  N   . LYS B 1 213 ? 79.843  56.543 32.207 1.00 50.00  ? 232  LYS B N   1 
+ATOM   5309 C  CA  . LYS B 1 213 ? 79.177  55.745 31.182 1.00 53.42  ? 232  LYS B CA  1 
+ATOM   5310 C  C   . LYS B 1 213 ? 77.928  56.468 30.665 1.00 52.95  ? 232  LYS B C   1 
+ATOM   5311 O  O   . LYS B 1 213 ? 77.645  56.438 29.470 1.00 57.08  ? 232  LYS B O   1 
+ATOM   5312 C  CB  . LYS B 1 213 ? 78.750  54.376 31.718 1.00 55.32  ? 232  LYS B CB  1 
+ATOM   5313 C  CG  . LYS B 1 213 ? 79.878  53.492 32.236 1.00 61.72  ? 232  LYS B CG  1 
+ATOM   5314 C  CD  . LYS B 1 213 ? 79.528  52.719 33.553 1.00 63.99  ? 232  LYS B CD  1 
+ATOM   5315 C  CE  . LYS B 1 213 ? 79.036  51.277 33.302 1.00 64.11  ? 232  LYS B CE  1 
+ATOM   5316 N  NZ  . LYS B 1 213 ? 78.534  50.640 34.559 1.00 62.81  ? 232  LYS B NZ  1 
+ATOM   5317 N  N   . LEU B 1 214 ? 77.175  57.095 31.568 1.00 48.05  ? 233  LEU B N   1 
+ATOM   5318 C  CA  . LEU B 1 214 ? 75.967  57.795 31.177 1.00 44.71  ? 233  LEU B CA  1 
+ATOM   5319 C  C   . LEU B 1 214 ? 76.313  58.989 30.309 1.00 46.49  ? 233  LEU B C   1 
+ATOM   5320 O  O   . LEU B 1 214 ? 75.709  59.177 29.251 1.00 46.35  ? 233  LEU B O   1 
+ATOM   5321 C  CB  . LEU B 1 214 ? 75.166  58.238 32.402 1.00 44.38  ? 233  LEU B CB  1 
+ATOM   5322 C  CG  . LEU B 1 214 ? 74.547  57.090 33.211 1.00 43.48  ? 233  LEU B CG  1 
+ATOM   5323 C  CD1 . LEU B 1 214 ? 74.098  57.553 34.594 1.00 38.48  ? 233  LEU B CD1 1 
+ATOM   5324 C  CD2 . LEU B 1 214 ? 73.384  56.443 32.432 1.00 43.85  ? 233  LEU B CD2 1 
+ATOM   5325 N  N   . LEU B 1 215 ? 77.291  59.782 30.756 1.00 49.00  ? 234  LEU B N   1 
+ATOM   5326 C  CA  . LEU B 1 215 ? 77.803  60.951 30.004 1.00 48.44  ? 234  LEU B CA  1 
+ATOM   5327 C  C   . LEU B 1 215 ? 78.315  60.591 28.609 1.00 46.44  ? 234  LEU B C   1 
+ATOM   5328 O  O   . LEU B 1 215 ? 78.085  61.317 27.634 1.00 44.51  ? 234  LEU B O   1 
+ATOM   5329 C  CB  . LEU B 1 215 ? 78.934  61.646 30.779 1.00 48.74  ? 234  LEU B CB  1 
+ATOM   5330 C  CG  . LEU B 1 215 ? 78.508  62.641 31.872 1.00 49.33  ? 234  LEU B CG  1 
+ATOM   5331 C  CD1 . LEU B 1 215 ? 79.686  63.060 32.760 1.00 50.34  ? 234  LEU B CD1 1 
+ATOM   5332 C  CD2 . LEU B 1 215 ? 77.853  63.847 31.266 1.00 48.52  ? 234  LEU B CD2 1 
+ATOM   5333 N  N   . LYS B 1 216 ? 78.987  59.452 28.537 1.00 45.08  ? 235  LYS B N   1 
+ATOM   5334 C  CA  . LYS B 1 216 ? 79.642  59.010 27.329 1.00 47.93  ? 235  LYS B CA  1 
+ATOM   5335 C  C   . LYS B 1 216 ? 78.565  58.648 26.343 1.00 46.41  ? 235  LYS B C   1 
+ATOM   5336 O  O   . LYS B 1 216 ? 78.640  58.990 25.170 1.00 49.22  ? 235  LYS B O   1 
+ATOM   5337 C  CB  . LYS B 1 216 ? 80.528  57.796 27.638 1.00 49.94  ? 235  LYS B CB  1 
+ATOM   5338 C  CG  . LYS B 1 216 ? 81.460  57.353 26.521 1.00 55.96  ? 235  LYS B CG  1 
+ATOM   5339 C  CD  . LYS B 1 216 ? 81.950  55.887 26.714 1.00 61.01  ? 235  LYS B CD  1 
+ATOM   5340 C  CE  . LYS B 1 216 ? 83.494  55.732 26.537 1.00 63.08  ? 235  LYS B CE  1 
+ATOM   5341 N  NZ  . LYS B 1 216 ? 84.292  55.931 27.813 1.00 57.60  ? 235  LYS B NZ  1 
+ATOM   5342 N  N   . ASN B 1 217 ? 77.547  57.964 26.838 1.00 47.47  ? 236  ASN B N   1 
+ATOM   5343 C  CA  . ASN B 1 217 ? 76.474  57.464 25.995 1.00 46.92  ? 236  ASN B CA  1 
+ATOM   5344 C  C   . ASN B 1 217 ? 75.562  58.584 25.530 1.00 46.06  ? 236  ASN B C   1 
+ATOM   5345 O  O   . ASN B 1 217 ? 75.074  58.547 24.414 1.00 42.49  ? 236  ASN B O   1 
+ATOM   5346 C  CB  . ASN B 1 217 ? 75.694  56.385 26.732 1.00 47.62  ? 236  ASN B CB  1 
+ATOM   5347 C  CG  . ASN B 1 217 ? 76.463  55.089 26.831 1.00 47.51  ? 236  ASN B CG  1 
+ATOM   5348 O  OD1 . ASN B 1 217 ? 75.960  54.098 27.338 1.00 51.37  ? 236  ASN B OD1 1 
+ATOM   5349 N  ND2 . ASN B 1 217 ? 77.678  55.085 26.321 1.00 50.41  ? 236  ASN B ND2 1 
+ATOM   5350 N  N   . VAL B 1 218 ? 75.381  59.599 26.373 1.00 45.66  ? 237  VAL B N   1 
+ATOM   5351 C  CA  . VAL B 1 218 ? 74.584  60.765 26.015 1.00 46.83  ? 237  VAL B CA  1 
+ATOM   5352 C  C   . VAL B 1 218 ? 75.330  61.638 25.005 1.00 48.98  ? 237  VAL B C   1 
+ATOM   5353 O  O   . VAL B 1 218 ? 74.711  62.400 24.278 1.00 52.52  ? 237  VAL B O   1 
+ATOM   5354 C  CB  . VAL B 1 218 ? 74.164  61.583 27.274 1.00 44.74  ? 237  VAL B CB  1 
+ATOM   5355 C  CG1 . VAL B 1 218 ? 73.561  62.933 26.904 1.00 45.68  ? 237  VAL B CG1 1 
+ATOM   5356 C  CG2 . VAL B 1 218 ? 73.156  60.805 28.074 1.00 43.82  ? 237  VAL B CG2 1 
+ATOM   5357 N  N   . ALA B 1 219 ? 76.654  61.524 24.969 1.00 50.88  ? 238  ALA B N   1 
+ATOM   5358 C  CA  . ALA B 1 219 ? 77.484  62.283 24.026 1.00 47.23  ? 238  ALA B CA  1 
+ATOM   5359 C  C   . ALA B 1 219 ? 77.444  61.601 22.660 1.00 42.41  ? 238  ALA B C   1 
+ATOM   5360 O  O   . ALA B 1 219 ? 77.338  62.270 21.631 1.00 43.67  ? 238  ALA B O   1 
+ATOM   5361 C  CB  . ALA B 1 219 ? 78.930  62.405 24.546 1.00 45.04  ? 238  ALA B CB  1 
+ATOM   5362 N  N   . PHE B 1 220 ? 77.524  60.274 22.661 1.00 37.92  ? 239  PHE B N   1 
+ATOM   5363 C  CA  . PHE B 1 220 ? 77.375  59.470 21.446 1.00 38.78  ? 239  PHE B CA  1 
+ATOM   5364 C  C   . PHE B 1 220 ? 76.023  59.758 20.786 1.00 40.38  ? 239  PHE B C   1 
+ATOM   5365 O  O   . PHE B 1 220 ? 75.950  60.034 19.602 1.00 42.64  ? 239  PHE B O   1 
+ATOM   5366 C  CB  . PHE B 1 220 ? 77.501  57.977 21.784 1.00 36.59  ? 239  PHE B CB  1 
+ATOM   5367 C  CG  . PHE B 1 220 ? 77.401  57.070 20.590 1.00 38.09  ? 239  PHE B CG  1 
+ATOM   5368 C  CD1 . PHE B 1 220 ? 76.155  56.757 20.038 1.00 40.54  ? 239  PHE B CD1 1 
+ATOM   5369 C  CD2 . PHE B 1 220 ? 78.552  56.531 20.006 1.00 37.52  ? 239  PHE B CD2 1 
+ATOM   5370 C  CE1 . PHE B 1 220 ? 76.055  55.918 18.925 1.00 38.07  ? 239  PHE B CE1 1 
+ATOM   5371 C  CE2 . PHE B 1 220 ? 78.465  55.690 18.891 1.00 34.70  ? 239  PHE B CE2 1 
+ATOM   5372 C  CZ  . PHE B 1 220 ? 77.221  55.384 18.352 1.00 39.38  ? 239  PHE B CZ  1 
+ATOM   5373 N  N   . MET B 1 221 ? 74.960  59.724 21.587 1.00 45.03  ? 240  MET B N   1 
+ATOM   5374 C  CA  . MET B 1 221 ? 73.611  60.038 21.128 1.00 44.91  ? 240  MET B CA  1 
+ATOM   5375 C  C   . MET B 1 221 ? 73.511  61.468 20.607 1.00 44.94  ? 240  MET B C   1 
+ATOM   5376 O  O   . MET B 1 221 ? 72.946  61.699 19.548 1.00 45.53  ? 240  MET B O   1 
+ATOM   5377 C  CB  . MET B 1 221 ? 72.587  59.799 22.254 1.00 45.96  ? 240  MET B CB  1 
+ATOM   5378 C  CG  . MET B 1 221 ? 72.196  58.327 22.362 1.00 44.94  ? 240  MET B CG  1 
+ATOM   5379 S  SD  . MET B 1 221 ? 71.003  57.867 23.613 1.00 51.63  ? 240  MET B SD  1 
+ATOM   5380 C  CE  . MET B 1 221 ? 71.548  58.680 25.058 1.00 46.78  ? 240  MET B CE  1 
+ATOM   5381 N  N   . LYS B 1 222 ? 74.088  62.417 21.331 1.00 40.87  ? 241  LYS B N   1 
+ATOM   5382 C  CA  . LYS B 1 222 ? 73.992  63.815 20.940 1.00 40.76  ? 241  LYS B CA  1 
+ATOM   5383 C  C   . LYS B 1 222 ? 74.637  64.094 19.594 1.00 44.44  ? 241  LYS B C   1 
+ATOM   5384 O  O   . LYS B 1 222 ? 74.047  64.749 18.753 1.00 46.88  ? 241  LYS B O   1 
+ATOM   5385 C  CB  . LYS B 1 222 ? 74.631  64.725 21.977 1.00 37.19  ? 241  LYS B CB  1 
+ATOM   5386 C  CG  . LYS B 1 222 ? 73.687  65.221 23.014 1.00 38.72  ? 241  LYS B CG  1 
+ATOM   5387 C  CD  . LYS B 1 222 ? 74.260  66.399 23.742 1.00 42.24  ? 241  LYS B CD  1 
+ATOM   5388 C  CE  . LYS B 1 222 ? 73.877  66.397 25.183 1.00 46.22  ? 241  LYS B CE  1 
+ATOM   5389 N  NZ  . LYS B 1 222 ? 74.688  67.392 25.946 1.00 50.91  ? 241  LYS B NZ  1 
+ATOM   5390 N  N   . SER B 1 223 ? 75.858  63.621 19.400 1.00 49.58  ? 242  SER B N   1 
+ATOM   5391 C  CA  . SER B 1 223 ? 76.615  63.981 18.208 1.00 48.08  ? 242  SER B CA  1 
+ATOM   5392 C  C   . SER B 1 223 ? 76.100  63.161 17.029 1.00 45.38  ? 242  SER B C   1 
+ATOM   5393 O  O   . SER B 1 223 ? 76.243  63.576 15.894 1.00 48.48  ? 242  SER B O   1 
+ATOM   5394 C  CB  . SER B 1 223 ? 78.129  63.804 18.409 1.00 46.17  ? 242  SER B CB  1 
+ATOM   5395 O  OG  . SER B 1 223 ? 78.520  62.526 17.964 1.00 42.60  ? 242  SER B OG  1 
+ATOM   5396 N  N   . TYR B 1 224 ? 75.486  62.014 17.295 1.00 45.27  ? 243  TYR B N   1 
+ATOM   5397 C  CA  . TYR B 1 224 ? 74.735  61.291 16.248 1.00 45.03  ? 243  TYR B CA  1 
+ATOM   5398 C  C   . TYR B 1 224 ? 73.513  62.071 15.739 1.00 46.40  ? 243  TYR B C   1 
+ATOM   5399 O  O   . TYR B 1 224 ? 73.199  62.038 14.567 1.00 49.36  ? 243  TYR B O   1 
+ATOM   5400 C  CB  . TYR B 1 224 ? 74.261  59.941 16.756 1.00 40.61  ? 243  TYR B CB  1 
+ATOM   5401 C  CG  . TYR B 1 224 ? 73.250  59.300 15.845 1.00 44.20  ? 243  TYR B CG  1 
+ATOM   5402 C  CD1 . TYR B 1 224 ? 73.609  58.851 14.584 1.00 43.44  ? 243  TYR B CD1 1 
+ATOM   5403 C  CD2 . TYR B 1 224 ? 71.925  59.159 16.238 1.00 49.74  ? 243  TYR B CD2 1 
+ATOM   5404 C  CE1 . TYR B 1 224 ? 72.680  58.263 13.733 1.00 47.55  ? 243  TYR B CE1 1 
+ATOM   5405 C  CE2 . TYR B 1 224 ? 70.981  58.555 15.405 1.00 50.58  ? 243  TYR B CE2 1 
+ATOM   5406 C  CZ  . TYR B 1 224 ? 71.361  58.115 14.146 1.00 52.95  ? 243  TYR B CZ  1 
+ATOM   5407 O  OH  . TYR B 1 224 ? 70.418  57.525 13.315 1.00 57.39  ? 243  TYR B OH  1 
+ATOM   5408 N  N   . ILE B 1 225 ? 72.821  62.755 16.643 1.00 47.66  ? 244  ILE B N   1 
+ATOM   5409 C  CA  . ILE B 1 225 ? 71.690  63.586 16.294 1.00 45.40  ? 244  ILE B CA  1 
+ATOM   5410 C  C   . ILE B 1 225 ? 72.160  64.813 15.562 1.00 46.76  ? 244  ILE B C   1 
+ATOM   5411 O  O   . ILE B 1 225 ? 71.508  65.254 14.621 1.00 46.95  ? 244  ILE B O   1 
+ATOM   5412 C  CB  . ILE B 1 225 ? 70.885  63.964 17.560 1.00 45.87  ? 244  ILE B CB  1 
+ATOM   5413 C  CG1 . ILE B 1 225 ? 69.960  62.808 17.942 1.00 45.67  ? 244  ILE B CG1 1 
+ATOM   5414 C  CG2 . ILE B 1 225 ? 70.054  65.239 17.345 1.00 46.14  ? 244  ILE B CG2 1 
+ATOM   5415 C  CD1 . ILE B 1 225 ? 69.590  62.782 19.371 1.00 46.75  ? 244  ILE B CD1 1 
+ATOM   5416 N  N   . LEU B 1 226 ? 73.295  65.356 16.003 1.00 51.05  ? 245  LEU B N   1 
+ATOM   5417 C  CA  . LEU B 1 226 ? 73.949  66.529 15.393 1.00 50.93  ? 245  LEU B CA  1 
+ATOM   5418 C  C   . LEU B 1 226 ? 74.289  66.221 13.932 1.00 51.61  ? 245  LEU B C   1 
+ATOM   5419 O  O   . LEU B 1 226 ? 74.166  67.056 13.056 1.00 54.59  ? 245  LEU B O   1 
+ATOM   5420 C  CB  . LEU B 1 226 ? 75.225  66.851 16.182 1.00 52.92  ? 245  LEU B CB  1 
+ATOM   5421 C  CG  . LEU B 1 226 ? 75.961  68.202 16.147 1.00 57.19  ? 245  LEU B CG  1 
+ATOM   5422 C  CD1 . LEU B 1 226 ? 77.349  68.042 15.520 1.00 60.36  ? 245  LEU B CD1 1 
+ATOM   5423 C  CD2 . LEU B 1 226 ? 75.163  69.304 15.461 1.00 55.37  ? 245  LEU B CD2 1 
+ATOM   5424 N  N   . GLU B 1 227 ? 74.692  64.992 13.677 1.00 51.38  ? 246  GLU B N   1 
+ATOM   5425 C  CA  . GLU B 1 227 ? 74.941  64.527 12.331 1.00 56.33  ? 246  GLU B CA  1 
+ATOM   5426 C  C   . GLU B 1 227 ? 73.641  64.688 11.561 1.00 53.48  ? 246  GLU B C   1 
+ATOM   5427 O  O   . GLU B 1 227 ? 73.622  65.217 10.463 1.00 55.08  ? 246  GLU B O   1 
+ATOM   5428 C  CB  . GLU B 1 227 ? 75.380  63.054 12.399 1.00 61.49  ? 246  GLU B CB  1 
+ATOM   5429 C  CG  . GLU B 1 227 ? 76.137  62.459 11.223 1.00 66.11  ? 246  GLU B CG  1 
+ATOM   5430 C  CD  . GLU B 1 227 ? 76.296  60.946 11.394 1.00 72.90  ? 246  GLU B CD  1 
+ATOM   5431 O  OE1 . GLU B 1 227 ? 76.616  60.516 12.530 1.00 74.85  ? 246  GLU B OE1 1 
+ATOM   5432 O  OE2 . GLU B 1 227 ? 76.078  60.180 10.418 1.00 77.25  ? 246  GLU B OE2 1 
+ATOM   5433 N  N   . LYS B 1 228 ? 72.551  64.255 12.179 1.00 53.18  ? 247  LYS B N   1 
+ATOM   5434 C  CA  . LYS B 1 228 ? 71.231  64.337 11.583 1.00 51.62  ? 247  LYS B CA  1 
+ATOM   5435 C  C   . LYS B 1 228 ? 70.703  65.760 11.432 1.00 50.78  ? 247  LYS B C   1 
+ATOM   5436 O  O   . LYS B 1 228 ? 69.921  66.004 10.510 1.00 49.41  ? 247  LYS B O   1 
+ATOM   5437 C  CB  . LYS B 1 228 ? 70.218  63.512 12.385 1.00 51.92  ? 247  LYS B CB  1 
+ATOM   5438 C  CG  . LYS B 1 228 ? 69.711  62.308 11.652 1.00 50.90  ? 247  LYS B CG  1 
+ATOM   5439 C  CD  . LYS B 1 228 ? 70.801  61.292 11.502 1.00 52.18  ? 247  LYS B CD  1 
+ATOM   5440 C  CE  . LYS B 1 228 ? 70.245  59.952 11.079 1.00 50.30  ? 247  LYS B CE  1 
+ATOM   5441 N  NZ  . LYS B 1 228 ? 69.655  60.023 9.723  1.00 48.12  ? 247  LYS B NZ  1 
+ATOM   5442 N  N   . VAL B 1 229 ? 71.092  66.695 12.304 1.00 48.26  ? 248  VAL B N   1 
+ATOM   5443 C  CA  . VAL B 1 229 ? 70.560  68.055 12.177 1.00 49.18  ? 248  VAL B CA  1 
+ATOM   5444 C  C   . VAL B 1 229 ? 71.300  68.844 11.116 1.00 51.98  ? 248  VAL B C   1 
+ATOM   5445 O  O   . VAL B 1 229 ? 70.845  69.902 10.697 1.00 52.01  ? 248  VAL B O   1 
+ATOM   5446 C  CB  . VAL B 1 229 ? 70.583  68.874 13.471 1.00 48.03  ? 248  VAL B CB  1 
+ATOM   5447 C  CG1 . VAL B 1 229 ? 70.173  68.049 14.664 1.00 46.43  ? 248  VAL B CG1 1 
+ATOM   5448 C  CG2 . VAL B 1 229 ? 71.922  69.498 13.673 1.00 54.13  ? 248  VAL B CG2 1 
+ATOM   5449 N  N   . LYS B 1 230 ? 72.457  68.338 10.712 1.00 56.30  ? 249  LYS B N   1 
+ATOM   5450 C  CA  . LYS B 1 230 ? 73.248  68.957 9.671  1.00 56.37  ? 249  LYS B CA  1 
+ATOM   5451 C  C   . LYS B 1 230 ? 72.710  68.506 8.312  1.00 57.32  ? 249  LYS B C   1 
+ATOM   5452 O  O   . LYS B 1 230 ? 72.604  69.321 7.401  1.00 62.53  ? 249  LYS B O   1 
+ATOM   5453 C  CB  . LYS B 1 230 ? 74.724  68.598 9.856  1.00 57.72  ? 249  LYS B CB  1 
+ATOM   5454 C  CG  . LYS B 1 230 ? 75.430  69.404 10.946 1.00 56.55  ? 249  LYS B CG  1 
+ATOM   5455 C  CD  . LYS B 1 230 ? 76.919  69.033 11.014 1.00 59.50  ? 249  LYS B CD  1 
+ATOM   5456 C  CE  . LYS B 1 230 ? 77.676  69.835 12.069 1.00 61.67  ? 249  LYS B CE  1 
+ATOM   5457 N  NZ  . LYS B 1 230 ? 77.740  71.301 11.748 1.00 65.84  ? 249  LYS B NZ  1 
+ATOM   5458 N  N   . GLU B 1 231 ? 72.379  67.217 8.185  1.00 55.49  ? 250  GLU B N   1 
+ATOM   5459 C  CA  . GLU B 1 231 ? 71.606  66.689 7.047  1.00 57.45  ? 250  GLU B CA  1 
+ATOM   5460 C  C   . GLU B 1 231 ? 70.289  67.438 6.834  1.00 57.43  ? 250  GLU B C   1 
+ATOM   5461 O  O   . GLU B 1 231 ? 69.788  67.523 5.717  1.00 62.37  ? 250  GLU B O   1 
+ATOM   5462 C  CB  . GLU B 1 231 ? 71.239  65.210 7.266  1.00 58.54  ? 250  GLU B CB  1 
+ATOM   5463 C  CG  . GLU B 1 231 ? 72.283  64.199 6.830  1.00 62.41  ? 250  GLU B CG  1 
+ATOM   5464 C  CD  . GLU B 1 231 ? 72.126  62.817 7.473  1.00 65.17  ? 250  GLU B CD  1 
+ATOM   5465 O  OE1 . GLU B 1 231 ? 73.171  62.180 7.725  1.00 70.77  ? 250  GLU B OE1 1 
+ATOM   5466 O  OE2 . GLU B 1 231 ? 70.988  62.350 7.722  1.00 65.36  ? 250  GLU B OE2 1 
+ATOM   5467 N  N   . HIS B 1 232 ? 69.698  67.930 7.917  1.00 55.15  ? 251  HIS B N   1 
+ATOM   5468 C  CA  . HIS B 1 232 ? 68.476  68.711 7.827  1.00 52.42  ? 251  HIS B CA  1 
+ATOM   5469 C  C   . HIS B 1 232 ? 68.831  70.139 7.430  1.00 53.18  ? 251  HIS B C   1 
+ATOM   5470 O  O   . HIS B 1 232 ? 68.176  70.702 6.587  1.00 55.41  ? 251  HIS B O   1 
+ATOM   5471 C  CB  . HIS B 1 232 ? 67.710  68.718 9.158  1.00 49.60  ? 251  HIS B CB  1 
+ATOM   5472 C  CG  . HIS B 1 232 ? 66.877  67.495 9.419  1.00 43.65  ? 251  HIS B CG  1 
+ATOM   5473 N  ND1 . HIS B 1 232 ? 67.356  66.205 9.299  1.00 42.43  ? 251  HIS B ND1 1 
+ATOM   5474 C  CD2 . HIS B 1 232 ? 65.597  67.377 9.845  1.00 42.88  ? 251  HIS B CD2 1 
+ATOM   5475 C  CE1 . HIS B 1 232 ? 66.401  65.348 9.624  1.00 36.40  ? 251  HIS B CE1 1 
+ATOM   5476 N  NE2 . HIS B 1 232 ? 65.318  66.035 9.946  1.00 39.77  ? 251  HIS B NE2 1 
+ATOM   5477 N  N   . GLN B 1 233 ? 69.871  70.719 8.031  1.00 56.89  ? 252  GLN B N   1 
+ATOM   5478 C  CA  . GLN B 1 233 ? 70.232  72.127 7.800  1.00 58.75  ? 252  GLN B CA  1 
+ATOM   5479 C  C   . GLN B 1 233 ? 70.453  72.409 6.309  1.00 63.10  ? 252  GLN B C   1 
+ATOM   5480 O  O   . GLN B 1 233 ? 70.302  73.535 5.845  1.00 61.78  ? 252  GLN B O   1 
+ATOM   5481 C  CB  . GLN B 1 233 ? 71.491  72.505 8.598  1.00 59.93  ? 252  GLN B CB  1 
+ATOM   5482 C  CG  . GLN B 1 233 ? 71.222  73.202 9.941  1.00 60.55  ? 252  GLN B CG  1 
+ATOM   5483 C  CD  . GLN B 1 233 ? 72.475  73.384 10.798 1.00 60.61  ? 252  GLN B CD  1 
+ATOM   5484 O  OE1 . GLN B 1 233 ? 72.668  74.434 11.407 1.00 58.33  ? 252  GLN B OE1 1 
+ATOM   5485 N  NE2 . GLN B 1 233 ? 73.319  72.361 10.846 1.00 63.96  ? 252  GLN B NE2 1 
+ATOM   5486 N  N   . GLU B 1 234 ? 70.821  71.362 5.579  1.00 69.87  ? 253  GLU B N   1 
+ATOM   5487 C  CA  . GLU B 1 234 ? 70.967  71.383 4.127  1.00 75.34  ? 253  GLU B CA  1 
+ATOM   5488 C  C   . GLU B 1 234 ? 69.583  71.263 3.440  1.00 75.91  ? 253  GLU B C   1 
+ATOM   5489 O  O   . GLU B 1 234 ? 69.164  72.188 2.738  1.00 74.54  ? 253  GLU B O   1 
+ATOM   5490 C  CB  . GLU B 1 234 ? 71.916  70.230 3.712  1.00 79.57  ? 253  GLU B CB  1 
+ATOM   5491 C  CG  . GLU B 1 234 ? 72.671  70.412 2.397  1.00 86.04  ? 253  GLU B CG  1 
+ATOM   5492 C  CD  . GLU B 1 234 ? 71.907  69.873 1.192  1.00 92.12  ? 253  GLU B CD  1 
+ATOM   5493 O  OE1 . GLU B 1 234 ? 71.965  70.490 0.093  1.00 95.57  ? 253  GLU B OE1 1 
+ATOM   5494 O  OE2 . GLU B 1 234 ? 71.237  68.829 1.341  1.00 95.41  ? 253  GLU B OE2 1 
+ATOM   5495 N  N   . SER B 1 235 ? 68.880  70.146 3.684  1.00 77.16  ? 254  SER B N   1 
+ATOM   5496 C  CA  . SER B 1 235 ? 67.572  69.821 3.066  1.00 77.29  ? 254  SER B CA  1 
+ATOM   5497 C  C   . SER B 1 235 ? 66.452  70.792 3.400  1.00 75.76  ? 254  SER B C   1 
+ATOM   5498 O  O   . SER B 1 235 ? 66.054  71.578 2.561  1.00 75.78  ? 254  SER B O   1 
+ATOM   5499 C  CB  . SER B 1 235 ? 67.114  68.422 3.490  1.00 78.80  ? 254  SER B CB  1 
+ATOM   5500 O  OG  . SER B 1 235 ? 67.830  67.422 2.800  1.00 83.17  ? 254  SER B OG  1 
+ATOM   5501 N  N   . MET B 1 236 ? 65.918  70.680 4.615  1.00 78.79  ? 255  MET B N   1 
+ATOM   5502 C  CA  . MET B 1 236 ? 64.967  71.636 5.187  1.00 80.03  ? 255  MET B CA  1 
+ATOM   5503 C  C   . MET B 1 236 ? 64.515  72.747 4.235  1.00 78.15  ? 255  MET B C   1 
+ATOM   5504 O  O   . MET B 1 236 ? 65.250  73.698 3.964  1.00 74.47  ? 255  MET B O   1 
+ATOM   5505 C  CB  . MET B 1 236 ? 65.576  72.276 6.448  1.00 82.08  ? 255  MET B CB  1 
+ATOM   5506 C  CG  . MET B 1 236 ? 64.562  72.863 7.435  1.00 84.03  ? 255  MET B CG  1 
+ATOM   5507 S  SD  . MET B 1 236 ? 64.800  74.604 7.910  1.00 88.56  ? 255  MET B SD  1 
+ATOM   5508 C  CE  . MET B 1 236 ? 66.637  74.877 7.724  1.00 89.69  ? 255  MET B CE  1 
+ATOM   5509 N  N   . ASP B 1 237 ? 63.301  72.589 3.723  1.00 77.54  ? 256  ASP B N   1 
+ATOM   5510 C  CA  . ASP B 1 237 ? 62.570  73.671 3.078  1.00 76.31  ? 256  ASP B CA  1 
+ATOM   5511 C  C   . ASP B 1 237 ? 62.001  74.529 4.202  1.00 74.07  ? 256  ASP B C   1 
+ATOM   5512 O  O   . ASP B 1 237 ? 61.292  74.017 5.069  1.00 72.65  ? 256  ASP B O   1 
+ATOM   5513 C  CB  . ASP B 1 237 ? 61.432  73.092 2.228  1.00 78.24  ? 256  ASP B CB  1 
+ATOM   5514 C  CG  . ASP B 1 237 ? 60.928  74.051 1.171  1.00 79.63  ? 256  ASP B CG  1 
+ATOM   5515 O  OD1 . ASP B 1 237 ? 60.573  75.194 1.515  1.00 77.36  ? 256  ASP B OD1 1 
+ATOM   5516 O  OD2 . ASP B 1 237 ? 60.831  73.732 -0.035 1.00 86.06  ? 256  ASP B OD2 1 
+ATOM   5517 N  N   . MET B 1 238 ? 62.321  75.821 4.191  1.00 72.70  ? 257  MET B N   1 
+ATOM   5518 C  CA  . MET B 1 238 ? 61.813  76.767 5.190  1.00 73.66  ? 257  MET B CA  1 
+ATOM   5519 C  C   . MET B 1 238 ? 60.287  76.933 5.209  1.00 68.70  ? 257  MET B C   1 
+ATOM   5520 O  O   . MET B 1 238 ? 59.752  77.429 6.184  1.00 66.93  ? 257  MET B O   1 
+ATOM   5521 C  CB  . MET B 1 238 ? 62.452  78.150 4.988  1.00 78.63  ? 257  MET B CB  1 
+ATOM   5522 C  CG  . MET B 1 238 ? 63.801  78.325 5.676  1.00 84.37  ? 257  MET B CG  1 
+ATOM   5523 S  SD  . MET B 1 238 ? 63.690  78.296 7.500  1.00 92.67  ? 257  MET B SD  1 
+ATOM   5524 C  CE  . MET B 1 238 ? 65.506  78.193 7.924  1.00 91.18  ? 257  MET B CE  1 
+ATOM   5525 N  N   . ASN B 1 239 ? 59.606  76.538 4.134  1.00 67.17  ? 258  ASN B N   1 
+ATOM   5526 C  CA  . ASN B 1 239 ? 58.143  76.619 4.019  1.00 65.69  ? 258  ASN B CA  1 
+ATOM   5527 C  C   . ASN B 1 239 ? 57.415  75.289 4.218  1.00 65.51  ? 258  ASN B C   1 
+ATOM   5528 O  O   . ASN B 1 239 ? 56.186  75.264 4.301  1.00 64.96  ? 258  ASN B O   1 
+ATOM   5529 C  CB  . ASN B 1 239 ? 57.763  77.151 2.634  1.00 66.01  ? 258  ASN B CB  1 
+ATOM   5530 C  CG  . ASN B 1 239 ? 58.645  78.294 2.187  1.00 65.31  ? 258  ASN B CG  1 
+ATOM   5531 O  OD1 . ASN B 1 239 ? 58.674  79.336 2.822  1.00 65.48  ? 258  ASN B OD1 1 
+ATOM   5532 N  ND2 . ASN B 1 239 ? 59.375  78.100 1.094  1.00 64.76  ? 258  ASN B ND2 1 
+ATOM   5533 N  N   . ASN B 1 240 ? 58.172  74.191 4.243  1.00 66.61  ? 259  ASN B N   1 
+ATOM   5534 C  CA  . ASN B 1 240 ? 57.629  72.837 4.389  1.00 67.86  ? 259  ASN B CA  1 
+ATOM   5535 C  C   . ASN B 1 240 ? 58.361  72.038 5.466  1.00 67.38  ? 259  ASN B C   1 
+ATOM   5536 O  O   . ASN B 1 240 ? 59.122  71.119 5.152  1.00 71.60  ? 259  ASN B O   1 
+ATOM   5537 C  CB  . ASN B 1 240 ? 57.713  72.081 3.060  1.00 69.16  ? 259  ASN B CB  1 
+ATOM   5538 C  CG  . ASN B 1 240 ? 57.028  72.815 1.933  1.00 69.32  ? 259  ASN B CG  1 
+ATOM   5539 O  OD1 . ASN B 1 240 ? 55.799  72.857 1.873  1.00 68.53  ? 259  ASN B OD1 1 
+ATOM   5540 N  ND2 . ASN B 1 240 ? 57.818  73.429 1.042  1.00 68.49  ? 259  ASN B ND2 1 
+ATOM   5541 N  N   . PRO B 1 241 ? 58.131  72.382 6.733  1.00 64.03  ? 260  PRO B N   1 
+ATOM   5542 C  CA  . PRO B 1 241 ? 58.682  71.611 7.847  1.00 60.29  ? 260  PRO B CA  1 
+ATOM   5543 C  C   . PRO B 1 241 ? 57.983  70.277 7.939  1.00 56.55  ? 260  PRO B C   1 
+ATOM   5544 O  O   . PRO B 1 241 ? 56.752  70.264 7.829  1.00 55.21  ? 260  PRO B O   1 
+ATOM   5545 C  CB  . PRO B 1 241 ? 58.322  72.458 9.069  1.00 61.68  ? 260  PRO B CB  1 
+ATOM   5546 C  CG  . PRO B 1 241 ? 57.136  73.229 8.664  1.00 63.40  ? 260  PRO B CG  1 
+ATOM   5547 C  CD  . PRO B 1 241 ? 57.305  73.508 7.205  1.00 63.19  ? 260  PRO B CD  1 
+ATOM   5548 N  N   . GLN B 1 242 ? 58.737  69.194 8.147  1.00 54.18  ? 261  GLN B N   1 
+ATOM   5549 C  CA  . GLN B 1 242 ? 58.153  67.845 8.209  1.00 50.65  ? 261  GLN B CA  1 
+ATOM   5550 C  C   . GLN B 1 242 ? 58.488  67.031 9.477  1.00 47.52  ? 261  GLN B C   1 
+ATOM   5551 O  O   . GLN B 1 242 ? 58.048  65.887 9.612  1.00 47.37  ? 261  GLN B O   1 
+ATOM   5552 C  CB  . GLN B 1 242 ? 58.567  67.059 6.972  1.00 51.99  ? 261  GLN B CB  1 
+ATOM   5553 C  CG  . GLN B 1 242 ? 58.358  67.807 5.646  1.00 56.17  ? 261  GLN B CG  1 
+ATOM   5554 C  CD  . GLN B 1 242 ? 58.504  66.899 4.428  1.00 60.06  ? 261  GLN B CD  1 
+ATOM   5555 O  OE1 . GLN B 1 242 ? 57.504  66.484 3.834  1.00 61.16  ? 261  GLN B OE1 1 
+ATOM   5556 N  NE2 . GLN B 1 242 ? 59.749  66.580 4.064  1.00 60.08  ? 261  GLN B NE2 1 
+ATOM   5557 N  N   . ASP B 1 243 ? 59.264  67.596 10.400 1.00 43.22  ? 262  ASP B N   1 
+ATOM   5558 C  CA  . ASP B 1 243 ? 59.664  66.851 11.604 1.00 42.21  ? 262  ASP B CA  1 
+ATOM   5559 C  C   . ASP B 1 243 ? 60.181  67.779 12.682 1.00 36.98  ? 262  ASP B C   1 
+ATOM   5560 O  O   . ASP B 1 243 ? 60.236  68.981 12.484 1.00 39.94  ? 262  ASP B O   1 
+ATOM   5561 C  CB  . ASP B 1 243 ? 60.687  65.719 11.282 1.00 41.05  ? 262  ASP B CB  1 
+ATOM   5562 C  CG  . ASP B 1 243 ? 61.972  66.234 10.669 1.00 43.12  ? 262  ASP B CG  1 
+ATOM   5563 O  OD1 . ASP B 1 243 ? 62.663  65.474 9.948  1.00 35.33  ? 262  ASP B OD1 1 
+ATOM   5564 O  OD2 . ASP B 1 243 ? 62.368  67.400 10.856 1.00 45.36  ? 262  ASP B OD2 1 
+ATOM   5565 N  N   . PHE B 1 244 ? 60.544  67.218 13.825 1.00 34.72  ? 263  PHE B N   1 
+ATOM   5566 C  CA  . PHE B 1 244 ? 60.844  68.006 15.018 1.00 35.92  ? 263  PHE B CA  1 
+ATOM   5567 C  C   . PHE B 1 244 ? 62.041  68.906 14.790 1.00 39.07  ? 263  PHE B C   1 
+ATOM   5568 O  O   . PHE B 1 244 ? 62.069  70.060 15.222 1.00 37.31  ? 263  PHE B O   1 
+ATOM   5569 C  CB  . PHE B 1 244 ? 61.104  67.077 16.187 1.00 36.71  ? 263  PHE B CB  1 
+ATOM   5570 C  CG  . PHE B 1 244 ? 61.174  67.757 17.494 1.00 39.61  ? 263  PHE B CG  1 
+ATOM   5571 C  CD1 . PHE B 1 244 ? 60.031  67.940 18.255 1.00 43.44  ? 263  PHE B CD1 1 
+ATOM   5572 C  CD2 . PHE B 1 244 ? 62.389  68.186 17.999 1.00 44.63  ? 263  PHE B CD2 1 
+ATOM   5573 C  CE1 . PHE B 1 244 ? 60.089  68.564 19.497 1.00 41.38  ? 263  PHE B CE1 1 
+ATOM   5574 C  CE2 . PHE B 1 244 ? 62.456  68.808 19.235 1.00 44.59  ? 263  PHE B CE2 1 
+ATOM   5575 C  CZ  . PHE B 1 244 ? 61.295  69.004 19.980 1.00 44.10  ? 263  PHE B CZ  1 
+ATOM   5576 N  N   . ILE B 1 245 ? 63.026  68.369 14.084 1.00 41.38  ? 264  ILE B N   1 
+ATOM   5577 C  CA  . ILE B 1 245 ? 64.202  69.125 13.740 1.00 41.92  ? 264  ILE B CA  1 
+ATOM   5578 C  C   . ILE B 1 245 ? 63.863  70.301 12.828 1.00 41.25  ? 264  ILE B C   1 
+ATOM   5579 O  O   . ILE B 1 245 ? 64.314  71.414 13.091 1.00 46.56  ? 264  ILE B O   1 
+ATOM   5580 C  CB  . ILE B 1 245 ? 65.255  68.210 13.091 1.00 45.68  ? 264  ILE B CB  1 
+ATOM   5581 C  CG1 . ILE B 1 245 ? 65.754  67.154 14.092 1.00 46.61  ? 264  ILE B CG1 1 
+ATOM   5582 C  CG2 . ILE B 1 245 ? 66.438  69.040 12.548 1.00 46.67  ? 264  ILE B CG2 1 
+ATOM   5583 C  CD1 . ILE B 1 245 ? 66.604  66.004 13.442 1.00 44.67  ? 264  ILE B CD1 1 
+ATOM   5584 N  N   . ASP B 1 246 ? 63.094  70.075 11.759 1.00 43.33  ? 265  ASP B N   1 
+ATOM   5585 C  CA  . ASP B 1 246 ? 62.776  71.153 10.793 1.00 41.64  ? 265  ASP B CA  1 
+ATOM   5586 C  C   . ASP B 1 246 ? 62.065  72.265 11.563 1.00 42.00  ? 265  ASP B C   1 
+ATOM   5587 O  O   . ASP B 1 246 ? 62.405  73.431 11.419 1.00 41.09  ? 265  ASP B O   1 
+ATOM   5588 C  CB  . ASP B 1 246 ? 61.892  70.687 9.623  1.00 40.51  ? 265  ASP B CB  1 
+ATOM   5589 C  CG  . ASP B 1 246 ? 62.629  69.800 8.588  1.00 46.45  ? 265  ASP B CG  1 
+ATOM   5590 O  OD1 . ASP B 1 246 ? 63.886  69.866 8.467  1.00 44.40  ? 265  ASP B OD1 1 
+ATOM   5591 O  OD2 . ASP B 1 246 ? 61.995  69.012 7.818  1.00 45.61  ? 265  ASP B OD2 1 
+ATOM   5592 N  N   . CYS B 1 247 ? 61.118  71.904 12.424 1.00 43.20  ? 266  CYS B N   1 
+ATOM   5593 C  CA  . CYS B 1 247 ? 60.374  72.915 13.195 1.00 48.35  ? 266  CYS B CA  1 
+ATOM   5594 C  C   . CYS B 1 247 ? 61.261  73.674 14.194 1.00 49.09  ? 266  CYS B C   1 
+ATOM   5595 O  O   . CYS B 1 247 ? 61.049  74.857 14.460 1.00 54.68  ? 266  CYS B O   1 
+ATOM   5596 C  CB  . CYS B 1 247 ? 59.197  72.293 13.951 1.00 47.26  ? 266  CYS B CB  1 
+ATOM   5597 S  SG  . CYS B 1 247 ? 57.968  71.492 12.907 1.00 48.83  ? 266  CYS B SG  1 
+ATOM   5598 N  N   . PHE B 1 248 ? 62.234  72.980 14.759 1.00 48.14  ? 267  PHE B N   1 
+ATOM   5599 C  CA  . PHE B 1 248 ? 63.121  73.579 15.727 1.00 47.35  ? 267  PHE B CA  1 
+ATOM   5600 C  C   . PHE B 1 248 ? 64.046  74.532 14.986 1.00 48.72  ? 267  PHE B C   1 
+ATOM   5601 O  O   . PHE B 1 248 ? 64.254  75.661 15.400 1.00 44.61  ? 267  PHE B O   1 
+ATOM   5602 C  CB  . PHE B 1 248 ? 63.922  72.487 16.441 1.00 47.05  ? 267  PHE B CB  1 
+ATOM   5603 C  CG  . PHE B 1 248 ? 64.571  72.946 17.699 1.00 43.64  ? 267  PHE B CG  1 
+ATOM   5604 C  CD1 . PHE B 1 248 ? 64.036  72.613 18.916 1.00 41.93  ? 267  PHE B CD1 1 
+ATOM   5605 C  CD2 . PHE B 1 248 ? 65.723  73.725 17.660 1.00 48.19  ? 267  PHE B CD2 1 
+ATOM   5606 C  CE1 . PHE B 1 248 ? 64.632  73.037 20.079 1.00 42.51  ? 267  PHE B CE1 1 
+ATOM   5607 C  CE2 . PHE B 1 248 ? 66.326  74.163 18.823 1.00 46.37  ? 267  PHE B CE2 1 
+ATOM   5608 C  CZ  . PHE B 1 248 ? 65.782  73.813 20.037 1.00 44.32  ? 267  PHE B CZ  1 
+ATOM   5609 N  N   . LEU B 1 249 ? 64.600  74.052 13.879 1.00 51.07  ? 268  LEU B N   1 
+ATOM   5610 C  CA  . LEU B 1 249 ? 65.502  74.843 13.067 1.00 51.95  ? 268  LEU B CA  1 
+ATOM   5611 C  C   . LEU B 1 249 ? 64.859  76.163 12.621 1.00 54.96  ? 268  LEU B C   1 
+ATOM   5612 O  O   . LEU B 1 249 ? 65.518  77.199 12.619 1.00 56.67  ? 268  LEU B O   1 
+ATOM   5613 C  CB  . LEU B 1 249 ? 65.943  74.035 11.851 1.00 50.97  ? 268  LEU B CB  1 
+ATOM   5614 C  CG  . LEU B 1 249 ? 67.413  73.647 11.702 1.00 52.55  ? 268  LEU B CG  1 
+ATOM   5615 C  CD1 . LEU B 1 249 ? 68.243  73.721 13.009 1.00 52.33  ? 268  LEU B CD1 1 
+ATOM   5616 C  CD2 . LEU B 1 249 ? 67.492  72.255 11.072 1.00 51.41  ? 268  LEU B CD2 1 
+ATOM   5617 N  N   . MET B 1 250 ? 63.577  76.137 12.274 1.00 56.11  ? 269  MET B N   1 
+ATOM   5618 C  CA  . MET B 1 250 ? 62.921  77.339 11.789 1.00 60.71  ? 269  MET B CA  1 
+ATOM   5619 C  C   . MET B 1 250 ? 62.364  78.193 12.934 1.00 60.72  ? 269  MET B C   1 
+ATOM   5620 O  O   . MET B 1 250 ? 62.023  79.364 12.742 1.00 61.36  ? 269  MET B O   1 
+ATOM   5621 C  CB  . MET B 1 250 ? 61.867  76.986 10.729 1.00 63.23  ? 269  MET B CB  1 
+ATOM   5622 C  CG  . MET B 1 250 ? 60.479  76.643 11.238 1.00 65.13  ? 269  MET B CG  1 
+ATOM   5623 S  SD  . MET B 1 250 ? 59.311  76.301 9.864  1.00 70.07  ? 269  MET B SD  1 
+ATOM   5624 C  CE  . MET B 1 250 ? 60.319  75.242 8.744  1.00 68.18  ? 269  MET B CE  1 
+ATOM   5625 N  N   . LYS B 1 251 ? 62.301  77.615 14.130 1.00 62.89  ? 270  LYS B N   1 
+ATOM   5626 C  CA  . LYS B 1 251 ? 62.028  78.385 15.345 1.00 61.21  ? 270  LYS B CA  1 
+ATOM   5627 C  C   . LYS B 1 251 ? 63.256  79.196 15.714 1.00 61.23  ? 270  LYS B C   1 
+ATOM   5628 O  O   . LYS B 1 251 ? 63.142  80.209 16.378 1.00 66.24  ? 270  LYS B O   1 
+ATOM   5629 C  CB  . LYS B 1 251 ? 61.617  77.469 16.506 1.00 60.17  ? 270  LYS B CB  1 
+ATOM   5630 C  CG  . LYS B 1 251 ? 61.382  78.174 17.853 1.00 58.46  ? 270  LYS B CG  1 
+ATOM   5631 C  CD  . LYS B 1 251 ? 60.150  79.072 17.844 1.00 56.94  ? 270  LYS B CD  1 
+ATOM   5632 C  CE  . LYS B 1 251 ? 59.830  79.568 19.259 1.00 54.35  ? 270  LYS B CE  1 
+ATOM   5633 N  NZ  . LYS B 1 251 ? 58.495  80.173 19.379 1.00 48.36  ? 270  LYS B NZ  1 
+ATOM   5634 N  N   . MET B 1 252 ? 64.427  78.758 15.279 1.00 62.80  ? 271  MET B N   1 
+ATOM   5635 C  CA  . MET B 1 252 ? 65.650  79.517 15.494 1.00 65.95  ? 271  MET B CA  1 
+ATOM   5636 C  C   . MET B 1 252 ? 65.779  80.687 14.527 1.00 71.84  ? 271  MET B C   1 
+ATOM   5637 O  O   . MET B 1 252 ? 66.503  81.634 14.812 1.00 77.37  ? 271  MET B O   1 
+ATOM   5638 C  CB  . MET B 1 252 ? 66.862  78.614 15.340 1.00 64.73  ? 271  MET B CB  1 
+ATOM   5639 C  CG  . MET B 1 252 ? 66.930  77.549 16.395 1.00 63.31  ? 271  MET B CG  1 
+ATOM   5640 S  SD  . MET B 1 252 ? 68.283  76.423 16.127 1.00 63.42  ? 271  MET B SD  1 
+ATOM   5641 C  CE  . MET B 1 252 ? 69.752  77.547 16.392 1.00 58.05  ? 271  MET B CE  1 
+ATOM   5642 N  N   . GLU B 1 253 ? 65.093  80.624 13.387 1.00 77.37  ? 272  GLU B N   1 
+ATOM   5643 C  CA  . GLU B 1 253 ? 65.033  81.758 12.460 1.00 80.83  ? 272  GLU B CA  1 
+ATOM   5644 C  C   . GLU B 1 253 ? 64.206  82.913 13.045 1.00 81.58  ? 272  GLU B C   1 
+ATOM   5645 O  O   . GLU B 1 253 ? 64.694  84.045 13.122 1.00 82.64  ? 272  GLU B O   1 
+ATOM   5646 C  CB  . GLU B 1 253 ? 64.467  81.332 11.101 1.00 83.78  ? 272  GLU B CB  1 
+ATOM   5647 C  CG  . GLU B 1 253 ? 65.030  82.131 9.934  1.00 86.43  ? 272  GLU B CG  1 
+ATOM   5648 C  CD  . GLU B 1 253 ? 66.516  81.898 9.728  1.00 89.15  ? 272  GLU B CD  1 
+ATOM   5649 O  OE1 . GLU B 1 253 ? 67.031  80.841 10.164 1.00 89.46  ? 272  GLU B OE1 1 
+ATOM   5650 O  OE2 . GLU B 1 253 ? 67.171  82.778 9.131  1.00 90.80  ? 272  GLU B OE2 1 
+ATOM   5651 N  N   . LYS B 1 254 ? 62.965  82.638 13.455 1.00 81.25  ? 273  LYS B N   1 
+ATOM   5652 C  CA  . LYS B 1 254 ? 62.296  83.532 14.399 1.00 82.15  ? 273  LYS B CA  1 
+ATOM   5653 C  C   . LYS B 1 254 ? 63.257  83.571 15.588 1.00 83.88  ? 273  LYS B C   1 
+ATOM   5654 O  O   . LYS B 1 254 ? 64.191  82.776 15.653 1.00 83.50  ? 273  LYS B O   1 
+ATOM   5655 C  CB  . LYS B 1 254 ? 60.924  83.000 14.840 1.00 81.95  ? 273  LYS B CB  1 
+ATOM   5656 C  CG  . LYS B 1 254 ? 59.926  82.659 13.709 1.00 82.03  ? 273  LYS B CG  1 
+ATOM   5657 C  CD  . LYS B 1 254 ? 58.550  82.203 14.264 1.00 81.05  ? 273  LYS B CD  1 
+ATOM   5658 C  CE  . LYS B 1 254 ? 57.751  83.365 14.885 1.00 79.62  ? 273  LYS B CE  1 
+ATOM   5659 N  NZ  . LYS B 1 254 ? 56.329  83.028 15.183 1.00 75.20  ? 273  LYS B NZ  1 
+ATOM   5660 N  N   . GLU B 1 255 ? 63.067  84.488 16.522 1.00 86.90  ? 274  GLU B N   1 
+ATOM   5661 C  CA  . GLU B 1 255 ? 63.973  84.585 17.683 1.00 89.06  ? 274  GLU B CA  1 
+ATOM   5662 C  C   . GLU B 1 255 ? 65.407  85.026 17.353 1.00 90.59  ? 274  GLU B C   1 
+ATOM   5663 O  O   . GLU B 1 255 ? 66.214  85.167 18.269 1.00 92.99  ? 274  GLU B O   1 
+ATOM   5664 C  CB  . GLU B 1 255 ? 64.080  83.249 18.452 1.00 88.86  ? 274  GLU B CB  1 
+ATOM   5665 C  CG  . GLU B 1 255 ? 62.776  82.510 18.710 1.00 88.48  ? 274  GLU B CG  1 
+ATOM   5666 C  CD  . GLU B 1 255 ? 62.182  82.816 20.067 1.00 88.40  ? 274  GLU B CD  1 
+ATOM   5667 O  OE1 . GLU B 1 255 ? 62.936  82.857 21.062 1.00 89.80  ? 274  GLU B OE1 1 
+ATOM   5668 O  OE2 . GLU B 1 255 ? 60.954  83.007 20.137 1.00 88.12  ? 274  GLU B OE2 1 
+ATOM   5669 N  N   . LYS B 1 256 ? 65.748  85.238 16.082 1.00 91.48  ? 275  LYS B N   1 
+ATOM   5670 C  CA  . LYS B 1 256 ? 67.117  85.627 15.744 1.00 92.44  ? 275  LYS B CA  1 
+ATOM   5671 C  C   . LYS B 1 256 ? 67.400  87.099 16.080 1.00 93.42  ? 275  LYS B C   1 
+ATOM   5672 O  O   . LYS B 1 256 ? 68.558  87.495 16.191 1.00 93.24  ? 275  LYS B O   1 
+ATOM   5673 C  CB  . LYS B 1 256 ? 67.416  85.351 14.275 1.00 92.78  ? 275  LYS B CB  1 
+ATOM   5674 C  CG  . LYS B 1 256 ? 68.907  85.374 13.947 1.00 93.12  ? 275  LYS B CG  1 
+ATOM   5675 C  CD  . LYS B 1 256 ? 69.202  84.711 12.617 1.00 92.83  ? 275  LYS B CD  1 
+ATOM   5676 C  CE  . LYS B 1 256 ? 68.617  85.503 11.462 1.00 92.53  ? 275  LYS B CE  1 
+ATOM   5677 N  NZ  . LYS B 1 256 ? 68.766  84.758 10.197 1.00 93.76  ? 275  LYS B NZ  1 
+ATOM   5678 N  N   . HIS B 1 257 ? 66.339  87.889 16.264 1.00 94.74  ? 276  HIS B N   1 
+ATOM   5679 C  CA  . HIS B 1 257 ? 66.460  89.293 16.674 1.00 95.98  ? 276  HIS B CA  1 
+ATOM   5680 C  C   . HIS B 1 257 ? 66.643  89.307 18.209 1.00 96.15  ? 276  HIS B C   1 
+ATOM   5681 O  O   . HIS B 1 257 ? 67.411  90.122 18.732 1.00 96.46  ? 276  HIS B O   1 
+ATOM   5682 C  CB  . HIS B 1 257 ? 65.256  90.159 16.145 1.00 97.82  ? 276  HIS B CB  1 
+ATOM   5683 C  CG  . HIS B 1 257 ? 64.840  89.772 14.742 1.00 101.34 ? 276  HIS B CG  1 
+ATOM   5684 N  ND1 . HIS B 1 257 ? 64.914  88.429 14.361 1.00 103.71 ? 276  HIS B ND1 1 
+ATOM   5685 C  CD2 . HIS B 1 257 ? 64.274  90.468 13.686 1.00 102.55 ? 276  HIS B CD2 1 
+ATOM   5686 C  CE1 . HIS B 1 257 ? 64.452  88.304 13.117 1.00 102.94 ? 276  HIS B CE1 1 
+ATOM   5687 N  NE2 . HIS B 1 257 ? 64.067  89.531 12.680 1.00 103.14 ? 276  HIS B NE2 1 
+ATOM   5688 N  N   . ASN B 1 258 ? 66.002  88.352 18.900 1.00 96.29  ? 277  ASN B N   1 
+ATOM   5689 C  CA  . ASN B 1 258 ? 66.101  88.174 20.367 1.00 95.53  ? 277  ASN B CA  1 
+ATOM   5690 C  C   . ASN B 1 258 ? 67.247  87.213 20.741 1.00 94.59  ? 277  ASN B C   1 
+ATOM   5691 O  O   . ASN B 1 258 ? 67.001  86.069 21.130 1.00 91.06  ? 277  ASN B O   1 
+ATOM   5692 C  CB  . ASN B 1 258 ? 64.771  87.637 20.941 1.00 96.36  ? 277  ASN B CB  1 
+ATOM   5693 C  CG  . ASN B 1 258 ? 63.540  88.354 20.377 1.00 97.76  ? 277  ASN B CG  1 
+ATOM   5694 O  OD1 . ASN B 1 258 ? 63.239  88.264 19.181 1.00 97.88  ? 277  ASN B OD1 1 
+ATOM   5695 N  ND2 . ASN B 1 258 ? 62.813  89.062 21.243 1.00 98.03  ? 277  ASN B ND2 1 
+ATOM   5696 N  N   . GLN B 1 259 ? 68.488  87.705 20.665 1.00 94.94  ? 278  GLN B N   1 
+ATOM   5697 C  CA  . GLN B 1 259 ? 69.675  86.842 20.526 1.00 95.13  ? 278  GLN B CA  1 
+ATOM   5698 C  C   . GLN B 1 259 ? 70.257  86.167 21.784 1.00 92.71  ? 278  GLN B C   1 
+ATOM   5699 O  O   . GLN B 1 259 ? 71.153  85.327 21.664 1.00 94.45  ? 278  GLN B O   1 
+ATOM   5700 C  CB  . GLN B 1 259 ? 70.790  87.585 19.757 1.00 97.14  ? 278  GLN B CB  1 
+ATOM   5701 C  CG  . GLN B 1 259 ? 71.948  86.703 19.178 1.00 97.76  ? 278  GLN B CG  1 
+ATOM   5702 C  CD  . GLN B 1 259 ? 71.501  85.392 18.479 1.00 98.09  ? 278  GLN B CD  1 
+ATOM   5703 O  OE1 . GLN B 1 259 ? 70.352  85.250 18.044 1.00 97.19  ? 278  GLN B OE1 1 
+ATOM   5704 N  NE2 . GLN B 1 259 ? 72.431  84.450 18.357 1.00 97.32  ? 278  GLN B NE2 1 
+ATOM   5705 N  N   . PRO B 1 260 ? 69.802  86.519 22.980 1.00 88.02  ? 279  PRO B N   1 
+ATOM   5706 C  CA  . PRO B 1 260 ? 69.864  85.562 24.097 1.00 85.59  ? 279  PRO B CA  1 
+ATOM   5707 C  C   . PRO B 1 260 ? 68.724  84.489 24.029 1.00 81.31  ? 279  PRO B C   1 
+ATOM   5708 O  O   . PRO B 1 260 ? 67.882  84.464 24.927 1.00 82.10  ? 279  PRO B O   1 
+ATOM   5709 C  CB  . PRO B 1 260 ? 69.755  86.470 25.343 1.00 86.43  ? 279  PRO B CB  1 
+ATOM   5710 C  CG  . PRO B 1 260 ? 69.811  87.907 24.813 1.00 86.87  ? 279  PRO B CG  1 
+ATOM   5711 C  CD  . PRO B 1 260 ? 69.321  87.844 23.404 1.00 87.02  ? 279  PRO B CD  1 
+ATOM   5712 N  N   . SER B 1 261 ? 68.716  83.618 23.007 1.00 75.50  ? 280  SER B N   1 
+ATOM   5713 C  CA  . SER B 1 261 ? 67.609  82.656 22.765 1.00 70.81  ? 280  SER B CA  1 
+ATOM   5714 C  C   . SER B 1 261 ? 67.788  81.249 23.362 1.00 69.19  ? 280  SER B C   1 
+ATOM   5715 O  O   . SER B 1 261 ? 68.890  80.708 23.431 1.00 65.60  ? 280  SER B O   1 
+ATOM   5716 C  CB  . SER B 1 261 ? 67.338  82.485 21.263 1.00 70.14  ? 280  SER B CB  1 
+ATOM   5717 O  OG  . SER B 1 261 ? 66.106  81.806 21.013 1.00 66.92  ? 280  SER B OG  1 
+ATOM   5718 N  N   . GLU B 1 262 ? 66.651  80.667 23.735 1.00 68.59  ? 281  GLU B N   1 
+ATOM   5719 C  CA  . GLU B 1 262 ? 66.540  79.318 24.300 1.00 65.52  ? 281  GLU B CA  1 
+ATOM   5720 C  C   . GLU B 1 262 ? 66.720  78.198 23.280 1.00 60.69  ? 281  GLU B C   1 
+ATOM   5721 O  O   . GLU B 1 262 ? 67.050  77.071 23.633 1.00 57.09  ? 281  GLU B O   1 
+ATOM   5722 C  CB  . GLU B 1 262 ? 65.150  79.163 24.905 1.00 67.67  ? 281  GLU B CB  1 
+ATOM   5723 C  CG  . GLU B 1 262 ? 65.121  79.002 26.410 1.00 74.74  ? 281  GLU B CG  1 
+ATOM   5724 C  CD  . GLU B 1 262 ? 65.902  80.059 27.176 1.00 77.16  ? 281  GLU B CD  1 
+ATOM   5725 O  OE1 . GLU B 1 262 ? 67.104  79.821 27.430 1.00 78.42  ? 281  GLU B OE1 1 
+ATOM   5726 O  OE2 . GLU B 1 262 ? 65.304  81.099 27.551 1.00 77.76  ? 281  GLU B OE2 1 
+ATOM   5727 N  N   . PHE B 1 263 ? 66.467  78.506 22.017 1.00 56.75  ? 282  PHE B N   1 
+ATOM   5728 C  CA  . PHE B 1 263 ? 66.534  77.510 20.973 1.00 52.96  ? 282  PHE B CA  1 
+ATOM   5729 C  C   . PHE B 1 263 ? 67.888  77.600 20.269 1.00 52.45  ? 282  PHE B C   1 
+ATOM   5730 O  O   . PHE B 1 263 ? 68.103  78.492 19.463 1.00 55.88  ? 282  PHE B O   1 
+ATOM   5731 C  CB  . PHE B 1 263 ? 65.377  77.726 19.993 1.00 50.22  ? 282  PHE B CB  1 
+ATOM   5732 C  CG  . PHE B 1 263 ? 64.022  77.597 20.623 1.00 44.28  ? 282  PHE B CG  1 
+ATOM   5733 C  CD1 . PHE B 1 263 ? 63.425  78.673 21.240 1.00 46.37  ? 282  PHE B CD1 1 
+ATOM   5734 C  CD2 . PHE B 1 263 ? 63.354  76.404 20.599 1.00 38.92  ? 282  PHE B CD2 1 
+ATOM   5735 C  CE1 . PHE B 1 263 ? 62.172  78.555 21.837 1.00 45.72  ? 282  PHE B CE1 1 
+ATOM   5736 C  CE2 . PHE B 1 263 ? 62.112  76.270 21.181 1.00 43.71  ? 282  PHE B CE2 1 
+ATOM   5737 C  CZ  . PHE B 1 263 ? 61.515  77.350 21.802 1.00 47.36  ? 282  PHE B CZ  1 
+ATOM   5738 N  N   . THR B 1 264 ? 68.804  76.698 20.616 1.00 49.98  ? 283  THR B N   1 
+ATOM   5739 C  CA  . THR B 1 264 ? 70.087  76.515 19.913 1.00 47.66  ? 283  THR B CA  1 
+ATOM   5740 C  C   . THR B 1 264 ? 70.300  75.062 19.488 1.00 47.12  ? 283  THR B C   1 
+ATOM   5741 O  O   . THR B 1 264 ? 69.602  74.168 19.920 1.00 44.81  ? 283  THR B O   1 
+ATOM   5742 C  CB  . THR B 1 264 ? 71.265  76.862 20.826 1.00 47.23  ? 283  THR B CB  1 
+ATOM   5743 O  OG1 . THR B 1 264 ? 71.364  75.864 21.853 1.00 49.13  ? 283  THR B OG1 1 
+ATOM   5744 C  CG2 . THR B 1 264 ? 71.053  78.200 21.581 1.00 45.37  ? 283  THR B CG2 1 
+ATOM   5745 N  N   . ILE B 1 265 ? 71.318  74.818 18.682 1.00 47.29  ? 284  ILE B N   1 
+ATOM   5746 C  CA  . ILE B 1 265 ? 71.620  73.454 18.288 1.00 46.14  ? 284  ILE B CA  1 
+ATOM   5747 C  C   . ILE B 1 265 ? 71.861  72.601 19.536 1.00 47.76  ? 284  ILE B C   1 
+ATOM   5748 O  O   . ILE B 1 265 ? 71.511  71.423 19.564 1.00 46.83  ? 284  ILE B O   1 
+ATOM   5749 C  CB  . ILE B 1 265 ? 72.835  73.404 17.347 1.00 46.90  ? 284  ILE B CB  1 
+ATOM   5750 C  CG1 . ILE B 1 265 ? 72.602  74.254 16.075 1.00 46.50  ? 284  ILE B CG1 1 
+ATOM   5751 C  CG2 . ILE B 1 265 ? 73.176  71.946 16.978 1.00 47.41  ? 284  ILE B CG2 1 
+ATOM   5752 C  CD1 . ILE B 1 265 ? 71.411  73.857 15.228 1.00 46.93  ? 284  ILE B CD1 1 
+ATOM   5753 N  N   . GLU B 1 266 ? 72.448  73.200 20.571 1.00 51.41  ? 285  GLU B N   1 
+ATOM   5754 C  CA  . GLU B 1 266 ? 72.642  72.514 21.859 1.00 53.32  ? 285  GLU B CA  1 
+ATOM   5755 C  C   . GLU B 1 266 ? 71.295  72.088 22.479 1.00 48.82  ? 285  GLU B C   1 
+ATOM   5756 O  O   . GLU B 1 266 ? 71.104  70.910 22.744 1.00 37.69  ? 285  GLU B O   1 
+ATOM   5757 C  CB  . GLU B 1 266 ? 73.461  73.370 22.850 1.00 55.94  ? 285  GLU B CB  1 
+ATOM   5758 C  CG  . GLU B 1 266 ? 74.708  72.675 23.381 1.00 61.21  ? 285  GLU B CG  1 
+ATOM   5759 C  CD  . GLU B 1 266 ? 75.254  73.318 24.649 1.00 65.63  ? 285  GLU B CD  1 
+ATOM   5760 O  OE1 . GLU B 1 266 ? 75.609  74.528 24.612 1.00 70.21  ? 285  GLU B OE1 1 
+ATOM   5761 O  OE2 . GLU B 1 266 ? 75.330  72.613 25.683 1.00 65.67  ? 285  GLU B OE2 1 
+ATOM   5762 N  N   . SER B 1 267 ? 70.384  73.051 22.688 1.00 45.91  ? 286  SER B N   1 
+ATOM   5763 C  CA  . SER B 1 267 ? 69.017  72.781 23.161 1.00 44.75  ? 286  SER B CA  1 
+ATOM   5764 C  C   . SER B 1 267 ? 68.352  71.660 22.381 1.00 44.42  ? 286  SER B C   1 
+ATOM   5765 O  O   . SER B 1 267 ? 67.669  70.832 22.943 1.00 44.79  ? 286  SER B O   1 
+ATOM   5766 C  CB  . SER B 1 267 ? 68.127  74.005 22.983 1.00 44.92  ? 286  SER B CB  1 
+ATOM   5767 O  OG  . SER B 1 267 ? 68.652  75.143 23.622 1.00 50.05  ? 286  SER B OG  1 
+ATOM   5768 N  N   . LEU B 1 268 ? 68.537  71.673 21.068 1.00 46.13  ? 287  LEU B N   1 
+ATOM   5769 C  CA  . LEU B 1 268 ? 67.895  70.734 20.169 1.00 45.53  ? 287  LEU B CA  1 
+ATOM   5770 C  C   . LEU B 1 268 ? 68.432  69.346 20.432 1.00 43.23  ? 287  LEU B C   1 
+ATOM   5771 O  O   . LEU B 1 268 ? 67.674  68.412 20.536 1.00 44.79  ? 287  LEU B O   1 
+ATOM   5772 C  CB  . LEU B 1 268 ? 68.146  71.147 18.708 1.00 46.81  ? 287  LEU B CB  1 
+ATOM   5773 C  CG  . LEU B 1 268 ? 67.771  70.161 17.597 1.00 49.54  ? 287  LEU B CG  1 
+ATOM   5774 C  CD1 . LEU B 1 268 ? 66.356  69.594 17.798 1.00 51.62  ? 287  LEU B CD1 1 
+ATOM   5775 C  CD2 . LEU B 1 268 ? 67.911  70.842 16.253 1.00 48.78  ? 287  LEU B CD2 1 
+ATOM   5776 N  N   . GLU B 1 269 ? 69.745  69.221 20.521 1.00 44.08  ? 288  GLU B N   1 
+ATOM   5777 C  CA  . GLU B 1 269 ? 70.380  67.951 20.843 1.00 45.36  ? 288  GLU B CA  1 
+ATOM   5778 C  C   . GLU B 1 269 ? 69.853  67.399 22.172 1.00 42.79  ? 288  GLU B C   1 
+ATOM   5779 O  O   . GLU B 1 269 ? 69.509  66.210 22.279 1.00 42.43  ? 288  GLU B O   1 
+ATOM   5780 C  CB  . GLU B 1 269 ? 71.890  68.140 20.962 1.00 46.06  ? 288  GLU B CB  1 
+ATOM   5781 C  CG  . GLU B 1 269 ? 72.649  68.211 19.659 1.00 47.63  ? 288  GLU B CG  1 
+ATOM   5782 C  CD  . GLU B 1 269 ? 74.135  68.470 19.893 1.00 55.24  ? 288  GLU B CD  1 
+ATOM   5783 O  OE1 . GLU B 1 269 ? 74.533  68.781 21.056 1.00 55.65  ? 288  GLU B OE1 1 
+ATOM   5784 O  OE2 . GLU B 1 269 ? 74.914  68.350 18.920 1.00 53.00  ? 288  GLU B OE2 1 
+ATOM   5785 N  N   . ASN B 1 270 ? 69.811  68.274 23.176 1.00 39.50  ? 289  ASN B N   1 
+ATOM   5786 C  CA  . ASN B 1 270 ? 69.354  67.922 24.514 1.00 39.66  ? 289  ASN B CA  1 
+ATOM   5787 C  C   . ASN B 1 270 ? 67.919  67.476 24.531 1.00 38.63  ? 289  ASN B C   1 
+ATOM   5788 O  O   . ASN B 1 270 ? 67.607  66.432 25.091 1.00 36.57  ? 289  ASN B O   1 
+ATOM   5789 C  CB  . ASN B 1 270 ? 69.491  69.104 25.458 1.00 41.74  ? 289  ASN B CB  1 
+ATOM   5790 C  CG  . ASN B 1 270 ? 70.928  69.473 25.723 1.00 44.62  ? 289  ASN B CG  1 
+ATOM   5791 O  OD1 . ASN B 1 270 ? 71.248  70.649 25.959 1.00 46.06  ? 289  ASN B OD1 1 
+ATOM   5792 N  ND2 . ASN B 1 270 ? 71.807  68.473 25.700 1.00 38.92  ? 289  ASN B ND2 1 
+ATOM   5793 N  N   . THR B 1 271 ? 67.061  68.277 23.908 1.00 35.13  ? 290  THR B N   1 
+ATOM   5794 C  CA  . THR B 1 271 ? 65.639  68.012 23.841 1.00 37.99  ? 290  THR B CA  1 
+ATOM   5795 C  C   . THR B 1 271 ? 65.337  66.734 23.056 1.00 36.28  ? 290  THR B C   1 
+ATOM   5796 O  O   . THR B 1 271 ? 64.349  66.051 23.311 1.00 40.63  ? 290  THR B O   1 
+ATOM   5797 C  CB  . THR B 1 271 ? 64.888  69.238 23.221 1.00 42.32  ? 290  THR B CB  1 
+ATOM   5798 O  OG1 . THR B 1 271 ? 65.090  70.426 24.027 1.00 40.59  ? 290  THR B OG1 1 
+ATOM   5799 C  CG2 . THR B 1 271 ? 63.367  69.019 23.230 1.00 42.28  ? 290  THR B CG2 1 
+ATOM   5800 N  N   . ALA B 1 272 ? 66.200  66.383 22.126 1.00 34.55  ? 291  ALA B N   1 
+ATOM   5801 C  CA  . ALA B 1 272 ? 65.967  65.215 21.304 1.00 34.26  ? 291  ALA B CA  1 
+ATOM   5802 C  C   . ALA B 1 272 ? 66.323  63.942 22.043 1.00 35.81  ? 291  ALA B C   1 
+ATOM   5803 O  O   . ALA B 1 272 ? 65.584  62.982 21.945 1.00 38.84  ? 291  ALA B O   1 
+ATOM   5804 C  CB  . ALA B 1 272 ? 66.757  65.312 20.017 1.00 35.61  ? 291  ALA B CB  1 
+ATOM   5805 N  N   . VAL B 1 273 ? 67.449  63.915 22.765 1.00 37.82  ? 292  VAL B N   1 
+ATOM   5806 C  CA  . VAL B 1 273 ? 67.804  62.729 23.566 1.00 39.60  ? 292  VAL B CA  1 
+ATOM   5807 C  C   . VAL B 1 273 ? 66.812  62.494 24.687 1.00 36.96  ? 292  VAL B C   1 
+ATOM   5808 O  O   . VAL B 1 273 ? 66.443  61.340 24.951 1.00 37.80  ? 292  VAL B O   1 
+ATOM   5809 C  CB  . VAL B 1 273 ? 69.249  62.741 24.163 1.00 42.13  ? 292  VAL B CB  1 
+ATOM   5810 C  CG1 . VAL B 1 273 ? 70.281  62.701 23.054 1.00 44.63  ? 292  VAL B CG1 1 
+ATOM   5811 C  CG2 . VAL B 1 273 ? 69.491  63.927 25.055 1.00 44.95  ? 292  VAL B CG2 1 
+ATOM   5812 N  N   . ASP B 1 274 ? 66.359  63.576 25.317 1.00 34.96  ? 293  ASP B N   1 
+ATOM   5813 C  CA  . ASP B 1 274 ? 65.292  63.501 26.327 1.00 36.11  ? 293  ASP B CA  1 
+ATOM   5814 C  C   . ASP B 1 274 ? 64.080  62.770 25.758 1.00 33.25  ? 293  ASP B C   1 
+ATOM   5815 O  O   . ASP B 1 274 ? 63.503  61.921 26.429 1.00 35.77  ? 293  ASP B O   1 
+ATOM   5816 C  CB  . ASP B 1 274 ? 64.866  64.896 26.830 1.00 40.30  ? 293  ASP B CB  1 
+ATOM   5817 C  CG  . ASP B 1 274 ? 65.871  65.530 27.833 1.00 46.08  ? 293  ASP B CG  1 
+ATOM   5818 O  OD1 . ASP B 1 274 ? 65.622  66.687 28.247 1.00 51.67  ? 293  ASP B OD1 1 
+ATOM   5819 O  OD2 . ASP B 1 274 ? 66.931  64.995 28.256 1.00 50.65  ? 293  ASP B OD2 1 
+ATOM   5820 N  N   . LEU B 1 275 ? 63.714  63.069 24.512 1.00 32.63  ? 294  LEU B N   1 
+ATOM   5821 C  CA  . LEU B 1 275 ? 62.539  62.446 23.893 1.00 32.76  ? 294  LEU B CA  1 
+ATOM   5822 C  C   . LEU B 1 275 ? 62.787  61.004 23.650 1.00 33.41  ? 294  LEU B C   1 
+ATOM   5823 O  O   . LEU B 1 275 ? 61.912  60.196 23.972 1.00 41.06  ? 294  LEU B O   1 
+ATOM   5824 C  CB  . LEU B 1 275 ? 62.115  63.106 22.578 1.00 32.03  ? 294  LEU B CB  1 
+ATOM   5825 C  CG  . LEU B 1 275 ? 61.636  64.550 22.704 1.00 32.83  ? 294  LEU B CG  1 
+ATOM   5826 C  CD1 . LEU B 1 275 ? 61.312  65.047 21.340 1.00 35.84  ? 294  LEU B CD1 1 
+ATOM   5827 C  CD2 . LEU B 1 275 ? 60.423  64.685 23.609 1.00 37.92  ? 294  LEU B CD2 1 
+ATOM   5828 N  N   . PHE B 1 276 ? 63.958  60.665 23.101 1.00 30.96  ? 295  PHE B N   1 
+ATOM   5829 C  CA  . PHE B 1 276 ? 64.358  59.248 22.995 1.00 29.64  ? 295  PHE B CA  1 
+ATOM   5830 C  C   . PHE B 1 276 ? 64.337  58.545 24.334 1.00 27.55  ? 295  PHE B C   1 
+ATOM   5831 O  O   . PHE B 1 276 ? 63.928  57.414 24.406 1.00 32.05  ? 295  PHE B O   1 
+ATOM   5832 C  CB  . PHE B 1 276 ? 65.735  59.075 22.356 1.00 31.56  ? 295  PHE B CB  1 
+ATOM   5833 C  CG  . PHE B 1 276 ? 65.719  59.187 20.868 1.00 32.04  ? 295  PHE B CG  1 
+ATOM   5834 C  CD1 . PHE B 1 276 ? 65.210  58.157 20.093 1.00 35.06  ? 295  PHE B CD1 1 
+ATOM   5835 C  CD2 . PHE B 1 276 ? 66.152  60.350 20.245 1.00 30.27  ? 295  PHE B CD2 1 
+ATOM   5836 C  CE1 . PHE B 1 276 ? 65.163  58.273 18.704 1.00 37.76  ? 295  PHE B CE1 1 
+ATOM   5837 C  CE2 . PHE B 1 276 ? 66.112  60.479 18.877 1.00 33.63  ? 295  PHE B CE2 1 
+ATOM   5838 C  CZ  . PHE B 1 276 ? 65.620  59.440 18.094 1.00 38.09  ? 295  PHE B CZ  1 
+ATOM   5839 N  N   . GLY B 1 277 ? 64.740  59.222 25.398 1.00 31.29  ? 296  GLY B N   1 
+ATOM   5840 C  CA  . GLY B 1 277 ? 64.911  58.574 26.689 1.00 34.14  ? 296  GLY B CA  1 
+ATOM   5841 C  C   . GLY B 1 277 ? 63.595  58.343 27.381 1.00 35.67  ? 296  GLY B C   1 
+ATOM   5842 O  O   . GLY B 1 277 ? 63.279  57.231 27.804 1.00 40.30  ? 296  GLY B O   1 
+ATOM   5843 N  N   . ALA B 1 278 ? 62.822  59.412 27.484 1.00 36.38  ? 297  ALA B N   1 
+ATOM   5844 C  CA  . ALA B 1 278 ? 61.443  59.350 27.982 1.00 38.26  ? 297  ALA B CA  1 
+ATOM   5845 C  C   . ALA B 1 278 ? 60.481  58.587 27.054 1.00 36.36  ? 297  ALA B C   1 
+ATOM   5846 O  O   . ALA B 1 278 ? 59.552  57.909 27.517 1.00 40.05  ? 297  ALA B O   1 
+ATOM   5847 C  CB  . ALA B 1 278 ? 60.931  60.767 28.192 1.00 38.71  ? 297  ALA B CB  1 
+ATOM   5848 N  N   . GLY B 1 279 ? 60.700  58.707 25.750 1.00 35.07  ? 298  GLY B N   1 
+ATOM   5849 C  CA  . GLY B 1 279 ? 59.826  58.084 24.764 1.00 38.35  ? 298  GLY B CA  1 
+ATOM   5850 C  C   . GLY B 1 279 ? 59.868  56.559 24.683 1.00 40.65  ? 298  GLY B C   1 
+ATOM   5851 O  O   . GLY B 1 279 ? 58.929  55.921 24.213 1.00 44.58  ? 298  GLY B O   1 
+ATOM   5852 N  N   . THR B 1 280 ? 60.939  55.964 25.180 1.00 41.30  ? 299  THR B N   1 
+ATOM   5853 C  CA  . THR B 1 280 ? 61.261  54.609 24.819 1.00 39.38  ? 299  THR B CA  1 
+ATOM   5854 C  C   . THR B 1 280 ? 60.983  53.596 25.907 1.00 36.34  ? 299  THR B C   1 
+ATOM   5855 O  O   . THR B 1 280 ? 60.170  52.707 25.712 1.00 34.64  ? 299  THR B O   1 
+ATOM   5856 C  CB  . THR B 1 280 ? 62.721  54.580 24.380 1.00 42.34  ? 299  THR B CB  1 
+ATOM   5857 O  OG1 . THR B 1 280 ? 62.832  55.317 23.156 1.00 39.13  ? 299  THR B OG1 1 
+ATOM   5858 C  CG2 . THR B 1 280 ? 63.150  53.174 23.977 1.00 49.10  ? 299  THR B CG2 1 
+ATOM   5859 N  N   . GLU B 1 281 ? 61.641  53.730 27.050 1.00 35.94  ? 300  GLU B N   1 
+ATOM   5860 C  CA  . GLU B 1 281 ? 61.613  52.681 28.083 1.00 37.68  ? 300  GLU B CA  1 
+ATOM   5861 C  C   . GLU B 1 281 ? 60.206  52.399 28.595 1.00 37.09  ? 300  GLU B C   1 
+ATOM   5862 O  O   . GLU B 1 281 ? 59.773  51.250 28.609 1.00 31.01  ? 300  GLU B O   1 
+ATOM   5863 C  CB  . GLU B 1 281 ? 62.491  53.088 29.275 1.00 40.99  ? 300  GLU B CB  1 
+ATOM   5864 C  CG  . GLU B 1 281 ? 63.204  52.004 30.093 1.00 49.09  ? 300  GLU B CG  1 
+ATOM   5865 C  CD  . GLU B 1 281 ? 62.596  50.591 30.159 1.00 59.54  ? 300  GLU B CD  1 
+ATOM   5866 O  OE1 . GLU B 1 281 ? 62.105  50.215 31.266 1.00 67.68  ? 300  GLU B OE1 1 
+ATOM   5867 O  OE2 . GLU B 1 281 ? 62.689  49.812 29.160 1.00 62.82  ? 300  GLU B OE2 1 
+ATOM   5868 N  N   . THR B 1 282 ? 59.513  53.460 29.033 1.00 39.14  ? 301  THR B N   1 
+ATOM   5869 C  CA  . THR B 1 282 ? 58.242  53.341 29.754 1.00 34.02  ? 301  THR B CA  1 
+ATOM   5870 C  C   . THR B 1 282 ? 57.196  52.785 28.829 1.00 32.36  ? 301  THR B C   1 
+ATOM   5871 O  O   . THR B 1 282 ? 56.371  51.956 29.209 1.00 29.01  ? 301  THR B O   1 
+ATOM   5872 C  CB  . THR B 1 282 ? 57.775  54.719 30.265 1.00 38.10  ? 301  THR B CB  1 
+ATOM   5873 O  OG1 . THR B 1 282 ? 58.874  55.474 30.790 1.00 37.56  ? 301  THR B OG1 1 
+ATOM   5874 C  CG2 . THR B 1 282 ? 56.900  54.563 31.463 1.00 37.75  ? 301  THR B CG2 1 
+ATOM   5875 N  N   . THR B 1 283 ? 57.256  53.234 27.583 1.00 29.12  ? 302  THR B N   1 
+ATOM   5876 C  CA  . THR B 1 283 ? 56.313  52.792 26.596 1.00 27.50  ? 302  THR B CA  1 
+ATOM   5877 C  C   . THR B 1 283 ? 56.545  51.317 26.321 1.00 29.80  ? 302  THR B C   1 
+ATOM   5878 O  O   . THR B 1 283 ? 55.609  50.512 26.189 1.00 25.37  ? 302  THR B O   1 
+ATOM   5879 C  CB  . THR B 1 283 ? 56.533  53.584 25.340 1.00 29.87  ? 302  THR B CB  1 
+ATOM   5880 O  OG1 . THR B 1 283 ? 56.649  54.990 25.649 1.00 29.74  ? 302  THR B OG1 1 
+ATOM   5881 C  CG2 . THR B 1 283 ? 55.344  53.450 24.436 1.00 29.39  ? 302  THR B CG2 1 
+ATOM   5882 N  N   . SER B 1 284 ? 57.827  50.973 26.238 1.00 32.48  ? 303  SER B N   1 
+ATOM   5883 C  CA  . SER B 1 284 ? 58.256  49.640 25.825 1.00 31.83  ? 303  SER B CA  1 
+ATOM   5884 C  C   . SER B 1 284 ? 57.885  48.686 26.933 1.00 28.96  ? 303  SER B C   1 
+ATOM   5885 O  O   . SER B 1 284 ? 57.309  47.627 26.713 1.00 26.94  ? 303  SER B O   1 
+ATOM   5886 C  CB  . SER B 1 284 ? 59.763  49.619 25.566 1.00 32.59  ? 303  SER B CB  1 
+ATOM   5887 O  OG  . SER B 1 284 ? 60.190  48.319 25.210 1.00 39.59  ? 303  SER B OG  1 
+ATOM   5888 N  N   . THR B 1 285 ? 58.168  49.120 28.144 1.00 31.19  ? 304  THR B N   1 
+ATOM   5889 C  CA  . THR B 1 285 ? 57.878  48.351 29.338 1.00 33.09  ? 304  THR B CA  1 
+ATOM   5890 C  C   . THR B 1 285 ? 56.385  48.114 29.493 1.00 34.08  ? 304  THR B C   1 
+ATOM   5891 O  O   . THR B 1 285 ? 55.955  46.989 29.718 1.00 30.20  ? 304  THR B O   1 
+ATOM   5892 C  CB  . THR B 1 285 ? 58.431  49.102 30.527 1.00 30.24  ? 304  THR B CB  1 
+ATOM   5893 O  OG1 . THR B 1 285 ? 59.851  49.180 30.372 1.00 31.10  ? 304  THR B OG1 1 
+ATOM   5894 C  CG2 . THR B 1 285 ? 58.231  48.338 31.795 1.00 29.39  ? 304  THR B CG2 1 
+ATOM   5895 N  N   . THR B 1 286 ? 55.609  49.185 29.335 1.00 34.68  ? 305  THR B N   1 
+ATOM   5896 C  CA  . THR B 1 286 ? 54.168  49.103 29.417 1.00 31.71  ? 305  THR B CA  1 
+ATOM   5897 C  C   . THR B 1 286 ? 53.646  48.040 28.468 1.00 30.11  ? 305  THR B C   1 
+ATOM   5898 O  O   . THR B 1 286 ? 52.867  47.184 28.888 1.00 28.55  ? 305  THR B O   1 
+ATOM   5899 C  CB  . THR B 1 286 ? 53.581  50.476 29.099 1.00 35.82  ? 305  THR B CB  1 
+ATOM   5900 O  OG1 . THR B 1 286 ? 53.943  51.383 30.148 1.00 35.93  ? 305  THR B OG1 1 
+ATOM   5901 C  CG2 . THR B 1 286 ? 52.052  50.460 29.136 1.00 36.37  ? 305  THR B CG2 1 
+ATOM   5902 N  N   . LEU B 1 287 ? 54.107  48.069 27.210 1.00 28.89  ? 306  LEU B N   1 
+ATOM   5903 C  CA  . LEU B 1 287 ? 53.702  47.077 26.212 1.00 30.27  ? 306  LEU B CA  1 
+ATOM   5904 C  C   . LEU B 1 287 ? 54.016  45.665 26.643 1.00 33.86  ? 306  LEU B C   1 
+ATOM   5905 O  O   . LEU B 1 287 ? 53.185  44.766 26.508 1.00 32.27  ? 306  LEU B O   1 
+ATOM   5906 C  CB  . LEU B 1 287 ? 54.413  47.294 24.904 1.00 29.29  ? 306  LEU B CB  1 
+ATOM   5907 C  CG  . LEU B 1 287 ? 54.085  48.565 24.154 1.00 33.32  ? 306  LEU B CG  1 
+ATOM   5908 C  CD1 . LEU B 1 287 ? 55.001  48.641 22.935 1.00 33.01  ? 306  LEU B CD1 1 
+ATOM   5909 C  CD2 . LEU B 1 287 ? 52.619  48.591 23.749 1.00 36.01  ? 306  LEU B CD2 1 
+ATOM   5910 N  N   . ARG B 1 288 ? 55.237  45.479 27.137 1.00 35.00  ? 307  ARG B N   1 
+ATOM   5911 C  CA  . ARG B 1 288 ? 55.727  44.163 27.539 1.00 34.66  ? 307  ARG B CA  1 
+ATOM   5912 C  C   . ARG B 1 288 ? 54.882  43.659 28.687 1.00 31.61  ? 307  ARG B C   1 
+ATOM   5913 O  O   . ARG B 1 288 ? 54.512  42.486 28.757 1.00 30.70  ? 307  ARG B O   1 
+ATOM   5914 C  CB  . ARG B 1 288 ? 57.199  44.263 27.967 1.00 36.21  ? 307  ARG B CB  1 
+ATOM   5915 C  CG  . ARG B 1 288 ? 57.992  42.945 27.982 1.00 37.82  ? 307  ARG B CG  1 
+ATOM   5916 C  CD  . ARG B 1 288 ? 59.269  43.017 28.866 1.00 40.56  ? 307  ARG B CD  1 
+ATOM   5917 N  NE  . ARG B 1 288 ? 59.920  44.310 28.667 1.00 40.58  ? 307  ARG B NE  1 
+ATOM   5918 C  CZ  . ARG B 1 288 ? 60.687  44.938 29.534 1.00 40.84  ? 307  ARG B CZ  1 
+ATOM   5919 N  NH1 . ARG B 1 288 ? 60.978  44.415 30.706 1.00 42.42  ? 307  ARG B NH1 1 
+ATOM   5920 N  NH2 . ARG B 1 288 ? 61.169  46.131 29.215 1.00 51.90  ? 307  ARG B NH2 1 
+ATOM   5921 N  N   . TYR B 1 289 ? 54.554  44.568 29.585 1.00 29.66  ? 308  TYR B N   1 
+ATOM   5922 C  CA  . TYR B 1 289 ? 53.749  44.213 30.731 1.00 28.76  ? 308  TYR B CA  1 
+ATOM   5923 C  C   . TYR B 1 289 ? 52.318  43.949 30.302 1.00 30.66  ? 308  TYR B C   1 
+ATOM   5924 O  O   . TYR B 1 289 ? 51.669  43.038 30.818 1.00 29.93  ? 308  TYR B O   1 
+ATOM   5925 C  CB  . TYR B 1 289 ? 53.806  45.291 31.784 1.00 25.72  ? 308  TYR B CB  1 
+ATOM   5926 C  CG  . TYR B 1 289 ? 54.023  44.774 33.181 1.00 26.21  ? 308  TYR B CG  1 
+ATOM   5927 C  CD1 . TYR B 1 289 ? 54.825  45.476 34.081 1.00 28.70  ? 308  TYR B CD1 1 
+ATOM   5928 C  CD2 . TYR B 1 289 ? 53.409  43.602 33.619 1.00 24.46  ? 308  TYR B CD2 1 
+ATOM   5929 C  CE1 . TYR B 1 289 ? 55.008  45.015 35.373 1.00 29.67  ? 308  TYR B CE1 1 
+ATOM   5930 C  CE2 . TYR B 1 289 ? 53.583  43.143 34.895 1.00 27.23  ? 308  TYR B CE2 1 
+ATOM   5931 C  CZ  . TYR B 1 289 ? 54.384  43.851 35.771 1.00 28.76  ? 308  TYR B CZ  1 
+ATOM   5932 O  OH  . TYR B 1 289 ? 54.544  43.390 37.052 1.00 31.06  ? 308  TYR B OH  1 
+ATOM   5933 N  N   . ALA B 1 290 ? 51.847  44.690 29.307 1.00 29.89  ? 309  ALA B N   1 
+ATOM   5934 C  CA  . ALA B 1 290 ? 50.514  44.434 28.780 1.00 29.36  ? 309  ALA B CA  1 
+ATOM   5935 C  C   . ALA B 1 290 ? 50.369  42.992 28.267 1.00 27.41  ? 309  ALA B C   1 
+ATOM   5936 O  O   . ALA B 1 290 ? 49.407  42.324 28.581 1.00 31.07  ? 309  ALA B O   1 
+ATOM   5937 C  CB  . ALA B 1 290 ? 50.156  45.459 27.704 1.00 28.43  ? 309  ALA B CB  1 
+ATOM   5938 N  N   . LEU B 1 291 ? 51.336  42.504 27.510 1.00 30.30  ? 310  LEU B N   1 
+ATOM   5939 C  CA  . LEU B 1 291 ? 51.239  41.177 26.910 1.00 34.64  ? 310  LEU B CA  1 
+ATOM   5940 C  C   . LEU B 1 291 ? 51.373  40.072 27.953 1.00 35.87  ? 310  LEU B C   1 
+ATOM   5941 O  O   . LEU B 1 291 ? 50.812  38.980 27.799 1.00 35.84  ? 310  LEU B O   1 
+ATOM   5942 C  CB  . LEU B 1 291 ? 52.322  40.978 25.859 1.00 36.77  ? 310  LEU B CB  1 
+ATOM   5943 C  CG  . LEU B 1 291 ? 52.346  41.950 24.682 1.00 41.03  ? 310  LEU B CG  1 
+ATOM   5944 C  CD1 . LEU B 1 291 ? 53.507  41.591 23.758 1.00 45.14  ? 310  LEU B CD1 1 
+ATOM   5945 C  CD2 . LEU B 1 291 ? 51.043  41.895 23.918 1.00 43.92  ? 310  LEU B CD2 1 
+ATOM   5946 N  N   . LEU B 1 292 ? 52.126  40.349 29.006 1.00 35.80  ? 311  LEU B N   1 
+ATOM   5947 C  CA  . LEU B 1 292 ? 52.242  39.399 30.094 1.00 36.94  ? 311  LEU B CA  1 
+ATOM   5948 C  C   . LEU B 1 292 ? 50.881  39.217 30.761 1.00 37.08  ? 311  LEU B C   1 
+ATOM   5949 O  O   . LEU B 1 292 ? 50.458  38.113 31.090 1.00 34.60  ? 311  LEU B O   1 
+ATOM   5950 C  CB  . LEU B 1 292 ? 53.263  39.893 31.127 1.00 36.49  ? 311  LEU B CB  1 
+ATOM   5951 C  CG  . LEU B 1 292 ? 53.419  38.985 32.360 1.00 31.37  ? 311  LEU B CG  1 
+ATOM   5952 C  CD1 . LEU B 1 292 ? 53.669  37.527 31.963 1.00 27.26  ? 311  LEU B CD1 1 
+ATOM   5953 C  CD2 . LEU B 1 292 ? 54.530  39.506 33.221 1.00 28.96  ? 311  LEU B CD2 1 
+ATOM   5954 N  N   . LEU B 1 293 ? 50.197  40.331 30.951 1.00 40.08  ? 312  LEU B N   1 
+ATOM   5955 C  CA  . LEU B 1 293 ? 48.907  40.336 31.622 1.00 37.31  ? 312  LEU B CA  1 
+ATOM   5956 C  C   . LEU B 1 293 ? 47.849  39.680 30.738 1.00 36.05  ? 312  LEU B C   1 
+ATOM   5957 O  O   . LEU B 1 293 ? 46.928  39.065 31.222 1.00 36.18  ? 312  LEU B O   1 
+ATOM   5958 C  CB  . LEU B 1 293 ? 48.531  41.773 31.969 1.00 31.54  ? 312  LEU B CB  1 
+ATOM   5959 C  CG  . LEU B 1 293 ? 49.375  42.307 33.110 1.00 29.55  ? 312  LEU B CG  1 
+ATOM   5960 C  CD1 . LEU B 1 293 ? 49.316  43.825 33.214 1.00 32.48  ? 312  LEU B CD1 1 
+ATOM   5961 C  CD2 . LEU B 1 293 ? 48.962  41.682 34.424 1.00 31.10  ? 312  LEU B CD2 1 
+ATOM   5962 N  N   . LEU B 1 294 ? 48.019  39.794 29.435 1.00 39.14  ? 313  LEU B N   1 
+ATOM   5963 C  CA  . LEU B 1 294 ? 47.069  39.238 28.479 1.00 42.67  ? 313  LEU B CA  1 
+ATOM   5964 C  C   . LEU B 1 294 ? 47.299  37.718 28.321 1.00 42.64  ? 313  LEU B C   1 
+ATOM   5965 O  O   . LEU B 1 294 ? 46.383  36.958 28.003 1.00 42.54  ? 313  LEU B O   1 
+ATOM   5966 C  CB  . LEU B 1 294 ? 47.190  40.006 27.145 1.00 42.81  ? 313  LEU B CB  1 
+ATOM   5967 C  CG  . LEU B 1 294 ? 46.751  41.485 27.133 1.00 40.03  ? 313  LEU B CG  1 
+ATOM   5968 C  CD1 . LEU B 1 294 ? 47.175  42.174 25.866 1.00 41.13  ? 313  LEU B CD1 1 
+ATOM   5969 C  CD2 . LEU B 1 294 ? 45.268  41.614 27.238 1.00 44.82  ? 313  LEU B CD2 1 
+ATOM   5970 N  N   . LEU B 1 295 ? 48.526  37.279 28.575 1.00 44.31  ? 314  LEU B N   1 
+ATOM   5971 C  CA  . LEU B 1 295 ? 48.806  35.851 28.721 1.00 42.72  ? 314  LEU B CA  1 
+ATOM   5972 C  C   . LEU B 1 295 ? 48.191  35.301 29.982 1.00 38.88  ? 314  LEU B C   1 
+ATOM   5973 O  O   . LEU B 1 295 ? 47.608  34.251 29.942 1.00 42.25  ? 314  LEU B O   1 
+ATOM   5974 C  CB  . LEU B 1 295 ? 50.296  35.588 28.820 1.00 42.99  ? 314  LEU B CB  1 
+ATOM   5975 C  CG  . LEU B 1 295 ? 51.105  35.540 27.552 1.00 42.56  ? 314  LEU B CG  1 
+ATOM   5976 C  CD1 . LEU B 1 295 ? 52.547  35.323 27.968 1.00 45.60  ? 314  LEU B CD1 1 
+ATOM   5977 C  CD2 . LEU B 1 295 ? 50.623  34.435 26.621 1.00 42.23  ? 314  LEU B CD2 1 
+ATOM   5978 N  N   . LYS B 1 296 ? 48.360  35.994 31.101 1.00 39.20  ? 315  LYS B N   1 
+ATOM   5979 C  CA  . LYS B 1 296 ? 47.841  35.510 32.380 1.00 45.28  ? 315  LYS B CA  1 
+ATOM   5980 C  C   . LYS B 1 296 ? 46.317  35.526 32.433 1.00 46.86  ? 315  LYS B C   1 
+ATOM   5981 O  O   . LYS B 1 296 ? 45.714  34.706 33.127 1.00 48.68  ? 315  LYS B O   1 
+ATOM   5982 C  CB  . LYS B 1 296 ? 48.381  36.308 33.576 1.00 44.53  ? 315  LYS B CB  1 
+ATOM   5983 C  CG  . LYS B 1 296 ? 47.820  35.784 34.910 1.00 47.88  ? 315  LYS B CG  1 
+ATOM   5984 C  CD  . LYS B 1 296 ? 48.754  36.014 36.067 1.00 52.84  ? 315  LYS B CD  1 
+ATOM   5985 C  CE  . LYS B 1 296 ? 48.343  35.219 37.306 1.00 56.01  ? 315  LYS B CE  1 
+ATOM   5986 N  NZ  . LYS B 1 296 ? 48.780  33.783 37.264 1.00 57.08  ? 315  LYS B NZ  1 
+ATOM   5987 N  N   . HIS B 1 297 ? 45.707  36.457 31.704 1.00 48.03  ? 316  HIS B N   1 
+ATOM   5988 C  CA  . HIS B 1 297 ? 44.263  36.652 31.738 1.00 47.77  ? 316  HIS B CA  1 
+ATOM   5989 C  C   . HIS B 1 297 ? 43.668  36.396 30.331 1.00 49.33  ? 316  HIS B C   1 
+ATOM   5990 O  O   . HIS B 1 297 ? 43.322  37.316 29.609 1.00 48.74  ? 316  HIS B O   1 
+ATOM   5991 C  CB  . HIS B 1 297 ? 43.942  38.042 32.287 1.00 44.95  ? 316  HIS B CB  1 
+ATOM   5992 C  CG  . HIS B 1 297 ? 44.509  38.299 33.654 1.00 43.68  ? 316  HIS B CG  1 
+ATOM   5993 N  ND1 . HIS B 1 297 ? 43.828  38.000 34.810 1.00 43.30  ? 316  HIS B ND1 1 
+ATOM   5994 C  CD2 . HIS B 1 297 ? 45.690  38.839 34.048 1.00 44.83  ? 316  HIS B CD2 1 
+ATOM   5995 C  CE1 . HIS B 1 297 ? 44.555  38.355 35.858 1.00 41.75  ? 316  HIS B CE1 1 
+ATOM   5996 N  NE2 . HIS B 1 297 ? 45.692  38.866 35.422 1.00 40.58  ? 316  HIS B NE2 1 
+ATOM   5997 N  N   . PRO B 1 298 ? 43.583  35.128 29.928 1.00 54.10  ? 317  PRO B N   1 
+ATOM   5998 C  CA  . PRO B 1 298 ? 43.051  34.795 28.603 1.00 54.52  ? 317  PRO B CA  1 
+ATOM   5999 C  C   . PRO B 1 298 ? 41.611  35.237 28.405 1.00 56.08  ? 317  PRO B C   1 
+ATOM   6000 O  O   . PRO B 1 298 ? 41.263  35.526 27.283 1.00 54.33  ? 317  PRO B O   1 
+ATOM   6001 C  CB  . PRO B 1 298 ? 43.166  33.267 28.551 1.00 52.87  ? 317  PRO B CB  1 
+ATOM   6002 C  CG  . PRO B 1 298 ? 43.252  32.840 29.956 1.00 51.93  ? 317  PRO B CG  1 
+ATOM   6003 C  CD  . PRO B 1 298 ? 43.999  33.913 30.664 1.00 52.95  ? 317  PRO B CD  1 
+ATOM   6004 N  N   . GLU B 1 299 ? 40.796  35.274 29.455 1.00 59.96  ? 318  GLU B N   1 
+ATOM   6005 C  CA  . GLU B 1 299 ? 39.414  35.761 29.342 1.00 62.84  ? 318  GLU B CA  1 
+ATOM   6006 C  C   . GLU B 1 299 ? 39.334  37.226 28.916 1.00 57.99  ? 318  GLU B C   1 
+ATOM   6007 O  O   . GLU B 1 299 ? 38.493  37.612 28.107 1.00 59.79  ? 318  GLU B O   1 
+ATOM   6008 C  CB  . GLU B 1 299 ? 38.701  35.644 30.684 1.00 68.33  ? 318  GLU B CB  1 
+ATOM   6009 C  CG  . GLU B 1 299 ? 38.151  34.262 30.985 1.00 75.43  ? 318  GLU B CG  1 
+ATOM   6010 C  CD  . GLU B 1 299 ? 38.009  34.018 32.479 1.00 82.96  ? 318  GLU B CD  1 
+ATOM   6011 O  OE1 . GLU B 1 299 ? 37.444  32.967 32.859 1.00 87.35  ? 318  GLU B OE1 1 
+ATOM   6012 O  OE2 . GLU B 1 299 ? 38.468  34.876 33.278 1.00 88.63  ? 318  GLU B OE2 1 
+ATOM   6013 N  N   . VAL B 1 300 ? 40.190  38.041 29.509 1.00 51.89  ? 319  VAL B N   1 
+ATOM   6014 C  CA  . VAL B 1 300 ? 40.272  39.445 29.173 1.00 48.11  ? 319  VAL B CA  1 
+ATOM   6015 C  C   . VAL B 1 300 ? 40.693  39.612 27.717 1.00 47.51  ? 319  VAL B C   1 
+ATOM   6016 O  O   . VAL B 1 300 ? 40.116  40.395 26.960 1.00 48.97  ? 319  VAL B O   1 
+ATOM   6017 C  CB  . VAL B 1 300 ? 41.300  40.141 30.052 1.00 46.50  ? 319  VAL B CB  1 
+ATOM   6018 C  CG1 . VAL B 1 300 ? 41.499  41.600 29.593 1.00 44.79  ? 319  VAL B CG1 1 
+ATOM   6019 C  CG2 . VAL B 1 300 ? 40.879  40.055 31.526 1.00 45.81  ? 319  VAL B CG2 1 
+ATOM   6020 N  N   . THR B 1 301 ? 41.704  38.865 27.322 1.00 43.71  ? 320  THR B N   1 
+ATOM   6021 C  CA  . THR B 1 301 ? 42.178  38.929 25.960 1.00 43.54  ? 320  THR B CA  1 
+ATOM   6022 C  C   . THR B 1 301 ? 41.099  38.610 24.930 1.00 42.70  ? 320  THR B C   1 
+ATOM   6023 O  O   . THR B 1 301 ? 40.999  39.275 23.909 1.00 44.80  ? 320  THR B O   1 
+ATOM   6024 C  CB  . THR B 1 301 ? 43.376  38.018 25.839 1.00 42.83  ? 320  THR B CB  1 
+ATOM   6025 O  OG1 . THR B 1 301 ? 44.453  38.628 26.557 1.00 45.66  ? 320  THR B OG1 1 
+ATOM   6026 C  CG2 . THR B 1 301 ? 43.879  37.889 24.397 1.00 39.81  ? 320  THR B CG2 1 
+ATOM   6027 N  N   . ALA B 1 302 ? 40.272  37.614 25.207 1.00 44.93  ? 321  ALA B N   1 
+ATOM   6028 C  CA  . ALA B 1 302 ? 39.246  37.196 24.249 1.00 46.10  ? 321  ALA B CA  1 
+ATOM   6029 C  C   . ALA B 1 302 ? 38.196  38.279 24.066 1.00 46.26  ? 321  ALA B C   1 
+ATOM   6030 O  O   . ALA B 1 302 ? 37.777  38.527 22.933 1.00 48.24  ? 321  ALA B O   1 
+ATOM   6031 C  CB  . ALA B 1 302 ? 38.593  35.905 24.674 1.00 44.12  ? 321  ALA B CB  1 
+ATOM   6032 N  N   . LYS B 1 303 ? 37.786  38.925 25.160 1.00 43.98  ? 322  LYS B N   1 
+ATOM   6033 C  CA  . LYS B 1 303 ? 36.810  40.016 25.067 1.00 46.81  ? 322  LYS B CA  1 
+ATOM   6034 C  C   . LYS B 1 303 ? 37.344  41.189 24.227 1.00 44.92  ? 322  LYS B C   1 
+ATOM   6035 O  O   . LYS B 1 303 ? 36.594  41.794 23.442 1.00 42.91  ? 322  LYS B O   1 
+ATOM   6036 C  CB  . LYS B 1 303 ? 36.374  40.502 26.451 1.00 46.38  ? 322  LYS B CB  1 
+ATOM   6037 C  CG  . LYS B 1 303 ? 35.365  39.603 27.114 1.00 48.81  ? 322  LYS B CG  1 
+ATOM   6038 C  CD  . LYS B 1 303 ? 34.779  40.262 28.355 1.00 52.57  ? 322  LYS B CD  1 
+ATOM   6039 C  CE  . LYS B 1 303 ? 34.453  39.232 29.420 1.00 54.91  ? 322  LYS B CE  1 
+ATOM   6040 N  NZ  . LYS B 1 303 ? 33.454  39.784 30.380 1.00 60.48  ? 322  LYS B NZ  1 
+ATOM   6041 N  N   . VAL B 1 304 ? 38.633  41.488 24.396 1.00 41.09  ? 323  VAL B N   1 
+ATOM   6042 C  CA  . VAL B 1 304 ? 39.326  42.478 23.570 1.00 37.70  ? 323  VAL B CA  1 
+ATOM   6043 C  C   . VAL B 1 304 ? 39.325  42.062 22.096 1.00 40.36  ? 323  VAL B C   1 
+ATOM   6044 O  O   . VAL B 1 304 ? 39.181  42.902 21.194 1.00 42.66  ? 323  VAL B O   1 
+ATOM   6045 C  CB  . VAL B 1 304 ? 40.786  42.689 24.034 1.00 32.10  ? 323  VAL B CB  1 
+ATOM   6046 C  CG1 . VAL B 1 304 ? 41.588  43.486 23.006 1.00 31.21  ? 323  VAL B CG1 1 
+ATOM   6047 C  CG2 . VAL B 1 304 ? 40.806  43.381 25.366 1.00 31.20  ? 323  VAL B CG2 1 
+ATOM   6048 N  N   . GLN B 1 305 ? 39.499  40.780 21.833 1.00 40.69  ? 324  GLN B N   1 
+ATOM   6049 C  CA  . GLN B 1 305 ? 39.479  40.345 20.452 1.00 42.94  ? 324  GLN B CA  1 
+ATOM   6050 C  C   . GLN B 1 305 ? 38.068  40.466 19.861 1.00 45.79  ? 324  GLN B C   1 
+ATOM   6051 O  O   . GLN B 1 305 ? 37.965  40.738 18.664 1.00 45.30  ? 324  GLN B O   1 
+ATOM   6052 C  CB  . GLN B 1 305 ? 40.108  38.955 20.272 1.00 41.53  ? 324  GLN B CB  1 
+ATOM   6053 C  CG  . GLN B 1 305 ? 41.589  39.059 19.908 1.00 40.85  ? 324  GLN B CG  1 
+ATOM   6054 C  CD  . GLN B 1 305 ? 42.383  37.785 20.114 1.00 44.29  ? 324  GLN B CD  1 
+ATOM   6055 O  OE1 . GLN B 1 305 ? 43.375  37.566 19.429 1.00 44.23  ? 324  GLN B OE1 1 
+ATOM   6056 N  NE2 . GLN B 1 305 ? 41.965  36.956 21.064 1.00 43.10  ? 324  GLN B NE2 1 
+ATOM   6057 N  N   . GLU B 1 306 ? 37.005  40.312 20.680 1.00 47.59  ? 325  GLU B N   1 
+ATOM   6058 C  CA  . GLU B 1 306 ? 35.609  40.424 20.186 1.00 51.73  ? 325  GLU B CA  1 
+ATOM   6059 C  C   . GLU B 1 306 ? 35.401  41.835 19.672 1.00 51.42  ? 325  GLU B C   1 
+ATOM   6060 O  O   . GLU B 1 306 ? 34.987  42.042 18.534 1.00 50.44  ? 325  GLU B O   1 
+ATOM   6061 C  CB  . GLU B 1 306 ? 34.546  40.171 21.272 1.00 57.74  ? 325  GLU B CB  1 
+ATOM   6062 C  CG  . GLU B 1 306 ? 34.251  38.717 21.651 1.00 64.44  ? 325  GLU B CG  1 
+ATOM   6063 C  CD  . GLU B 1 306 ? 33.438  38.589 22.967 1.00 71.38  ? 325  GLU B CD  1 
+ATOM   6064 O  OE1 . GLU B 1 306 ? 33.973  38.078 23.999 1.00 70.36  ? 325  GLU B OE1 1 
+ATOM   6065 O  OE2 . GLU B 1 306 ? 32.249  38.999 22.981 1.00 74.79  ? 325  GLU B OE2 1 
+ATOM   6066 N  N   . GLU B 1 307 ? 35.694  42.803 20.533 1.00 49.00  ? 326  GLU B N   1 
+ATOM   6067 C  CA  . GLU B 1 307 ? 35.717  44.202 20.150 1.00 49.23  ? 326  GLU B CA  1 
+ATOM   6068 C  C   . GLU B 1 307 ? 36.516  44.455 18.875 1.00 49.61  ? 326  GLU B C   1 
+ATOM   6069 O  O   . GLU B 1 307 ? 36.063  45.207 18.010 1.00 53.26  ? 326  GLU B O   1 
+ATOM   6070 C  CB  . GLU B 1 307 ? 36.263  45.071 21.289 1.00 50.78  ? 326  GLU B CB  1 
+ATOM   6071 C  CG  . GLU B 1 307 ? 35.263  45.269 22.424 1.00 53.03  ? 326  GLU B CG  1 
+ATOM   6072 C  CD  . GLU B 1 307 ? 35.499  46.535 23.218 1.00 54.81  ? 326  GLU B CD  1 
+ATOM   6073 O  OE1 . GLU B 1 307 ? 34.564  46.972 23.918 1.00 55.68  ? 326  GLU B OE1 1 
+ATOM   6074 O  OE2 . GLU B 1 307 ? 36.613  47.088 23.153 1.00 57.25  ? 326  GLU B OE2 1 
+ATOM   6075 N  N   . ILE B 1 308 ? 37.686  43.840 18.729 1.00 49.05  ? 327  ILE B N   1 
+ATOM   6076 C  CA  . ILE B 1 308 ? 38.459  44.071 17.515 1.00 49.13  ? 327  ILE B CA  1 
+ATOM   6077 C  C   . ILE B 1 308 ? 37.765  43.466 16.276 1.00 52.37  ? 327  ILE B C   1 
+ATOM   6078 O  O   . ILE B 1 308 ? 37.618  44.162 15.284 1.00 53.70  ? 327  ILE B O   1 
+ATOM   6079 C  CB  . ILE B 1 308 ? 39.927  43.628 17.657 1.00 48.28  ? 327  ILE B CB  1 
+ATOM   6080 C  CG1 . ILE B 1 308 ? 40.657  44.503 18.684 1.00 44.91  ? 327  ILE B CG1 1 
+ATOM   6081 C  CG2 . ILE B 1 308 ? 40.660  43.736 16.319 1.00 45.94  ? 327  ILE B CG2 1 
+ATOM   6082 C  CD1 . ILE B 1 308 ? 41.939  43.879 19.216 1.00 41.80  ? 327  ILE B CD1 1 
+ATOM   6083 N  N   . GLU B 1 309 ? 37.297  42.215 16.335 1.00 54.56  ? 328  GLU B N   1 
+ATOM   6084 C  CA  . GLU B 1 309 ? 36.585  41.605 15.193 1.00 56.63  ? 328  GLU B CA  1 
+ATOM   6085 C  C   . GLU B 1 309 ? 35.366  42.411 14.730 1.00 56.31  ? 328  GLU B C   1 
+ATOM   6086 O  O   . GLU B 1 309 ? 35.072  42.453 13.540 1.00 56.03  ? 328  GLU B O   1 
+ATOM   6087 C  CB  . GLU B 1 309 ? 36.124  40.177 15.508 1.00 60.16  ? 328  GLU B CB  1 
+ATOM   6088 C  CG  . GLU B 1 309 ? 37.166  39.098 15.244 1.00 67.68  ? 328  GLU B CG  1 
+ATOM   6089 C  CD  . GLU B 1 309 ? 37.258  38.695 13.777 1.00 75.82  ? 328  GLU B CD  1 
+ATOM   6090 O  OE1 . GLU B 1 309 ? 37.581  37.510 13.517 1.00 80.86  ? 328  GLU B OE1 1 
+ATOM   6091 O  OE2 . GLU B 1 309 ? 37.020  39.551 12.878 1.00 80.83  ? 328  GLU B OE2 1 
+ATOM   6092 N  N   . ARG B 1 310 ? 34.678  43.056 15.675 1.00 55.54  ? 329  ARG B N   1 
+ATOM   6093 C  CA  . ARG B 1 310 ? 33.396  43.706 15.427 1.00 51.95  ? 329  ARG B CA  1 
+ATOM   6094 C  C   . ARG B 1 310 ? 33.532  45.161 14.974 1.00 50.23  ? 329  ARG B C   1 
+ATOM   6095 O  O   . ARG B 1 310 ? 32.888  45.562 14.015 1.00 52.14  ? 329  ARG B O   1 
+ATOM   6096 C  CB  . ARG B 1 310 ? 32.563  43.649 16.698 1.00 53.35  ? 329  ARG B CB  1 
+ATOM   6097 C  CG  . ARG B 1 310 ? 31.133  44.137 16.560 1.00 53.54  ? 329  ARG B CG  1 
+ATOM   6098 C  CD  . ARG B 1 310 ? 30.235  43.641 17.673 1.00 53.07  ? 329  ARG B CD  1 
+ATOM   6099 N  NE  . ARG B 1 310 ? 30.943  43.662 18.948 1.00 55.73  ? 329  ARG B NE  1 
+ATOM   6100 C  CZ  . ARG B 1 310 ? 31.198  44.760 19.666 1.00 55.55  ? 329  ARG B CZ  1 
+ATOM   6101 N  NH1 . ARG B 1 310 ? 31.876  44.656 20.809 1.00 53.37  ? 329  ARG B NH1 1 
+ATOM   6102 N  NH2 . ARG B 1 310 ? 30.786  45.958 19.256 1.00 53.68  ? 329  ARG B NH2 1 
+ATOM   6103 N  N   . VAL B 1 311 ? 34.357  45.944 15.660 1.00 45.19  ? 330  VAL B N   1 
+ATOM   6104 C  CA  . VAL B 1 311 ? 34.509  47.374 15.361 1.00 44.83  ? 330  VAL B CA  1 
+ATOM   6105 C  C   . VAL B 1 311 ? 35.473  47.618 14.195 1.00 47.84  ? 330  VAL B C   1 
+ATOM   6106 O  O   . VAL B 1 311 ? 35.306  48.561 13.396 1.00 45.31  ? 330  VAL B O   1 
+ATOM   6107 C  CB  . VAL B 1 311 ? 35.063  48.148 16.584 1.00 42.37  ? 330  VAL B CB  1 
+ATOM   6108 C  CG1 . VAL B 1 311 ? 35.317  49.609 16.225 1.00 39.33  ? 330  VAL B CG1 1 
+ATOM   6109 C  CG2 . VAL B 1 311 ? 34.125  48.036 17.771 1.00 40.05  ? 330  VAL B CG2 1 
+ATOM   6110 N  N   . ILE B 1 312 ? 36.517  46.795 14.165 1.00 51.01  ? 331  ILE B N   1 
+ATOM   6111 C  CA  . ILE B 1 312 ? 37.516  46.769 13.097 1.00 52.82  ? 331  ILE B CA  1 
+ATOM   6112 C  C   . ILE B 1 312 ? 37.365  45.445 12.335 1.00 56.51  ? 331  ILE B C   1 
+ATOM   6113 O  O   . ILE B 1 312 ? 36.986  44.416 12.902 1.00 59.42  ? 331  ILE B O   1 
+ATOM   6114 C  CB  . ILE B 1 312 ? 38.943  46.904 13.724 1.00 50.59  ? 331  ILE B CB  1 
+ATOM   6115 C  CG1 . ILE B 1 312 ? 39.015  48.142 14.636 1.00 48.52  ? 331  ILE B CG1 1 
+ATOM   6116 C  CG2 . ILE B 1 312 ? 39.999  47.008 12.646 1.00 50.48  ? 331  ILE B CG2 1 
+ATOM   6117 C  CD1 . ILE B 1 312 ? 40.127  48.117 15.684 1.00 49.03  ? 331  ILE B CD1 1 
+ATOM   6118 N  N   . GLY B 1 313 ? 37.639  45.434 11.048 1.00 60.33  ? 332  GLY B N   1 
+ATOM   6119 C  CA  . GLY B 1 313 ? 37.641  44.152 10.362 1.00 63.25  ? 332  GLY B CA  1 
+ATOM   6120 C  C   . GLY B 1 313 ? 38.836  43.301 10.774 1.00 63.78  ? 332  GLY B C   1 
+ATOM   6121 O  O   . GLY B 1 313 ? 39.479  43.550 11.789 1.00 57.35  ? 332  GLY B O   1 
+ATOM   6122 N  N   . ARG B 1 314 ? 39.122  42.278 9.979  1.00 68.79  ? 333  ARG B N   1 
+ATOM   6123 C  CA  . ARG B 1 314 ? 40.450  41.679 9.973  1.00 72.05  ? 333  ARG B CA  1 
+ATOM   6124 C  C   . ARG B 1 314 ? 41.287  42.416 8.930  1.00 72.07  ? 333  ARG B C   1 
+ATOM   6125 O  O   . ARG B 1 314 ? 42.514  42.401 8.998  1.00 72.21  ? 333  ARG B O   1 
+ATOM   6126 C  CB  . ARG B 1 314 ? 40.386  40.178 9.658  1.00 75.29  ? 333  ARG B CB  1 
+ATOM   6127 C  CG  . ARG B 1 314 ? 40.587  39.275 10.878 1.00 80.45  ? 333  ARG B CG  1 
+ATOM   6128 C  CD  . ARG B 1 314 ? 41.294  37.953 10.579 1.00 84.54  ? 333  ARG B CD  1 
+ATOM   6129 N  NE  . ARG B 1 314 ? 40.838  36.877 11.464 1.00 90.01  ? 333  ARG B NE  1 
+ATOM   6130 C  CZ  . ARG B 1 314 ? 39.666  36.235 11.364 1.00 94.47  ? 333  ARG B CZ  1 
+ATOM   6131 N  NH1 . ARG B 1 314 ? 38.771  36.541 10.418 1.00 96.99  ? 333  ARG B NH1 1 
+ATOM   6132 N  NH2 . ARG B 1 314 ? 39.381  35.274 12.236 1.00 95.05  ? 333  ARG B NH2 1 
+ATOM   6133 N  N   . ASN B 1 315 ? 40.612  43.083 7.990  1.00 71.97  ? 334  ASN B N   1 
+ATOM   6134 C  CA  . ASN B 1 315 ? 41.276  43.711 6.847  1.00 72.04  ? 334  ASN B CA  1 
+ATOM   6135 C  C   . ASN B 1 315 ? 42.011  44.994 7.222  1.00 67.53  ? 334  ASN B C   1 
+ATOM   6136 O  O   . ASN B 1 315 ? 43.239  45.000 7.253  1.00 68.52  ? 334  ASN B O   1 
+ATOM   6137 C  CB  . ASN B 1 315 ? 40.281  43.978 5.701  1.00 73.89  ? 334  ASN B CB  1 
+ATOM   6138 C  CG  . ASN B 1 315 ? 39.644  42.699 5.168  1.00 76.22  ? 334  ASN B CG  1 
+ATOM   6139 O  OD1 . ASN B 1 315 ? 38.437  42.652 4.911  1.00 80.28  ? 334  ASN B OD1 1 
+ATOM   6140 N  ND2 . ASN B 1 315 ? 40.448  41.650 5.017  1.00 75.92  ? 334  ASN B ND2 1 
+ATOM   6141 N  N   . ARG B 1 316 ? 41.279  46.070 7.515  1.00 60.88  ? 335  ARG B N   1 
+ATOM   6142 C  CA  . ARG B 1 316 ? 41.921  47.364 7.779  1.00 55.97  ? 335  ARG B CA  1 
+ATOM   6143 C  C   . ARG B 1 316 ? 42.638  47.446 9.129  1.00 54.90  ? 335  ARG B C   1 
+ATOM   6144 O  O   . ARG B 1 316 ? 42.315  46.741 10.104 1.00 52.17  ? 335  ARG B O   1 
+ATOM   6145 C  CB  . ARG B 1 316 ? 40.933  48.523 7.668  1.00 54.56  ? 335  ARG B CB  1 
+ATOM   6146 C  CG  . ARG B 1 316 ? 39.811  48.529 8.684  1.00 51.91  ? 335  ARG B CG  1 
+ATOM   6147 C  CD  . ARG B 1 316 ? 38.986  49.796 8.621  1.00 54.15  ? 335  ARG B CD  1 
+ATOM   6148 N  NE  . ARG B 1 316 ? 39.018  50.508 9.892  1.00 55.24  ? 335  ARG B NE  1 
+ATOM   6149 C  CZ  . ARG B 1 316 ? 38.210  50.270 10.902 1.00 52.39  ? 335  ARG B CZ  1 
+ATOM   6150 N  NH1 . ARG B 1 316 ? 37.264  49.345 10.812 1.00 60.64  ? 335  ARG B NH1 1 
+ATOM   6151 N  NH2 . ARG B 1 316 ? 38.344  50.957 12.007 1.00 47.19  ? 335  ARG B NH2 1 
+ATOM   6152 N  N   . SER B 1 317 ? 43.617  48.334 9.175  1.00 50.64  ? 336  SER B N   1 
+ATOM   6153 C  CA  . SER B 1 317 ? 44.401  48.503 10.378 1.00 49.64  ? 336  SER B CA  1 
+ATOM   6154 C  C   . SER B 1 317 ? 43.649  49.419 11.374 1.00 45.36  ? 336  SER B C   1 
+ATOM   6155 O  O   . SER B 1 317 ? 42.806  50.242 10.969 1.00 44.10  ? 336  SER B O   1 
+ATOM   6156 C  CB  . SER B 1 317 ? 45.808  49.010 10.015 1.00 51.18  ? 336  SER B CB  1 
+ATOM   6157 O  OG  . SER B 1 317 ? 45.860  50.413 10.001 1.00 52.19  ? 336  SER B OG  1 
+ATOM   6158 N  N   . PRO B 1 318 ? 43.884  49.236 12.672 1.00 39.02  ? 337  PRO B N   1 
+ATOM   6159 C  CA  . PRO B 1 318 ? 43.179  50.032 13.687 1.00 36.79  ? 337  PRO B CA  1 
+ATOM   6160 C  C   . PRO B 1 318 ? 43.581  51.467 13.611 1.00 32.90  ? 337  PRO B C   1 
+ATOM   6161 O  O   . PRO B 1 318 ? 44.591  51.757 12.978 1.00 31.41  ? 337  PRO B O   1 
+ATOM   6162 C  CB  . PRO B 1 318 ? 43.636  49.419 15.004 1.00 39.79  ? 337  PRO B CB  1 
+ATOM   6163 C  CG  . PRO B 1 318 ? 44.065  48.018 14.604 1.00 41.37  ? 337  PRO B CG  1 
+ATOM   6164 C  CD  . PRO B 1 318 ? 44.760  48.232 13.286 1.00 38.31  ? 337  PRO B CD  1 
+ATOM   6165 N  N   . CYS B 1 319 ? 42.765  52.333 14.198 1.00 31.34  ? 338  CYS B N   1 
+ATOM   6166 C  CA  . CYS B 1 319 ? 43.050  53.767 14.302 1.00 33.19  ? 338  CYS B CA  1 
+ATOM   6167 C  C   . CYS B 1 319 ? 42.376  54.321 15.540 1.00 31.25  ? 338  CYS B C   1 
+ATOM   6168 O  O   . CYS B 1 319 ? 41.558  53.650 16.156 1.00 33.29  ? 338  CYS B O   1 
+ATOM   6169 C  CB  . CYS B 1 319 ? 42.604  54.519 13.061 1.00 33.40  ? 338  CYS B CB  1 
+ATOM   6170 S  SG  . CYS B 1 319 ? 40.819  54.752 12.978 1.00 41.64  ? 338  CYS B SG  1 
+ATOM   6171 N  N   . MET B 1 320 ? 42.748  55.531 15.923 1.00 33.28  ? 339  MET B N   1 
+ATOM   6172 C  CA  . MET B 1 320 ? 42.302  56.097 17.192 1.00 33.94  ? 339  MET B CA  1 
+ATOM   6173 C  C   . MET B 1 320 ? 40.780  56.254 17.297 1.00 36.78  ? 339  MET B C   1 
+ATOM   6174 O  O   . MET B 1 320 ? 40.210  56.151 18.381 1.00 36.23  ? 339  MET B O   1 
+ATOM   6175 C  CB  . MET B 1 320 ? 42.988  57.445 17.419 1.00 34.41  ? 339  MET B CB  1 
+ATOM   6176 C  CG  . MET B 1 320 ? 44.480  57.338 17.716 1.00 35.79  ? 339  MET B CG  1 
+ATOM   6177 S  SD  . MET B 1 320 ? 44.792  56.018 18.892 1.00 36.24  ? 339  MET B SD  1 
+ATOM   6178 C  CE  . MET B 1 320 ? 44.226  56.678 20.362 1.00 39.22  ? 339  MET B CE  1 
+ATOM   6179 N  N   . GLN B 1 321 ? 40.120  56.498 16.170 1.00 41.14  ? 340  GLN B N   1 
+ATOM   6180 C  CA  . GLN B 1 321 ? 38.672  56.689 16.166 1.00 41.45  ? 340  GLN B CA  1 
+ATOM   6181 C  C   . GLN B 1 321 ? 37.947  55.467 16.698 1.00 41.44  ? 340  GLN B C   1 
+ATOM   6182 O  O   . GLN B 1 321 ? 36.864  55.612 17.256 1.00 44.50  ? 340  GLN B O   1 
+ATOM   6183 C  CB  . GLN B 1 321 ? 38.145  57.037 14.765 1.00 44.15  ? 340  GLN B CB  1 
+ATOM   6184 C  CG  . GLN B 1 321 ? 37.870  58.535 14.569 1.00 47.15  ? 340  GLN B CG  1 
+ATOM   6185 C  CD  . GLN B 1 321 ? 37.539  58.884 13.123 1.00 49.99  ? 340  GLN B CD  1 
+ATOM   6186 O  OE1 . GLN B 1 321 ? 36.647  58.275 12.525 1.00 51.07  ? 340  GLN B OE1 1 
+ATOM   6187 N  NE2 . GLN B 1 321 ? 38.253  59.867 12.562 1.00 46.81  ? 340  GLN B NE2 1 
+ATOM   6188 N  N   . ASP B 1 322 ? 38.536  54.281 16.538 1.00 36.37  ? 341  ASP B N   1 
+ATOM   6189 C  CA  . ASP B 1 322 ? 37.915  53.042 17.017 1.00 38.63  ? 341  ASP B CA  1 
+ATOM   6190 C  C   . ASP B 1 322 ? 37.806  52.883 18.523 1.00 38.43  ? 341  ASP B C   1 
+ATOM   6191 O  O   . ASP B 1 322 ? 37.096  51.992 19.001 1.00 33.70  ? 341  ASP B O   1 
+ATOM   6192 C  CB  . ASP B 1 322 ? 38.650  51.816 16.474 1.00 40.50  ? 341  ASP B CB  1 
+ATOM   6193 C  CG  . ASP B 1 322 ? 38.762  51.838 14.968 1.00 41.40  ? 341  ASP B CG  1 
+ATOM   6194 O  OD1 . ASP B 1 322 ? 37.776  52.263 14.320 1.00 42.18  ? 341  ASP B OD1 1 
+ATOM   6195 O  OD2 . ASP B 1 322 ? 39.784  51.472 14.357 1.00 36.42  ? 341  ASP B OD2 1 
+ATOM   6196 N  N   . ARG B 1 323 ? 38.504  53.725 19.272 1.00 37.87  ? 342  ARG B N   1 
+ATOM   6197 C  CA  . ARG B 1 323 ? 38.649  53.489 20.692 1.00 39.28  ? 342  ARG B CA  1 
+ATOM   6198 C  C   . ARG B 1 323 ? 37.393  53.886 21.469 1.00 41.11  ? 342  ARG B C   1 
+ATOM   6199 O  O   . ARG B 1 323 ? 37.026  53.219 22.437 1.00 41.10  ? 342  ARG B O   1 
+ATOM   6200 C  CB  . ARG B 1 323 ? 39.903  54.183 21.227 1.00 39.17  ? 342  ARG B CB  1 
+ATOM   6201 C  CG  . ARG B 1 323 ? 40.089  53.995 22.719 1.00 37.38  ? 342  ARG B CG  1 
+ATOM   6202 C  CD  . ARG B 1 323 ? 41.400  54.421 23.211 1.00 39.19  ? 342  ARG B CD  1 
+ATOM   6203 N  NE  . ARG B 1 323 ? 41.615  55.844 23.008 1.00 39.45  ? 342  ARG B NE  1 
+ATOM   6204 C  CZ  . ARG B 1 323 ? 42.608  56.528 23.544 1.00 38.41  ? 342  ARG B CZ  1 
+ATOM   6205 N  NH1 . ARG B 1 323 ? 43.496  55.922 24.326 1.00 39.77  ? 342  ARG B NH1 1 
+ATOM   6206 N  NH2 . ARG B 1 323 ? 42.715  57.829 23.298 1.00 37.59  ? 342  ARG B NH2 1 
+ATOM   6207 N  N   . SER B 1 324 ? 36.737  54.956 21.034 1.00 44.29  ? 343  SER B N   1 
+ATOM   6208 C  CA  . SER B 1 324 ? 35.395  55.314 21.513 1.00 47.12  ? 343  SER B CA  1 
+ATOM   6209 C  C   . SER B 1 324 ? 34.382  54.163 21.406 1.00 43.28  ? 343  SER B C   1 
+ATOM   6210 O  O   . SER B 1 324 ? 33.567  53.976 22.303 1.00 48.73  ? 343  SER B O   1 
+ATOM   6211 C  CB  . SER B 1 324 ? 34.868  56.526 20.744 1.00 49.96  ? 343  SER B CB  1 
+ATOM   6212 O  OG  . SER B 1 324 ? 34.690  56.202 19.370 1.00 59.03  ? 343  SER B OG  1 
+ATOM   6213 N  N   . HIS B 1 325 ? 34.451  53.385 20.334 1.00 41.65  ? 344  HIS B N   1 
+ATOM   6214 C  CA  . HIS B 1 325 ? 33.577  52.205 20.163 1.00 45.79  ? 344  HIS B CA  1 
+ATOM   6215 C  C   . HIS B 1 325 ? 34.143  50.924 20.797 1.00 44.26  ? 344  HIS B C   1 
+ATOM   6216 O  O   . HIS B 1 325 ? 33.556  49.852 20.656 1.00 43.11  ? 344  HIS B O   1 
+ATOM   6217 C  CB  . HIS B 1 325 ? 33.254  51.962 18.661 1.00 47.84  ? 344  HIS B CB  1 
+ATOM   6218 C  CG  . HIS B 1 325 ? 32.834  53.206 17.940 1.00 50.49  ? 344  HIS B CG  1 
+ATOM   6219 N  ND1 . HIS B 1 325 ? 32.015  54.155 18.518 1.00 55.44  ? 344  HIS B ND1 1 
+ATOM   6220 C  CD2 . HIS B 1 325 ? 33.166  53.690 16.722 1.00 52.06  ? 344  HIS B CD2 1 
+ATOM   6221 C  CE1 . HIS B 1 325 ? 31.852  55.165 17.682 1.00 53.22  ? 344  HIS B CE1 1 
+ATOM   6222 N  NE2 . HIS B 1 325 ? 32.536  54.907 16.583 1.00 52.02  ? 344  HIS B NE2 1 
+ATOM   6223 N  N   . MET B 1 326 ? 35.266  51.043 21.506 1.00 42.99  ? 345  MET B N   1 
+ATOM   6224 C  CA  . MET B 1 326 ? 35.953  49.886 22.069 1.00 42.46  ? 345  MET B CA  1 
+ATOM   6225 C  C   . MET B 1 326 ? 36.273  50.092 23.555 1.00 42.23  ? 345  MET B C   1 
+ATOM   6226 O  O   . MET B 1 326 ? 37.422  50.057 23.972 1.00 40.47  ? 345  MET B O   1 
+ATOM   6227 C  CB  . MET B 1 326 ? 37.233  49.623 21.292 1.00 40.38  ? 345  MET B CB  1 
+ATOM   6228 C  CG  . MET B 1 326 ? 37.006  49.006 19.963 1.00 36.72  ? 345  MET B CG  1 
+ATOM   6229 S  SD  . MET B 1 326 ? 38.515  49.011 19.010 1.00 34.57  ? 345  MET B SD  1 
+ATOM   6230 C  CE  . MET B 1 326 ? 38.974  47.310 19.258 1.00 36.27  ? 345  MET B CE  1 
+ATOM   6231 N  N   . PRO B 1 327 ? 35.236  50.258 24.360 1.00 41.15  ? 346  PRO B N   1 
+ATOM   6232 C  CA  . PRO B 1 327 ? 35.404  50.659 25.756 1.00 38.60  ? 346  PRO B CA  1 
+ATOM   6233 C  C   . PRO B 1 327 ? 36.115  49.616 26.615 1.00 37.80  ? 346  PRO B C   1 
+ATOM   6234 O  O   . PRO B 1 327 ? 36.835  49.987 27.546 1.00 36.60  ? 346  PRO B O   1 
+ATOM   6235 C  CB  . PRO B 1 327 ? 33.957  50.817 26.224 1.00 38.43  ? 346  PRO B CB  1 
+ATOM   6236 C  CG  . PRO B 1 327 ? 33.198  49.891 25.376 1.00 37.38  ? 346  PRO B CG  1 
+ATOM   6237 C  CD  . PRO B 1 327 ? 33.819  50.021 24.023 1.00 39.83  ? 346  PRO B CD  1 
+ATOM   6238 N  N   . TYR B 1 328 ? 35.882  48.335 26.334 1.00 35.54  ? 347  TYR B N   1 
+ATOM   6239 C  CA  . TYR B 1 328 ? 36.524  47.277 27.082 1.00 36.67  ? 347  TYR B CA  1 
+ATOM   6240 C  C   . TYR B 1 328 ? 38.041  47.307 26.869 1.00 37.49  ? 347  TYR B C   1 
+ATOM   6241 O  O   . TYR B 1 328 ? 38.792  47.263 27.822 1.00 35.90  ? 347  TYR B O   1 
+ATOM   6242 C  CB  . TYR B 1 328 ? 35.989  45.922 26.676 1.00 37.35  ? 347  TYR B CB  1 
+ATOM   6243 C  CG  . TYR B 1 328 ? 36.485  44.838 27.577 1.00 38.56  ? 347  TYR B CG  1 
+ATOM   6244 C  CD1 . TYR B 1 328 ? 35.931  44.659 28.834 1.00 43.04  ? 347  TYR B CD1 1 
+ATOM   6245 C  CD2 . TYR B 1 328 ? 37.519  44.003 27.191 1.00 42.36  ? 347  TYR B CD2 1 
+ATOM   6246 C  CE1 . TYR B 1 328 ? 36.389  43.660 29.697 1.00 44.67  ? 347  TYR B CE1 1 
+ATOM   6247 C  CE2 . TYR B 1 328 ? 37.981  42.991 28.035 1.00 47.68  ? 347  TYR B CE2 1 
+ATOM   6248 C  CZ  . TYR B 1 328 ? 37.410  42.831 29.294 1.00 45.05  ? 347  TYR B CZ  1 
+ATOM   6249 O  OH  . TYR B 1 328 ? 37.852  41.856 30.143 1.00 46.80  ? 347  TYR B OH  1 
+ATOM   6250 N  N   . THR B 1 329 ? 38.471  47.382 25.616 1.00 36.38  ? 348  THR B N   1 
+ATOM   6251 C  CA  . THR B 1 329 ? 39.880  47.531 25.295 1.00 39.58  ? 348  THR B CA  1 
+ATOM   6252 C  C   . THR B 1 329 ? 40.490  48.792 25.961 1.00 42.29  ? 348  THR B C   1 
+ATOM   6253 O  O   . THR B 1 329 ? 41.536  48.697 26.600 1.00 49.54  ? 348  THR B O   1 
+ATOM   6254 C  CB  . THR B 1 329 ? 40.093  47.545 23.760 1.00 38.43  ? 348  THR B CB  1 
+ATOM   6255 O  OG1 . THR B 1 329 ? 39.642  46.312 23.206 1.00 36.76  ? 348  THR B OG1 1 
+ATOM   6256 C  CG2 . THR B 1 329 ? 41.572  47.557 23.413 1.00 39.15  ? 348  THR B CG2 1 
+ATOM   6257 N  N   . ASP B 1 330 ? 39.845  49.950 25.807 1.00 39.16  ? 349  ASP B N   1 
+ATOM   6258 C  CA  . ASP B 1 330 ? 40.223  51.179 26.504 1.00 36.76  ? 349  ASP B CA  1 
+ATOM   6259 C  C   . ASP B 1 330 ? 40.379  50.875 27.989 1.00 35.92  ? 349  ASP B C   1 
+ATOM   6260 O  O   . ASP B 1 330 ? 41.304  51.336 28.635 1.00 37.77  ? 349  ASP B O   1 
+ATOM   6261 C  CB  . ASP B 1 330 ? 39.126  52.248 26.308 1.00 41.53  ? 349  ASP B CB  1 
+ATOM   6262 C  CG  . ASP B 1 330 ? 39.656  53.695 26.290 1.00 41.38  ? 349  ASP B CG  1 
+ATOM   6263 O  OD1 . ASP B 1 330 ? 40.833  53.926 26.612 1.00 45.66  ? 349  ASP B OD1 1 
+ATOM   6264 O  OD2 . ASP B 1 330 ? 38.937  54.672 25.978 1.00 40.43  ? 349  ASP B OD2 1 
+ATOM   6265 N  N   . ALA B 1 331 ? 39.475  50.083 28.538 1.00 34.79  ? 350  ALA B N   1 
+ATOM   6266 C  CA  . ALA B 1 331 ? 39.554  49.746 29.948 1.00 34.27  ? 350  ALA B CA  1 
+ATOM   6267 C  C   . ALA B 1 331 ? 40.747  48.837 30.243 1.00 35.32  ? 350  ALA B C   1 
+ATOM   6268 O  O   . ALA B 1 331 ? 41.423  49.012 31.257 1.00 37.32  ? 350  ALA B O   1 
+ATOM   6269 C  CB  . ALA B 1 331 ? 38.289  49.090 30.377 1.00 36.78  ? 350  ALA B CB  1 
+ATOM   6270 N  N   . VAL B 1 332 ? 41.025  47.882 29.358 1.00 29.37  ? 351  VAL B N   1 
+ATOM   6271 C  CA  . VAL B 1 332 ? 42.189  47.012 29.532 1.00 30.32  ? 351  VAL B CA  1 
+ATOM   6272 C  C   . VAL B 1 332 ? 43.517  47.807 29.508 1.00 32.35  ? 351  VAL B C   1 
+ATOM   6273 O  O   . VAL B 1 332 ? 44.425  47.532 30.291 1.00 30.99  ? 351  VAL B O   1 
+ATOM   6274 C  CB  . VAL B 1 332 ? 42.207  45.892 28.483 1.00 28.80  ? 351  VAL B CB  1 
+ATOM   6275 C  CG1 . VAL B 1 332 ? 43.512  45.169 28.487 1.00 30.95  ? 351  VAL B CG1 1 
+ATOM   6276 C  CG2 . VAL B 1 332 ? 41.084  44.898 28.764 1.00 30.97  ? 351  VAL B CG2 1 
+ATOM   6277 N  N   . VAL B 1 333 ? 43.621  48.788 28.617 1.00 33.65  ? 352  VAL B N   1 
+ATOM   6278 C  CA  . VAL B 1 333 ? 44.849  49.549 28.470 1.00 33.11  ? 352  VAL B CA  1 
+ATOM   6279 C  C   . VAL B 1 333 ? 45.042  50.415 29.700 1.00 33.70  ? 352  VAL B C   1 
+ATOM   6280 O  O   . VAL B 1 333 ? 46.122  50.452 30.272 1.00 32.66  ? 352  VAL B O   1 
+ATOM   6281 C  CB  . VAL B 1 333 ? 44.848  50.396 27.203 1.00 33.71  ? 352  VAL B CB  1 
+ATOM   6282 C  CG1 . VAL B 1 333 ? 46.065  51.300 27.185 1.00 36.03  ? 352  VAL B CG1 1 
+ATOM   6283 C  CG2 . VAL B 1 333 ? 44.867  49.498 25.955 1.00 32.35  ? 352  VAL B CG2 1 
+ATOM   6284 N  N   . HIS B 1 334 ? 43.968  51.071 30.122 1.00 35.06  ? 353  HIS B N   1 
+ATOM   6285 C  CA  . HIS B 1 334 ? 43.971  51.891 31.326 1.00 32.62  ? 353  HIS B CA  1 
+ATOM   6286 C  C   . HIS B 1 334 ? 44.334  51.071 32.550 1.00 33.48  ? 353  HIS B C   1 
+ATOM   6287 O  O   . HIS B 1 334 ? 45.126  51.498 33.382 1.00 35.13  ? 353  HIS B O   1 
+ATOM   6288 C  CB  . HIS B 1 334 ? 42.596  52.530 31.534 1.00 30.92  ? 353  HIS B CB  1 
+ATOM   6289 C  CG  . HIS B 1 334 ? 42.393  53.779 30.743 1.00 30.34  ? 353  HIS B CG  1 
+ATOM   6290 N  ND1 . HIS B 1 334 ? 42.588  55.035 31.285 1.00 26.60  ? 353  HIS B ND1 1 
+ATOM   6291 C  CD2 . HIS B 1 334 ? 42.067  53.968 29.440 1.00 21.13  ? 353  HIS B CD2 1 
+ATOM   6292 C  CE1 . HIS B 1 334 ? 42.381  55.943 30.349 1.00 27.82  ? 353  HIS B CE1 1 
+ATOM   6293 N  NE2 . HIS B 1 334 ? 42.060  55.322 29.225 1.00 28.55  ? 353  HIS B NE2 1 
+ATOM   6294 N  N   . GLU B 1 335 ? 43.764  49.884 32.655 1.00 33.62  ? 354  GLU B N   1 
+ATOM   6295 C  CA  . GLU B 1 335 ? 44.067  49.015 33.787 1.00 36.17  ? 354  GLU B CA  1 
+ATOM   6296 C  C   . GLU B 1 335 ? 45.507  48.463 33.766 1.00 36.74  ? 354  GLU B C   1 
+ATOM   6297 O  O   . GLU B 1 335 ? 46.090  48.263 34.837 1.00 39.44  ? 354  GLU B O   1 
+ATOM   6298 C  CB  . GLU B 1 335 ? 43.075  47.848 33.863 1.00 34.98  ? 354  GLU B CB  1 
+ATOM   6299 C  CG  . GLU B 1 335 ? 43.353  46.872 35.004 1.00 37.28  ? 354  GLU B CG  1 
+ATOM   6300 C  CD  . GLU B 1 335 ? 43.110  47.500 36.351 1.00 38.61  ? 354  GLU B CD  1 
+ATOM   6301 O  OE1 . GLU B 1 335 ? 42.766  48.683 36.352 1.00 34.32  ? 354  GLU B OE1 1 
+ATOM   6302 O  OE2 . GLU B 1 335 ? 43.231  46.829 37.392 1.00 38.85  ? 354  GLU B OE2 1 
+ATOM   6303 N  N   . VAL B 1 336 ? 46.069  48.201 32.577 1.00 31.98  ? 355  VAL B N   1 
+ATOM   6304 C  CA  . VAL B 1 336 ? 47.454  47.792 32.499 1.00 29.72  ? 355  VAL B CA  1 
+ATOM   6305 C  C   . VAL B 1 336 ? 48.263  48.919 33.148 1.00 29.85  ? 355  VAL B C   1 
+ATOM   6306 O  O   . VAL B 1 336 ? 48.976  48.699 34.089 1.00 28.08  ? 355  VAL B O   1 
+ATOM   6307 C  CB  . VAL B 1 336 ? 47.920  47.533 31.044 1.00 32.39  ? 355  VAL B CB  1 
+ATOM   6308 C  CG1 . VAL B 1 336 ? 49.456  47.522 30.945 1.00 34.09  ? 355  VAL B CG1 1 
+ATOM   6309 C  CG2 . VAL B 1 336 ? 47.363  46.220 30.515 1.00 34.62  ? 355  VAL B CG2 1 
+ATOM   6310 N  N   . GLN B 1 337 ? 48.114  50.140 32.666 1.00 29.40  ? 356  GLN B N   1 
+ATOM   6311 C  CA  . GLN B 1 337 ? 48.912  51.239 33.169 1.00 30.70  ? 356  GLN B CA  1 
+ATOM   6312 C  C   . GLN B 1 337 ? 48.731  51.393 34.676 1.00 33.48  ? 356  GLN B C   1 
+ATOM   6313 O  O   . GLN B 1 337 ? 49.678  51.669 35.397 1.00 37.63  ? 356  GLN B O   1 
+ATOM   6314 C  CB  . GLN B 1 337 ? 48.520  52.551 32.477 1.00 29.30  ? 356  GLN B CB  1 
+ATOM   6315 C  CG  . GLN B 1 337 ? 48.798  52.591 31.002 1.00 29.08  ? 356  GLN B CG  1 
+ATOM   6316 C  CD  . GLN B 1 337 ? 49.120  53.999 30.517 1.00 32.59  ? 356  GLN B CD  1 
+ATOM   6317 O  OE1 . GLN B 1 337 ? 48.228  54.696 30.047 1.00 34.56  ? 356  GLN B OE1 1 
+ATOM   6318 N  NE2 . GLN B 1 337 ? 50.392  54.421 30.629 1.00 25.88  ? 356  GLN B NE2 1 
+ATOM   6319 N  N   . ARG B 1 338 ? 47.504  51.225 35.147 1.00 37.50  ? 357  ARG B N   1 
+ATOM   6320 C  CA  . ARG B 1 338 ? 47.167  51.532 36.532 1.00 35.53  ? 357  ARG B CA  1 
+ATOM   6321 C  C   . ARG B 1 338 ? 47.834  50.559 37.458 1.00 32.30  ? 357  ARG B C   1 
+ATOM   6322 O  O   . ARG B 1 338 ? 48.495  50.952 38.413 1.00 33.13  ? 357  ARG B O   1 
+ATOM   6323 C  CB  . ARG B 1 338 ? 45.649  51.458 36.764 1.00 35.67  ? 357  ARG B CB  1 
+ATOM   6324 C  CG  . ARG B 1 338 ? 45.213  52.062 38.123 1.00 35.77  ? 357  ARG B CG  1 
+ATOM   6325 C  CD  . ARG B 1 338 ? 44.046  51.402 38.791 1.00 30.12  ? 357  ARG B CD  1 
+ATOM   6326 N  NE  . ARG B 1 338 ? 44.164  49.949 38.842 1.00 34.47  ? 357  ARG B NE  1 
+ATOM   6327 C  CZ  . ARG B 1 338 ? 44.564  49.241 39.885 1.00 34.03  ? 357  ARG B CZ  1 
+ATOM   6328 N  NH1 . ARG B 1 338 ? 44.615  47.928 39.792 1.00 34.70  ? 357  ARG B NH1 1 
+ATOM   6329 N  NH2 . ARG B 1 338 ? 44.935  49.826 41.010 1.00 38.45  ? 357  ARG B NH2 1 
+ATOM   6330 N  N   . TYR B 1 339 ? 47.626  49.287 37.161 1.00 32.82  ? 358  TYR B N   1 
+ATOM   6331 C  CA  . TYR B 1 339 ? 48.107  48.194 37.983 1.00 35.40  ? 358  TYR B CA  1 
+ATOM   6332 C  C   . TYR B 1 339 ? 49.627  48.188 38.061 1.00 33.63  ? 358  TYR B C   1 
+ATOM   6333 O  O   . TYR B 1 339 ? 50.157  48.057 39.152 1.00 38.26  ? 358  TYR B O   1 
+ATOM   6334 C  CB  . TYR B 1 339 ? 47.572  46.890 37.410 1.00 37.07  ? 358  TYR B CB  1 
+ATOM   6335 C  CG  . TYR B 1 339 ? 48.150  45.604 37.971 1.00 42.58  ? 358  TYR B CG  1 
+ATOM   6336 C  CD1 . TYR B 1 339 ? 49.348  45.092 37.495 1.00 42.00  ? 358  TYR B CD1 1 
+ATOM   6337 C  CD2 . TYR B 1 339 ? 47.460  44.862 38.931 1.00 42.82  ? 358  TYR B CD2 1 
+ATOM   6338 C  CE1 . TYR B 1 339 ? 49.856  43.904 37.984 1.00 42.25  ? 358  TYR B CE1 1 
+ATOM   6339 C  CE2 . TYR B 1 339 ? 47.973  43.668 39.416 1.00 41.08  ? 358  TYR B CE2 1 
+ATOM   6340 C  CZ  . TYR B 1 339 ? 49.163  43.201 38.937 1.00 40.87  ? 358  TYR B CZ  1 
+ATOM   6341 O  OH  . TYR B 1 339 ? 49.683  42.032 39.420 1.00 42.65  ? 358  TYR B OH  1 
+ATOM   6342 N  N   . ILE B 1 340 ? 50.320  48.355 36.930 1.00 29.32  ? 359  ILE B N   1 
+ATOM   6343 C  CA  . ILE B 1 340 ? 51.789  48.235 36.902 1.00 28.01  ? 359  ILE B CA  1 
+ATOM   6344 C  C   . ILE B 1 340 ? 52.539  49.353 37.597 1.00 28.17  ? 359  ILE B C   1 
+ATOM   6345 O  O   . ILE B 1 340 ? 53.642  49.146 38.086 1.00 25.82  ? 359  ILE B O   1 
+ATOM   6346 C  CB  . ILE B 1 340 ? 52.380  48.071 35.475 1.00 26.93  ? 359  ILE B CB  1 
+ATOM   6347 C  CG1 . ILE B 1 340 ? 52.198  49.336 34.648 1.00 29.92  ? 359  ILE B CG1 1 
+ATOM   6348 C  CG2 . ILE B 1 340 ? 51.829  46.820 34.774 1.00 30.95  ? 359  ILE B CG2 1 
+ATOM   6349 C  CD1 . ILE B 1 340 ? 52.649  49.135 33.214 1.00 32.66  ? 359  ILE B CD1 1 
+ATOM   6350 N  N   . ASP B 1 341 ? 51.965  50.539 37.620 1.00 30.58  ? 360  ASP B N   1 
+ATOM   6351 C  CA  . ASP B 1 341 ? 52.526  51.632 38.405 1.00 35.05  ? 360  ASP B CA  1 
+ATOM   6352 C  C   . ASP B 1 341 ? 54.037  51.765 38.195 1.00 33.22  ? 360  ASP B C   1 
+ATOM   6353 O  O   . ASP B 1 341 ? 54.840  51.473 39.072 1.00 38.25  ? 360  ASP B O   1 
+ATOM   6354 C  CB  . ASP B 1 341 ? 52.194  51.434 39.879 1.00 35.91  ? 360  ASP B CB  1 
+ATOM   6355 C  CG  . ASP B 1 341 ? 52.812  52.501 40.758 1.00 43.84  ? 360  ASP B CG  1 
+ATOM   6356 O  OD1 . ASP B 1 341 ? 53.281  52.149 41.883 1.00 48.45  ? 360  ASP B OD1 1 
+ATOM   6357 O  OD2 . ASP B 1 341 ? 52.865  53.710 40.396 1.00 49.25  ? 360  ASP B OD2 1 
+ATOM   6358 N  N   . LEU B 1 342 ? 54.387  52.265 37.025 1.00 35.85  ? 361  LEU B N   1 
+ATOM   6359 C  CA  . LEU B 1 342 ? 55.719  52.146 36.469 1.00 36.03  ? 361  LEU B CA  1 
+ATOM   6360 C  C   . LEU B 1 342 ? 56.680  53.180 37.036 1.00 38.85  ? 361  LEU B C   1 
+ATOM   6361 O  O   . LEU B 1 342 ? 57.849  52.874 37.255 1.00 39.49  ? 361  LEU B O   1 
+ATOM   6362 C  CB  . LEU B 1 342 ? 55.642  52.264 34.941 1.00 35.29  ? 361  LEU B CB  1 
+ATOM   6363 C  CG  . LEU B 1 342 ? 56.292  51.119 34.176 1.00 34.52  ? 361  LEU B CG  1 
+ATOM   6364 C  CD1 . LEU B 1 342 ? 55.660  49.783 34.490 1.00 26.62  ? 361  LEU B CD1 1 
+ATOM   6365 C  CD2 . LEU B 1 342 ? 56.225  51.419 32.712 1.00 37.25  ? 361  LEU B CD2 1 
+ATOM   6366 N  N   . LEU B 1 343 ? 56.194  54.396 37.272 1.00 37.42  ? 362  LEU B N   1 
+ATOM   6367 C  CA  . LEU B 1 343 ? 56.976  55.409 37.949 1.00 33.09  ? 362  LEU B CA  1 
+ATOM   6368 C  C   . LEU B 1 343 ? 56.280  55.769 39.254 1.00 35.40  ? 362  LEU B C   1 
+ATOM   6369 O  O   . LEU B 1 343 ? 55.643  56.823 39.348 1.00 32.69  ? 362  LEU B O   1 
+ATOM   6370 C  CB  . LEU B 1 343 ? 57.098  56.609 37.041 1.00 34.84  ? 362  LEU B CB  1 
+ATOM   6371 C  CG  . LEU B 1 343 ? 57.903  56.297 35.766 1.00 36.11  ? 362  LEU B CG  1 
+ATOM   6372 C  CD1 . LEU B 1 343 ? 57.113  56.639 34.510 1.00 39.88  ? 362  LEU B CD1 1 
+ATOM   6373 C  CD2 . LEU B 1 343 ? 59.174  57.062 35.739 1.00 32.15  ? 362  LEU B CD2 1 
+ATOM   6374 N  N   . PRO B 1 344 ? 56.391  54.887 40.255 1.00 37.91  ? 363  PRO B N   1 
+ATOM   6375 C  CA  . PRO B 1 344 ? 55.667  55.006 41.542 1.00 38.19  ? 363  PRO B CA  1 
+ATOM   6376 C  C   . PRO B 1 344 ? 55.798  56.340 42.265 1.00 35.51  ? 363  PRO B C   1 
+ATOM   6377 O  O   . PRO B 1 344 ? 54.926  56.694 43.053 1.00 40.03  ? 363  PRO B O   1 
+ATOM   6378 C  CB  . PRO B 1 344 ? 56.287  53.895 42.416 1.00 36.07  ? 363  PRO B CB  1 
+ATOM   6379 C  CG  . PRO B 1 344 ? 56.968  52.974 41.527 1.00 38.54  ? 363  PRO B CG  1 
+ATOM   6380 C  CD  . PRO B 1 344 ? 57.219  53.669 40.222 1.00 40.09  ? 363  PRO B CD  1 
+ATOM   6381 N  N   . THR B 1 345 ? 56.946  56.969 42.096 1.00 36.51  ? 364  THR B N   1 
+ATOM   6382 C  CA  . THR B 1 345 ? 57.148  58.376 42.356 1.00 39.26  ? 364  THR B CA  1 
+ATOM   6383 C  C   . THR B 1 345 ? 57.456  58.914 40.972 1.00 42.69  ? 364  THR B C   1 
+ATOM   6384 O  O   . THR B 1 345 ? 58.484  58.567 40.330 1.00 52.72  ? 364  THR B O   1 
+ATOM   6385 C  CB  . THR B 1 345 ? 58.307  58.623 43.353 1.00 39.57  ? 364  THR B CB  1 
+ATOM   6386 O  OG1 . THR B 1 345 ? 59.567  58.166 42.832 1.00 42.80  ? 364  THR B OG1 1 
+ATOM   6387 C  CG2 . THR B 1 345 ? 58.136  57.772 44.592 1.00 38.97  ? 364  THR B CG2 1 
+ATOM   6388 N  N   . SER B 1 346 ? 56.501  59.635 40.426 1.00 41.32  ? 365  SER B N   1 
+ATOM   6389 C  CA  . SER B 1 346 ? 56.735  60.287 39.172 1.00 41.54  ? 365  SER B CA  1 
+ATOM   6390 C  C   . SER B 1 346 ? 58.125  60.853 39.368 1.00 41.28  ? 365  SER B C   1 
+ATOM   6391 O  O   . SER B 1 346 ? 58.606  60.902 40.513 1.00 53.09  ? 365  SER B O   1 
+ATOM   6392 C  CB  . SER B 1 346 ? 55.699  61.400 38.970 1.00 41.61  ? 365  SER B CB  1 
+ATOM   6393 O  OG  . SER B 1 346 ? 56.260  62.563 38.409 1.00 39.86  ? 365  SER B OG  1 
+ATOM   6394 N  N   . LEU B 1 347 ? 58.763  61.273 38.293 1.00 32.84  ? 366  LEU B N   1 
+ATOM   6395 C  CA  . LEU B 1 347 ? 59.961  62.057 38.397 1.00 34.01  ? 366  LEU B CA  1 
+ATOM   6396 C  C   . LEU B 1 347 ? 59.868  63.180 39.440 1.00 34.74  ? 366  LEU B C   1 
+ATOM   6397 O  O   . LEU B 1 347 ? 58.846  63.820 39.552 1.00 34.87  ? 366  LEU B O   1 
+ATOM   6398 C  CB  . LEU B 1 347 ? 60.301  62.676 37.048 1.00 35.63  ? 366  LEU B CB  1 
+ATOM   6399 C  CG  . LEU B 1 347 ? 61.257  61.914 36.147 1.00 37.36  ? 366  LEU B CG  1 
+ATOM   6400 C  CD1 . LEU B 1 347 ? 60.768  60.474 35.910 1.00 36.43  ? 366  LEU B CD1 1 
+ATOM   6401 C  CD2 . LEU B 1 347 ? 61.401  62.698 34.824 1.00 37.52  ? 366  LEU B CD2 1 
+ATOM   6402 N  N   . PRO B 1 348 ? 60.966  63.473 40.134 1.00 39.60  ? 367  PRO B N   1 
+ATOM   6403 C  CA  . PRO B 1 348 ? 60.959  64.417 41.258 1.00 41.51  ? 367  PRO B CA  1 
+ATOM   6404 C  C   . PRO B 1 348 ? 60.701  65.861 40.875 1.00 41.13  ? 367  PRO B C   1 
+ATOM   6405 O  O   . PRO B 1 348 ? 61.340  66.327 39.938 1.00 36.29  ? 367  PRO B O   1 
+ATOM   6406 C  CB  . PRO B 1 348 ? 62.387  64.317 41.811 1.00 43.82  ? 367  PRO B CB  1 
+ATOM   6407 C  CG  . PRO B 1 348 ? 62.959  63.110 41.196 1.00 44.53  ? 367  PRO B CG  1 
+ATOM   6408 C  CD  . PRO B 1 348 ? 62.323  62.962 39.868 1.00 42.52  ? 367  PRO B CD  1 
+ATOM   6409 N  N   . HIS B 1 349 ? 59.810  66.535 41.622 1.00 42.12  ? 368  HIS B N   1 
+ATOM   6410 C  CA  . HIS B 1 349 ? 59.483  67.957 41.458 1.00 40.17  ? 368  HIS B CA  1 
+ATOM   6411 C  C   . HIS B 1 349 ? 60.271  68.828 42.454 1.00 42.29  ? 368  HIS B C   1 
+ATOM   6412 O  O   . HIS B 1 349 ? 61.063  68.333 43.243 1.00 42.66  ? 368  HIS B O   1 
+ATOM   6413 C  CB  . HIS B 1 349 ? 57.977  68.164 41.685 1.00 41.90  ? 368  HIS B CB  1 
+ATOM   6414 C  CG  . HIS B 1 349 ? 57.120  67.647 40.576 1.00 40.31  ? 368  HIS B CG  1 
+ATOM   6415 N  ND1 . HIS B 1 349 ? 56.560  68.475 39.632 1.00 40.58  ? 368  HIS B ND1 1 
+ATOM   6416 C  CD2 . HIS B 1 349 ? 56.733  66.389 40.254 1.00 38.09  ? 368  HIS B CD2 1 
+ATOM   6417 C  CE1 . HIS B 1 349 ? 55.880  67.746 38.766 1.00 41.94  ? 368  HIS B CE1 1 
+ATOM   6418 N  NE2 . HIS B 1 349 ? 55.970  66.476 39.119 1.00 34.31  ? 368  HIS B NE2 1 
+ATOM   6419 N  N   . ALA B 1 350 ? 60.048  70.131 42.422 1.00 44.85  ? 369  ALA B N   1 
+ATOM   6420 C  CA  . ALA B 1 350 ? 60.652  71.036 43.401 1.00 47.14  ? 369  ALA B CA  1 
+ATOM   6421 C  C   . ALA B 1 350 ? 59.843  72.322 43.467 1.00 49.35  ? 369  ALA B C   1 
+ATOM   6422 O  O   . ALA B 1 350 ? 59.382  72.830 42.431 1.00 51.09  ? 369  ALA B O   1 
+ATOM   6423 C  CB  . ALA B 1 350 ? 62.091  71.340 43.040 1.00 46.47  ? 369  ALA B CB  1 
+ATOM   6424 N  N   . VAL B 1 351 ? 59.650  72.840 44.680 1.00 51.37  ? 370  VAL B N   1 
+ATOM   6425 C  CA  . VAL B 1 351 ? 58.808  74.026 44.850 1.00 52.84  ? 370  VAL B CA  1 
+ATOM   6426 C  C   . VAL B 1 351 ? 59.561  75.225 44.322 1.00 52.55  ? 370  VAL B C   1 
+ATOM   6427 O  O   . VAL B 1 351 ? 60.744  75.392 44.543 1.00 50.33  ? 370  VAL B O   1 
+ATOM   6428 C  CB  . VAL B 1 351 ? 58.284  74.254 46.303 1.00 51.85  ? 370  VAL B CB  1 
+ATOM   6429 C  CG1 . VAL B 1 351 ? 57.466  73.074 46.746 1.00 49.12  ? 370  VAL B CG1 1 
+ATOM   6430 C  CG2 . VAL B 1 351 ? 59.408  74.527 47.287 1.00 57.14  ? 370  VAL B CG2 1 
+ATOM   6431 N  N   . THR B 1 352 ? 58.845  76.059 43.610 1.00 56.00  ? 371  THR B N   1 
+ATOM   6432 C  CA  . THR B 1 352 ? 59.465  77.052 42.774 1.00 59.50  ? 371  THR B CA  1 
+ATOM   6433 C  C   . THR B 1 352 ? 59.617  78.384 43.535 1.00 62.64  ? 371  THR B C   1 
+ATOM   6434 O  O   . THR B 1 352 ? 60.103  79.374 42.993 1.00 63.95  ? 371  THR B O   1 
+ATOM   6435 C  CB  . THR B 1 352 ? 58.608  77.171 41.511 1.00 58.20  ? 371  THR B CB  1 
+ATOM   6436 O  OG1 . THR B 1 352 ? 59.346  77.815 40.492 1.00 58.74  ? 371  THR B OG1 1 
+ATOM   6437 C  CG2 . THR B 1 352 ? 57.419  78.078 41.723 1.00 59.40  ? 371  THR B CG2 1 
+ATOM   6438 N  N   . CYS B 1 353 ? 59.203  78.380 44.801 1.00 65.51  ? 372  CYS B N   1 
+ATOM   6439 C  CA  . CYS B 1 353 ? 59.212  79.564 45.667 1.00 67.07  ? 372  CYS B CA  1 
+ATOM   6440 C  C   . CYS B 1 353 ? 58.838  79.146 47.099 1.00 70.15  ? 372  CYS B C   1 
+ATOM   6441 O  O   . CYS B 1 353 ? 58.271  78.058 47.310 1.00 69.61  ? 372  CYS B O   1 
+ATOM   6442 C  CB  . CYS B 1 353 ? 58.220  80.618 45.160 1.00 65.47  ? 372  CYS B CB  1 
+ATOM   6443 S  SG  . CYS B 1 353 ? 56.509  80.032 44.994 1.00 66.09  ? 372  CYS B SG  1 
+ATOM   6444 N  N   . ASP B 1 354 ? 59.157  79.994 48.082 1.00 72.21  ? 373  ASP B N   1 
+ATOM   6445 C  CA  . ASP B 1 354 ? 58.731  79.738 49.464 1.00 72.13  ? 373  ASP B CA  1 
+ATOM   6446 C  C   . ASP B 1 354 ? 57.214  79.661 49.498 1.00 71.53  ? 373  ASP B C   1 
+ATOM   6447 O  O   . ASP B 1 354 ? 56.556  80.666 49.262 1.00 72.88  ? 373  ASP B O   1 
+ATOM   6448 C  CB  . ASP B 1 354 ? 59.205  80.840 50.406 1.00 71.90  ? 373  ASP B CB  1 
+ATOM   6449 C  CG  . ASP B 1 354 ? 60.700  80.762 50.707 1.00 73.11  ? 373  ASP B CG  1 
+ATOM   6450 O  OD1 . ASP B 1 354 ? 61.271  81.774 51.169 1.00 75.11  ? 373  ASP B OD1 1 
+ATOM   6451 O  OD2 . ASP B 1 354 ? 61.391  79.744 50.521 1.00 67.37  ? 373  ASP B OD2 1 
+ATOM   6452 N  N   . ILE B 1 355 ? 56.672  78.466 49.738 1.00 70.16  ? 374  ILE B N   1 
+ATOM   6453 C  CA  . ILE B 1 355 ? 55.228  78.248 49.814 1.00 69.59  ? 374  ILE B CA  1 
+ATOM   6454 C  C   . ILE B 1 355 ? 54.836  77.805 51.218 1.00 70.76  ? 374  ILE B C   1 
+ATOM   6455 O  O   . ILE B 1 355 ? 55.655  77.246 51.942 1.00 66.12  ? 374  ILE B O   1 
+ATOM   6456 C  CB  . ILE B 1 355 ? 54.770  77.176 48.746 1.00 70.73  ? 374  ILE B CB  1 
+ATOM   6457 C  CG1 . ILE B 1 355 ? 53.284  77.314 48.400 1.00 73.05  ? 374  ILE B CG1 1 
+ATOM   6458 C  CG2 . ILE B 1 355 ? 54.999  75.729 49.225 1.00 68.83  ? 374  ILE B CG2 1 
+ATOM   6459 C  CD1 . ILE B 1 355 ? 52.904  78.606 47.696 1.00 75.68  ? 374  ILE B CD1 1 
+ATOM   6460 N  N   . LYS B 1 356 ? 53.585  78.075 51.596 1.00 73.73  ? 375  LYS B N   1 
+ATOM   6461 C  CA  . LYS B 1 356 ? 52.951  77.434 52.756 1.00 75.87  ? 375  LYS B CA  1 
+ATOM   6462 C  C   . LYS B 1 356 ? 51.946  76.438 52.208 1.00 71.26  ? 375  LYS B C   1 
+ATOM   6463 O  O   . LYS B 1 356 ? 51.171  76.768 51.317 1.00 67.81  ? 375  LYS B O   1 
+ATOM   6464 C  CB  . LYS B 1 356 ? 52.240  78.461 53.659 1.00 80.37  ? 375  LYS B CB  1 
+ATOM   6465 C  CG  . LYS B 1 356 ? 51.490  77.862 54.885 1.00 83.93  ? 375  LYS B CG  1 
+ATOM   6466 C  CD  . LYS B 1 356 ? 50.855  78.949 55.790 1.00 85.88  ? 375  LYS B CD  1 
+ATOM   6467 C  CE  . LYS B 1 356 ? 51.900  79.708 56.633 1.00 86.80  ? 375  LYS B CE  1 
+ATOM   6468 N  NZ  . LYS B 1 356 ? 51.751  79.451 58.099 1.00 87.29  ? 375  LYS B NZ  1 
+ATOM   6469 N  N   . PHE B 1 357 ? 51.947  75.229 52.745 1.00 68.39  ? 376  PHE B N   1 
+ATOM   6470 C  CA  . PHE B 1 357 ? 51.138  74.165 52.175 1.00 67.00  ? 376  PHE B CA  1 
+ATOM   6471 C  C   . PHE B 1 357 ? 50.601  73.300 53.296 1.00 67.83  ? 376  PHE B C   1 
+ATOM   6472 O  O   . PHE B 1 357 ? 51.362  72.597 53.947 1.00 67.08  ? 376  PHE B O   1 
+ATOM   6473 C  CB  . PHE B 1 357 ? 51.996  73.343 51.194 1.00 66.49  ? 376  PHE B CB  1 
+ATOM   6474 C  CG  . PHE B 1 357 ? 51.278  72.168 50.579 1.00 62.44  ? 376  PHE B CG  1 
+ATOM   6475 C  CD1 . PHE B 1 357 ? 50.359  72.358 49.566 1.00 61.84  ? 376  PHE B CD1 1 
+ATOM   6476 C  CD2 . PHE B 1 357 ? 51.521  70.873 51.026 1.00 60.76  ? 376  PHE B CD2 1 
+ATOM   6477 C  CE1 . PHE B 1 357 ? 49.690  71.276 49.007 1.00 62.27  ? 376  PHE B CE1 1 
+ATOM   6478 C  CE2 . PHE B 1 357 ? 50.858  69.791 50.476 1.00 59.48  ? 376  PHE B CE2 1 
+ATOM   6479 C  CZ  . PHE B 1 357 ? 49.946  69.991 49.464 1.00 62.16  ? 376  PHE B CZ  1 
+ATOM   6480 N  N   . ARG B 1 358 ? 49.288  73.358 53.512 1.00 70.38  ? 377  ARG B N   1 
+ATOM   6481 C  CA  . ARG B 1 358 ? 48.629  72.691 54.657 1.00 73.47  ? 377  ARG B CA  1 
+ATOM   6482 C  C   . ARG B 1 358 ? 49.211  73.152 56.026 1.00 76.56  ? 377  ARG B C   1 
+ATOM   6483 O  O   . ARG B 1 358 ? 49.385  72.340 56.952 1.00 75.25  ? 377  ARG B O   1 
+ATOM   6484 C  CB  . ARG B 1 358 ? 48.666  71.144 54.518 1.00 71.51  ? 377  ARG B CB  1 
+ATOM   6485 C  CG  . ARG B 1 358 ? 48.481  70.590 53.081 1.00 68.11  ? 377  ARG B CG  1 
+ATOM   6486 C  CD  . ARG B 1 358 ? 47.060  70.124 52.708 1.00 60.89  ? 377  ARG B CD  1 
+ATOM   6487 N  NE  . ARG B 1 358 ? 46.855  68.722 53.055 1.00 57.14  ? 377  ARG B NE  1 
+ATOM   6488 C  CZ  . ARG B 1 358 ? 46.158  67.838 52.349 1.00 56.98  ? 377  ARG B CZ  1 
+ATOM   6489 N  NH1 . ARG B 1 358 ? 45.563  68.184 51.211 1.00 58.96  ? 377  ARG B NH1 1 
+ATOM   6490 N  NH2 . ARG B 1 358 ? 46.046  66.585 52.792 1.00 55.70  ? 377  ARG B NH2 1 
+ATOM   6491 N  N   . ASN B 1 359 ? 49.465  74.464 56.141 1.00 79.17  ? 378  ASN B N   1 
+ATOM   6492 C  CA  . ASN B 1 359 ? 50.223  75.041 57.256 1.00 82.59  ? 378  ASN B CA  1 
+ATOM   6493 C  C   . ASN B 1 359 ? 51.450  74.187 57.564 1.00 82.51  ? 378  ASN B C   1 
+ATOM   6494 O  O   . ASN B 1 359 ? 51.598  73.673 58.679 1.00 85.09  ? 378  ASN B O   1 
+ATOM   6495 C  CB  . ASN B 1 359 ? 49.350  75.213 58.520 1.00 84.25  ? 378  ASN B CB  1 
+ATOM   6496 C  CG  . ASN B 1 359 ? 50.145  75.766 59.734 1.00 87.52  ? 378  ASN B CG  1 
+ATOM   6497 O  OD1 . ASN B 1 359 ? 50.061  75.223 60.842 1.00 87.49  ? 378  ASN B OD1 1 
+ATOM   6498 N  ND2 . ASN B 1 359 ? 50.924  76.830 59.514 1.00 86.98  ? 378  ASN B ND2 1 
+ATOM   6499 N  N   . TYR B 1 360 ? 52.322  74.012 56.575 1.00 81.17  ? 379  TYR B N   1 
+ATOM   6500 C  CA  . TYR B 1 360 ? 53.507  73.196 56.803 1.00 80.34  ? 379  TYR B CA  1 
+ATOM   6501 C  C   . TYR B 1 360 ? 54.829  73.763 56.311 1.00 81.87  ? 379  TYR B C   1 
+ATOM   6502 O  O   . TYR B 1 360 ? 55.854  73.102 56.497 1.00 87.12  ? 379  TYR B O   1 
+ATOM   6503 C  CB  . TYR B 1 360 ? 53.298  71.794 56.249 1.00 78.98  ? 379  TYR B CB  1 
+ATOM   6504 C  CG  . TYR B 1 360 ? 52.728  70.782 57.228 1.00 78.35  ? 379  TYR B CG  1 
+ATOM   6505 C  CD1 . TYR B 1 360 ? 51.724  69.909 56.832 1.00 79.04  ? 379  TYR B CD1 1 
+ATOM   6506 C  CD2 . TYR B 1 360 ? 53.209  70.671 58.527 1.00 76.81  ? 379  TYR B CD2 1 
+ATOM   6507 C  CE1 . TYR B 1 360 ? 51.205  68.958 57.697 1.00 78.96  ? 379  TYR B CE1 1 
+ATOM   6508 C  CE2 . TYR B 1 360 ? 52.694  69.724 59.401 1.00 76.73  ? 379  TYR B CE2 1 
+ATOM   6509 C  CZ  . TYR B 1 360 ? 51.696  68.867 58.974 1.00 79.13  ? 379  TYR B CZ  1 
+ATOM   6510 O  OH  . TYR B 1 360 ? 51.176  67.917 59.816 1.00 79.38  ? 379  TYR B OH  1 
+ATOM   6511 N  N   . LEU B 1 361 ? 54.830  74.966 55.725 1.00 80.43  ? 380  LEU B N   1 
+ATOM   6512 C  CA  . LEU B 1 361 ? 56.067  75.764 55.579 1.00 80.24  ? 380  LEU B CA  1 
+ATOM   6513 C  C   . LEU B 1 361 ? 57.196  75.062 54.757 1.00 77.97  ? 380  LEU B C   1 
+ATOM   6514 O  O   . LEU B 1 361 ? 58.114  74.473 55.326 1.00 78.30  ? 380  LEU B O   1 
+ATOM   6515 C  CB  . LEU B 1 361 ? 56.563  76.274 56.982 1.00 80.96  ? 380  LEU B CB  1 
+ATOM   6516 C  CG  . LEU B 1 361 ? 57.091  75.419 58.190 1.00 82.33  ? 380  LEU B CG  1 
+ATOM   6517 C  CD1 . LEU B 1 361 ? 58.126  76.214 59.019 1.00 82.34  ? 380  LEU B CD1 1 
+ATOM   6518 C  CD2 . LEU B 1 361 ? 56.016  74.873 59.172 1.00 81.19  ? 380  LEU B CD2 1 
+ATOM   6519 N  N   . ILE B 1 362 ? 57.104  75.112 53.421 1.00 75.08  ? 381  ILE B N   1 
+ATOM   6520 C  CA  . ILE B 1 362 ? 58.097  74.486 52.526 1.00 70.31  ? 381  ILE B CA  1 
+ATOM   6521 C  C   . ILE B 1 362 ? 58.979  75.519 51.824 1.00 69.06  ? 381  ILE B C   1 
+ATOM   6522 O  O   . ILE B 1 362 ? 58.492  76.311 51.011 1.00 68.65  ? 381  ILE B O   1 
+ATOM   6523 C  CB  . ILE B 1 362 ? 57.432  73.613 51.425 1.00 69.27  ? 381  ILE B CB  1 
+ATOM   6524 C  CG1 . ILE B 1 362 ? 56.317  72.726 51.980 1.00 67.61  ? 381  ILE B CG1 1 
+ATOM   6525 C  CG2 . ILE B 1 362 ? 58.484  72.728 50.764 1.00 69.42  ? 381  ILE B CG2 1 
+ATOM   6526 C  CD1 . ILE B 1 362 ? 55.531  72.023 50.898 1.00 66.53  ? 381  ILE B CD1 1 
+ATOM   6527 N  N   . PRO B 1 363 ? 60.282  75.482 52.089 1.00 67.29  ? 382  PRO B N   1 
+ATOM   6528 C  CA  . PRO B 1 363 ? 61.205  76.464 51.495 1.00 65.55  ? 382  PRO B CA  1 
+ATOM   6529 C  C   . PRO B 1 363 ? 61.486  76.235 50.001 1.00 64.92  ? 382  PRO B C   1 
+ATOM   6530 O  O   . PRO B 1 363 ? 61.467  75.093 49.553 1.00 63.06  ? 382  PRO B O   1 
+ATOM   6531 C  CB  . PRO B 1 363 ? 62.481  76.310 52.326 1.00 64.94  ? 382  PRO B CB  1 
+ATOM   6532 C  CG  . PRO B 1 363 ? 62.397  74.943 52.991 1.00 66.86  ? 382  PRO B CG  1 
+ATOM   6533 C  CD  . PRO B 1 363 ? 60.966  74.507 52.961 1.00 66.58  ? 382  PRO B CD  1 
+ATOM   6534 N  N   . LYS B 1 364 ? 61.711  77.329 49.262 1.00 64.87  ? 383  LYS B N   1 
+ATOM   6535 C  CA  . LYS B 1 364 ? 62.067  77.326 47.832 1.00 62.79  ? 383  LYS B CA  1 
+ATOM   6536 C  C   . LYS B 1 364 ? 63.248  76.401 47.495 1.00 60.10  ? 383  LYS B C   1 
+ATOM   6537 O  O   . LYS B 1 364 ? 64.262  76.396 48.188 1.00 61.13  ? 383  LYS B O   1 
+ATOM   6538 C  CB  . LYS B 1 364 ? 62.417  78.751 47.374 1.00 63.27  ? 383  LYS B CB  1 
+ATOM   6539 C  CG  . LYS B 1 364 ? 63.014  78.818 45.975 1.00 66.75  ? 383  LYS B CG  1 
+ATOM   6540 C  CD  . LYS B 1 364 ? 63.327  80.234 45.509 1.00 68.99  ? 383  LYS B CD  1 
+ATOM   6541 C  CE  . LYS B 1 364 ? 63.961  80.200 44.103 1.00 70.03  ? 383  LYS B CE  1 
+ATOM   6542 N  NZ  . LYS B 1 364 ? 64.624  81.482 43.721 1.00 70.35  ? 383  LYS B NZ  1 
+ATOM   6543 N  N   . GLY B 1 365 ? 63.103  75.647 46.408 1.00 55.83  ? 384  GLY B N   1 
+ATOM   6544 C  CA  . GLY B 1 365 ? 64.074  74.651 45.994 1.00 53.11  ? 384  GLY B CA  1 
+ATOM   6545 C  C   . GLY B 1 365 ? 63.908  73.265 46.605 1.00 51.01  ? 384  GLY B C   1 
+ATOM   6546 O  O   . GLY B 1 365 ? 64.557  72.330 46.150 1.00 53.13  ? 384  GLY B O   1 
+ATOM   6547 N  N   . THR B 1 366 ? 63.055  73.114 47.616 1.00 49.02  ? 385  THR B N   1 
+ATOM   6548 C  CA  . THR B 1 366 ? 62.890  71.826 48.298 1.00 47.14  ? 385  THR B CA  1 
+ATOM   6549 C  C   . THR B 1 366 ? 62.437  70.752 47.314 1.00 46.94  ? 385  THR B C   1 
+ATOM   6550 O  O   . THR B 1 366 ? 61.555  70.984 46.511 1.00 50.79  ? 385  THR B O   1 
+ATOM   6551 C  CB  . THR B 1 366 ? 61.843  71.913 49.449 1.00 45.25  ? 385  THR B CB  1 
+ATOM   6552 O  OG1 . THR B 1 366 ? 62.271  72.824 50.466 1.00 41.05  ? 385  THR B OG1 1 
+ATOM   6553 C  CG2 . THR B 1 366 ? 61.753  70.580 50.183 1.00 45.28  ? 385  THR B CG2 1 
+ATOM   6554 N  N   . THR B 1 367 ? 63.025  69.568 47.390 1.00 45.95  ? 386  THR B N   1 
+ATOM   6555 C  CA  . THR B 1 367 ? 62.625  68.479 46.510 1.00 42.71  ? 386  THR B CA  1 
+ATOM   6556 C  C   . THR B 1 367 ? 61.313  67.867 46.967 1.00 41.20  ? 386  THR B C   1 
+ATOM   6557 O  O   . THR B 1 367 ? 61.087  67.710 48.157 1.00 44.93  ? 386  THR B O   1 
+ATOM   6558 C  CB  . THR B 1 367 ? 63.725  67.420 46.442 1.00 42.35  ? 386  THR B CB  1 
+ATOM   6559 O  OG1 . THR B 1 367 ? 64.892  67.982 45.819 1.00 39.32  ? 386  THR B OG1 1 
+ATOM   6560 C  CG2 . THR B 1 367 ? 63.326  66.261 45.519 1.00 42.59  ? 386  THR B CG2 1 
+ATOM   6561 N  N   . ILE B 1 368 ? 60.456  67.522 46.005 1.00 41.69  ? 387  ILE B N   1 
+ATOM   6562 C  CA  . ILE B 1 368 ? 59.113  66.980 46.262 1.00 38.88  ? 387  ILE B CA  1 
+ATOM   6563 C  C   . ILE B 1 368 ? 58.950  65.654 45.544 1.00 37.78  ? 387  ILE B C   1 
+ATOM   6564 O  O   . ILE B 1 368 ? 59.176  65.579 44.342 1.00 38.90  ? 387  ILE B O   1 
+ATOM   6565 C  CB  . ILE B 1 368 ? 58.035  67.938 45.722 1.00 41.00  ? 387  ILE B CB  1 
+ATOM   6566 C  CG1 . ILE B 1 368 ? 58.302  69.393 46.152 1.00 45.89  ? 387  ILE B CG1 1 
+ATOM   6567 C  CG2 . ILE B 1 368 ? 56.652  67.482 46.150 1.00 40.76  ? 387  ILE B CG2 1 
+ATOM   6568 C  CD1 . ILE B 1 368 ? 58.039  69.670 47.611 1.00 47.77  ? 387  ILE B CD1 1 
+ATOM   6569 N  N   . LEU B 1 369 ? 58.562  64.617 46.260 1.00 33.81  ? 388  LEU B N   1 
+ATOM   6570 C  CA  . LEU B 1 369 ? 58.258  63.364 45.630 1.00 40.13  ? 388  LEU B CA  1 
+ATOM   6571 C  C   . LEU B 1 369 ? 56.755  63.147 45.637 1.00 42.79  ? 388  LEU B C   1 
+ATOM   6572 O  O   . LEU B 1 369 ? 56.147  63.163 46.692 1.00 44.30  ? 388  LEU B O   1 
+ATOM   6573 C  CB  . LEU B 1 369 ? 58.960  62.220 46.368 1.00 45.81  ? 388  LEU B CB  1 
+ATOM   6574 C  CG  . LEU B 1 369 ? 60.474  62.064 46.146 1.00 46.08  ? 388  LEU B CG  1 
+ATOM   6575 C  CD1 . LEU B 1 369 ? 60.900  60.676 46.550 1.00 48.04  ? 388  LEU B CD1 1 
+ATOM   6576 C  CD2 . LEU B 1 369 ? 60.886  62.327 44.710 1.00 43.46  ? 388  LEU B CD2 1 
+ATOM   6577 N  N   . ILE B 1 370 ? 56.168  62.945 44.454 1.00 44.22  ? 389  ILE B N   1 
+ATOM   6578 C  CA  . ILE B 1 370 ? 54.737  62.716 44.299 1.00 37.54  ? 389  ILE B CA  1 
+ATOM   6579 C  C   . ILE B 1 370 ? 54.511  61.234 44.298 1.00 37.32  ? 389  ILE B C   1 
+ATOM   6580 O  O   . ILE B 1 370 ? 55.123  60.522 43.522 1.00 37.03  ? 389  ILE B O   1 
+ATOM   6581 C  CB  . ILE B 1 370 ? 54.279  63.274 42.954 1.00 40.94  ? 389  ILE B CB  1 
+ATOM   6582 C  CG1 . ILE B 1 370 ? 54.633  64.756 42.847 1.00 44.25  ? 389  ILE B CG1 1 
+ATOM   6583 C  CG2 . ILE B 1 370 ? 52.775  63.078 42.753 1.00 39.26  ? 389  ILE B CG2 1 
+ATOM   6584 C  CD1 . ILE B 1 370 ? 53.904  65.634 43.848 1.00 46.17  ? 389  ILE B CD1 1 
+ATOM   6585 N  N   . SER B 1 371 ? 53.615  60.747 45.137 1.00 33.93  ? 390  SER B N   1 
+ATOM   6586 C  CA  . SER B 1 371 ? 53.409  59.320 45.200 1.00 33.65  ? 390  SER B CA  1 
+ATOM   6587 C  C   . SER B 1 371 ? 52.308  58.956 44.226 1.00 36.51  ? 390  SER B C   1 
+ATOM   6588 O  O   . SER B 1 371 ? 51.134  59.058 44.546 1.00 40.69  ? 390  SER B O   1 
+ATOM   6589 C  CB  . SER B 1 371 ? 53.088  58.873 46.622 1.00 31.05  ? 390  SER B CB  1 
+ATOM   6590 O  OG  . SER B 1 371 ? 52.819  57.477 46.659 1.00 30.51  ? 390  SER B OG  1 
+ATOM   6591 N  N   . LEU B 1 372 ? 52.674  58.559 43.010 1.00 40.31  ? 391  LEU B N   1 
+ATOM   6592 C  CA  . LEU B 1 372 ? 51.656  58.113 42.049 1.00 37.77  ? 391  LEU B CA  1 
+ATOM   6593 C  C   . LEU B 1 372 ? 50.970  56.820 42.470 1.00 37.25  ? 391  LEU B C   1 
+ATOM   6594 O  O   . LEU B 1 372 ? 49.811  56.633 42.174 1.00 38.85  ? 391  LEU B O   1 
+ATOM   6595 C  CB  . LEU B 1 372 ? 52.223  57.997 40.642 1.00 35.31  ? 391  LEU B CB  1 
+ATOM   6596 C  CG  . LEU B 1 372 ? 52.711  59.315 40.028 1.00 36.43  ? 391  LEU B CG  1 
+ATOM   6597 C  CD1 . LEU B 1 372 ? 53.014  59.123 38.536 1.00 37.52  ? 391  LEU B CD1 1 
+ATOM   6598 C  CD2 . LEU B 1 372 ? 51.721  60.449 40.207 1.00 35.84  ? 391  LEU B CD2 1 
+ATOM   6599 N  N   . THR B 1 373 ? 51.673  55.945 43.182 1.00 42.35  ? 392  THR B N   1 
+ATOM   6600 C  CA  . THR B 1 373 ? 51.087  54.683 43.673 1.00 39.20  ? 392  THR B CA  1 
+ATOM   6601 C  C   . THR B 1 373 ? 49.884  54.930 44.543 1.00 39.72  ? 392  THR B C   1 
+ATOM   6602 O  O   . THR B 1 373 ? 48.916  54.179 44.515 1.00 33.91  ? 392  THR B O   1 
+ATOM   6603 C  CB  . THR B 1 373 ? 52.079  53.903 44.544 1.00 34.66  ? 392  THR B CB  1 
+ATOM   6604 O  OG1 . THR B 1 373 ? 53.338  53.826 43.885 1.00 39.97  ? 392  THR B OG1 1 
+ATOM   6605 C  CG2 . THR B 1 373 ? 51.646  52.452 44.666 1.00 36.18  ? 392  THR B CG2 1 
+ATOM   6606 N  N   . SER B 1 374 ? 49.984  55.965 45.367 1.00 39.73  ? 393  SER B N   1 
+ATOM   6607 C  CA  . SER B 1 374 ? 48.954  56.224 46.351 1.00 37.67  ? 393  SER B CA  1 
+ATOM   6608 C  C   . SER B 1 374 ? 47.674  56.655 45.669 1.00 38.86  ? 393  SER B C   1 
+ATOM   6609 O  O   . SER B 1 374 ? 46.572  56.434 46.206 1.00 44.74  ? 393  SER B O   1 
+ATOM   6610 C  CB  . SER B 1 374 ? 49.420  57.269 47.335 1.00 33.00  ? 393  SER B CB  1 
+ATOM   6611 O  OG  . SER B 1 374 ? 49.668  58.470 46.664 1.00 32.02  ? 393  SER B OG  1 
+ATOM   6612 N  N   . VAL B 1 375 ? 47.818  57.238 44.482 1.00 36.30  ? 394  VAL B N   1 
+ATOM   6613 C  CA  . VAL B 1 375 ? 46.672  57.588 43.658 1.00 36.58  ? 394  VAL B CA  1 
+ATOM   6614 C  C   . VAL B 1 375 ? 46.234  56.449 42.737 1.00 35.99  ? 394  VAL B C   1 
+ATOM   6615 O  O   . VAL B 1 375 ? 45.055  56.136 42.650 1.00 38.91  ? 394  VAL B O   1 
+ATOM   6616 C  CB  . VAL B 1 375 ? 46.960  58.830 42.845 1.00 36.66  ? 394  VAL B CB  1 
+ATOM   6617 C  CG1 . VAL B 1 375 ? 45.720  59.240 42.060 1.00 35.82  ? 394  VAL B CG1 1 
+ATOM   6618 C  CG2 . VAL B 1 375 ? 47.435  59.948 43.780 1.00 37.92  ? 394  VAL B CG2 1 
+ATOM   6619 N  N   . LEU B 1 376 ? 47.181  55.806 42.074 1.00 36.20  ? 395  LEU B N   1 
+ATOM   6620 C  CA  . LEU B 1 376 ? 46.848  54.746 41.122 1.00 34.88  ? 395  LEU B CA  1 
+ATOM   6621 C  C   . LEU B 1 376 ? 46.293  53.536 41.830 1.00 32.19  ? 395  LEU B C   1 
+ATOM   6622 O  O   . LEU B 1 376 ? 45.687  52.685 41.201 1.00 27.95  ? 395  LEU B O   1 
+ATOM   6623 C  CB  . LEU B 1 376 ? 48.083  54.313 40.328 1.00 37.44  ? 395  LEU B CB  1 
+ATOM   6624 C  CG  . LEU B 1 376 ? 48.308  54.720 38.864 1.00 39.79  ? 395  LEU B CG  1 
+ATOM   6625 C  CD1 . LEU B 1 376 ? 47.895  56.106 38.574 1.00 39.54  ? 395  LEU B CD1 1 
+ATOM   6626 C  CD2 . LEU B 1 376 ? 49.795  54.556 38.512 1.00 40.13  ? 395  LEU B CD2 1 
+ATOM   6627 N  N   . HIS B 1 377 ? 46.523  53.443 43.137 1.00 35.00  ? 396  HIS B N   1 
+ATOM   6628 C  CA  . HIS B 1 377 ? 46.139  52.260 43.907 1.00 35.55  ? 396  HIS B CA  1 
+ATOM   6629 C  C   . HIS B 1 377 ? 45.258  52.593 45.086 1.00 37.57  ? 396  HIS B C   1 
+ATOM   6630 O  O   . HIS B 1 377 ? 45.227  51.811 46.013 1.00 38.51  ? 396  HIS B O   1 
+ATOM   6631 C  CB  . HIS B 1 377 ? 47.373  51.493 44.387 1.00 35.98  ? 396  HIS B CB  1 
+ATOM   6632 C  CG  . HIS B 1 377 ? 48.061  50.741 43.303 1.00 38.30  ? 396  HIS B CG  1 
+ATOM   6633 N  ND1 . HIS B 1 377 ? 47.952  49.377 43.164 1.00 42.39  ? 396  HIS B ND1 1 
+ATOM   6634 C  CD2 . HIS B 1 377 ? 48.835  51.162 42.281 1.00 39.80  ? 396  HIS B CD2 1 
+ATOM   6635 C  CE1 . HIS B 1 377 ? 48.634  48.990 42.102 1.00 42.69  ? 396  HIS B CE1 1 
+ATOM   6636 N  NE2 . HIS B 1 377 ? 49.178  50.053 41.548 1.00 41.18  ? 396  HIS B NE2 1 
+ATOM   6637 N  N   . ASP B 1 378 ? 44.525  53.719 45.027 1.00 42.77  ? 397  ASP B N   1 
+ATOM   6638 C  CA  . ASP B 1 378 ? 43.501  54.090 46.028 1.00 44.20  ? 397  ASP B CA  1 
+ATOM   6639 C  C   . ASP B 1 378 ? 42.490  52.940 46.286 1.00 44.77  ? 397  ASP B C   1 
+ATOM   6640 O  O   . ASP B 1 378 ? 41.929  52.422 45.330 1.00 46.09  ? 397  ASP B O   1 
+ATOM   6641 C  CB  . ASP B 1 378 ? 42.786  55.354 45.525 1.00 46.11  ? 397  ASP B CB  1 
+ATOM   6642 C  CG  . ASP B 1 378 ? 42.135  56.163 46.636 1.00 46.21  ? 397  ASP B CG  1 
+ATOM   6643 O  OD1 . ASP B 1 378 ? 40.945  55.886 46.921 1.00 47.63  ? 397  ASP B OD1 1 
+ATOM   6644 O  OD2 . ASP B 1 378 ? 42.718  57.106 47.236 1.00 37.91  ? 397  ASP B OD2 1 
+ATOM   6645 N  N   . ASN B 1 379 ? 42.307  52.523 47.549 1.00 45.51  ? 398  ASN B N   1 
+ATOM   6646 C  CA  . ASN B 1 379 ? 41.303  51.511 47.967 1.00 50.02  ? 398  ASN B CA  1 
+ATOM   6647 C  C   . ASN B 1 379 ? 39.882  51.856 47.657 1.00 48.23  ? 398  ASN B C   1 
+ATOM   6648 O  O   . ASN B 1 379 ? 39.097  50.971 47.394 1.00 45.67  ? 398  ASN B O   1 
+ATOM   6649 C  CB  . ASN B 1 379 ? 41.224  51.360 49.491 1.00 53.98  ? 398  ASN B CB  1 
+ATOM   6650 C  CG  . ASN B 1 379 ? 42.384  50.694 50.049 1.00 63.01  ? 398  ASN B CG  1 
+ATOM   6651 O  OD1 . ASN B 1 379 ? 43.167  51.325 50.757 1.00 73.61  ? 398  ASN B OD1 1 
+ATOM   6652 N  ND2 . ASN B 1 379 ? 42.554  49.402 49.730 1.00 70.07  ? 398  ASN B ND2 1 
+ATOM   6653 N  N   . LYS B 1 380 ? 39.525  53.125 47.831 1.00 49.07  ? 399  LYS B N   1 
+ATOM   6654 C  CA  . LYS B 1 380 ? 38.138  53.555 47.646 1.00 52.97  ? 399  LYS B CA  1 
+ATOM   6655 C  C   . LYS B 1 380 ? 37.848  53.503 46.148 1.00 49.66  ? 399  LYS B C   1 
+ATOM   6656 O  O   . LYS B 1 380 ? 37.047  52.695 45.707 1.00 46.23  ? 399  LYS B O   1 
+ATOM   6657 C  CB  . LYS B 1 380 ? 37.874  54.968 48.215 1.00 55.28  ? 399  LYS B CB  1 
+ATOM   6658 C  CG  . LYS B 1 380 ? 38.290  55.184 49.685 1.00 60.24  ? 399  LYS B CG  1 
+ATOM   6659 C  CD  . LYS B 1 380 ? 37.129  55.001 50.680 1.00 66.26  ? 399  LYS B CD  1 
+ATOM   6660 C  CE  . LYS B 1 380 ? 36.350  56.306 50.922 1.00 68.25  ? 399  LYS B CE  1 
+ATOM   6661 N  NZ  . LYS B 1 380 ? 35.754  56.831 49.649 1.00 70.08  ? 399  LYS B NZ  1 
+ATOM   6662 N  N   . GLU B 1 381 ? 38.571  54.315 45.375 1.00 48.18  ? 400  GLU B N   1 
+ATOM   6663 C  CA  . GLU B 1 381 ? 38.407  54.387 43.917 1.00 48.07  ? 400  GLU B CA  1 
+ATOM   6664 C  C   . GLU B 1 381 ? 38.575  53.062 43.151 1.00 46.13  ? 400  GLU B C   1 
+ATOM   6665 O  O   . GLU B 1 381 ? 37.865  52.825 42.172 1.00 40.35  ? 400  GLU B O   1 
+ATOM   6666 C  CB  . GLU B 1 381 ? 39.369  55.414 43.329 1.00 48.20  ? 400  GLU B CB  1 
+ATOM   6667 C  CG  . GLU B 1 381 ? 39.110  55.700 41.859 1.00 52.03  ? 400  GLU B CG  1 
+ATOM   6668 C  CD  . GLU B 1 381 ? 37.903  56.583 41.627 1.00 51.09  ? 400  GLU B CD  1 
+ATOM   6669 O  OE1 . GLU B 1 381 ? 37.682  57.012 40.467 1.00 43.41  ? 400  GLU B OE1 1 
+ATOM   6670 O  OE2 . GLU B 1 381 ? 37.192  56.858 42.615 1.00 52.40  ? 400  GLU B OE2 1 
+ATOM   6671 N  N   . PHE B 1 382 ? 39.489  52.205 43.606 1.00 46.07  ? 401  PHE B N   1 
+ATOM   6672 C  CA  . PHE B 1 382 ? 39.783  50.924 42.934 1.00 45.41  ? 401  PHE B CA  1 
+ATOM   6673 C  C   . PHE B 1 382 ? 39.643  49.736 43.911 1.00 48.62  ? 401  PHE B C   1 
+ATOM   6674 O  O   . PHE B 1 382 ? 40.631  49.211 44.380 1.00 52.47  ? 401  PHE B O   1 
+ATOM   6675 C  CB  . PHE B 1 382 ? 41.194  50.980 42.312 1.00 38.06  ? 401  PHE B CB  1 
+ATOM   6676 C  CG  . PHE B 1 382 ? 41.383  52.098 41.323 1.00 30.63  ? 401  PHE B CG  1 
+ATOM   6677 C  CD1 . PHE B 1 382 ? 42.309  53.110 41.578 1.00 28.10  ? 401  PHE B CD1 1 
+ATOM   6678 C  CD2 . PHE B 1 382 ? 40.647  52.150 40.150 1.00 26.88  ? 401  PHE B CD2 1 
+ATOM   6679 C  CE1 . PHE B 1 382 ? 42.476  54.163 40.689 1.00 28.29  ? 401  PHE B CE1 1 
+ATOM   6680 C  CE2 . PHE B 1 382 ? 40.807  53.204 39.247 1.00 26.11  ? 401  PHE B CE2 1 
+ATOM   6681 C  CZ  . PHE B 1 382 ? 41.729  54.203 39.509 1.00 28.57  ? 401  PHE B CZ  1 
+ATOM   6682 N  N   . PRO B 1 383 ? 38.418  49.330 44.245 1.00 56.69  ? 402  PRO B N   1 
+ATOM   6683 C  CA  . PRO B 1 383 ? 38.195  48.323 45.288 1.00 57.74  ? 402  PRO B CA  1 
+ATOM   6684 C  C   . PRO B 1 383 ? 39.401  47.440 45.632 1.00 59.86  ? 402  PRO B C   1 
+ATOM   6685 O  O   . PRO B 1 383 ? 39.966  47.660 46.712 1.00 68.42  ? 402  PRO B O   1 
+ATOM   6686 C  CB  . PRO B 1 383 ? 37.015  47.539 44.739 1.00 58.69  ? 402  PRO B CB  1 
+ATOM   6687 C  CG  . PRO B 1 383 ? 36.170  48.646 44.083 1.00 58.35  ? 402  PRO B CG  1 
+ATOM   6688 C  CD  . PRO B 1 383 ? 37.129  49.790 43.692 1.00 57.20  ? 402  PRO B CD  1 
+ATOM   6689 N  N   . ASN B 1 384 ? 39.812  46.503 44.792 1.00 56.84  ? 403  ASN B N   1 
+ATOM   6690 C  CA  . ASN B 1 384 ? 40.953  45.663 45.157 1.00 58.12  ? 403  ASN B CA  1 
+ATOM   6691 C  C   . ASN B 1 384 ? 42.168  46.053 44.315 1.00 55.99  ? 403  ASN B C   1 
+ATOM   6692 O  O   . ASN B 1 384 ? 42.435  45.424 43.295 1.00 53.64  ? 403  ASN B O   1 
+ATOM   6693 C  CB  . ASN B 1 384 ? 40.605  44.168 44.991 1.00 61.93  ? 403  ASN B CB  1 
+ATOM   6694 C  CG  . ASN B 1 384 ? 39.306  43.777 45.710 1.00 64.70  ? 403  ASN B CG  1 
+ATOM   6695 O  OD1 . ASN B 1 384 ? 39.275  43.626 46.926 1.00 68.82  ? 403  ASN B OD1 1 
+ATOM   6696 N  ND2 . ASN B 1 384 ? 38.232  43.623 44.952 1.00 68.38  ? 403  ASN B ND2 1 
+ATOM   6697 N  N   . PRO B 1 385 ? 42.932  47.055 44.750 1.00 53.36  ? 404  PRO B N   1 
+ATOM   6698 C  CA  . PRO B 1 385 ? 43.845  47.755 43.843 1.00 51.93  ? 404  PRO B CA  1 
+ATOM   6699 C  C   . PRO B 1 385 ? 45.062  46.910 43.402 1.00 52.95  ? 404  PRO B C   1 
+ATOM   6700 O  O   . PRO B 1 385 ? 45.730  47.306 42.449 1.00 48.68  ? 404  PRO B O   1 
+ATOM   6701 C  CB  . PRO B 1 385 ? 44.259  48.999 44.650 1.00 49.92  ? 404  PRO B CB  1 
+ATOM   6702 C  CG  . PRO B 1 385 ? 44.190  48.576 46.065 1.00 51.28  ? 404  PRO B CG  1 
+ATOM   6703 C  CD  . PRO B 1 385 ? 43.071  47.550 46.130 1.00 55.07  ? 404  PRO B CD  1 
+ATOM   6704 N  N   . GLU B 1 386 ? 45.322  45.768 44.040 1.00 54.48  ? 405  GLU B N   1 
+ATOM   6705 C  CA  . GLU B 1 386 ? 46.463  44.924 43.667 1.00 55.71  ? 405  GLU B CA  1 
+ATOM   6706 C  C   . GLU B 1 386 ? 46.121  43.843 42.678 1.00 53.14  ? 405  GLU B C   1 
+ATOM   6707 O  O   . GLU B 1 386 ? 46.995  43.085 42.296 1.00 57.00  ? 405  GLU B O   1 
+ATOM   6708 C  CB  . GLU B 1 386 ? 47.097  44.273 44.892 1.00 60.17  ? 405  GLU B CB  1 
+ATOM   6709 C  CG  . GLU B 1 386 ? 47.567  45.262 45.958 1.00 70.90  ? 405  GLU B CG  1 
+ATOM   6710 C  CD  . GLU B 1 386 ? 48.835  46.036 45.574 1.00 75.49  ? 405  GLU B CD  1 
+ATOM   6711 O  OE1 . GLU B 1 386 ? 49.899  45.796 46.195 1.00 78.46  ? 405  GLU B OE1 1 
+ATOM   6712 O  OE2 . GLU B 1 386 ? 48.766  46.902 44.670 1.00 80.00  ? 405  GLU B OE2 1 
+ATOM   6713 N  N   . MET B 1 387 ? 44.862  43.762 42.269 1.00 53.26  ? 406  MET B N   1 
+ATOM   6714 C  CA  . MET B 1 387 ? 44.443  42.839 41.216 1.00 54.32  ? 406  MET B CA  1 
+ATOM   6715 C  C   . MET B 1 387 ? 44.364  43.525 39.842 1.00 49.65  ? 406  MET B C   1 
+ATOM   6716 O  O   . MET B 1 387 ? 43.923  44.666 39.737 1.00 44.17  ? 406  MET B O   1 
+ATOM   6717 C  CB  . MET B 1 387 ? 43.053  42.278 41.522 1.00 59.26  ? 406  MET B CB  1 
+ATOM   6718 C  CG  . MET B 1 387 ? 42.890  41.634 42.892 1.00 65.55  ? 406  MET B CG  1 
+ATOM   6719 S  SD  . MET B 1 387 ? 43.903  40.165 43.059 1.00 73.73  ? 406  MET B SD  1 
+ATOM   6720 C  CE  . MET B 1 387 ? 43.123  38.951 41.829 1.00 66.04  ? 406  MET B CE  1 
+ATOM   6721 N  N   . PHE B 1 388 ? 44.761  42.810 38.792 1.00 42.34  ? 407  PHE B N   1 
+ATOM   6722 C  CA  . PHE B 1 388 ? 44.406  43.211 37.443 1.00 37.77  ? 407  PHE B CA  1 
+ATOM   6723 C  C   . PHE B 1 388 ? 42.911  42.954 37.205 1.00 42.85  ? 407  PHE B C   1 
+ATOM   6724 O  O   . PHE B 1 388 ? 42.474  41.796 37.073 1.00 39.75  ? 407  PHE B O   1 
+ATOM   6725 C  CB  . PHE B 1 388 ? 45.224  42.448 36.409 1.00 34.49  ? 407  PHE B CB  1 
+ATOM   6726 C  CG  . PHE B 1 388 ? 45.042  42.953 35.020 1.00 32.24  ? 407  PHE B CG  1 
+ATOM   6727 C  CD1 . PHE B 1 388 ? 45.583  44.172 34.638 1.00 33.05  ? 407  PHE B CD1 1 
+ATOM   6728 C  CD2 . PHE B 1 388 ? 44.322  42.239 34.100 1.00 34.76  ? 407  PHE B CD2 1 
+ATOM   6729 C  CE1 . PHE B 1 388 ? 45.417  44.644 33.368 1.00 29.24  ? 407  PHE B CE1 1 
+ATOM   6730 C  CE2 . PHE B 1 388 ? 44.143  42.720 32.811 1.00 33.15  ? 407  PHE B CE2 1 
+ATOM   6731 C  CZ  . PHE B 1 388 ? 44.689  43.913 32.456 1.00 33.40  ? 407  PHE B CZ  1 
+ATOM   6732 N  N   . ASP B 1 389 ? 42.137  44.038 37.158 1.00 42.94  ? 408  ASP B N   1 
+ATOM   6733 C  CA  . ASP B 1 389 ? 40.726  43.966 36.802 1.00 44.24  ? 408  ASP B CA  1 
+ATOM   6734 C  C   . ASP B 1 389 ? 40.306  45.159 35.947 1.00 41.54  ? 408  ASP B C   1 
+ATOM   6735 O  O   . ASP B 1 389 ? 40.192  46.287 36.458 1.00 31.52  ? 408  ASP B O   1 
+ATOM   6736 C  CB  . ASP B 1 389 ? 39.864  43.916 38.058 1.00 48.45  ? 408  ASP B CB  1 
+ATOM   6737 C  CG  . ASP B 1 389 ? 38.393  43.694 37.751 1.00 51.42  ? 408  ASP B CG  1 
+ATOM   6738 O  OD1 . ASP B 1 389 ? 37.585  43.673 38.705 1.00 61.18  ? 408  ASP B OD1 1 
+ATOM   6739 O  OD2 . ASP B 1 389 ? 37.953  43.503 36.600 1.00 55.69  ? 408  ASP B OD2 1 
+ATOM   6740 N  N   . PRO B 1 390 ? 40.052  44.919 34.657 1.00 39.01  ? 409  PRO B N   1 
+ATOM   6741 C  CA  . PRO B 1 390 ? 39.650  46.007 33.759 1.00 40.67  ? 409  PRO B CA  1 
+ATOM   6742 C  C   . PRO B 1 390 ? 38.347  46.719 34.189 1.00 41.38  ? 409  PRO B C   1 
+ATOM   6743 O  O   . PRO B 1 390 ? 38.154  47.876 33.794 1.00 35.27  ? 409  PRO B O   1 
+ATOM   6744 C  CB  . PRO B 1 390 ? 39.506  45.322 32.387 1.00 41.75  ? 409  PRO B CB  1 
+ATOM   6745 C  CG  . PRO B 1 390 ? 40.161  43.971 32.516 1.00 40.78  ? 409  PRO B CG  1 
+ATOM   6746 C  CD  . PRO B 1 390 ? 40.113  43.621 33.961 1.00 41.74  ? 409  PRO B CD  1 
+ATOM   6747 N  N   . HIS B 1 391 ? 37.497  46.066 34.993 1.00 44.48  ? 410  HIS B N   1 
+ATOM   6748 C  CA  . HIS B 1 391 ? 36.230  46.677 35.441 1.00 45.62  ? 410  HIS B CA  1 
+ATOM   6749 C  C   . HIS B 1 391 ? 36.436  47.871 36.362 1.00 44.02  ? 410  HIS B C   1 
+ATOM   6750 O  O   . HIS B 1 391 ? 35.506  48.614 36.631 1.00 45.97  ? 410  HIS B O   1 
+ATOM   6751 C  CB  . HIS B 1 391 ? 35.285  45.625 36.063 1.00 48.18  ? 410  HIS B CB  1 
+ATOM   6752 C  CG  . HIS B 1 391 ? 34.637  44.740 35.043 1.00 51.72  ? 410  HIS B CG  1 
+ATOM   6753 N  ND1 . HIS B 1 391 ? 33.476  45.094 34.382 1.00 51.63  ? 410  HIS B ND1 1 
+ATOM   6754 C  CD2 . HIS B 1 391 ? 35.032  43.555 34.511 1.00 53.25  ? 410  HIS B CD2 1 
+ATOM   6755 C  CE1 . HIS B 1 391 ? 33.176  44.155 33.501 1.00 56.83  ? 410  HIS B CE1 1 
+ATOM   6756 N  NE2 . HIS B 1 391 ? 34.104  43.209 33.558 1.00 55.65  ? 410  HIS B NE2 1 
+ATOM   6757 N  N   . HIS B 1 392 ? 37.666  48.047 36.837 1.00 47.01  ? 411  HIS B N   1 
+ATOM   6758 C  CA  . HIS B 1 392 ? 38.092  49.246 37.554 1.00 45.91  ? 411  HIS B CA  1 
+ATOM   6759 C  C   . HIS B 1 392 ? 37.871  50.489 36.642 1.00 43.05  ? 411  HIS B C   1 
+ATOM   6760 O  O   . HIS B 1 392 ? 37.872  51.625 37.105 1.00 41.89  ? 411  HIS B O   1 
+ATOM   6761 C  CB  . HIS B 1 392 ? 39.588  49.132 37.932 1.00 46.82  ? 411  HIS B CB  1 
+ATOM   6762 C  CG  . HIS B 1 392 ? 39.904  48.333 39.168 1.00 47.89  ? 411  HIS B CG  1 
+ATOM   6763 N  ND1 . HIS B 1 392 ? 40.402  48.962 40.283 1.00 57.14  ? 411  HIS B ND1 1 
+ATOM   6764 C  CD2 . HIS B 1 392 ? 39.974  46.989 39.431 1.00 50.06  ? 411  HIS B CD2 1 
+ATOM   6765 C  CE1 . HIS B 1 392 ? 40.702  48.052 41.205 1.00 58.22  ? 411  HIS B CE1 1 
+ATOM   6766 N  NE2 . HIS B 1 392 ? 40.456  46.843 40.710 1.00 52.28  ? 411  HIS B NE2 1 
+ATOM   6767 N  N   . PHE B 1 393 ? 37.705  50.261 35.339 1.00 44.22  ? 412  PHE B N   1 
+ATOM   6768 C  CA  . PHE B 1 393 ? 37.428  51.326 34.361 1.00 43.55  ? 412  PHE B CA  1 
+ATOM   6769 C  C   . PHE B 1 393 ? 36.212  50.987 33.491 1.00 44.26  ? 412  PHE B C   1 
+ATOM   6770 O  O   . PHE B 1 393 ? 36.196  51.294 32.300 1.00 44.30  ? 412  PHE B O   1 
+ATOM   6771 C  CB  . PHE B 1 393 ? 38.663  51.599 33.464 1.00 41.08  ? 412  PHE B CB  1 
+ATOM   6772 C  CG  . PHE B 1 393 ? 39.847  52.157 34.212 1.00 35.75  ? 412  PHE B CG  1 
+ATOM   6773 C  CD1 . PHE B 1 393 ? 40.781  51.307 34.782 1.00 30.99  ? 412  PHE B CD1 1 
+ATOM   6774 C  CD2 . PHE B 1 393 ? 40.017  53.527 34.348 1.00 32.97  ? 412  PHE B CD2 1 
+ATOM   6775 C  CE1 . PHE B 1 393 ? 41.857  51.804 35.484 1.00 33.70  ? 412  PHE B CE1 1 
+ATOM   6776 C  CE2 . PHE B 1 393 ? 41.102  54.036 35.049 1.00 37.32  ? 412  PHE B CE2 1 
+ATOM   6777 C  CZ  . PHE B 1 393 ? 42.030  53.171 35.618 1.00 34.69  ? 412  PHE B CZ  1 
+ATOM   6778 N  N   . LEU B 1 394 ? 35.194  50.384 34.105 1.00 47.09  ? 413  LEU B N   1 
+ATOM   6779 C  CA  . LEU B 1 394 ? 33.927  50.058 33.444 1.00 48.12  ? 413  LEU B CA  1 
+ATOM   6780 C  C   . LEU B 1 394 ? 32.703  50.188 34.384 1.00 52.07  ? 413  LEU B C   1 
+ATOM   6781 O  O   . LEU B 1 394 ? 32.705  49.684 35.526 1.00 51.79  ? 413  LEU B O   1 
+ATOM   6782 C  CB  . LEU B 1 394 ? 33.972  48.636 32.898 1.00 45.27  ? 413  LEU B CB  1 
+ATOM   6783 C  CG  . LEU B 1 394 ? 34.900  48.303 31.743 1.00 40.01  ? 413  LEU B CG  1 
+ATOM   6784 C  CD1 . LEU B 1 394 ? 34.821  46.814 31.517 1.00 42.30  ? 413  LEU B CD1 1 
+ATOM   6785 C  CD2 . LEU B 1 394 ? 34.539  49.027 30.468 1.00 37.59  ? 413  LEU B CD2 1 
+ATOM   6786 N  N   . ASP B 1 395 ? 31.649  50.819 33.861 1.00 54.94  ? 414  ASP B N   1 
+ATOM   6787 C  CA  . ASP B 1 395 ? 30.425  51.102 34.613 1.00 56.14  ? 414  ASP B CA  1 
+ATOM   6788 C  C   . ASP B 1 395 ? 29.457  49.932 34.505 1.00 59.66  ? 414  ASP B C   1 
+ATOM   6789 O  O   . ASP B 1 395 ? 29.833  48.876 34.006 1.00 58.36  ? 414  ASP B O   1 
+ATOM   6790 C  CB  . ASP B 1 395 ? 29.784  52.429 34.136 1.00 55.19  ? 414  ASP B CB  1 
+ATOM   6791 C  CG  . ASP B 1 395 ? 29.136  52.329 32.746 1.00 55.31  ? 414  ASP B CG  1 
+ATOM   6792 O  OD1 . ASP B 1 395 ? 28.803  53.385 32.153 1.00 58.16  ? 414  ASP B OD1 1 
+ATOM   6793 O  OD2 . ASP B 1 395 ? 28.913  51.252 32.158 1.00 59.46  ? 414  ASP B OD2 1 
+ATOM   6794 N  N   . GLU B 1 396 ? 28.244  50.137 35.025 1.00 67.04  ? 415  GLU B N   1 
+ATOM   6795 C  CA  . GLU B 1 396 ? 27.063  49.266 34.853 1.00 71.76  ? 415  GLU B CA  1 
+ATOM   6796 C  C   . GLU B 1 396 ? 26.992  48.411 33.561 1.00 70.54  ? 415  GLU B C   1 
+ATOM   6797 O  O   . GLU B 1 396 ? 27.021  47.177 33.644 1.00 66.03  ? 415  GLU B O   1 
+ATOM   6798 C  CB  . GLU B 1 396 ? 25.774  50.120 35.004 1.00 78.38  ? 415  GLU B CB  1 
+ATOM   6799 C  CG  . GLU B 1 396 ? 25.727  51.452 34.216 1.00 84.92  ? 415  GLU B CG  1 
+ATOM   6800 C  CD  . GLU B 1 396 ? 25.231  52.670 35.025 1.00 90.18  ? 415  GLU B CD  1 
+ATOM   6801 O  OE1 . GLU B 1 396 ? 25.543  52.769 36.239 1.00 93.04  ? 415  GLU B OE1 1 
+ATOM   6802 O  OE2 . GLU B 1 396 ? 24.539  53.554 34.438 1.00 93.54  ? 415  GLU B OE2 1 
+ATOM   6803 N  N   . GLY B 1 397 ? 26.886  49.054 32.389 1.00 70.90  ? 416  GLY B N   1 
+ATOM   6804 C  CA  . GLY B 1 397 ? 26.936  48.359 31.101 1.00 73.04  ? 416  GLY B CA  1 
+ATOM   6805 C  C   . GLY B 1 397 ? 28.365  47.964 30.733 1.00 75.08  ? 416  GLY B C   1 
+ATOM   6806 O  O   . GLY B 1 397 ? 29.120  47.485 31.585 1.00 81.29  ? 416  GLY B O   1 
+ATOM   6807 N  N   . GLY B 1 398 ? 28.756  48.128 29.473 1.00 72.70  ? 417  GLY B N   1 
+ATOM   6808 C  CA  . GLY B 1 398 ? 30.180  48.127 29.134 1.00 69.51  ? 417  GLY B CA  1 
+ATOM   6809 C  C   . GLY B 1 398 ? 30.680  49.502 29.541 1.00 64.77  ? 417  GLY B C   1 
+ATOM   6810 O  O   . GLY B 1 398 ? 30.852  49.778 30.715 1.00 67.45  ? 417  GLY B O   1 
+ATOM   6811 N  N   . ASN B 1 399 ? 30.853  50.381 28.567 1.00 60.66  ? 418  ASN B N   1 
+ATOM   6812 C  CA  . ASN B 1 399 ? 30.988  51.833 28.798 1.00 58.32  ? 418  ASN B CA  1 
+ATOM   6813 C  C   . ASN B 1 399 ? 32.177  52.228 29.684 1.00 52.88  ? 418  ASN B C   1 
+ATOM   6814 O  O   . ASN B 1 399 ? 32.330  51.802 30.828 1.00 43.58  ? 418  ASN B O   1 
+ATOM   6815 C  CB  . ASN B 1 399 ? 29.667  52.483 29.278 1.00 59.79  ? 418  ASN B CB  1 
+ATOM   6816 C  CG  . ASN B 1 399 ? 28.415  51.742 28.775 1.00 65.54  ? 418  ASN B CG  1 
+ATOM   6817 O  OD1 . ASN B 1 399 ? 27.708  51.080 29.556 1.00 71.46  ? 418  ASN B OD1 1 
+ATOM   6818 N  ND2 . ASN B 1 399 ? 28.151  51.826 27.469 1.00 62.12  ? 418  ASN B ND2 1 
+ATOM   6819 N  N   . PHE B 1 400 ? 33.050  53.041 29.122 1.00 50.18  ? 419  PHE B N   1 
+ATOM   6820 C  CA  . PHE B 1 400 ? 34.307  53.302 29.778 1.00 47.92  ? 419  PHE B CA  1 
+ATOM   6821 C  C   . PHE B 1 400 ? 34.002  54.227 30.944 1.00 45.88  ? 419  PHE B C   1 
+ATOM   6822 O  O   . PHE B 1 400 ? 33.315  55.231 30.776 1.00 45.25  ? 419  PHE B O   1 
+ATOM   6823 C  CB  . PHE B 1 400 ? 35.324  53.889 28.791 1.00 46.10  ? 419  PHE B CB  1 
+ATOM   6824 C  CG  . PHE B 1 400 ? 36.619  54.305 29.431 1.00 48.82  ? 419  PHE B CG  1 
+ATOM   6825 C  CD1 . PHE B 1 400 ? 37.615  53.369 29.690 1.00 48.54  ? 419  PHE B CD1 1 
+ATOM   6826 C  CD2 . PHE B 1 400 ? 36.842  55.634 29.778 1.00 46.92  ? 419  PHE B CD2 1 
+ATOM   6827 C  CE1 . PHE B 1 400 ? 38.803  53.746 30.291 1.00 47.18  ? 419  PHE B CE1 1 
+ATOM   6828 C  CE2 . PHE B 1 400 ? 38.030  56.021 30.376 1.00 47.42  ? 419  PHE B CE2 1 
+ATOM   6829 C  CZ  . PHE B 1 400 ? 39.017  55.070 30.629 1.00 48.70  ? 419  PHE B CZ  1 
+ATOM   6830 N  N   . LYS B 1 401 ? 34.477  53.846 32.128 1.00 46.97  ? 420  LYS B N   1 
+ATOM   6831 C  CA  . LYS B 1 401 ? 34.353  54.650 33.357 1.00 43.93  ? 420  LYS B CA  1 
+ATOM   6832 C  C   . LYS B 1 401 ? 35.672  55.345 33.676 1.00 39.84  ? 420  LYS B C   1 
+ATOM   6833 O  O   . LYS B 1 401 ? 36.562  54.728 34.237 1.00 40.13  ? 420  LYS B O   1 
+ATOM   6834 C  CB  . LYS B 1 401 ? 33.944  53.759 34.547 1.00 43.06  ? 420  LYS B CB  1 
+ATOM   6835 C  CG  . LYS B 1 401 ? 33.539  54.533 35.807 1.00 43.99  ? 420  LYS B CG  1 
+ATOM   6836 C  CD  . LYS B 1 401 ? 33.715  53.735 37.128 1.00 48.52  ? 420  LYS B CD  1 
+ATOM   6837 C  CE  . LYS B 1 401 ? 33.486  52.231 36.998 1.00 49.39  ? 420  LYS B CE  1 
+ATOM   6838 N  NZ  . LYS B 1 401 ? 33.530  51.583 38.349 1.00 52.83  ? 420  LYS B NZ  1 
+ATOM   6839 N  N   . LYS B 1 402 ? 35.779  56.631 33.349 1.00 37.34  ? 421  LYS B N   1 
+ATOM   6840 C  CA  . LYS B 1 402 ? 37.002  57.407 33.577 1.00 38.71  ? 421  LYS B CA  1 
+ATOM   6841 C  C   . LYS B 1 402 ? 37.279  57.610 35.062 1.00 38.57  ? 421  LYS B C   1 
+ATOM   6842 O  O   . LYS B 1 402 ? 36.532  57.155 35.893 1.00 43.57  ? 421  LYS B O   1 
+ATOM   6843 C  CB  . LYS B 1 402 ? 36.958  58.751 32.821 1.00 39.76  ? 421  LYS B CB  1 
+ATOM   6844 C  CG  . LYS B 1 402 ? 36.041  59.820 33.375 1.00 40.83  ? 421  LYS B CG  1 
+ATOM   6845 C  CD  . LYS B 1 402 ? 35.922  60.968 32.387 1.00 41.52  ? 421  LYS B CD  1 
+ATOM   6846 C  CE  . LYS B 1 402 ? 34.976  62.051 32.900 1.00 41.77  ? 421  LYS B CE  1 
+ATOM   6847 N  NZ  . LYS B 1 402 ? 35.055  63.246 32.038 1.00 41.71  ? 421  LYS B NZ  1 
+ATOM   6848 N  N   . SER B 1 403 ? 38.380  58.261 35.398 1.00 40.86  ? 422  SER B N   1 
+ATOM   6849 C  CA  . SER B 1 403 ? 38.773  58.383 36.800 1.00 38.91  ? 422  SER B CA  1 
+ATOM   6850 C  C   . SER B 1 403 ? 39.838  59.441 36.947 1.00 38.13  ? 422  SER B C   1 
+ATOM   6851 O  O   . SER B 1 403 ? 40.744  59.531 36.141 1.00 41.75  ? 422  SER B O   1 
+ATOM   6852 C  CB  . SER B 1 403 ? 39.284  57.047 37.335 1.00 36.21  ? 422  SER B CB  1 
+ATOM   6853 O  OG  . SER B 1 403 ? 39.717  57.198 38.665 1.00 36.89  ? 422  SER B OG  1 
+ATOM   6854 N  N   . LYS B 1 404 ? 39.708  60.270 37.962 1.00 41.81  ? 423  LYS B N   1 
+ATOM   6855 C  CA  . LYS B 1 404 ? 40.656  61.357 38.162 1.00 44.22  ? 423  LYS B CA  1 
+ATOM   6856 C  C   . LYS B 1 404 ? 41.882  60.758 38.831 1.00 44.12  ? 423  LYS B C   1 
+ATOM   6857 O  O   . LYS B 1 404 ? 42.941  61.386 38.869 1.00 40.95  ? 423  LYS B O   1 
+ATOM   6858 C  CB  . LYS B 1 404 ? 40.050  62.515 38.990 1.00 46.38  ? 423  LYS B CB  1 
+ATOM   6859 C  CG  . LYS B 1 404 ? 39.094  62.107 40.128 1.00 50.12  ? 423  LYS B CG  1 
+ATOM   6860 C  CD  . LYS B 1 404 ? 38.448  63.331 40.796 1.00 54.96  ? 423  LYS B CD  1 
+ATOM   6861 C  CE  . LYS B 1 404 ? 37.880  63.022 42.203 1.00 56.74  ? 423  LYS B CE  1 
+ATOM   6862 N  NZ  . LYS B 1 404 ? 38.055  64.188 43.138 1.00 55.00  ? 423  LYS B NZ  1 
+ATOM   6863 N  N   . TYR B 1 405 ? 41.717  59.532 39.339 1.00 42.99  ? 424  TYR B N   1 
+ATOM   6864 C  CA  . TYR B 1 405 ? 42.783  58.795 40.014 1.00 47.27  ? 424  TYR B CA  1 
+ATOM   6865 C  C   . TYR B 1 405 ? 43.730  58.076 39.018 1.00 43.68  ? 424  TYR B C   1 
+ATOM   6866 O  O   . TYR B 1 405 ? 44.614  57.303 39.419 1.00 39.65  ? 424  TYR B O   1 
+ATOM   6867 C  CB  . TYR B 1 405 ? 42.185  57.780 41.022 1.00 48.62  ? 424  TYR B CB  1 
+ATOM   6868 C  CG  . TYR B 1 405 ? 41.593  58.404 42.275 1.00 52.47  ? 424  TYR B CG  1 
+ATOM   6869 C  CD1 . TYR B 1 405 ? 42.290  58.402 43.482 1.00 55.93  ? 424  TYR B CD1 1 
+ATOM   6870 C  CD2 . TYR B 1 405 ? 40.333  58.983 42.252 1.00 53.81  ? 424  TYR B CD2 1 
+ATOM   6871 C  CE1 . TYR B 1 405 ? 41.745  58.970 44.626 1.00 58.11  ? 424  TYR B CE1 1 
+ATOM   6872 C  CE2 . TYR B 1 405 ? 39.790  59.562 43.380 1.00 55.47  ? 424  TYR B CE2 1 
+ATOM   6873 C  CZ  . TYR B 1 405 ? 40.491  59.556 44.564 1.00 57.57  ? 424  TYR B CZ  1 
+ATOM   6874 O  OH  . TYR B 1 405 ? 39.919  60.133 45.673 1.00 51.80  ? 424  TYR B OH  1 
+ATOM   6875 N  N   . PHE B 1 406 ? 43.527  58.334 37.731 1.00 38.81  ? 425  PHE B N   1 
+ATOM   6876 C  CA  . PHE B 1 406 ? 44.346  57.760 36.670 1.00 35.42  ? 425  PHE B CA  1 
+ATOM   6877 C  C   . PHE B 1 406 ? 45.444  58.767 36.290 1.00 37.78  ? 425  PHE B C   1 
+ATOM   6878 O  O   . PHE B 1 406 ? 45.272  59.583 35.386 1.00 40.34  ? 425  PHE B O   1 
+ATOM   6879 C  CB  . PHE B 1 406 ? 43.467  57.423 35.488 1.00 28.73  ? 425  PHE B CB  1 
+ATOM   6880 C  CG  . PHE B 1 406 ? 44.194  56.830 34.352 1.00 30.69  ? 425  PHE B CG  1 
+ATOM   6881 C  CD1 . PHE B 1 406 ? 44.575  55.486 34.383 1.00 31.21  ? 425  PHE B CD1 1 
+ATOM   6882 C  CD2 . PHE B 1 406 ? 44.510  57.609 33.229 1.00 27.28  ? 425  PHE B CD2 1 
+ATOM   6883 C  CE1 . PHE B 1 406 ? 45.279  54.916 33.302 1.00 30.40  ? 425  PHE B CE1 1 
+ATOM   6884 C  CE2 . PHE B 1 406 ? 45.197  57.063 32.148 1.00 28.72  ? 425  PHE B CE2 1 
+ATOM   6885 C  CZ  . PHE B 1 406 ? 45.590  55.709 32.180 1.00 30.46  ? 425  PHE B CZ  1 
+ATOM   6886 N  N   . MET B 1 407 ? 46.559  58.706 37.015 1.00 34.73  ? 426  MET B N   1 
+ATOM   6887 C  CA  . MET B 1 407 ? 47.688  59.609 36.832 1.00 36.72  ? 426  MET B CA  1 
+ATOM   6888 C  C   . MET B 1 407 ? 49.062  58.933 36.537 1.00 34.33  ? 426  MET B C   1 
+ATOM   6889 O  O   . MET B 1 407 ? 50.076  59.351 37.104 1.00 33.11  ? 426  MET B O   1 
+ATOM   6890 C  CB  . MET B 1 407 ? 47.873  60.394 38.108 1.00 36.97  ? 426  MET B CB  1 
+ATOM   6891 C  CG  . MET B 1 407 ? 46.662  61.055 38.603 1.00 41.59  ? 426  MET B CG  1 
+ATOM   6892 S  SD  . MET B 1 407 ? 47.129  61.851 40.107 1.00 43.25  ? 426  MET B SD  1 
+ATOM   6893 C  CE  . MET B 1 407 ? 47.965  63.184 39.532 1.00 45.49  ? 426  MET B CE  1 
+ATOM   6894 N  N   . PRO B 1 408 ? 49.118  57.924 35.670 1.00 29.68  ? 427  PRO B N   1 
+ATOM   6895 C  CA  . PRO B 1 408 ? 50.385  57.238 35.377 1.00 27.28  ? 427  PRO B CA  1 
+ATOM   6896 C  C   . PRO B 1 408 ? 51.365  58.129 34.632 1.00 29.41  ? 427  PRO B C   1 
+ATOM   6897 O  O   . PRO B 1 408 ? 52.559  57.893 34.675 1.00 29.15  ? 427  PRO B O   1 
+ATOM   6898 C  CB  . PRO B 1 408 ? 49.957  56.087 34.489 1.00 27.83  ? 427  PRO B CB  1 
+ATOM   6899 C  CG  . PRO B 1 408 ? 48.661  56.546 33.890 1.00 30.49  ? 427  PRO B CG  1 
+ATOM   6900 C  CD  . PRO B 1 408 ? 47.996  57.389 34.879 1.00 28.87  ? 427  PRO B CD  1 
+ATOM   6901 N  N   . PHE B 1 409 ? 50.819  59.144 33.975 1.00 30.52  ? 428  PHE B N   1 
+ATOM   6902 C  CA  . PHE B 1 409 ? 51.570  60.173 33.296 1.00 29.97  ? 428  PHE B CA  1 
+ATOM   6903 C  C   . PHE B 1 409 ? 51.767  61.381 34.165 1.00 29.38  ? 428  PHE B C   1 
+ATOM   6904 O  O   . PHE B 1 409 ? 52.210  62.401 33.669 1.00 29.91  ? 428  PHE B O   1 
+ATOM   6905 C  CB  . PHE B 1 409 ? 50.790  60.622 32.048 1.00 28.79  ? 428  PHE B CB  1 
+ATOM   6906 C  CG  . PHE B 1 409 ? 50.625  59.548 31.018 1.00 28.17  ? 428  PHE B CG  1 
+ATOM   6907 C  CD1 . PHE B 1 409 ? 49.437  58.860 30.899 1.00 21.30  ? 428  PHE B CD1 1 
+ATOM   6908 C  CD2 . PHE B 1 409 ? 51.684  59.200 30.179 1.00 33.48  ? 428  PHE B CD2 1 
+ATOM   6909 C  CE1 . PHE B 1 409 ? 49.278  57.847 29.948 1.00 23.26  ? 428  PHE B CE1 1 
+ATOM   6910 C  CE2 . PHE B 1 409 ? 51.529  58.181 29.226 1.00 32.81  ? 428  PHE B CE2 1 
+ATOM   6911 C  CZ  . PHE B 1 409 ? 50.310  57.510 29.114 1.00 25.02  ? 428  PHE B CZ  1 
+ATOM   6912 N  N   . SER B 1 410 ? 51.421  61.279 35.446 1.00 31.88  ? 429  SER B N   1 
+ATOM   6913 C  CA  . SER B 1 410 ? 51.411  62.429 36.376 1.00 32.94  ? 429  SER B CA  1 
+ATOM   6914 C  C   . SER B 1 410 ? 50.267  63.460 36.135 1.00 34.60  ? 429  SER B C   1 
+ATOM   6915 O  O   . SER B 1 410 ? 49.258  63.135 35.505 1.00 35.01  ? 429  SER B O   1 
+ATOM   6916 C  CB  . SER B 1 410 ? 52.771  63.134 36.352 1.00 32.09  ? 429  SER B CB  1 
+ATOM   6917 O  OG  . SER B 1 410 ? 52.882  63.920 37.511 1.00 32.46  ? 429  SER B OG  1 
+ATOM   6918 N  N   . ALA B 1 411 ? 50.435  64.695 36.631 1.00 35.64  ? 430  ALA B N   1 
+ATOM   6919 C  CA  . ALA B 1 411 ? 49.419  65.739 36.493 1.00 33.65  ? 430  ALA B CA  1 
+ATOM   6920 C  C   . ALA B 1 411 ? 49.961  67.158 36.575 1.00 35.90  ? 430  ALA B C   1 
+ATOM   6921 O  O   . ALA B 1 411 ? 51.034  67.394 37.126 1.00 38.64  ? 430  ALA B O   1 
+ATOM   6922 C  CB  . ALA B 1 411 ? 48.401  65.569 37.528 1.00 32.06  ? 430  ALA B CB  1 
+ATOM   6923 N  N   . GLY B 1 412 ? 49.198  68.105 36.029 1.00 33.84  ? 431  GLY B N   1 
+ATOM   6924 C  CA  . GLY B 1 412 ? 49.535  69.503 36.133 1.00 32.80  ? 431  GLY B CA  1 
+ATOM   6925 C  C   . GLY B 1 412 ? 50.562  69.987 35.138 1.00 31.13  ? 431  GLY B C   1 
+ATOM   6926 O  O   . GLY B 1 412 ? 50.703  69.443 34.054 1.00 28.96  ? 431  GLY B O   1 
+ATOM   6927 N  N   . LYS B 1 413 ? 51.278  71.033 35.526 1.00 32.78  ? 432  LYS B N   1 
+ATOM   6928 C  CA  . LYS B 1 413 ? 52.176  71.743 34.622 1.00 39.69  ? 432  LYS B CA  1 
+ATOM   6929 C  C   . LYS B 1 413 ? 53.307  70.886 34.035 1.00 38.47  ? 432  LYS B C   1 
+ATOM   6930 O  O   . LYS B 1 413 ? 53.862  71.249 32.988 1.00 37.30  ? 432  LYS B O   1 
+ATOM   6931 C  CB  . LYS B 1 413 ? 52.771  72.984 35.321 1.00 44.44  ? 432  LYS B CB  1 
+ATOM   6932 C  CG  . LYS B 1 413 ? 51.806  74.163 35.477 1.00 49.83  ? 432  LYS B CG  1 
+ATOM   6933 C  CD  . LYS B 1 413 ? 51.760  75.042 34.208 1.00 57.11  ? 432  LYS B CD  1 
+ATOM   6934 C  CE  . LYS B 1 413 ? 51.023  76.415 34.415 1.00 59.68  ? 432  LYS B CE  1 
+ATOM   6935 N  NZ  . LYS B 1 413 ? 50.228  76.508 35.673 1.00 54.74  ? 432  LYS B NZ  1 
+ATOM   6936 N  N   . ARG B 1 414 ? 53.633  69.769 34.701 1.00 37.13  ? 433  ARG B N   1 
+ATOM   6937 C  CA  . ARG B 1 414 ? 54.715  68.860 34.288 1.00 35.10  ? 433  ARG B CA  1 
+ATOM   6938 C  C   . ARG B 1 414 ? 54.231  67.534 33.770 1.00 34.13  ? 433  ARG B C   1 
+ATOM   6939 O  O   . ARG B 1 414 ? 55.034  66.640 33.541 1.00 40.46  ? 433  ARG B O   1 
+ATOM   6940 C  CB  . ARG B 1 414 ? 55.635  68.556 35.459 1.00 35.77  ? 433  ARG B CB  1 
+ATOM   6941 C  CG  . ARG B 1 414 ? 56.653  69.607 35.718 1.00 34.67  ? 433  ARG B CG  1 
+ATOM   6942 C  CD  . ARG B 1 414 ? 57.909  69.481 34.891 1.00 36.31  ? 433  ARG B CD  1 
+ATOM   6943 N  NE  . ARG B 1 414 ? 58.840  70.543 35.269 1.00 33.46  ? 433  ARG B NE  1 
+ATOM   6944 C  CZ  . ARG B 1 414 ? 60.049  70.717 34.760 1.00 33.91  ? 433  ARG B CZ  1 
+ATOM   6945 N  NH1 . ARG B 1 414 ? 60.551  69.895 33.841 1.00 30.52  ? 433  ARG B NH1 1 
+ATOM   6946 N  NH2 . ARG B 1 414 ? 60.776  71.738 35.184 1.00 38.01  ? 433  ARG B NH2 1 
+ATOM   6947 N  N   . ILE B 1 415 ? 52.932  67.385 33.579 1.00 34.22  ? 434  ILE B N   1 
+ATOM   6948 C  CA  . ILE B 1 415 ? 52.369  66.122 33.111 1.00 30.98  ? 434  ILE B CA  1 
+ATOM   6949 C  C   . ILE B 1 415 ? 53.137  65.625 31.870 1.00 28.89  ? 434  ILE B C   1 
+ATOM   6950 O  O   . ILE B 1 415 ? 53.617  66.415 31.049 1.00 24.65  ? 434  ILE B O   1 
+ATOM   6951 C  CB  . ILE B 1 415 ? 50.851  66.323 32.824 1.00 33.97  ? 434  ILE B CB  1 
+ATOM   6952 C  CG1 . ILE B 1 415 ? 50.158  64.995 32.552 1.00 37.82  ? 434  ILE B CG1 1 
+ATOM   6953 C  CG2 . ILE B 1 415 ? 50.621  67.264 31.638 1.00 29.10  ? 434  ILE B CG2 1 
+ATOM   6954 C  CD1 . ILE B 1 415 ? 48.715  65.150 32.210 1.00 37.71  ? 434  ILE B CD1 1 
+ATOM   6955 N  N   . CYS B 1 416 ? 53.284  64.317 31.742 1.00 29.01  ? 435  CYS B N   1 
+ATOM   6956 C  CA  . CYS B 1 416 ? 54.013  63.738 30.605 1.00 32.38  ? 435  CYS B CA  1 
+ATOM   6957 C  C   . CYS B 1 416 ? 53.683  64.392 29.255 1.00 32.75  ? 435  CYS B C   1 
+ATOM   6958 O  O   . CYS B 1 416 ? 52.552  64.329 28.783 1.00 33.03  ? 435  CYS B O   1 
+ATOM   6959 C  CB  . CYS B 1 416 ? 53.716  62.250 30.490 1.00 35.24  ? 435  CYS B CB  1 
+ATOM   6960 S  SG  . CYS B 1 416 ? 54.402  61.523 28.992 1.00 40.22  ? 435  CYS B SG  1 
+ATOM   6961 N  N   . VAL B 1 417 ? 54.696  64.984 28.635 1.00 34.51  ? 436  VAL B N   1 
+ATOM   6962 C  CA  . VAL B 1 417 ? 54.588  65.631 27.329 1.00 33.47  ? 436  VAL B CA  1 
+ATOM   6963 C  C   . VAL B 1 417 ? 54.126  64.667 26.255 1.00 34.30  ? 436  VAL B C   1 
+ATOM   6964 O  O   . VAL B 1 417 ? 53.621  65.092 25.217 1.00 34.32  ? 436  VAL B O   1 
+ATOM   6965 C  CB  . VAL B 1 417 ? 55.970  66.177 26.898 1.00 36.40  ? 436  VAL B CB  1 
+ATOM   6966 C  CG1 . VAL B 1 417 ? 56.076  66.372 25.382 1.00 37.83  ? 436  VAL B CG1 1 
+ATOM   6967 C  CG2 . VAL B 1 417 ? 56.271  67.472 27.618 1.00 36.90  ? 436  VAL B CG2 1 
+ATOM   6968 N  N   . GLY B 1 418 ? 54.347  63.374 26.481 1.00 34.06  ? 437  GLY B N   1 
+ATOM   6969 C  CA  . GLY B 1 418 ? 54.048  62.364 25.492 1.00 32.38  ? 437  GLY B CA  1 
+ATOM   6970 C  C   . GLY B 1 418 ? 52.836  61.542 25.811 1.00 31.69  ? 437  GLY B C   1 
+ATOM   6971 O  O   . GLY B 1 418 ? 52.709  60.414 25.350 1.00 32.98  ? 437  GLY B O   1 
+ATOM   6972 N  N   . GLU B 1 419 ? 51.918  62.118 26.568 1.00 32.48  ? 438  GLU B N   1 
+ATOM   6973 C  CA  . GLU B 1 419 ? 50.712  61.407 26.990 1.00 34.87  ? 438  GLU B CA  1 
+ATOM   6974 C  C   . GLU B 1 419 ? 49.853  60.945 25.815 1.00 32.97  ? 438  GLU B C   1 
+ATOM   6975 O  O   . GLU B 1 419 ? 49.327  59.833 25.809 1.00 33.53  ? 438  GLU B O   1 
+ATOM   6976 C  CB  . GLU B 1 419 ? 49.891  62.335 27.877 1.00 39.60  ? 438  GLU B CB  1 
+ATOM   6977 C  CG  . GLU B 1 419 ? 48.772  61.652 28.638 1.00 42.64  ? 438  GLU B CG  1 
+ATOM   6978 C  CD  . GLU B 1 419 ? 47.861  62.627 29.368 1.00 45.69  ? 438  GLU B CD  1 
+ATOM   6979 O  OE1 . GLU B 1 419 ? 46.970  62.099 30.086 1.00 47.35  ? 438  GLU B OE1 1 
+ATOM   6980 O  OE2 . GLU B 1 419 ? 48.036  63.888 29.232 1.00 40.97  ? 438  GLU B OE2 1 
+ATOM   6981 N  N   . ALA B 1 420 ? 49.706  61.825 24.829 1.00 34.53  ? 439  ALA B N   1 
+ATOM   6982 C  CA  . ALA B 1 420 ? 48.920  61.538 23.646 1.00 31.79  ? 439  ALA B CA  1 
+ATOM   6983 C  C   . ALA B 1 420 ? 49.628  60.502 22.809 1.00 28.56  ? 439  ALA B C   1 
+ATOM   6984 O  O   . ALA B 1 420 ? 49.043  59.482 22.475 1.00 35.49  ? 439  ALA B O   1 
+ATOM   6985 C  CB  . ALA B 1 420 ? 48.662  62.818 22.860 1.00 32.69  ? 439  ALA B CB  1 
+ATOM   6986 N  N   . LEU B 1 421 ? 50.900  60.734 22.518 1.00 31.48  ? 440  LEU B N   1 
+ATOM   6987 C  CA  . LEU B 1 421 ? 51.722  59.764 21.787 1.00 29.25  ? 440  LEU B CA  1 
+ATOM   6988 C  C   . LEU B 1 421 ? 51.729  58.417 22.493 1.00 26.20  ? 440  LEU B C   1 
+ATOM   6989 O  O   . LEU B 1 421 ? 51.444  57.383 21.907 1.00 26.10  ? 440  LEU B O   1 
+ATOM   6990 C  CB  . LEU B 1 421 ? 53.156  60.275 21.637 1.00 31.94  ? 440  LEU B CB  1 
+ATOM   6991 C  CG  . LEU B 1 421 ? 54.095  59.363 20.846 1.00 32.31  ? 440  LEU B CG  1 
+ATOM   6992 C  CD1 . LEU B 1 421 ? 53.470  58.965 19.540 1.00 31.94  ? 440  LEU B CD1 1 
+ATOM   6993 C  CD2 . LEU B 1 421 ? 55.442  60.018 20.603 1.00 32.78  ? 440  LEU B CD2 1 
+ATOM   6994 N  N   . ALA B 1 422 ? 51.987  58.415 23.775 1.00 21.31  ? 441  ALA B N   1 
+ATOM   6995 C  CA  . ALA B 1 422 ? 51.999  57.156 24.463 1.00 23.54  ? 441  ALA B CA  1 
+ATOM   6996 C  C   . ALA B 1 422 ? 50.710  56.355 24.273 1.00 27.86  ? 441  ALA B C   1 
+ATOM   6997 O  O   . ALA B 1 422 ? 50.762  55.161 23.955 1.00 29.47  ? 441  ALA B O   1 
+ATOM   6998 C  CB  . ALA B 1 422 ? 52.284  57.369 25.908 1.00 25.96  ? 441  ALA B CB  1 
+ATOM   6999 N  N   . GLY B 1 423 ? 49.557  56.987 24.473 1.00 29.74  ? 442  GLY B N   1 
+ATOM   7000 C  CA  . GLY B 1 423 ? 48.308  56.248 24.516 1.00 30.14  ? 442  GLY B CA  1 
+ATOM   7001 C  C   . GLY B 1 423 ? 47.949  55.788 23.125 1.00 29.94  ? 442  GLY B C   1 
+ATOM   7002 O  O   . GLY B 1 423 ? 47.376  54.717 22.909 1.00 34.52  ? 442  GLY B O   1 
+ATOM   7003 N  N   . MET B 1 424 ? 48.296  56.615 22.161 1.00 28.36  ? 443  MET B N   1 
+ATOM   7004 C  CA  . MET B 1 424 ? 48.218  56.221 20.759 1.00 29.93  ? 443  MET B CA  1 
+ATOM   7005 C  C   . MET B 1 424 ? 49.084  54.972 20.422 1.00 28.36  ? 443  MET B C   1 
+ATOM   7006 O  O   . MET B 1 424 ? 48.623  54.087 19.743 1.00 29.12  ? 443  MET B O   1 
+ATOM   7007 C  CB  . MET B 1 424 ? 48.620  57.432 19.917 1.00 32.31  ? 443  MET B CB  1 
+ATOM   7008 C  CG  . MET B 1 424 ? 48.415  57.317 18.423 1.00 38.23  ? 443  MET B CG  1 
+ATOM   7009 S  SD  . MET B 1 424 ? 48.720  58.889 17.510 1.00 44.25  ? 443  MET B SD  1 
+ATOM   7010 C  CE  . MET B 1 424 ? 48.573  60.154 18.697 1.00 41.47  ? 443  MET B CE  1 
+ATOM   7011 N  N   . GLU B 1 425 ? 50.333  54.910 20.887 1.00 29.24  ? 444  GLU B N   1 
+ATOM   7012 C  CA  . GLU B 1 425 ? 51.187  53.717 20.720 1.00 28.50  ? 444  GLU B CA  1 
+ATOM   7013 C  C   . GLU B 1 425 ? 50.588  52.506 21.427 1.00 26.86  ? 444  GLU B C   1 
+ATOM   7014 O  O   . GLU B 1 425 ? 50.471  51.448 20.829 1.00 30.18  ? 444  GLU B O   1 
+ATOM   7015 C  CB  . GLU B 1 425 ? 52.623  53.965 21.248 1.00 31.85  ? 444  GLU B CB  1 
+ATOM   7016 C  CG  . GLU B 1 425 ? 53.419  55.006 20.465 1.00 31.73  ? 444  GLU B CG  1 
+ATOM   7017 C  CD  . GLU B 1 425 ? 54.884  55.096 20.852 1.00 37.45  ? 444  GLU B CD  1 
+ATOM   7018 O  OE1 . GLU B 1 425 ? 55.615  54.100 20.688 1.00 47.19  ? 444  GLU B OE1 1 
+ATOM   7019 O  OE2 . GLU B 1 425 ? 55.344  56.170 21.272 1.00 43.24  ? 444  GLU B OE2 1 
+ATOM   7020 N  N   . LEU B 1 426 ? 50.172  52.649 22.680 1.00 22.53  ? 445  LEU B N   1 
+ATOM   7021 C  CA  . LEU B 1 426 ? 49.597  51.505 23.404 1.00 24.31  ? 445  LEU B CA  1 
+ATOM   7022 C  C   . LEU B 1 426 ? 48.350  50.914 22.762 1.00 30.91  ? 445  LEU B C   1 
+ATOM   7023 O  O   . LEU B 1 426 ? 48.216  49.665 22.642 1.00 32.61  ? 445  LEU B O   1 
+ATOM   7024 C  CB  . LEU B 1 426 ? 49.231  51.872 24.827 1.00 23.96  ? 445  LEU B CB  1 
+ATOM   7025 C  CG  . LEU B 1 426 ? 50.359  52.423 25.690 1.00 24.61  ? 445  LEU B CG  1 
+ATOM   7026 C  CD1 . LEU B 1 426 ? 49.838  52.783 27.098 1.00 25.78  ? 445  LEU B CD1 1 
+ATOM   7027 C  CD2 . LEU B 1 426 ? 51.503  51.408 25.757 1.00 24.67  ? 445  LEU B CD2 1 
+ATOM   7028 N  N   . PHE B 1 427 ? 47.417  51.789 22.378 1.00 30.26  ? 446  PHE B N   1 
+ATOM   7029 C  CA  . PHE B 1 427 ? 46.136  51.327 21.854 1.00 27.67  ? 446  PHE B CA  1 
+ATOM   7030 C  C   . PHE B 1 427 ? 46.359  50.646 20.508 1.00 26.31  ? 446  PHE B C   1 
+ATOM   7031 O  O   . PHE B 1 427 ? 45.887  49.518 20.290 1.00 21.96  ? 446  PHE B O   1 
+ATOM   7032 C  CB  . PHE B 1 427 ? 45.129  52.485 21.714 1.00 32.47  ? 446  PHE B CB  1 
+ATOM   7033 C  CG  . PHE B 1 427 ? 43.833  52.067 21.079 1.00 32.31  ? 446  PHE B CG  1 
+ATOM   7034 C  CD1 . PHE B 1 427 ? 43.607  52.268 19.726 1.00 34.56  ? 446  PHE B CD1 1 
+ATOM   7035 C  CD2 . PHE B 1 427 ? 42.870  51.421 21.815 1.00 30.95  ? 446  PHE B CD2 1 
+ATOM   7036 C  CE1 . PHE B 1 427 ? 42.449  51.839 19.140 1.00 31.54  ? 446  PHE B CE1 1 
+ATOM   7037 C  CE2 . PHE B 1 427 ? 41.697  51.004 21.223 1.00 31.82  ? 446  PHE B CE2 1 
+ATOM   7038 C  CZ  . PHE B 1 427 ? 41.488  51.209 19.896 1.00 31.06  ? 446  PHE B CZ  1 
+ATOM   7039 N  N   . LEU B 1 428 ? 47.087  51.331 19.622 1.00 23.21  ? 447  LEU B N   1 
+ATOM   7040 C  CA  . LEU B 1 428 ? 47.286  50.871 18.243 1.00 25.15  ? 447  LEU B CA  1 
+ATOM   7041 C  C   . LEU B 1 428 ? 48.288  49.705 18.124 1.00 28.23  ? 447  LEU B C   1 
+ATOM   7042 O  O   . LEU B 1 428 ? 48.149  48.848 17.255 1.00 24.09  ? 447  LEU B O   1 
+ATOM   7043 C  CB  . LEU B 1 428 ? 47.752  52.013 17.346 1.00 24.66  ? 447  LEU B CB  1 
+ATOM   7044 C  CG  . LEU B 1 428 ? 46.864  53.249 17.182 1.00 27.82  ? 447  LEU B CG  1 
+ATOM   7045 C  CD1 . LEU B 1 428 ? 47.613  54.334 16.443 1.00 26.52  ? 447  LEU B CD1 1 
+ATOM   7046 C  CD2 . LEU B 1 428 ? 45.613  52.911 16.424 1.00 28.48  ? 447  LEU B CD2 1 
+ATOM   7047 N  N   . PHE B 1 429 ? 49.297  49.657 18.979 1.00 29.30  ? 448  PHE B N   1 
+ATOM   7048 C  CA  . PHE B 1 429 ? 50.202  48.511 18.925 1.00 32.24  ? 448  PHE B CA  1 
+ATOM   7049 C  C   . PHE B 1 429 ? 49.502  47.276 19.472 1.00 33.10  ? 448  PHE B C   1 
+ATOM   7050 O  O   . PHE B 1 429 ? 49.677  46.185 18.928 1.00 35.96  ? 448  PHE B O   1 
+ATOM   7051 C  CB  . PHE B 1 429 ? 51.507  48.735 19.697 1.00 30.95  ? 448  PHE B CB  1 
+ATOM   7052 C  CG  . PHE B 1 429 ? 52.456  49.687 19.049 1.00 26.44  ? 448  PHE B CG  1 
+ATOM   7053 C  CD1 . PHE B 1 429 ? 52.393  49.979 17.712 1.00 29.10  ? 448  PHE B CD1 1 
+ATOM   7054 C  CD2 . PHE B 1 429 ? 53.433  50.290 19.799 1.00 28.44  ? 448  PHE B CD2 1 
+ATOM   7055 C  CE1 . PHE B 1 429 ? 53.301  50.874 17.136 1.00 32.04  ? 448  PHE B CE1 1 
+ATOM   7056 C  CE2 . PHE B 1 429 ? 54.328  51.189 19.232 1.00 30.25  ? 448  PHE B CE2 1 
+ATOM   7057 C  CZ  . PHE B 1 429 ? 54.257  51.478 17.897 1.00 28.55  ? 448  PHE B CZ  1 
+ATOM   7058 N  N   . LEU B 1 430 ? 48.724  47.435 20.534 1.00 29.14  ? 449  LEU B N   1 
+ATOM   7059 C  CA  . LEU B 1 430 ? 48.137  46.269 21.175 1.00 33.26  ? 449  LEU B CA  1 
+ATOM   7060 C  C   . LEU B 1 430 ? 46.971  45.750 20.370 1.00 32.56  ? 449  LEU B C   1 
+ATOM   7061 O  O   . LEU B 1 430 ? 46.783  44.547 20.249 1.00 38.27  ? 449  LEU B O   1 
+ATOM   7062 C  CB  . LEU B 1 430 ? 47.697  46.569 22.612 1.00 34.61  ? 449  LEU B CB  1 
+ATOM   7063 C  CG  . LEU B 1 430 ? 48.858  46.765 23.570 1.00 40.31  ? 449  LEU B CG  1 
+ATOM   7064 C  CD1 . LEU B 1 430 ? 48.358  47.256 24.913 1.00 41.87  ? 449  LEU B CD1 1 
+ATOM   7065 C  CD2 . LEU B 1 430 ? 49.624  45.451 23.731 1.00 44.34  ? 449  LEU B CD2 1 
+ATOM   7066 N  N   . THR B 1 431 ? 46.172  46.647 19.816 1.00 36.85  ? 450  THR B N   1 
+ATOM   7067 C  CA  . THR B 1 431 ? 45.076  46.194 18.967 1.00 36.42  ? 450  THR B CA  1 
+ATOM   7068 C  C   . THR B 1 431 ? 45.647  45.566 17.703 1.00 34.14  ? 450  THR B C   1 
+ATOM   7069 O  O   . THR B 1 431 ? 45.146  44.549 17.256 1.00 35.23  ? 450  THR B O   1 
+ATOM   7070 C  CB  . THR B 1 431 ? 44.054  47.316 18.630 1.00 35.30  ? 450  THR B CB  1 
+ATOM   7071 O  OG1 . THR B 1 431 ? 44.716  48.456 18.053 1.00 36.21  ? 450  THR B OG1 1 
+ATOM   7072 C  CG2 . THR B 1 431 ? 43.367  47.818 19.896 1.00 32.98  ? 450  THR B CG2 1 
+ATOM   7073 N  N   . SER B 1 432 ? 46.702  46.149 17.137 1.00 34.82  ? 451  SER B N   1 
+ATOM   7074 C  CA  . SER B 1 432 ? 47.322  45.559 15.943 1.00 34.92  ? 451  SER B CA  1 
+ATOM   7075 C  C   . SER B 1 432 ? 47.862  44.152 16.207 1.00 35.55  ? 451  SER B C   1 
+ATOM   7076 O  O   . SER B 1 432 ? 47.775  43.288 15.349 1.00 36.73  ? 451  SER B O   1 
+ATOM   7077 C  CB  . SER B 1 432 ? 48.419  46.455 15.393 1.00 35.63  ? 451  SER B CB  1 
+ATOM   7078 O  OG  . SER B 1 432 ? 47.862  47.661 14.897 1.00 32.42  ? 451  SER B OG  1 
+ATOM   7079 N  N   . ILE B 1 433 ? 48.383  43.919 17.404 1.00 35.86  ? 452  ILE B N   1 
+ATOM   7080 C  CA  . ILE B 1 433 ? 48.900  42.607 17.766 1.00 36.18  ? 452  ILE B CA  1 
+ATOM   7081 C  C   . ILE B 1 433 ? 47.775  41.581 17.880 1.00 36.81  ? 452  ILE B C   1 
+ATOM   7082 O  O   . ILE B 1 433 ? 47.864  40.509 17.318 1.00 36.09  ? 452  ILE B O   1 
+ATOM   7083 C  CB  . ILE B 1 433 ? 49.729  42.691 19.068 1.00 34.03  ? 452  ILE B CB  1 
+ATOM   7084 C  CG1 . ILE B 1 433 ? 51.053  43.414 18.781 1.00 37.15  ? 452  ILE B CG1 1 
+ATOM   7085 C  CG2 . ILE B 1 433 ? 50.034  41.336 19.598 1.00 33.84  ? 452  ILE B CG2 1 
+ATOM   7086 C  CD1 . ILE B 1 433 ? 51.761  43.930 20.019 1.00 36.26  ? 452  ILE B CD1 1 
+ATOM   7087 N  N   . LEU B 1 434 ? 46.710  41.913 18.589 1.00 37.53  ? 453  LEU B N   1 
+ATOM   7088 C  CA  . LEU B 1 434 ? 45.697  40.922 18.903 1.00 38.81  ? 453  LEU B CA  1 
+ATOM   7089 C  C   . LEU B 1 434 ? 44.693  40.739 17.776 1.00 40.51  ? 453  LEU B C   1 
+ATOM   7090 O  O   . LEU B 1 434 ? 43.886  39.816 17.776 1.00 41.15  ? 453  LEU B O   1 
+ATOM   7091 C  CB  . LEU B 1 434 ? 44.970  41.333 20.161 1.00 41.94  ? 453  LEU B CB  1 
+ATOM   7092 C  CG  . LEU B 1 434 ? 45.786  41.492 21.430 1.00 41.74  ? 453  LEU B CG  1 
+ATOM   7093 C  CD1 . LEU B 1 434 ? 44.904  42.137 22.481 1.00 41.29  ? 453  LEU B CD1 1 
+ATOM   7094 C  CD2 . LEU B 1 434 ? 46.296  40.141 21.903 1.00 42.27  ? 453  LEU B CD2 1 
+ATOM   7095 N  N   . GLN B 1 435 ? 44.734  41.667 16.836 1.00 45.30  ? 454  GLN B N   1 
+ATOM   7096 C  CA  . GLN B 1 435 ? 44.021  41.555 15.573 1.00 45.13  ? 454  GLN B CA  1 
+ATOM   7097 C  C   . GLN B 1 435 ? 44.665  40.447 14.741 1.00 44.80  ? 454  GLN B C   1 
+ATOM   7098 O  O   . GLN B 1 435 ? 43.933  39.668 14.115 1.00 43.25  ? 454  GLN B O   1 
+ATOM   7099 C  CB  . GLN B 1 435 ? 44.062  42.900 14.810 1.00 42.80  ? 454  GLN B CB  1 
+ATOM   7100 C  CG  . GLN B 1 435 ? 43.790  42.793 13.319 1.00 42.59  ? 454  GLN B CG  1 
+ATOM   7101 C  CD  . GLN B 1 435 ? 43.665  44.139 12.619 1.00 40.89  ? 454  GLN B CD  1 
+ATOM   7102 O  OE1 . GLN B 1 435 ? 42.583  44.504 12.167 1.00 39.19  ? 454  GLN B OE1 1 
+ATOM   7103 N  NE2 . GLN B 1 435 ? 44.777  44.858 12.499 1.00 37.63  ? 454  GLN B NE2 1 
+ATOM   7104 N  N   . ASN B 1 436 ? 46.014  40.393 14.751 1.00 43.45  ? 455  ASN B N   1 
+ATOM   7105 C  CA  . ASN B 1 436 ? 46.814  39.480 13.902 1.00 44.89  ? 455  ASN B CA  1 
+ATOM   7106 C  C   . ASN B 1 436 ? 47.365  38.174 14.572 1.00 46.72  ? 455  ASN B C   1 
+ATOM   7107 O  O   . ASN B 1 436 ? 47.703  37.198 13.874 1.00 43.56  ? 455  ASN B O   1 
+ATOM   7108 C  CB  . ASN B 1 436 ? 47.982  40.253 13.247 1.00 43.42  ? 455  ASN B CB  1 
+ATOM   7109 C  CG  . ASN B 1 436 ? 47.515  41.397 12.300 1.00 42.65  ? 455  ASN B CG  1 
+ATOM   7110 O  OD1 . ASN B 1 436 ? 47.123  41.169 11.157 1.00 44.79  ? 455  ASN B OD1 1 
+ATOM   7111 N  ND2 . ASN B 1 436 ? 47.602  42.623 12.776 1.00 38.29  ? 455  ASN B ND2 1 
+ATOM   7112 N  N   . PHE B 1 437 ? 47.422  38.151 15.908 1.00 48.50  ? 456  PHE B N   1 
+ATOM   7113 C  CA  . PHE B 1 437 ? 47.967  37.017 16.679 1.00 46.70  ? 456  PHE B CA  1 
+ATOM   7114 C  C   . PHE B 1 437 ? 47.138  36.677 17.915 1.00 48.54  ? 456  PHE B C   1 
+ATOM   7115 O  O   . PHE B 1 437 ? 46.601  37.564 18.565 1.00 44.83  ? 456  PHE B O   1 
+ATOM   7116 C  CB  . PHE B 1 437 ? 49.403  37.312 17.149 1.00 45.78  ? 456  PHE B CB  1 
+ATOM   7117 C  CG  . PHE B 1 437 ? 50.326  37.756 16.039 1.00 44.56  ? 456  PHE B CG  1 
+ATOM   7118 C  CD1 . PHE B 1 437 ? 50.807  36.846 15.117 1.00 41.63  ? 456  PHE B CD1 1 
+ATOM   7119 C  CD2 . PHE B 1 437 ? 50.691  39.081 15.915 1.00 43.31  ? 456  PHE B CD2 1 
+ATOM   7120 C  CE1 . PHE B 1 437 ? 51.618  37.253 14.100 1.00 45.45  ? 456  PHE B CE1 1 
+ATOM   7121 C  CE2 . PHE B 1 437 ? 51.525  39.497 14.897 1.00 43.66  ? 456  PHE B CE2 1 
+ATOM   7122 C  CZ  . PHE B 1 437 ? 51.984  38.590 13.989 1.00 45.16  ? 456  PHE B CZ  1 
+ATOM   7123 N  N   . ASN B 1 438 ? 47.038  35.382 18.227 1.00 50.59  ? 457  ASN B N   1 
+ATOM   7124 C  CA  . ASN B 1 438 ? 46.747  34.926 19.593 1.00 49.53  ? 457  ASN B CA  1 
+ATOM   7125 C  C   . ASN B 1 438 ? 48.041  34.733 20.377 1.00 48.33  ? 457  ASN B C   1 
+ATOM   7126 O  O   . ASN B 1 438 ? 49.099  34.586 19.794 1.00 51.94  ? 457  ASN B O   1 
+ATOM   7127 C  CB  . ASN B 1 438 ? 45.964  33.639 19.560 1.00 47.87  ? 457  ASN B CB  1 
+ATOM   7128 C  CG  . ASN B 1 438 ? 44.751  33.745 18.698 1.00 49.67  ? 457  ASN B CG  1 
+ATOM   7129 O  OD1 . ASN B 1 438 ? 43.952  34.676 18.843 1.00 53.28  ? 457  ASN B OD1 1 
+ATOM   7130 N  ND2 . ASN B 1 438 ? 44.600  32.804 17.777 1.00 48.52  ? 457  ASN B ND2 1 
+ATOM   7131 N  N   . LEU B 1 439 ? 47.965  34.754 21.693 1.00 48.38  ? 458  LEU B N   1 
+ATOM   7132 C  CA  . LEU B 1 439 ? 49.162  34.603 22.501 1.00 51.94  ? 458  LEU B CA  1 
+ATOM   7133 C  C   . LEU B 1 439 ? 49.172  33.251 23.220 1.00 53.50  ? 458  LEU B C   1 
+ATOM   7134 O  O   . LEU B 1 439 ? 48.324  33.002 24.073 1.00 55.13  ? 458  LEU B O   1 
+ATOM   7135 C  CB  . LEU B 1 439 ? 49.245  35.744 23.520 1.00 52.08  ? 458  LEU B CB  1 
+ATOM   7136 C  CG  . LEU B 1 439 ? 48.887  37.157 23.058 1.00 49.79  ? 458  LEU B CG  1 
+ATOM   7137 C  CD1 . LEU B 1 439 ? 48.823  38.056 24.281 1.00 48.48  ? 458  LEU B CD1 1 
+ATOM   7138 C  CD2 . LEU B 1 439 ? 49.880  37.707 22.028 1.00 51.18  ? 458  LEU B CD2 1 
+ATOM   7139 N  N   . LYS B 1 440 ? 50.118  32.381 22.884 1.00 56.79  ? 459  LYS B N   1 
+ATOM   7140 C  CA  . LYS B 1 440 ? 50.225  31.085 23.547 1.00 62.31  ? 459  LYS B CA  1 
+ATOM   7141 C  C   . LYS B 1 440 ? 51.294  31.186 24.600 1.00 64.98  ? 459  LYS B C   1 
+ATOM   7142 O  O   . LYS B 1 440 ? 52.408  31.610 24.310 1.00 62.96  ? 459  LYS B O   1 
+ATOM   7143 C  CB  . LYS B 1 440 ? 50.581  29.977 22.555 1.00 65.32  ? 459  LYS B CB  1 
+ATOM   7144 C  CG  . LYS B 1 440 ? 50.675  28.574 23.165 1.00 68.73  ? 459  LYS B CG  1 
+ATOM   7145 C  CD  . LYS B 1 440 ? 50.832  27.487 22.078 1.00 72.79  ? 459  LYS B CD  1 
+ATOM   7146 C  CE  . LYS B 1 440 ? 50.131  26.174 22.461 1.00 73.74  ? 459  LYS B CE  1 
+ATOM   7147 N  NZ  . LYS B 1 440 ? 50.789  25.496 23.608 1.00 73.66  ? 459  LYS B NZ  1 
+ATOM   7148 N  N   . SER B 1 441 ? 50.949  30.812 25.829 1.00 70.46  ? 460  SER B N   1 
+ATOM   7149 C  CA  . SER B 1 441 ? 51.917  30.794 26.924 1.00 72.59  ? 460  SER B CA  1 
+ATOM   7150 C  C   . SER B 1 441 ? 52.792  29.575 26.750 1.00 74.55  ? 460  SER B C   1 
+ATOM   7151 O  O   . SER B 1 441 ? 52.376  28.586 26.137 1.00 73.15  ? 460  SER B O   1 
+ATOM   7152 C  CB  . SER B 1 441 ? 51.209  30.746 28.288 1.00 73.16  ? 460  SER B CB  1 
+ATOM   7153 O  OG  . SER B 1 441 ? 52.120  30.907 29.370 1.00 71.85  ? 460  SER B OG  1 
+ATOM   7154 N  N   . LEU B 1 442 ? 54.008  29.655 27.277 1.00 79.27  ? 461  LEU B N   1 
+ATOM   7155 C  CA  . LEU B 1 442 ? 54.916  28.512 27.268 1.00 82.90  ? 461  LEU B CA  1 
+ATOM   7156 C  C   . LEU B 1 442 ? 54.558  27.594 28.431 1.00 83.87  ? 461  LEU B C   1 
+ATOM   7157 O  O   . LEU B 1 442 ? 54.062  26.488 28.221 1.00 82.91  ? 461  LEU B O   1 
+ATOM   7158 C  CB  . LEU B 1 442 ? 56.387  28.963 27.359 1.00 84.22  ? 461  LEU B CB  1 
+ATOM   7159 C  CG  . LEU B 1 442 ? 57.221  28.731 26.090 1.00 85.47  ? 461  LEU B CG  1 
+ATOM   7160 C  CD1 . LEU B 1 442 ? 57.130  29.938 25.169 1.00 85.07  ? 461  LEU B CD1 1 
+ATOM   7161 C  CD2 . LEU B 1 442 ? 58.686  28.377 26.409 1.00 86.44  ? 461  LEU B CD2 1 
+ATOM   7162 N  N   . VAL B 1 443 ? 54.778  28.093 29.650 1.00 86.59  ? 462  VAL B N   1 
+ATOM   7163 C  CA  . VAL B 1 443 ? 54.629  27.316 30.886 1.00 88.56  ? 462  VAL B CA  1 
+ATOM   7164 C  C   . VAL B 1 443 ? 53.222  27.424 31.500 1.00 88.48  ? 462  VAL B C   1 
+ATOM   7165 O  O   . VAL B 1 443 ? 53.030  27.135 32.677 1.00 87.72  ? 462  VAL B O   1 
+ATOM   7166 C  CB  . VAL B 1 443 ? 55.729  27.725 31.933 1.00 89.56  ? 462  VAL B CB  1 
+ATOM   7167 C  CG1 . VAL B 1 443 ? 55.418  29.092 32.587 1.00 88.82  ? 462  VAL B CG1 1 
+ATOM   7168 C  CG2 . VAL B 1 443 ? 55.954  26.612 32.991 1.00 90.60  ? 462  VAL B CG2 1 
+ATOM   7169 N  N   . ASP B 1 444 ? 52.246  27.824 30.690 1.00 88.81  ? 463  ASP B N   1 
+ATOM   7170 C  CA  . ASP B 1 444 ? 50.838  27.869 31.094 1.00 90.17  ? 463  ASP B CA  1 
+ATOM   7171 C  C   . ASP B 1 444 ? 50.508  28.997 32.086 1.00 89.77  ? 463  ASP B C   1 
+ATOM   7172 O  O   . ASP B 1 444 ? 51.241  29.234 33.050 1.00 87.64  ? 463  ASP B O   1 
+ATOM   7173 C  CB  . ASP B 1 444 ? 50.356  26.513 31.636 1.00 91.94  ? 463  ASP B CB  1 
+ATOM   7174 C  CG  . ASP B 1 444 ? 50.016  26.559 33.123 1.00 94.60  ? 463  ASP B CG  1 
+ATOM   7175 O  OD1 . ASP B 1 444 ? 48.824  26.768 33.482 1.00 93.96  ? 463  ASP B OD1 1 
+ATOM   7176 O  OD2 . ASP B 1 444 ? 50.896  26.404 33.999 1.00 94.33  ? 463  ASP B OD2 1 
+ATOM   7177 N  N   . PRO B 1 445 ? 49.366  29.645 31.857 1.00 90.47  ? 464  PRO B N   1 
+ATOM   7178 C  CA  . PRO B 1 445 ? 49.041  30.939 32.475 1.00 89.98  ? 464  PRO B CA  1 
+ATOM   7179 C  C   . PRO B 1 445 ? 48.971  30.969 33.993 1.00 88.81  ? 464  PRO B C   1 
+ATOM   7180 O  O   . PRO B 1 445 ? 49.513  31.898 34.583 1.00 86.91  ? 464  PRO B O   1 
+ATOM   7181 C  CB  . PRO B 1 445 ? 47.656  31.273 31.891 1.00 91.39  ? 464  PRO B CB  1 
+ATOM   7182 C  CG  . PRO B 1 445 ? 47.101  29.978 31.403 1.00 91.74  ? 464  PRO B CG  1 
+ATOM   7183 C  CD  . PRO B 1 445 ? 48.284  29.178 30.970 1.00 91.42  ? 464  PRO B CD  1 
+ATOM   7184 N  N   . LYS B 1 446 ? 48.299  30.007 34.615 1.00 89.19  ? 465  LYS B N   1 
+ATOM   7185 C  CA  . LYS B 1 446 ? 48.081  30.075 36.062 1.00 89.98  ? 465  LYS B CA  1 
+ATOM   7186 C  C   . LYS B 1 446 ? 49.406  30.129 36.850 1.00 89.65  ? 465  LYS B C   1 
+ATOM   7187 O  O   . LYS B 1 446 ? 49.500  30.807 37.870 1.00 86.98  ? 465  LYS B O   1 
+ATOM   7188 C  CB  . LYS B 1 446 ? 47.213  28.903 36.537 1.00 90.51  ? 465  LYS B CB  1 
+ATOM   7189 C  CG  . LYS B 1 446 ? 46.954  28.908 38.047 1.00 91.19  ? 465  LYS B CG  1 
+ATOM   7190 C  CD  . LYS B 1 446 ? 45.653  28.175 38.437 1.00 90.99  ? 465  LYS B CD  1 
+ATOM   7191 C  CE  . LYS B 1 446 ? 44.937  28.881 39.610 1.00 89.64  ? 465  LYS B CE  1 
+ATOM   7192 N  NZ  . LYS B 1 446 ? 44.070  27.969 40.401 1.00 84.78  ? 465  LYS B NZ  1 
+ATOM   7193 N  N   . ASN B 1 447 ? 50.426  29.434 36.353 1.00 89.41  ? 466  ASN B N   1 
+ATOM   7194 C  CA  . ASN B 1 447 ? 51.726  29.371 37.023 1.00 89.80  ? 466  ASN B CA  1 
+ATOM   7195 C  C   . ASN B 1 447 ? 52.579  30.633 36.866 1.00 88.50  ? 466  ASN B C   1 
+ATOM   7196 O  O   . ASN B 1 447 ? 53.573  30.797 37.576 1.00 88.39  ? 466  ASN B O   1 
+ATOM   7197 C  CB  . ASN B 1 447 ? 52.527  28.154 36.522 1.00 91.85  ? 466  ASN B CB  1 
+ATOM   7198 C  CG  . ASN B 1 447 ? 53.311  27.457 37.640 1.00 93.86  ? 466  ASN B CG  1 
+ATOM   7199 O  OD1 . ASN B 1 447 ? 54.420  27.867 37.988 1.00 95.16  ? 466  ASN B OD1 1 
+ATOM   7200 N  ND2 . ASN B 1 447 ? 52.731  26.399 38.205 1.00 93.33  ? 466  ASN B ND2 1 
+ATOM   7201 N  N   . LEU B 1 448 ? 52.211  31.505 35.927 1.00 87.02  ? 467  LEU B N   1 
+ATOM   7202 C  CA  . LEU B 1 448 ? 52.955  32.742 35.681 1.00 83.16  ? 467  LEU B CA  1 
+ATOM   7203 C  C   . LEU B 1 448 ? 52.732  33.752 36.787 1.00 80.74  ? 467  LEU B C   1 
+ATOM   7204 O  O   . LEU B 1 448 ? 51.630  33.898 37.312 1.00 78.60  ? 467  LEU B O   1 
+ATOM   7205 C  CB  . LEU B 1 448 ? 52.554  33.392 34.351 1.00 83.67  ? 467  LEU B CB  1 
+ATOM   7206 C  CG  . LEU B 1 448 ? 53.023  32.748 33.049 1.00 83.44  ? 467  LEU B CG  1 
+ATOM   7207 C  CD1 . LEU B 1 448 ? 52.295  33.383 31.880 1.00 84.01  ? 467  LEU B CD1 1 
+ATOM   7208 C  CD2 . LEU B 1 448 ? 54.532  32.876 32.880 1.00 84.80  ? 467  LEU B CD2 1 
+ATOM   7209 N  N   . ASP B 1 449 ? 53.791  34.476 37.101 1.00 78.52  ? 468  ASP B N   1 
+ATOM   7210 C  CA  . ASP B 1 449 ? 53.759  35.456 38.155 1.00 78.88  ? 468  ASP B CA  1 
+ATOM   7211 C  C   . ASP B 1 449 ? 53.896  36.847 37.550 1.00 76.23  ? 468  ASP B C   1 
+ATOM   7212 O  O   . ASP B 1 449 ? 54.754  37.068 36.702 1.00 75.67  ? 468  ASP B O   1 
+ATOM   7213 C  CB  . ASP B 1 449 ? 54.910  35.178 39.105 1.00 82.16  ? 468  ASP B CB  1 
+ATOM   7214 C  CG  . ASP B 1 449 ? 54.902  36.093 40.293 1.00 86.23  ? 468  ASP B CG  1 
+ATOM   7215 O  OD1 . ASP B 1 449 ? 55.766  36.992 40.348 1.00 89.73  ? 468  ASP B OD1 1 
+ATOM   7216 O  OD2 . ASP B 1 449 ? 54.059  35.997 41.210 1.00 88.09  ? 468  ASP B OD2 1 
+ATOM   7217 N  N   . THR B 1 450 ? 53.053  37.778 37.984 1.00 73.67  ? 469  THR B N   1 
+ATOM   7218 C  CA  . THR B 1 450 ? 53.057  39.139 37.449 1.00 72.62  ? 469  THR B CA  1 
+ATOM   7219 C  C   . THR B 1 450 ? 53.395  40.172 38.523 1.00 75.78  ? 469  THR B C   1 
+ATOM   7220 O  O   . THR B 1 450 ? 52.973  41.328 38.446 1.00 75.09  ? 469  THR B O   1 
+ATOM   7221 C  CB  . THR B 1 450 ? 51.706  39.461 36.795 1.00 70.88  ? 469  THR B CB  1 
+ATOM   7222 O  OG1 . THR B 1 450 ? 50.710  39.709 37.796 1.00 68.76  ? 469  THR B OG1 1 
+ATOM   7223 C  CG2 . THR B 1 450 ? 51.179  38.261 36.027 1.00 69.44  ? 469  THR B CG2 1 
+ATOM   7224 N  N   . THR B 1 451 ? 54.170  39.732 39.512 1.00 78.39  ? 470  THR B N   1 
+ATOM   7225 C  CA  . THR B 1 451 ? 54.718  40.588 40.558 1.00 80.89  ? 470  THR B CA  1 
+ATOM   7226 C  C   . THR B 1 451 ? 55.700  41.601 39.952 1.00 78.04  ? 470  THR B C   1 
+ATOM   7227 O  O   . THR B 1 451 ? 56.792  41.214 39.489 1.00 74.28  ? 470  THR B O   1 
+ATOM   7228 C  CB  . THR B 1 451 ? 55.472  39.699 41.612 1.00 84.63  ? 470  THR B CB  1 
+ATOM   7229 O  OG1 . THR B 1 451 ? 54.549  38.799 42.240 1.00 87.74  ? 470  THR B OG1 1 
+ATOM   7230 C  CG2 . THR B 1 451 ? 56.079  40.518 42.785 1.00 85.74  ? 470  THR B CG2 1 
+ATOM   7231 N  N   . PRO B 1 452 ? 55.331  42.882 39.941 1.00 75.11  ? 471  PRO B N   1 
+ATOM   7232 C  CA  . PRO B 1 452 ? 56.292  43.916 39.548 1.00 75.77  ? 471  PRO B CA  1 
+ATOM   7233 C  C   . PRO B 1 452 ? 57.573  43.817 40.387 1.00 74.36  ? 471  PRO B C   1 
+ATOM   7234 O  O   . PRO B 1 452 ? 57.499  43.825 41.609 1.00 74.67  ? 471  PRO B O   1 
+ATOM   7235 C  CB  . PRO B 1 452 ? 55.534  45.240 39.810 1.00 76.60  ? 471  PRO B CB  1 
+ATOM   7236 C  CG  . PRO B 1 452 ? 54.068  44.881 39.808 1.00 75.36  ? 471  PRO B CG  1 
+ATOM   7237 C  CD  . PRO B 1 452 ? 54.011  43.450 40.284 1.00 75.37  ? 471  PRO B CD  1 
+ATOM   7238 N  N   . VAL B 1 453 ? 58.714  43.657 39.725 1.00 73.58  ? 472  VAL B N   1 
+ATOM   7239 C  CA  . VAL B 1 453 ? 60.026  43.794 40.355 1.00 73.16  ? 472  VAL B CA  1 
+ATOM   7240 C  C   . VAL B 1 453 ? 60.381  45.296 40.453 1.00 75.90  ? 472  VAL B C   1 
+ATOM   7241 O  O   . VAL B 1 453 ? 60.546  45.970 39.432 1.00 73.44  ? 472  VAL B O   1 
+ATOM   7242 C  CB  . VAL B 1 453 ? 61.104  43.046 39.528 1.00 72.34  ? 472  VAL B CB  1 
+ATOM   7243 C  CG1 . VAL B 1 453 ? 62.507  43.255 40.114 1.00 71.83  ? 472  VAL B CG1 1 
+ATOM   7244 C  CG2 . VAL B 1 453 ? 60.758  41.552 39.414 1.00 71.41  ? 472  VAL B CG2 1 
+ATOM   7245 N  N   . VAL B 1 454 ? 60.489  45.817 41.672 1.00 78.70  ? 473  VAL B N   1 
+ATOM   7246 C  CA  . VAL B 1 454 ? 60.766  47.244 41.876 1.00 83.22  ? 473  VAL B CA  1 
+ATOM   7247 C  C   . VAL B 1 454 ? 62.234  47.518 42.254 1.00 84.85  ? 473  VAL B C   1 
+ATOM   7248 O  O   . VAL B 1 454 ? 62.836  46.774 43.038 1.00 84.37  ? 473  VAL B O   1 
+ATOM   7249 C  CB  . VAL B 1 454 ? 59.852  47.847 42.978 1.00 84.51  ? 473  VAL B CB  1 
+ATOM   7250 C  CG1 . VAL B 1 454 ? 59.914  49.380 42.954 1.00 86.13  ? 473  VAL B CG1 1 
+ATOM   7251 C  CG2 . VAL B 1 454 ? 58.407  47.368 42.813 1.00 84.75  ? 473  VAL B CG2 1 
+ATOM   7252 N  N   . ASN B 1 455 ? 62.802  48.583 41.684 1.00 87.54  ? 474  ASN B N   1 
+ATOM   7253 C  CA  . ASN B 1 455 ? 64.121  49.091 42.095 1.00 89.57  ? 474  ASN B CA  1 
+ATOM   7254 C  C   . ASN B 1 455 ? 64.127  50.615 42.214 1.00 88.47  ? 474  ASN B C   1 
+ATOM   7255 O  O   . ASN B 1 455 ? 64.435  51.333 41.254 1.00 83.30  ? 474  ASN B O   1 
+ATOM   7256 C  CB  . ASN B 1 455 ? 65.214  48.610 41.137 1.00 91.42  ? 474  ASN B CB  1 
+ATOM   7257 C  CG  . ASN B 1 455 ? 65.423  47.102 41.210 1.00 94.19  ? 474  ASN B CG  1 
+ATOM   7258 O  OD1 . ASN B 1 455 ? 64.608  46.326 40.703 1.00 94.88  ? 474  ASN B OD1 1 
+ATOM   7259 N  ND2 . ASN B 1 455 ? 66.502  46.680 41.859 1.00 95.18  ? 474  ASN B ND2 1 
+ATOM   7260 N  N   . GLY B 1 456 ? 63.737  51.081 43.402 1.00 89.74  ? 475  GLY B N   1 
+ATOM   7261 C  CA  . GLY B 1 456 ? 63.748  52.490 43.758 1.00 90.50  ? 475  GLY B CA  1 
+ATOM   7262 C  C   . GLY B 1 456 ? 62.663  53.283 43.047 1.00 91.74  ? 475  GLY B C   1 
+ATOM   7263 O  O   . GLY B 1 456 ? 61.482  53.205 43.413 1.00 90.64  ? 475  GLY B O   1 
+ATOM   7264 N  N   . PHE B 1 457 ? 63.080  54.018 42.010 1.00 91.94  ? 476  PHE B N   1 
+ATOM   7265 C  CA  . PHE B 1 457 ? 62.236  54.982 41.285 1.00 89.81  ? 476  PHE B CA  1 
+ATOM   7266 C  C   . PHE B 1 457 ? 61.539  54.385 40.040 1.00 84.51  ? 476  PHE B C   1 
+ATOM   7267 O  O   . PHE B 1 457 ? 60.744  55.072 39.386 1.00 84.09  ? 476  PHE B O   1 
+ATOM   7268 C  CB  . PHE B 1 457 ? 63.088  56.196 40.822 1.00 91.80  ? 476  PHE B CB  1 
+ATOM   7269 C  CG  . PHE B 1 457 ? 63.626  57.090 41.950 1.00 94.77  ? 476  PHE B CG  1 
+ATOM   7270 C  CD1 . PHE B 1 457 ? 64.499  58.147 41.630 1.00 95.71  ? 476  PHE B CD1 1 
+ATOM   7271 C  CD2 . PHE B 1 457 ? 63.270  56.900 43.299 1.00 94.20  ? 476  PHE B CD2 1 
+ATOM   7272 C  CE1 . PHE B 1 457 ? 65.008  58.989 42.622 1.00 94.74  ? 476  PHE B CE1 1 
+ATOM   7273 C  CE2 . PHE B 1 457 ? 63.777  57.740 44.297 1.00 92.90  ? 476  PHE B CE2 1 
+ATOM   7274 C  CZ  . PHE B 1 457 ? 64.645  58.784 43.958 1.00 94.68  ? 476  PHE B CZ  1 
+ATOM   7275 N  N   . ALA B 1 458 ? 61.860  53.137 39.694 1.00 77.54  ? 477  ALA B N   1 
+ATOM   7276 C  CA  . ALA B 1 458 ? 61.253  52.459 38.539 1.00 72.44  ? 477  ALA B CA  1 
+ATOM   7277 C  C   . ALA B 1 458 ? 60.800  51.037 38.907 1.00 68.26  ? 477  ALA B C   1 
+ATOM   7278 O  O   . ALA B 1 458 ? 60.968  50.593 40.054 1.00 67.52  ? 477  ALA B O   1 
+ATOM   7279 C  CB  . ALA B 1 458 ? 62.228  52.436 37.341 1.00 70.79  ? 477  ALA B CB  1 
+ATOM   7280 N  N   . SER B 1 459 ? 60.193  50.353 37.939 1.00 60.70  ? 478  SER B N   1 
+ATOM   7281 C  CA  . SER B 1 459 ? 59.719  48.978 38.126 1.00 57.04  ? 478  SER B CA  1 
+ATOM   7282 C  C   . SER B 1 459 ? 59.391  48.352 36.790 1.00 52.88  ? 478  SER B C   1 
+ATOM   7283 O  O   . SER B 1 459 ? 59.073  49.062 35.834 1.00 49.59  ? 478  SER B O   1 
+ATOM   7284 C  CB  . SER B 1 459 ? 58.501  48.894 39.048 1.00 58.21  ? 478  SER B CB  1 
+ATOM   7285 O  OG  . SER B 1 459 ? 57.432  49.705 38.605 1.00 60.97  ? 478  SER B OG  1 
+ATOM   7286 N  N   . VAL B 1 460 ? 59.477  47.020 36.737 1.00 46.89  ? 479  VAL B N   1 
+ATOM   7287 C  CA  . VAL B 1 460 ? 59.535  46.285 35.471 1.00 44.49  ? 479  VAL B CA  1 
+ATOM   7288 C  C   . VAL B 1 460 ? 58.980  44.876 35.657 1.00 44.38  ? 479  VAL B C   1 
+ATOM   7289 O  O   . VAL B 1 460 ? 58.990  44.366 36.766 1.00 49.04  ? 479  VAL B O   1 
+ATOM   7290 C  CB  . VAL B 1 460 ? 60.991  46.170 34.954 1.00 40.35  ? 479  VAL B CB  1 
+ATOM   7291 C  CG1 . VAL B 1 460 ? 61.607  47.544 34.681 1.00 39.58  ? 479  VAL B CG1 1 
+ATOM   7292 C  CG2 . VAL B 1 460 ? 61.826  45.424 35.935 1.00 39.08  ? 479  VAL B CG2 1 
+ATOM   7293 N  N   . PRO B 1 461 ? 58.489  44.239 34.597 1.00 41.57  ? 480  PRO B N   1 
+ATOM   7294 C  CA  . PRO B 1 461 ? 57.885  42.912 34.751 1.00 42.61  ? 480  PRO B CA  1 
+ATOM   7295 C  C   . PRO B 1 461 ? 58.970  41.841 34.831 1.00 45.77  ? 480  PRO B C   1 
+ATOM   7296 O  O   . PRO B 1 461 ? 60.110  42.120 34.488 1.00 50.02  ? 480  PRO B O   1 
+ATOM   7297 C  CB  . PRO B 1 461 ? 57.074  42.744 33.463 1.00 39.62  ? 480  PRO B CB  1 
+ATOM   7298 C  CG  . PRO B 1 461 ? 57.833  43.543 32.453 1.00 39.43  ? 480  PRO B CG  1 
+ATOM   7299 C  CD  . PRO B 1 461 ? 58.470  44.695 33.197 1.00 38.63  ? 480  PRO B CD  1 
+ATOM   7300 N  N   . PRO B 1 462 ? 58.625  40.632 35.245 1.00 46.34  ? 481  PRO B N   1 
+ATOM   7301 C  CA  . PRO B 1 462 ? 59.593  39.542 35.225 1.00 47.12  ? 481  PRO B CA  1 
+ATOM   7302 C  C   . PRO B 1 462 ? 59.808  39.041 33.803 1.00 45.57  ? 481  PRO B C   1 
+ATOM   7303 O  O   . PRO B 1 462 ? 58.971  39.293 32.923 1.00 45.15  ? 481  PRO B O   1 
+ATOM   7304 C  CB  . PRO B 1 462 ? 58.925  38.453 36.099 1.00 45.16  ? 481  PRO B CB  1 
+ATOM   7305 C  CG  . PRO B 1 462 ? 57.480  38.684 35.941 1.00 46.23  ? 481  PRO B CG  1 
+ATOM   7306 C  CD  . PRO B 1 462 ? 57.311  40.188 35.746 1.00 47.53  ? 481  PRO B CD  1 
+ATOM   7307 N  N   . PHE B 1 463 ? 60.920  38.332 33.602 1.00 42.27  ? 482  PHE B N   1 
+ATOM   7308 C  CA  . PHE B 1 463 ? 61.213  37.693 32.341 1.00 39.00  ? 482  PHE B CA  1 
+ATOM   7309 C  C   . PHE B 1 463 ? 60.085  36.739 31.962 1.00 39.47  ? 482  PHE B C   1 
+ATOM   7310 O  O   . PHE B 1 463 ? 59.512  36.062 32.817 1.00 44.71  ? 482  PHE B O   1 
+ATOM   7311 C  CB  . PHE B 1 463 ? 62.532  36.924 32.427 1.00 39.89  ? 482  PHE B CB  1 
+ATOM   7312 C  CG  . PHE B 1 463 ? 62.852  36.160 31.177 1.00 40.74  ? 482  PHE B CG  1 
+ATOM   7313 C  CD1 . PHE B 1 463 ? 62.617  34.797 31.101 1.00 37.74  ? 482  PHE B CD1 1 
+ATOM   7314 C  CD2 . PHE B 1 463 ? 63.347  36.822 30.054 1.00 40.80  ? 482  PHE B CD2 1 
+ATOM   7315 C  CE1 . PHE B 1 463 ? 62.875  34.111 29.942 1.00 41.00  ? 482  PHE B CE1 1 
+ATOM   7316 C  CE2 . PHE B 1 463 ? 63.615  36.132 28.884 1.00 40.63  ? 482  PHE B CE2 1 
+ATOM   7317 C  CZ  . PHE B 1 463 ? 63.382  34.782 28.825 1.00 40.62  ? 482  PHE B CZ  1 
+ATOM   7318 N  N   . TYR B 1 464 ? 59.751  36.695 30.681 1.00 37.43  ? 483  TYR B N   1 
+ATOM   7319 C  CA  . TYR B 1 464 ? 58.804  35.698 30.195 1.00 38.26  ? 483  TYR B CA  1 
+ATOM   7320 C  C   . TYR B 1 464 ? 58.921  35.589 28.691 1.00 38.77  ? 483  TYR B C   1 
+ATOM   7321 O  O   . TYR B 1 464 ? 59.486  36.473 28.044 1.00 43.13  ? 483  TYR B O   1 
+ATOM   7322 C  CB  . TYR B 1 464 ? 57.359  36.052 30.576 1.00 37.96  ? 483  TYR B CB  1 
+ATOM   7323 C  CG  . TYR B 1 464 ? 56.801  37.161 29.723 1.00 36.10  ? 483  TYR B CG  1 
+ATOM   7324 C  CD1 . TYR B 1 464 ? 56.024  36.878 28.601 1.00 33.64  ? 483  TYR B CD1 1 
+ATOM   7325 C  CD2 . TYR B 1 464 ? 57.092  38.494 30.012 1.00 26.13  ? 483  TYR B CD2 1 
+ATOM   7326 C  CE1 . TYR B 1 464 ? 55.522  37.901 27.809 1.00 32.12  ? 483  TYR B CE1 1 
+ATOM   7327 C  CE2 . TYR B 1 464 ? 56.619  39.502 29.228 1.00 28.64  ? 483  TYR B CE2 1 
+ATOM   7328 C  CZ  . TYR B 1 464 ? 55.830  39.212 28.124 1.00 32.43  ? 483  TYR B CZ  1 
+ATOM   7329 O  OH  . TYR B 1 464 ? 55.353  40.242 27.327 1.00 35.93  ? 483  TYR B OH  1 
+ATOM   7330 N  N   . GLN B 1 465 ? 58.368  34.503 28.162 1.00 39.23  ? 484  GLN B N   1 
+ATOM   7331 C  CA  . GLN B 1 465 ? 58.339  34.232 26.733 1.00 42.80  ? 484  GLN B CA  1 
+ATOM   7332 C  C   . GLN B 1 465 ? 56.938  33.850 26.311 1.00 41.81  ? 484  GLN B C   1 
+ATOM   7333 O  O   . GLN B 1 465 ? 56.116  33.456 27.138 1.00 43.85  ? 484  GLN B O   1 
+ATOM   7334 C  CB  . GLN B 1 465 ? 59.247  33.060 26.360 1.00 45.49  ? 484  GLN B CB  1 
+ATOM   7335 C  CG  . GLN B 1 465 ? 60.728  33.221 26.678 1.00 51.47  ? 484  GLN B CG  1 
+ATOM   7336 C  CD  . GLN B 1 465 ? 61.505  31.901 26.506 1.00 54.57  ? 484  GLN B CD  1 
+ATOM   7337 O  OE1 . GLN B 1 465 ? 61.058  30.842 26.988 1.00 54.51  ? 484  GLN B OE1 1 
+ATOM   7338 N  NE2 . GLN B 1 465 ? 62.651  31.967 25.828 1.00 47.10  ? 484  GLN B NE2 1 
+ATOM   7339 N  N   . LEU B 1 466 ? 56.692  33.945 25.007 1.00 44.20  ? 485  LEU B N   1 
+ATOM   7340 C  CA  . LEU B 1 466 ? 55.407  33.586 24.409 1.00 43.57  ? 485  LEU B CA  1 
+ATOM   7341 C  C   . LEU B 1 466 ? 55.515  33.378 22.903 1.00 46.37  ? 485  LEU B C   1 
+ATOM   7342 O  O   . LEU B 1 466 ? 56.564  33.639 22.293 1.00 50.60  ? 485  LEU B O   1 
+ATOM   7343 C  CB  . LEU B 1 466 ? 54.394  34.691 24.675 1.00 42.60  ? 485  LEU B CB  1 
+ATOM   7344 C  CG  . LEU B 1 466 ? 54.405  35.931 23.771 1.00 40.44  ? 485  LEU B CG  1 
+ATOM   7345 C  CD1 . LEU B 1 466 ? 53.079  36.694 23.878 1.00 41.53  ? 485  LEU B CD1 1 
+ATOM   7346 C  CD2 . LEU B 1 466 ? 55.585  36.839 24.127 1.00 40.96  ? 485  LEU B CD2 1 
+ATOM   7347 N  N   . CYS B 1 467 ? 54.402  32.965 22.305 1.00 46.20  ? 486  CYS B N   1 
+ATOM   7348 C  CA  . CYS B 1 467 ? 54.303  32.803 20.861 1.00 46.00  ? 486  CYS B CA  1 
+ATOM   7349 C  C   . CYS B 1 467 ? 53.177  33.636 20.269 1.00 44.86  ? 486  CYS B C   1 
+ATOM   7350 O  O   . CYS B 1 467 ? 52.058  33.669 20.777 1.00 41.38  ? 486  CYS B O   1 
+ATOM   7351 C  CB  . CYS B 1 467 ? 54.036  31.354 20.524 1.00 48.22  ? 486  CYS B CB  1 
+ATOM   7352 S  SG  . CYS B 1 467 ? 55.149  30.221 21.337 1.00 55.68  ? 486  CYS B SG  1 
+ATOM   7353 N  N   . PHE B 1 468 ? 53.493  34.281 19.161 1.00 43.43  ? 487  PHE B N   1 
+ATOM   7354 C  CA  . PHE B 1 468 ? 52.539  35.018 18.393 1.00 40.56  ? 487  PHE B CA  1 
+ATOM   7355 C  C   . PHE B 1 468 ? 52.006  34.100 17.295 1.00 40.89  ? 487  PHE B C   1 
+ATOM   7356 O  O   . PHE B 1 468 ? 52.546  34.033 16.201 1.00 44.07  ? 487  PHE B O   1 
+ATOM   7357 C  CB  . PHE B 1 468 ? 53.233  36.267 17.873 1.00 39.13  ? 487  PHE B CB  1 
+ATOM   7358 C  CG  . PHE B 1 468 ? 53.699  37.186 18.979 1.00 39.59  ? 487  PHE B CG  1 
+ATOM   7359 C  CD1 . PHE B 1 468 ? 55.004  37.141 19.443 1.00 42.12  ? 487  PHE B CD1 1 
+ATOM   7360 C  CD2 . PHE B 1 468 ? 52.823  38.092 19.563 1.00 37.87  ? 487  PHE B CD2 1 
+ATOM   7361 C  CE1 . PHE B 1 468 ? 55.430  37.994 20.460 1.00 41.04  ? 487  PHE B CE1 1 
+ATOM   7362 C  CE2 . PHE B 1 468 ? 53.239  38.938 20.583 1.00 39.02  ? 487  PHE B CE2 1 
+ATOM   7363 C  CZ  . PHE B 1 468 ? 54.543  38.894 21.031 1.00 38.31  ? 487  PHE B CZ  1 
+ATOM   7364 N  N   . ILE B 1 469 ? 50.968  33.345 17.629 1.00 44.99  ? 488  ILE B N   1 
+ATOM   7365 C  CA  . ILE B 1 469 ? 50.336  32.413 16.690 1.00 48.17  ? 488  ILE B CA  1 
+ATOM   7366 C  C   . ILE B 1 469 ? 49.362  33.195 15.825 1.00 49.33  ? 488  ILE B C   1 
+ATOM   7367 O  O   . ILE B 1 469 ? 48.398  33.759 16.353 1.00 49.41  ? 488  ILE B O   1 
+ATOM   7368 C  CB  . ILE B 1 469 ? 49.576  31.286 17.454 1.00 49.83  ? 488  ILE B CB  1 
+ATOM   7369 C  CG1 . ILE B 1 469 ? 50.560  30.267 18.009 1.00 52.13  ? 488  ILE B CG1 1 
+ATOM   7370 C  CG2 . ILE B 1 469 ? 48.561  30.561 16.563 1.00 50.33  ? 488  ILE B CG2 1 
+ATOM   7371 C  CD1 . ILE B 1 469 ? 51.187  30.719 19.256 1.00 56.47  ? 488  ILE B CD1 1 
+ATOM   7372 N  N   . PRO B 1 470 ? 49.588  33.239 14.511 1.00 48.42  ? 489  PRO B N   1 
+ATOM   7373 C  CA  . PRO B 1 470 ? 48.637  33.879 13.591 1.00 47.81  ? 489  PRO B CA  1 
+ATOM   7374 C  C   . PRO B 1 470 ? 47.190  33.383 13.723 1.00 49.60  ? 489  PRO B C   1 
+ATOM   7375 O  O   . PRO B 1 470 ? 46.932  32.269 14.193 1.00 53.68  ? 489  PRO B O   1 
+ATOM   7376 C  CB  . PRO B 1 470 ? 49.207  33.526 12.223 1.00 45.70  ? 489  PRO B CB  1 
+ATOM   7377 C  CG  . PRO B 1 470 ? 50.650  33.421 12.468 1.00 46.66  ? 489  PRO B CG  1 
+ATOM   7378 C  CD  . PRO B 1 470 ? 50.765  32.726 13.792 1.00 47.29  ? 489  PRO B CD  1 
+ATOM   7379 N  N   . VAL B 1 471 ? 46.253  34.220 13.311 1.00 50.54  ? 490  VAL B N   1 
+ATOM   7380 C  CA  . VAL B 1 471 ? 44.839  33.910 13.460 1.00 53.88  ? 490  VAL B CA  1 
+ATOM   7381 C  C   . VAL B 1 471 ? 44.294  33.243 12.183 1.00 56.50  ? 490  VAL B C   1 
+ATOM   7382 O  O   . VAL B 1 471 ? 44.745  33.574 11.080 1.00 55.59  ? 490  VAL B O   1 
+ATOM   7383 C  CB  . VAL B 1 471 ? 44.021  35.189 13.822 1.00 56.65  ? 490  VAL B CB  1 
+ATOM   7384 C  CG1 . VAL B 1 471 ? 44.602  35.889 15.071 1.00 56.58  ? 490  VAL B CG1 1 
+ATOM   7385 C  CG2 . VAL B 1 471 ? 43.943  36.172 12.639 1.00 55.77  ? 490  VAL B CG2 1 
+ATOM   7386 N  N   . HIS B 1 472 ? 43.413  32.361 12.217 1.00 58.51  ? 491  HIS B N   1 
+HETATM 7387 FE FE  . HEC C 2 .   ? 13.626  69.638 19.959 1.00 36.38  ? 501  HEC A FE  1 
+HETATM 7388 C  CHA . HEC C 2 .   ? 11.256  68.083 22.112 1.00 23.38  ? 501  HEC A CHA 1 
+HETATM 7389 C  CHB . HEC C 2 .   ? 15.588  70.137 22.677 1.00 23.60  ? 501  HEC A CHB 1 
+HETATM 7390 C  CHC . HEC C 2 .   ? 15.813  71.194 17.823 1.00 18.28  ? 501  HEC A CHC 1 
+HETATM 7391 C  CHD . HEC C 2 .   ? 11.472  69.106 17.284 1.00 27.70  ? 501  HEC A CHD 1 
+HETATM 7392 N  NA  . HEC C 2 .   ? 13.463  69.168 22.102 1.00 31.77  ? 501  HEC A NA  1 
+HETATM 7393 C  C1A . HEC C 2 .   ? 12.449  68.557 22.751 1.00 28.30  ? 501  HEC A C1A 1 
+HETATM 7394 C  C2A . HEC C 2 .   ? 12.649  68.362 24.165 1.00 24.97  ? 501  HEC A C2A 1 
+HETATM 7395 C  C3A . HEC C 2 .   ? 13.968  68.988 24.403 1.00 25.34  ? 501  HEC A C3A 1 
+HETATM 7396 C  C4A . HEC C 2 .   ? 14.354  69.445 23.031 1.00 24.55  ? 501  HEC A C4A 1 
+HETATM 7397 C  CMA . HEC C 2 .   ? 14.746  69.134 25.660 1.00 28.53  ? 501  HEC A CMA 1 
+HETATM 7398 C  CAA . HEC C 2 .   ? 11.648  67.689 25.007 1.00 29.38  ? 501  HEC A CAA 1 
+HETATM 7399 C  CBA . HEC C 2 .   ? 12.040  67.205 26.355 1.00 39.94  ? 501  HEC A CBA 1 
+HETATM 7400 C  CGA . HEC C 2 .   ? 11.299  65.972 26.776 1.00 39.12  ? 501  HEC A CGA 1 
+HETATM 7401 O  O1A . HEC C 2 .   ? 10.122  65.814 26.496 1.00 39.32  ? 501  HEC A O1A 1 
+HETATM 7402 O  O2A . HEC C 2 .   ? 11.905  65.153 27.430 1.00 38.31  ? 501  HEC A O2A 1 
+HETATM 7403 N  NB  . HEC C 2 .   ? 15.336  70.467 20.228 1.00 20.63  ? 501  HEC A NB  1 
+HETATM 7404 C  C1B . HEC C 2 .   ? 16.040  70.621 21.369 1.00 19.40  ? 501  HEC A C1B 1 
+HETATM 7405 C  C2B . HEC C 2 .   ? 17.374  71.301 21.212 1.00 17.56  ? 501  HEC A C2B 1 
+HETATM 7406 C  C3B . HEC C 2 .   ? 17.390  71.619 19.787 1.00 13.66  ? 501  HEC A C3B 1 
+HETATM 7407 C  C4B . HEC C 2 .   ? 16.119  71.071 19.268 1.00 24.04  ? 501  HEC A C4B 1 
+HETATM 7408 C  CMB . HEC C 2 .   ? 18.416  71.627 22.231 1.00 22.78  ? 501  HEC A CMB 1 
+HETATM 7409 C  CAB . HEC C 2 .   ? 18.426  72.266 18.975 1.00 19.83  ? 501  HEC A CAB 1 
+HETATM 7410 C  CBB . HEC C 2 .   ? 19.563  73.052 19.589 1.00 33.37  ? 501  HEC A CBB 1 
+HETATM 7411 N  NC  . HEC C 2 .   ? 13.635  70.089 17.810 1.00 26.80  ? 501  HEC A NC  1 
+HETATM 7412 C  C1C . HEC C 2 .   ? 14.608  70.696 17.136 1.00 28.13  ? 501  HEC A C1C 1 
+HETATM 7413 C  C2C . HEC C 2 .   ? 14.356  70.825 15.667 1.00 28.61  ? 501  HEC A C2C 1 
+HETATM 7414 C  C3C . HEC C 2 .   ? 13.036  70.189 15.554 1.00 29.03  ? 501  HEC A C3C 1 
+HETATM 7415 C  C4C . HEC C 2 .   ? 12.704  69.776 16.908 1.00 25.59  ? 501  HEC A C4C 1 
+HETATM 7416 C  CMC . HEC C 2 .   ? 15.208  71.463 14.617 1.00 25.56  ? 501  HEC A CMC 1 
+HETATM 7417 C  CAC . HEC C 2 .   ? 12.213  69.994 14.339 1.00 35.39  ? 501  HEC A CAC 1 
+HETATM 7418 C  CBC . HEC C 2 .   ? 11.650  68.599 14.150 1.00 34.96  ? 501  HEC A CBC 1 
+HETATM 7419 N  ND  . HEC C 2 .   ? 11.888  68.813 19.774 1.00 36.51  ? 501  HEC A ND  1 
+HETATM 7420 C  C1D . HEC C 2 .   ? 11.129  68.655 18.628 1.00 22.63  ? 501  HEC A C1D 1 
+HETATM 7421 C  C2D . HEC C 2 .   ? 9.796   67.996 18.791 1.00 24.38  ? 501  HEC A C2D 1 
+HETATM 7422 C  C3D . HEC C 2 .   ? 9.740   67.672 20.185 1.00 26.53  ? 501  HEC A C3D 1 
+HETATM 7423 C  C4D . HEC C 2 .   ? 11.030  68.232 20.687 1.00 31.85  ? 501  HEC A C4D 1 
+HETATM 7424 C  CMD . HEC C 2 .   ? 8.687   67.608 17.826 1.00 27.11  ? 501  HEC A CMD 1 
+HETATM 7425 C  CAD . HEC C 2 .   ? 8.574   67.001 20.910 1.00 28.65  ? 501  HEC A CAD 1 
+HETATM 7426 C  CBD . HEC C 2 .   ? 8.714   65.558 21.310 1.00 31.21  ? 501  HEC A CBD 1 
+HETATM 7427 C  CGD . HEC C 2 .   ? 7.669   64.951 21.926 1.00 35.18  ? 501  HEC A CGD 1 
+HETATM 7428 O  O1D . HEC C 2 .   ? 7.475   63.748 21.841 1.00 32.41  ? 501  HEC A O1D 1 
+HETATM 7429 O  O2D . HEC C 2 .   ? 6.885   65.584 22.607 1.00 38.17  ? 501  HEC A O2D 1 
+HETATM 7430 FE FE  . HEC D 2 .   ? 56.503  60.393 29.813 1.00 32.88  ? 501  HEC B FE  1 
+HETATM 7431 C  CHA . HEC D 2 .   ? 57.536  62.926 32.056 1.00 16.56  ? 501  HEC B CHA 1 
+HETATM 7432 C  CHB . HEC D 2 .   ? 55.120  58.709 32.455 1.00 17.86  ? 501  HEC B CHB 1 
+HETATM 7433 C  CHC . HEC D 2 .   ? 55.594  57.974 27.581 1.00 21.69  ? 501  HEC B CHC 1 
+HETATM 7434 C  CHD . HEC D 2 .   ? 57.943  62.140 27.138 1.00 10.30  ? 501  HEC B CHD 1 
+HETATM 7435 N  NA  . HEC D 2 .   ? 56.374  60.791 31.957 1.00 18.63  ? 501  HEC B NA  1 
+HETATM 7436 C  C1A . HEC D 2 .   ? 56.836  61.829 32.676 1.00 15.05  ? 501  HEC B C1A 1 
+HETATM 7437 C  C2A . HEC D 2 .   ? 56.512  61.736 34.106 1.00 20.49  ? 501  HEC B C2A 1 
+HETATM 7438 C  C3A . HEC D 2 .   ? 55.758  60.477 34.234 1.00 19.04  ? 501  HEC B C3A 1 
+HETATM 7439 C  C4A . HEC D 2 .   ? 55.750  59.978 32.838 1.00 21.95  ? 501  HEC B C4A 1 
+HETATM 7440 C  CMA . HEC D 2 .   ? 55.231  59.858 35.465 1.00 21.81  ? 501  HEC B CMA 1 
+HETATM 7441 C  CAA . HEC D 2 .   ? 56.796  62.672 35.206 1.00 27.56  ? 501  HEC B CAA 1 
+HETATM 7442 C  CBA . HEC D 2 .   ? 56.286  64.081 34.968 1.00 32.06  ? 501  HEC B CBA 1 
+HETATM 7443 C  CGA . HEC D 2 .   ? 56.282  64.848 36.282 1.00 35.26  ? 501  HEC B CGA 1 
+HETATM 7444 O  O1A . HEC D 2 .   ? 57.200  65.605 36.553 1.00 38.75  ? 501  HEC B O1A 1 
+HETATM 7445 O  O2A . HEC D 2 .   ? 55.376  64.722 37.095 1.00 35.97  ? 501  HEC B O2A 1 
+HETATM 7446 N  NB  . HEC D 2 .   ? 55.591  58.704 29.980 1.00 14.65  ? 501  HEC B NB  1 
+HETATM 7447 C  C1B . HEC D 2 .   ? 55.053  58.124 31.105 1.00 18.61  ? 501  HEC B C1B 1 
+HETATM 7448 C  C2B . HEC D 2 .   ? 54.367  56.811 30.922 1.00 18.50  ? 501  HEC B C2B 1 
+HETATM 7449 C  C3B . HEC D 2 .   ? 54.559  56.637 29.485 1.00 17.32  ? 501  HEC B C3B 1 
+HETATM 7450 C  C4B . HEC D 2 .   ? 55.303  57.824 29.010 1.00 16.63  ? 501  HEC B C4B 1 
+HETATM 7451 C  CMB . HEC D 2 .   ? 53.684  55.894 31.906 1.00 20.53  ? 501  HEC B CMB 1 
+HETATM 7452 C  CAB . HEC D 2 .   ? 54.083  55.524 28.638 1.00 18.16  ? 501  HEC B CAB 1 
+HETATM 7453 C  CBB . HEC D 2 .   ? 53.726  54.224 29.268 1.00 20.16  ? 501  HEC B CBB 1 
+HETATM 7454 N  NC  . HEC D 2 .   ? 56.781  60.073 27.663 1.00 16.80  ? 501  HEC B NC  1 
+HETATM 7455 C  C1C . HEC D 2 .   ? 56.317  59.059 26.935 1.00 20.60  ? 501  HEC B C1C 1 
+HETATM 7456 C  C2C . HEC D 2 .   ? 56.549  59.148 25.455 1.00 13.87  ? 501  HEC B C2C 1 
+HETATM 7457 C  C3C . HEC D 2 .   ? 57.266  60.421 25.348 1.00 15.15  ? 501  HEC B C3C 1 
+HETATM 7458 C  C4C . HEC D 2 .   ? 57.338  60.904 26.740 1.00 15.54  ? 501  HEC B C4C 1 
+HETATM 7459 C  CMC . HEC D 2 .   ? 56.229  58.175 24.374 1.00 20.80  ? 501  HEC B CMC 1 
+HETATM 7460 C  CAC . HEC D 2 .   ? 57.822  60.986 24.097 1.00 19.75  ? 501  HEC B CAC 1 
+HETATM 7461 C  CBC . HEC D 2 .   ? 57.685  62.447 23.830 1.00 21.61  ? 501  HEC B CBC 1 
+HETATM 7462 N  ND  . HEC D 2 .   ? 57.469  62.064 29.648 1.00 29.60  ? 501  HEC B ND  1 
+HETATM 7463 C  C1D . HEC D 2 .   ? 57.978  62.643 28.502 1.00 19.94  ? 501  HEC B C1D 1 
+HETATM 7464 C  C2D . HEC D 2 .   ? 58.700  63.932 28.711 1.00 21.83  ? 501  HEC B C2D 1 
+HETATM 7465 C  C3D . HEC D 2 .   ? 58.574  64.187 30.139 1.00 19.96  ? 501  HEC B C3D 1 
+HETATM 7466 C  C4D . HEC D 2 .   ? 57.844  62.983 30.635 1.00 19.44  ? 501  HEC B C4D 1 
+HETATM 7467 C  CMD . HEC D 2 .   ? 59.349  64.823 27.697 1.00 22.05  ? 501  HEC B CMD 1 
+HETATM 7468 C  CAD . HEC D 2 .   ? 59.127  65.395 30.839 1.00 29.43  ? 501  HEC B CAD 1 
+HETATM 7469 C  CBD . HEC D 2 .   ? 58.129  66.515 31.050 1.00 40.72  ? 501  HEC B CBD 1 
+HETATM 7470 C  CGD . HEC D 2 .   ? 58.553  67.622 31.716 1.00 45.47  ? 501  HEC B CGD 1 
+HETATM 7471 O  O1D . HEC D 2 .   ? 58.025  68.709 31.535 1.00 42.97  ? 501  HEC B O1D 1 
+HETATM 7472 O  O2D . HEC D 2 .   ? 59.495  67.550 32.494 1.00 42.16  ? 501  HEC B O2D 1 
+HETATM 7473 O  O   . HOH E 3 .   ? 5.893   79.717 49.307 1.00 47.04  ? 2001 HOH A O   1 
+HETATM 7474 O  O   . HOH E 3 .   ? 21.062  65.582 42.101 1.00 45.14  ? 2002 HOH A O   1 
+HETATM 7475 O  O   . HOH E 3 .   ? 23.042  61.007 39.872 1.00 35.23  ? 2003 HOH A O   1 
+HETATM 7476 O  O   . HOH E 3 .   ? 20.142  61.268 40.826 1.00 34.58  ? 2004 HOH A O   1 
+HETATM 7477 O  O   . HOH E 3 .   ? 10.815  57.707 28.756 1.00 46.80  ? 2005 HOH A O   1 
+HETATM 7478 O  O   . HOH E 3 .   ? 9.027   50.947 31.814 1.00 47.11  ? 2006 HOH A O   1 
+HETATM 7479 O  O   . HOH E 3 .   ? 3.853   72.508 29.609 1.00 42.76  ? 2007 HOH A O   1 
+HETATM 7480 O  O   . HOH E 3 .   ? -5.059  76.270 32.784 1.00 48.36  ? 2008 HOH A O   1 
+HETATM 7481 O  O   . HOH E 3 .   ? -3.551  63.803 23.749 1.00 43.84  ? 2009 HOH A O   1 
+HETATM 7482 O  O   . HOH E 3 .   ? 13.188  63.252 4.505  1.00 33.45  ? 2010 HOH A O   1 
+HETATM 7483 O  O   . HOH E 3 .   ? 14.590  74.553 -1.456 1.00 39.13  ? 2011 HOH A O   1 
+HETATM 7484 O  O   . HOH E 3 .   ? 14.287  61.919 1.304  1.00 56.90  ? 2012 HOH A O   1 
+HETATM 7485 O  O   . HOH E 3 .   ? 27.500  67.000 -0.128 1.00 40.58  ? 2013 HOH A O   1 
+HETATM 7486 O  O   . HOH E 3 .   ? 32.566  60.101 16.354 1.00 47.53  ? 2014 HOH A O   1 
+HETATM 7487 O  O   . HOH E 3 .   ? 30.367  80.479 -0.742 1.00 43.57  ? 2015 HOH A O   1 
+HETATM 7488 O  O   . HOH E 3 .   ? 18.285  91.284 18.953 1.00 45.66  ? 2016 HOH A O   1 
+HETATM 7489 O  O   . HOH E 3 .   ? 19.089  94.703 16.262 1.00 51.56  ? 2017 HOH A O   1 
+HETATM 7490 O  O   . HOH E 3 .   ? 19.026  90.549 14.385 1.00 35.87  ? 2018 HOH A O   1 
+HETATM 7491 O  O   . HOH E 3 .   ? 18.845  88.815 20.249 1.00 30.91  ? 2019 HOH A O   1 
+HETATM 7492 O  O   . HOH E 3 .   ? 12.129  87.344 -2.599 1.00 45.59  ? 2020 HOH A O   1 
+HETATM 7493 O  O   . HOH E 3 .   ? 10.301  91.578 1.728  1.00 44.91  ? 2021 HOH A O   1 
+HETATM 7494 O  O   . HOH E 3 .   ? 23.207  64.875 15.270 1.00 45.85  ? 2022 HOH A O   1 
+HETATM 7495 O  O   . HOH E 3 .   ? 7.163   85.912 -3.043 1.00 45.72  ? 2023 HOH A O   1 
+HETATM 7496 O  O   . HOH E 3 .   ? 6.791   88.586 -1.220 1.00 45.57  ? 2024 HOH A O   1 
+HETATM 7497 O  O   . HOH E 3 .   ? 3.211   82.866 6.576  1.00 45.41  ? 2025 HOH A O   1 
+HETATM 7498 O  O   . HOH E 3 .   ? 4.851   79.290 18.114 1.00 33.85  ? 2026 HOH A O   1 
+HETATM 7499 O  O   . HOH E 3 .   ? -4.909  80.429 41.453 1.00 34.91  ? 2027 HOH A O   1 
+HETATM 7500 O  O   . HOH E 3 .   ? -5.040  76.592 -1.104 1.00 47.04  ? 2028 HOH A O   1 
+HETATM 7501 O  O   . HOH E 3 .   ? 0.340   54.413 -2.819 1.00 48.54  ? 2029 HOH A O   1 
+HETATM 7502 O  O   . HOH E 3 .   ? 1.104   69.686 20.708 1.00 35.67  ? 2030 HOH A O   1 
+HETATM 7503 O  O   . HOH E 3 .   ? 12.463  72.061 21.045 1.00 46.29  ? 2031 HOH A O   1 
+HETATM 7504 O  O   . HOH E 3 .   ? 15.610  83.594 21.904 1.00 40.99  ? 2032 HOH A O   1 
+HETATM 7505 O  O   . HOH E 3 .   ? 12.374  75.274 19.679 1.00 26.99  ? 2033 HOH A O   1 
+HETATM 7506 O  O   . HOH E 3 .   ? 19.193  83.690 16.494 1.00 43.76  ? 2034 HOH A O   1 
+HETATM 7507 O  O   . HOH E 3 .   ? 21.423  73.465 22.667 1.00 27.99  ? 2035 HOH A O   1 
+HETATM 7508 O  O   . HOH E 3 .   ? 37.168  87.666 18.527 1.00 39.28  ? 2036 HOH A O   1 
+HETATM 7509 O  O   . HOH E 3 .   ? 40.398  83.015 15.513 1.00 39.71  ? 2037 HOH A O   1 
+HETATM 7510 O  O   . HOH E 3 .   ? 44.677  79.411 24.432 1.00 61.22  ? 2038 HOH A O   1 
+HETATM 7511 O  O   . HOH E 3 .   ? 40.246  81.211 23.013 1.00 44.68  ? 2039 HOH A O   1 
+HETATM 7512 O  O   . HOH E 3 .   ? 43.102  78.613 11.891 1.00 40.26  ? 2040 HOH A O   1 
+HETATM 7513 O  O   . HOH E 3 .   ? 43.323  71.275 20.342 1.00 48.66  ? 2041 HOH A O   1 
+HETATM 7514 O  O   . HOH E 3 .   ? 41.339  74.411 22.961 1.00 43.80  ? 2042 HOH A O   1 
+HETATM 7515 O  O   . HOH E 3 .   ? 41.389  67.726 14.578 1.00 33.80  ? 2043 HOH A O   1 
+HETATM 7516 O  O   . HOH E 3 .   ? 42.043  66.017 3.726  1.00 48.82  ? 2044 HOH A O   1 
+HETATM 7517 O  O   . HOH E 3 .   ? 40.746  73.315 -0.984 1.00 42.65  ? 2045 HOH A O   1 
+HETATM 7518 O  O   . HOH E 3 .   ? 37.010  72.349 -0.985 1.00 36.47  ? 2046 HOH A O   1 
+HETATM 7519 O  O   . HOH E 3 .   ? 39.180  67.866 -0.001 0.50 43.93  ? 2047 HOH A O   1 
+HETATM 7520 O  O   . HOH E 3 .   ? 33.788  63.777 15.135 1.00 39.88  ? 2048 HOH A O   1 
+HETATM 7521 O  O   . HOH E 3 .   ? 35.356  61.598 15.387 1.00 28.04  ? 2049 HOH A O   1 
+HETATM 7522 O  O   . HOH E 3 .   ? 21.317  73.327 25.139 1.00 24.80  ? 2050 HOH A O   1 
+HETATM 7523 O  O   . HOH E 3 .   ? 18.922  71.640 28.786 1.00 29.70  ? 2051 HOH A O   1 
+HETATM 7524 O  O   . HOH E 3 .   ? 13.422  73.606 30.124 1.00 25.06  ? 2052 HOH A O   1 
+HETATM 7525 O  O   . HOH E 3 .   ? -5.363  57.919 31.417 1.00 55.31  ? 2053 HOH A O   1 
+HETATM 7526 O  O   . HOH E 3 .   ? 18.461  71.665 38.701 1.00 50.71  ? 2054 HOH A O   1 
+HETATM 7527 O  O   . HOH E 3 .   ? 24.050  64.615 37.173 1.00 34.60  ? 2055 HOH A O   1 
+HETATM 7528 O  O   . HOH E 3 .   ? 24.404  67.509 39.056 1.00 30.26  ? 2056 HOH A O   1 
+HETATM 7529 O  O   . HOH E 3 .   ? 24.256  75.099 36.311 1.00 53.60  ? 2057 HOH A O   1 
+HETATM 7530 O  O   . HOH E 3 .   ? 27.037  71.946 38.741 1.00 32.63  ? 2058 HOH A O   1 
+HETATM 7531 O  O   . HOH E 3 .   ? 28.270  65.046 40.231 1.00 50.04  ? 2059 HOH A O   1 
+HETATM 7532 O  O   . HOH E 3 .   ? 36.153  63.328 36.972 1.00 55.25  ? 2060 HOH A O   1 
+HETATM 7533 O  O   . HOH E 3 .   ? 31.072  61.378 36.156 1.00 41.52  ? 2061 HOH A O   1 
+HETATM 7534 O  O   . HOH E 3 .   ? 34.488  65.660 30.544 1.00 36.77  ? 2062 HOH A O   1 
+HETATM 7535 O  O   . HOH E 3 .   ? 33.399  80.082 29.766 1.00 39.25  ? 2063 HOH A O   1 
+HETATM 7536 O  O   . HOH E 3 .   ? 32.972  63.966 27.350 1.00 43.89  ? 2064 HOH A O   1 
+HETATM 7537 O  O   . HOH E 3 .   ? 39.038  57.746 22.032 1.00 35.60  ? 2065 HOH A O   1 
+HETATM 7538 O  O   . HOH E 3 .   ? 46.289  59.623 22.260 1.00 31.71  ? 2066 HOH A O   1 
+HETATM 7539 O  O   . HOH E 3 .   ? 41.100  67.380 17.930 1.00 46.94  ? 2067 HOH A O   1 
+HETATM 7540 O  O   . HOH E 3 .   ? 37.456  61.356 17.014 1.00 44.00  ? 2068 HOH A O   1 
+HETATM 7541 O  O   . HOH E 3 .   ? 27.914  57.685 35.536 1.00 50.29  ? 2069 HOH A O   1 
+HETATM 7542 O  O   . HOH E 3 .   ? 20.333  64.581 24.405 1.00 29.67  ? 2070 HOH A O   1 
+HETATM 7543 O  O   . HOH E 3 .   ? 20.274  60.935 25.175 1.00 47.32  ? 2071 HOH A O   1 
+HETATM 7544 O  O   . HOH E 3 .   ? 8.566   57.157 21.230 1.00 35.27  ? 2072 HOH A O   1 
+HETATM 7545 O  O   . HOH E 3 .   ? 15.474  61.460 18.010 1.00 42.53  ? 2073 HOH A O   1 
+HETATM 7546 O  O   . HOH E 3 .   ? 16.173  62.268 15.557 1.00 43.22  ? 2074 HOH A O   1 
+HETATM 7547 O  O   . HOH E 3 .   ? 22.509  64.354 19.629 1.00 29.76  ? 2075 HOH A O   1 
+HETATM 7548 O  O   . HOH E 3 .   ? 22.332  66.101 17.605 1.00 37.45  ? 2076 HOH A O   1 
+HETATM 7549 O  O   . HOH E 3 .   ? 27.712  76.184 2.633  1.00 34.87  ? 2077 HOH A O   1 
+HETATM 7550 O  O   . HOH E 3 .   ? 38.313  79.194 7.522  1.00 42.45  ? 2078 HOH A O   1 
+HETATM 7551 O  O   . HOH E 3 .   ? 40.340  81.794 8.593  1.00 39.78  ? 2079 HOH A O   1 
+HETATM 7552 O  O   . HOH E 3 .   ? 37.145  84.259 13.711 1.00 43.51  ? 2080 HOH A O   1 
+HETATM 7553 O  O   . HOH E 3 .   ? 32.604  82.082 28.159 1.00 48.32  ? 2081 HOH A O   1 
+HETATM 7554 O  O   . HOH E 3 .   ? 22.056  87.604 21.635 1.00 34.04  ? 2082 HOH A O   1 
+HETATM 7555 O  O   . HOH E 3 .   ? 22.803  89.331 19.487 1.00 40.93  ? 2083 HOH A O   1 
+HETATM 7556 O  O   . HOH E 3 .   ? 29.985  90.236 5.363  1.00 46.25  ? 2084 HOH A O   1 
+HETATM 7557 O  O   . HOH F 3 .   ? 57.810  72.353 58.736 1.00 39.48  ? 2001 HOH B O   1 
+HETATM 7558 O  O   . HOH F 3 .   ? 51.306  65.283 57.193 1.00 51.70  ? 2002 HOH B O   1 
+HETATM 7559 O  O   . HOH F 3 .   ? 48.140  60.129 55.097 1.00 57.45  ? 2003 HOH B O   1 
+HETATM 7560 O  O   . HOH F 3 .   ? 73.513  64.709 51.194 1.00 47.01  ? 2004 HOH B O   1 
+HETATM 7561 O  O   . HOH F 3 .   ? 43.912  61.853 49.587 1.00 29.39  ? 2005 HOH B O   1 
+HETATM 7562 O  O   . HOH F 3 .   ? 66.548  62.932 39.588 1.00 46.10  ? 2006 HOH B O   1 
+HETATM 7563 O  O   . HOH F 3 .   ? 75.339  65.933 42.709 1.00 48.86  ? 2007 HOH B O   1 
+HETATM 7564 O  O   . HOH F 3 .   ? 69.630  67.238 30.880 1.00 44.69  ? 2008 HOH B O   1 
+HETATM 7565 O  O   . HOH F 3 .   ? 58.163  78.128 22.903 1.00 40.57  ? 2009 HOH B O   1 
+HETATM 7566 O  O   . HOH F 3 .   ? 51.487  63.405 20.558 1.00 50.11  ? 2010 HOH B O   1 
+HETATM 7567 O  O   . HOH F 3 .   ? 48.382  64.875 19.930 1.00 44.49  ? 2011 HOH B O   1 
+HETATM 7568 O  O   . HOH F 3 .   ? 46.028  66.475 18.676 1.00 35.21  ? 2012 HOH B O   1 
+HETATM 7569 O  O   . HOH F 3 .   ? 46.352  68.326 16.051 1.00 48.79  ? 2013 HOH B O   1 
+HETATM 7570 O  O   . HOH F 3 .   ? 44.914  60.927 12.475 1.00 33.55  ? 2014 HOH B O   1 
+HETATM 7571 O  O   . HOH F 3 .   ? 43.704  55.027 9.399  1.00 48.17  ? 2015 HOH B O   1 
+HETATM 7572 O  O   . HOH F 3 .   ? 47.258  55.781 8.498  1.00 43.88  ? 2016 HOH B O   1 
+HETATM 7573 O  O   . HOH F 3 .   ? 57.487  54.923 12.576 1.00 50.67  ? 2017 HOH B O   1 
+HETATM 7574 O  O   . HOH F 3 .   ? 50.180  51.852 7.951  1.00 49.89  ? 2018 HOH B O   1 
+HETATM 7575 O  O   . HOH F 3 .   ? 59.208  44.926 9.970  1.00 39.38  ? 2019 HOH B O   1 
+HETATM 7576 O  O   . HOH F 3 .   ? 51.862  41.653 8.303  1.00 48.32  ? 2020 HOH B O   1 
+HETATM 7577 O  O   . HOH F 3 .   ? 56.325  34.032 17.981 1.00 38.49  ? 2021 HOH B O   1 
+HETATM 7578 O  O   . HOH F 3 .   ? 65.707  40.223 27.196 1.00 47.47  ? 2022 HOH B O   1 
+HETATM 7579 O  O   . HOH F 3 .   ? 64.260  35.932 22.077 1.00 46.02  ? 2023 HOH B O   1 
+HETATM 7580 O  O   . HOH F 3 .   ? 64.278  40.124 23.122 1.00 37.93  ? 2024 HOH B O   1 
+HETATM 7581 O  O   . HOH F 3 .   ? 67.010  44.372 14.800 1.00 47.78  ? 2025 HOH B O   1 
+HETATM 7582 O  O   . HOH F 3 .   ? 71.185  50.063 6.674  1.00 40.06  ? 2026 HOH B O   1 
+HETATM 7583 O  O   . HOH F 3 .   ? 73.105  55.966 15.979 1.00 32.51  ? 2027 HOH B O   1 
+HETATM 7584 O  O   . HOH F 3 .   ? 70.632  47.533 19.435 1.00 39.84  ? 2028 HOH B O   1 
+HETATM 7585 O  O   . HOH F 3 .   ? 67.555  55.467 27.913 1.00 38.67  ? 2029 HOH B O   1 
+HETATM 7586 O  O   . HOH F 3 .   ? 78.009  62.329 50.788 1.00 42.03  ? 2030 HOH B O   1 
+HETATM 7587 O  O   . HOH F 3 .   ? 68.555  63.944 8.402  1.00 40.91  ? 2031 HOH B O   1 
+HETATM 7588 O  O   . HOH F 3 .   ? 53.383  75.850 2.941  1.00 45.69  ? 2032 HOH B O   1 
+HETATM 7589 O  O   . HOH F 3 .   ? 77.146  70.278 21.222 1.00 47.23  ? 2033 HOH B O   1 
+HETATM 7590 O  O   . HOH F 3 .   ? 69.829  66.355 27.368 1.00 52.23  ? 2034 HOH B O   1 
+HETATM 7591 O  O   . HOH F 3 .   ? 59.860  45.727 25.893 1.00 37.84  ? 2035 HOH B O   1 
+HETATM 7592 O  O   . HOH F 3 .   ? 52.449  52.777 32.088 1.00 33.67  ? 2036 HOH B O   1 
+HETATM 7593 O  O   . HOH F 3 .   ? 42.270  34.506 24.787 1.00 50.88  ? 2037 HOH B O   1 
+HETATM 7594 O  O   . HOH F 3 .   ? 43.290  34.923 22.085 1.00 49.93  ? 2038 HOH B O   1 
+HETATM 7595 O  O   . HOH F 3 .   ? 35.084  47.566 10.023 1.00 49.92  ? 2039 HOH B O   1 
+HETATM 7596 O  O   . HOH F 3 .   ? 35.382  53.095 14.452 1.00 49.66  ? 2040 HOH B O   1 
+HETATM 7597 O  O   . HOH F 3 .   ? 37.940  57.210 19.756 1.00 37.00  ? 2041 HOH B O   1 
+HETATM 7598 O  O   . HOH F 3 .   ? 38.732  58.096 26.834 1.00 40.92  ? 2042 HOH B O   1 
+HETATM 7599 O  O   . HOH F 3 .   ? 52.026  52.759 34.670 1.00 30.35  ? 2043 HOH B O   1 
+HETATM 7600 O  O   . HOH F 3 .   ? 53.199  55.077 37.993 1.00 39.19  ? 2044 HOH B O   1 
+HETATM 7601 O  O   . HOH F 3 .   ? 46.151  55.467 48.645 1.00 38.98  ? 2045 HOH B O   1 
+HETATM 7602 O  O   . HOH F 3 .   ? 41.755  56.513 49.754 1.00 38.72  ? 2046 HOH B O   1 
+HETATM 7603 O  O   . HOH F 3 .   ? 43.974  53.957 49.363 1.00 29.29  ? 2047 HOH B O   1 
+HETATM 7604 O  O   . HOH F 3 .   ? 37.648  57.703 45.503 1.00 44.52  ? 2048 HOH B O   1 
+HETATM 7605 O  O   . HOH F 3 .   ? 44.346  44.119 46.365 1.00 36.97  ? 2049 HOH B O   1 
+HETATM 7606 O  O   . HOH F 3 .   ? 37.104  54.141 37.044 1.00 35.00  ? 2050 HOH B O   1 
+HETATM 7607 O  O   . HOH F 3 .   ? 31.906  53.732 26.215 1.00 43.51  ? 2051 HOH B O   1 
+HETATM 7608 O  O   . HOH F 3 .   ? 33.768  57.756 31.272 1.00 30.61  ? 2052 HOH B O   1 
+HETATM 7609 O  O   . HOH F 3 .   ? 37.570  62.837 45.268 1.00 58.00  ? 2053 HOH B O   1 
+HETATM 7610 O  O   . HOH F 3 .   ? 43.050  63.744 37.293 1.00 31.66  ? 2054 HOH B O   1 
+HETATM 7611 O  O   . HOH F 3 .   ? 53.060  55.100 35.460 1.00 24.11  ? 2055 HOH B O   1 
+HETATM 7612 O  O   . HOH F 3 .   ? 46.199  64.053 35.617 1.00 52.04  ? 2056 HOH B O   1 
+HETATM 7613 O  O   . HOH F 3 .   ? 48.276  60.966 34.185 1.00 40.69  ? 2057 HOH B O   1 
+HETATM 7614 O  O   . HOH F 3 .   ? 53.080  68.858 37.482 1.00 34.76  ? 2058 HOH B O   1 
+HETATM 7615 O  O   . HOH F 3 .   ? 46.578  67.109 34.965 1.00 34.20  ? 2059 HOH B O   1 
+HETATM 7616 O  O   . HOH F 3 .   ? 53.346  73.731 31.643 1.00 36.70  ? 2060 HOH B O   1 
+HETATM 7617 O  O   . HOH F 3 .   ? 50.371  65.017 25.354 1.00 31.31  ? 2061 HOH B O   1 
+HETATM 7618 O  O   . HOH F 3 .   ? 45.806  64.411 30.466 1.00 36.58  ? 2062 HOH B O   1 
+HETATM 7619 O  O   . HOH F 3 .   ? 60.174  59.468 31.827 1.00 30.97  ? 2063 HOH B O   1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   MET 1   20  ?   ?   ?   A . n 
+A 1 2   ALA 2   21  ?   ?   ?   A . n 
+A 1 3   LYS 3   22  ?   ?   ?   A . n 
+A 1 4   LYS 4   23  ?   ?   ?   A . n 
+A 1 5   THR 5   24  ?   ?   ?   A . n 
+A 1 6   SER 6   25  ?   ?   ?   A . n 
+A 1 7   SER 7   26  ?   ?   ?   A . n 
+A 1 8   LYS 8   27  ?   ?   ?   A . n 
+A 1 9   GLY 9   28  ?   ?   ?   A . n 
+A 1 10  ARG 10  29  ?   ?   ?   A . n 
+A 1 11  PRO 11  30  30  PRO PRO A . n 
+A 1 12  PRO 12  31  31  PRO PRO A . n 
+A 1 13  GLY 13  32  32  GLY GLY A . n 
+A 1 14  PRO 14  33  33  PRO PRO A . n 
+A 1 15  THR 15  34  34  THR THR A . n 
+A 1 16  PRO 16  35  35  PRO PRO A . n 
+A 1 17  LEU 17  36  36  LEU LEU A . n 
+A 1 18  PRO 18  37  37  PRO PRO A . n 
+A 1 19  VAL 19  38  38  VAL VAL A . n 
+A 1 20  ILE 20  39  39  ILE ILE A . n 
+A 1 21  GLY 21  40  40  GLY GLY A . n 
+A 1 22  ASN 22  41  41  ASN ASN A . n 
+A 1 23  ILE 23  42  42  ILE ILE A . n 
+A 1 24  LEU 24  43  43  LEU LEU A . n 
+A 1 25  GLN 25  44  44  GLN GLN A . n 
+A 1 26  ILE 26  45  45  ILE ILE A . n 
+A 1 27  GLY 27  46  46  GLY GLY A . n 
+A 1 28  ILE 28  47  47  ILE ILE A . n 
+A 1 29  LYS 29  48  48  LYS LYS A . n 
+A 1 30  ASP 30  49  49  ASP ASP A . n 
+A 1 31  ILE 31  50  50  ILE ILE A . n 
+A 1 32  SER 32  51  51  SER SER A . n 
+A 1 33  LYS 33  52  52  LYS LYS A . n 
+A 1 34  SER 34  53  53  SER SER A . n 
+A 1 35  LEU 35  54  54  LEU LEU A . n 
+A 1 36  THR 36  55  55  THR THR A . n 
+A 1 37  ASN 37  56  56  ASN ASN A . n 
+A 1 38  LEU 38  57  57  LEU LEU A . n 
+A 1 39  SER 39  58  58  SER SER A . n 
+A 1 40  LYS 40  59  59  LYS LYS A . n 
+A 1 41  VAL 41  60  60  VAL VAL A . n 
+A 1 42  TYR 42  61  61  TYR TYR A . n 
+A 1 43  GLY 43  62  62  GLY GLY A . n 
+A 1 44  PRO 44  63  63  PRO PRO A . n 
+A 1 45  VAL 45  64  64  VAL VAL A . n 
+A 1 46  PHE 46  65  65  PHE PHE A . n 
+A 1 47  THR 47  66  66  THR THR A . n 
+A 1 48  LEU 48  67  67  LEU LEU A . n 
+A 1 49  TYR 49  68  68  TYR TYR A . n 
+A 1 50  PHE 50  69  69  PHE PHE A . n 
+A 1 51  GLY 51  70  70  GLY GLY A . n 
+A 1 52  LEU 52  71  71  LEU LEU A . n 
+A 1 53  LYS 53  72  72  LYS LYS A . n 
+A 1 54  PRO 54  73  73  PRO PRO A . n 
+A 1 55  ILE 55  74  74  ILE ILE A . n 
+A 1 56  VAL 56  75  75  VAL VAL A . n 
+A 1 57  VAL 57  76  76  VAL VAL A . n 
+A 1 58  LEU 58  77  77  LEU LEU A . n 
+A 1 59  HIS 59  78  78  HIS HIS A . n 
+A 1 60  GLY 60  79  79  GLY GLY A . n 
+A 1 61  TYR 61  80  80  TYR TYR A . n 
+A 1 62  GLU 62  81  81  GLU GLU A . n 
+A 1 63  ALA 63  82  82  ALA ALA A . n 
+A 1 64  VAL 64  83  83  VAL VAL A . n 
+A 1 65  LYS 65  84  84  LYS LYS A . n 
+A 1 66  GLU 66  85  85  GLU GLU A . n 
+A 1 67  ALA 67  86  86  ALA ALA A . n 
+A 1 68  LEU 68  87  87  LEU LEU A . n 
+A 1 69  ILE 69  88  88  ILE ILE A . n 
+A 1 70  ASP 70  89  89  ASP ASP A . n 
+A 1 71  LEU 71  90  90  LEU LEU A . n 
+A 1 72  GLY 72  91  91  GLY GLY A . n 
+A 1 73  GLU 73  92  92  GLU GLU A . n 
+A 1 74  GLU 74  93  93  GLU GLU A . n 
+A 1 75  PHE 75  94  94  PHE PHE A . n 
+A 1 76  SER 76  95  95  SER SER A . n 
+A 1 77  GLY 77  96  96  GLY GLY A . n 
+A 1 78  ARG 78  97  97  ARG ARG A . n 
+A 1 79  GLY 79  98  98  GLY GLY A . n 
+A 1 80  ILE 80  99  99  ILE ILE A . n 
+A 1 81  PHE 81  100 100 PHE PHE A . n 
+A 1 82  PRO 82  101 101 PRO PRO A . n 
+A 1 83  LEU 83  102 102 LEU LEU A . n 
+A 1 84  ALA 84  103 103 ALA ALA A . n 
+A 1 85  GLU 85  104 104 GLU GLU A . n 
+A 1 86  ARG 86  105 105 ARG ARG A . n 
+A 1 87  ALA 87  106 106 ALA ALA A . n 
+A 1 88  ASN 88  107 107 ASN ASN A . n 
+A 1 89  ARG 89  108 108 ARG ARG A . n 
+A 1 90  GLY 90  109 109 GLY GLY A . n 
+A 1 91  PHE 91  110 110 PHE PHE A . n 
+A 1 92  GLY 92  111 111 GLY GLY A . n 
+A 1 93  ILE 93  112 112 ILE ILE A . n 
+A 1 94  VAL 94  113 113 VAL VAL A . n 
+A 1 95  PHE 95  114 114 PHE PHE A . n 
+A 1 96  SER 96  115 115 SER SER A . n 
+A 1 97  ASN 97  116 116 ASN ASN A . n 
+A 1 98  GLY 98  117 117 GLY GLY A . n 
+A 1 99  LYS 99  118 118 LYS LYS A . n 
+A 1 100 LYS 100 119 119 LYS LYS A . n 
+A 1 101 TRP 101 120 120 TRP TRP A . n 
+A 1 102 LYS 102 121 121 LYS LYS A . n 
+A 1 103 GLU 103 122 122 GLU GLU A . n 
+A 1 104 ILE 104 123 123 ILE ILE A . n 
+A 1 105 ARG 105 124 124 ARG ARG A . n 
+A 1 106 ARG 106 125 125 ARG ARG A . n 
+A 1 107 PHE 107 126 126 PHE PHE A . n 
+A 1 108 SER 108 127 127 SER SER A . n 
+A 1 109 LEU 109 128 128 LEU LEU A . n 
+A 1 110 MET 110 129 129 MET MET A . n 
+A 1 111 THR 111 130 130 THR THR A . n 
+A 1 112 LEU 112 131 131 LEU LEU A . n 
+A 1 113 ARG 113 132 132 ARG ARG A . n 
+A 1 114 ASN 114 133 133 ASN ASN A . n 
+A 1 115 PHE 115 134 134 PHE PHE A . n 
+A 1 116 GLY 116 135 135 GLY GLY A . n 
+A 1 117 MET 117 136 136 MET MET A . n 
+A 1 118 GLY 118 137 137 GLY GLY A . n 
+A 1 119 LYS 119 138 138 LYS LYS A . n 
+A 1 120 ARG 120 139 139 ARG ARG A . n 
+A 1 121 SER 121 140 140 SER SER A . n 
+A 1 122 ILE 122 141 141 ILE ILE A . n 
+A 1 123 GLU 123 142 142 GLU GLU A . n 
+A 1 124 ASP 124 143 143 ASP ASP A . n 
+A 1 125 ARG 125 144 144 ARG ARG A . n 
+A 1 126 VAL 126 145 145 VAL VAL A . n 
+A 1 127 GLN 127 146 146 GLN GLN A . n 
+A 1 128 GLU 128 147 147 GLU GLU A . n 
+A 1 129 GLU 129 148 148 GLU GLU A . n 
+A 1 130 ALA 130 149 149 ALA ALA A . n 
+A 1 131 ARG 131 150 150 ARG ARG A . n 
+A 1 132 CYS 132 151 151 CYS CYS A . n 
+A 1 133 LEU 133 152 152 LEU LEU A . n 
+A 1 134 VAL 134 153 153 VAL VAL A . n 
+A 1 135 GLU 135 154 154 GLU GLU A . n 
+A 1 136 GLU 136 155 155 GLU GLU A . n 
+A 1 137 LEU 137 156 156 LEU LEU A . n 
+A 1 138 ARG 138 157 157 ARG ARG A . n 
+A 1 139 LYS 139 158 158 LYS LYS A . n 
+A 1 140 THR 140 159 159 THR THR A . n 
+A 1 141 LYS 141 160 160 LYS LYS A . n 
+A 1 142 ALA 142 161 161 ALA ALA A . n 
+A 1 143 SER 143 162 162 SER SER A . n 
+A 1 144 PRO 144 163 163 PRO PRO A . n 
+A 1 145 CYS 145 164 164 CYS CYS A . n 
+A 1 146 ASP 146 165 165 ASP ASP A . n 
+A 1 147 PRO 147 166 166 PRO PRO A . n 
+A 1 148 THR 148 167 167 THR THR A . n 
+A 1 149 PHE 149 168 168 PHE PHE A . n 
+A 1 150 ILE 150 169 169 ILE ILE A . n 
+A 1 151 LEU 151 170 170 LEU LEU A . n 
+A 1 152 GLY 152 171 171 GLY GLY A . n 
+A 1 153 CYS 153 172 172 CYS CYS A . n 
+A 1 154 ALA 154 173 173 ALA ALA A . n 
+A 1 155 PRO 155 174 174 PRO PRO A . n 
+A 1 156 CYS 156 175 175 CYS CYS A . n 
+A 1 157 ASN 157 176 176 ASN ASN A . n 
+A 1 158 VAL 158 177 177 VAL VAL A . n 
+A 1 159 ILE 159 178 178 ILE ILE A . n 
+A 1 160 CYS 160 179 179 CYS CYS A . n 
+A 1 161 SER 161 180 180 SER SER A . n 
+A 1 162 ILE 162 181 181 ILE ILE A . n 
+A 1 163 ILE 163 182 182 ILE ILE A . n 
+A 1 164 PHE 164 183 183 PHE PHE A . n 
+A 1 165 HIS 165 184 184 HIS HIS A . n 
+A 1 166 LYS 166 185 185 LYS LYS A . n 
+A 1 167 ARG 167 186 186 ARG ARG A . n 
+A 1 168 PHE 168 187 187 PHE PHE A . n 
+A 1 169 ASP 169 188 188 ASP ASP A . n 
+A 1 170 TYR 170 189 189 TYR TYR A . n 
+A 1 171 LYS 171 190 190 LYS LYS A . n 
+A 1 172 ASP 172 191 191 ASP ASP A . n 
+A 1 173 GLN 173 192 192 GLN GLN A . n 
+A 1 174 GLN 174 193 193 GLN GLN A . n 
+A 1 175 PHE 175 194 194 PHE PHE A . n 
+A 1 176 LEU 176 195 195 LEU LEU A . n 
+A 1 177 ASN 177 196 196 ASN ASN A . n 
+A 1 178 LEU 178 197 197 LEU LEU A . n 
+A 1 179 MET 179 198 198 MET MET A . n 
+A 1 180 GLU 180 199 199 GLU GLU A . n 
+A 1 181 LYS 181 200 200 LYS LYS A . n 
+A 1 182 LEU 182 201 201 LEU LEU A . n 
+A 1 183 ASN 183 202 202 ASN ASN A . n 
+A 1 184 GLU 184 203 203 GLU GLU A . n 
+A 1 185 ASN 185 204 204 ASN ASN A . n 
+A 1 186 ILE 186 205 205 ILE ILE A . n 
+A 1 187 GLU 187 206 206 GLU GLU A . n 
+A 1 188 ILE 188 207 207 ILE ILE A . n 
+A 1 189 LEU 189 208 208 LEU LEU A . n 
+A 1 190 SER 190 209 209 SER SER A . n 
+A 1 191 SER 191 210 210 SER SER A . n 
+A 1 192 PRO 192 211 211 PRO PRO A . n 
+A 1 193 TRP 193 212 212 TRP TRP A . n 
+A 1 194 ILE 194 213 213 ILE ILE A . n 
+A 1 195 GLN 195 214 214 GLN GLN A . n 
+A 1 196 VAL 196 215 215 VAL VAL A . n 
+A 1 197 TYR 197 216 216 TYR TYR A . n 
+A 1 198 ASN 198 217 217 ASN ASN A . n 
+A 1 199 ASN 199 218 218 ASN ASN A . n 
+A 1 200 PHE 200 219 219 PHE PHE A . n 
+A 1 201 PRO 201 220 220 PRO PRO A . n 
+A 1 202 ALA 202 221 221 ALA ALA A . n 
+A 1 203 LEU 203 222 222 LEU LEU A . n 
+A 1 204 LEU 204 223 223 LEU LEU A . n 
+A 1 205 ASP 205 224 224 ASP ASP A . n 
+A 1 206 TYR 206 225 225 TYR TYR A . n 
+A 1 207 PHE 207 226 226 PHE PHE A . n 
+A 1 208 PRO 208 227 227 PRO PRO A . n 
+A 1 209 GLY 209 228 228 GLY GLY A . n 
+A 1 210 THR 210 229 229 THR THR A . n 
+A 1 211 HIS 211 230 230 HIS HIS A . n 
+A 1 212 ASN 212 231 231 ASN ASN A . n 
+A 1 213 LYS 213 232 232 LYS LYS A . n 
+A 1 214 LEU 214 233 233 LEU LEU A . n 
+A 1 215 LEU 215 234 234 LEU LEU A . n 
+A 1 216 LYS 216 235 235 LYS LYS A . n 
+A 1 217 ASN 217 236 236 ASN ASN A . n 
+A 1 218 VAL 218 237 237 VAL VAL A . n 
+A 1 219 ALA 219 238 238 ALA ALA A . n 
+A 1 220 PHE 220 239 239 PHE PHE A . n 
+A 1 221 MET 221 240 240 MET MET A . n 
+A 1 222 LYS 222 241 241 LYS LYS A . n 
+A 1 223 SER 223 242 242 SER SER A . n 
+A 1 224 TYR 224 243 243 TYR TYR A . n 
+A 1 225 ILE 225 244 244 ILE ILE A . n 
+A 1 226 LEU 226 245 245 LEU LEU A . n 
+A 1 227 GLU 227 246 246 GLU GLU A . n 
+A 1 228 LYS 228 247 247 LYS LYS A . n 
+A 1 229 VAL 229 248 248 VAL VAL A . n 
+A 1 230 LYS 230 249 249 LYS LYS A . n 
+A 1 231 GLU 231 250 250 GLU GLU A . n 
+A 1 232 HIS 232 251 251 HIS HIS A . n 
+A 1 233 GLN 233 252 252 GLN GLN A . n 
+A 1 234 GLU 234 253 253 GLU GLU A . n 
+A 1 235 SER 235 254 254 SER SER A . n 
+A 1 236 MET 236 255 255 MET MET A . n 
+A 1 237 ASP 237 256 256 ASP ASP A . n 
+A 1 238 MET 238 257 257 MET MET A . n 
+A 1 239 ASN 239 258 258 ASN ASN A . n 
+A 1 240 ASN 240 259 259 ASN ASN A . n 
+A 1 241 PRO 241 260 260 PRO PRO A . n 
+A 1 242 GLN 242 261 261 GLN GLN A . n 
+A 1 243 ASP 243 262 262 ASP ASP A . n 
+A 1 244 PHE 244 263 263 PHE PHE A . n 
+A 1 245 ILE 245 264 264 ILE ILE A . n 
+A 1 246 ASP 246 265 265 ASP ASP A . n 
+A 1 247 CYS 247 266 266 CYS CYS A . n 
+A 1 248 PHE 248 267 267 PHE PHE A . n 
+A 1 249 LEU 249 268 268 LEU LEU A . n 
+A 1 250 MET 250 269 269 MET MET A . n 
+A 1 251 LYS 251 270 270 LYS LYS A . n 
+A 1 252 MET 252 271 271 MET MET A . n 
+A 1 253 GLU 253 272 272 GLU GLU A . n 
+A 1 254 LYS 254 273 273 LYS LYS A . n 
+A 1 255 GLU 255 274 274 GLU GLU A . n 
+A 1 256 LYS 256 275 275 LYS LYS A . n 
+A 1 257 HIS 257 276 276 HIS HIS A . n 
+A 1 258 ASN 258 277 277 ASN ASN A . n 
+A 1 259 GLN 259 278 278 GLN GLN A . n 
+A 1 260 PRO 260 279 279 PRO PRO A . n 
+A 1 261 SER 261 280 280 SER SER A . n 
+A 1 262 GLU 262 281 281 GLU GLU A . n 
+A 1 263 PHE 263 282 282 PHE PHE A . n 
+A 1 264 THR 264 283 283 THR THR A . n 
+A 1 265 ILE 265 284 284 ILE ILE A . n 
+A 1 266 GLU 266 285 285 GLU GLU A . n 
+A 1 267 SER 267 286 286 SER SER A . n 
+A 1 268 LEU 268 287 287 LEU LEU A . n 
+A 1 269 GLU 269 288 288 GLU GLU A . n 
+A 1 270 ASN 270 289 289 ASN ASN A . n 
+A 1 271 THR 271 290 290 THR THR A . n 
+A 1 272 ALA 272 291 291 ALA ALA A . n 
+A 1 273 VAL 273 292 292 VAL VAL A . n 
+A 1 274 ASP 274 293 293 ASP ASP A . n 
+A 1 275 LEU 275 294 294 LEU LEU A . n 
+A 1 276 PHE 276 295 295 PHE PHE A . n 
+A 1 277 GLY 277 296 296 GLY GLY A . n 
+A 1 278 ALA 278 297 297 ALA ALA A . n 
+A 1 279 GLY 279 298 298 GLY GLY A . n 
+A 1 280 THR 280 299 299 THR THR A . n 
+A 1 281 GLU 281 300 300 GLU GLU A . n 
+A 1 282 THR 282 301 301 THR THR A . n 
+A 1 283 THR 283 302 302 THR THR A . n 
+A 1 284 SER 284 303 303 SER SER A . n 
+A 1 285 THR 285 304 304 THR THR A . n 
+A 1 286 THR 286 305 305 THR THR A . n 
+A 1 287 LEU 287 306 306 LEU LEU A . n 
+A 1 288 ARG 288 307 307 ARG ARG A . n 
+A 1 289 TYR 289 308 308 TYR TYR A . n 
+A 1 290 ALA 290 309 309 ALA ALA A . n 
+A 1 291 LEU 291 310 310 LEU LEU A . n 
+A 1 292 LEU 292 311 311 LEU LEU A . n 
+A 1 293 LEU 293 312 312 LEU LEU A . n 
+A 1 294 LEU 294 313 313 LEU LEU A . n 
+A 1 295 LEU 295 314 314 LEU LEU A . n 
+A 1 296 LYS 296 315 315 LYS LYS A . n 
+A 1 297 HIS 297 316 316 HIS HIS A . n 
+A 1 298 PRO 298 317 317 PRO PRO A . n 
+A 1 299 GLU 299 318 318 GLU GLU A . n 
+A 1 300 VAL 300 319 319 VAL VAL A . n 
+A 1 301 THR 301 320 320 THR THR A . n 
+A 1 302 ALA 302 321 321 ALA ALA A . n 
+A 1 303 LYS 303 322 322 LYS LYS A . n 
+A 1 304 VAL 304 323 323 VAL VAL A . n 
+A 1 305 GLN 305 324 324 GLN GLN A . n 
+A 1 306 GLU 306 325 325 GLU GLU A . n 
+A 1 307 GLU 307 326 326 GLU GLU A . n 
+A 1 308 ILE 308 327 327 ILE ILE A . n 
+A 1 309 GLU 309 328 328 GLU GLU A . n 
+A 1 310 ARG 310 329 329 ARG ARG A . n 
+A 1 311 VAL 311 330 330 VAL VAL A . n 
+A 1 312 ILE 312 331 331 ILE ILE A . n 
+A 1 313 GLY 313 332 332 GLY GLY A . n 
+A 1 314 ARG 314 333 333 ARG ARG A . n 
+A 1 315 ASN 315 334 334 ASN ASN A . n 
+A 1 316 ARG 316 335 335 ARG ARG A . n 
+A 1 317 SER 317 336 336 SER SER A . n 
+A 1 318 PRO 318 337 337 PRO PRO A . n 
+A 1 319 CYS 319 338 338 CYS CYS A . n 
+A 1 320 MET 320 339 339 MET MET A . n 
+A 1 321 GLN 321 340 340 GLN GLN A . n 
+A 1 322 ASP 322 341 341 ASP ASP A . n 
+A 1 323 ARG 323 342 342 ARG ARG A . n 
+A 1 324 SER 324 343 343 SER SER A . n 
+A 1 325 HIS 325 344 344 HIS HIS A . n 
+A 1 326 MET 326 345 345 MET MET A . n 
+A 1 327 PRO 327 346 346 PRO PRO A . n 
+A 1 328 TYR 328 347 347 TYR TYR A . n 
+A 1 329 THR 329 348 348 THR THR A . n 
+A 1 330 ASP 330 349 349 ASP ASP A . n 
+A 1 331 ALA 331 350 350 ALA ALA A . n 
+A 1 332 VAL 332 351 351 VAL VAL A . n 
+A 1 333 VAL 333 352 352 VAL VAL A . n 
+A 1 334 HIS 334 353 353 HIS HIS A . n 
+A 1 335 GLU 335 354 354 GLU GLU A . n 
+A 1 336 VAL 336 355 355 VAL VAL A . n 
+A 1 337 GLN 337 356 356 GLN GLN A . n 
+A 1 338 ARG 338 357 357 ARG ARG A . n 
+A 1 339 TYR 339 358 358 TYR TYR A . n 
+A 1 340 ILE 340 359 359 ILE ILE A . n 
+A 1 341 ASP 341 360 360 ASP ASP A . n 
+A 1 342 LEU 342 361 361 LEU LEU A . n 
+A 1 343 LEU 343 362 362 LEU LEU A . n 
+A 1 344 PRO 344 363 363 PRO PRO A . n 
+A 1 345 THR 345 364 364 THR THR A . n 
+A 1 346 SER 346 365 365 SER SER A . n 
+A 1 347 LEU 347 366 366 LEU LEU A . n 
+A 1 348 PRO 348 367 367 PRO PRO A . n 
+A 1 349 HIS 349 368 368 HIS HIS A . n 
+A 1 350 ALA 350 369 369 ALA ALA A . n 
+A 1 351 VAL 351 370 370 VAL VAL A . n 
+A 1 352 THR 352 371 371 THR THR A . n 
+A 1 353 CYS 353 372 372 CYS CYS A . n 
+A 1 354 ASP 354 373 373 ASP ASP A . n 
+A 1 355 ILE 355 374 374 ILE ILE A . n 
+A 1 356 LYS 356 375 375 LYS LYS A . n 
+A 1 357 PHE 357 376 376 PHE PHE A . n 
+A 1 358 ARG 358 377 377 ARG ARG A . n 
+A 1 359 ASN 359 378 378 ASN ASN A . n 
+A 1 360 TYR 360 379 379 TYR TYR A . n 
+A 1 361 LEU 361 380 380 LEU LEU A . n 
+A 1 362 ILE 362 381 381 ILE ILE A . n 
+A 1 363 PRO 363 382 382 PRO PRO A . n 
+A 1 364 LYS 364 383 383 LYS LYS A . n 
+A 1 365 GLY 365 384 384 GLY GLY A . n 
+A 1 366 THR 366 385 385 THR THR A . n 
+A 1 367 THR 367 386 386 THR THR A . n 
+A 1 368 ILE 368 387 387 ILE ILE A . n 
+A 1 369 LEU 369 388 388 LEU LEU A . n 
+A 1 370 ILE 370 389 389 ILE ILE A . n 
+A 1 371 SER 371 390 390 SER SER A . n 
+A 1 372 LEU 372 391 391 LEU LEU A . n 
+A 1 373 THR 373 392 392 THR THR A . n 
+A 1 374 SER 374 393 393 SER SER A . n 
+A 1 375 VAL 375 394 394 VAL VAL A . n 
+A 1 376 LEU 376 395 395 LEU LEU A . n 
+A 1 377 HIS 377 396 396 HIS HIS A . n 
+A 1 378 ASP 378 397 397 ASP ASP A . n 
+A 1 379 ASN 379 398 398 ASN ASN A . n 
+A 1 380 LYS 380 399 399 LYS LYS A . n 
+A 1 381 GLU 381 400 400 GLU GLU A . n 
+A 1 382 PHE 382 401 401 PHE PHE A . n 
+A 1 383 PRO 383 402 402 PRO PRO A . n 
+A 1 384 ASN 384 403 403 ASN ASN A . n 
+A 1 385 PRO 385 404 404 PRO PRO A . n 
+A 1 386 GLU 386 405 405 GLU GLU A . n 
+A 1 387 MET 387 406 406 MET MET A . n 
+A 1 388 PHE 388 407 407 PHE PHE A . n 
+A 1 389 ASP 389 408 408 ASP ASP A . n 
+A 1 390 PRO 390 409 409 PRO PRO A . n 
+A 1 391 HIS 391 410 410 HIS HIS A . n 
+A 1 392 HIS 392 411 411 HIS HIS A . n 
+A 1 393 PHE 393 412 412 PHE PHE A . n 
+A 1 394 LEU 394 413 413 LEU LEU A . n 
+A 1 395 ASP 395 414 414 ASP ASP A . n 
+A 1 396 GLU 396 415 415 GLU GLU A . n 
+A 1 397 GLY 397 416 416 GLY GLY A . n 
+A 1 398 GLY 398 417 417 GLY GLY A . n 
+A 1 399 ASN 399 418 418 ASN ASN A . n 
+A 1 400 PHE 400 419 419 PHE PHE A . n 
+A 1 401 LYS 401 420 420 LYS LYS A . n 
+A 1 402 LYS 402 421 421 LYS LYS A . n 
+A 1 403 SER 403 422 422 SER SER A . n 
+A 1 404 LYS 404 423 423 LYS LYS A . n 
+A 1 405 TYR 405 424 424 TYR TYR A . n 
+A 1 406 PHE 406 425 425 PHE PHE A . n 
+A 1 407 MET 407 426 426 MET MET A . n 
+A 1 408 PRO 408 427 427 PRO PRO A . n 
+A 1 409 PHE 409 428 428 PHE PHE A . n 
+A 1 410 SER 410 429 429 SER SER A . n 
+A 1 411 ALA 411 430 430 ALA ALA A . n 
+A 1 412 GLY 412 431 431 GLY GLY A . n 
+A 1 413 LYS 413 432 432 LYS LYS A . n 
+A 1 414 ARG 414 433 433 ARG ARG A . n 
+A 1 415 ILE 415 434 434 ILE ILE A . n 
+A 1 416 CYS 416 435 435 CYS CYS A . n 
+A 1 417 VAL 417 436 436 VAL VAL A . n 
+A 1 418 GLY 418 437 437 GLY GLY A . n 
+A 1 419 GLU 419 438 438 GLU GLU A . n 
+A 1 420 ALA 420 439 439 ALA ALA A . n 
+A 1 421 LEU 421 440 440 LEU LEU A . n 
+A 1 422 ALA 422 441 441 ALA ALA A . n 
+A 1 423 GLY 423 442 442 GLY GLY A . n 
+A 1 424 MET 424 443 443 MET MET A . n 
+A 1 425 GLU 425 444 444 GLU GLU A . n 
+A 1 426 LEU 426 445 445 LEU LEU A . n 
+A 1 427 PHE 427 446 446 PHE PHE A . n 
+A 1 428 LEU 428 447 447 LEU LEU A . n 
+A 1 429 PHE 429 448 448 PHE PHE A . n 
+A 1 430 LEU 430 449 449 LEU LEU A . n 
+A 1 431 THR 431 450 450 THR THR A . n 
+A 1 432 SER 432 451 451 SER SER A . n 
+A 1 433 ILE 433 452 452 ILE ILE A . n 
+A 1 434 LEU 434 453 453 LEU LEU A . n 
+A 1 435 GLN 435 454 454 GLN GLN A . n 
+A 1 436 ASN 436 455 455 ASN ASN A . n 
+A 1 437 PHE 437 456 456 PHE PHE A . n 
+A 1 438 ASN 438 457 457 ASN ASN A . n 
+A 1 439 LEU 439 458 458 LEU LEU A . n 
+A 1 440 LYS 440 459 459 LYS LYS A . n 
+A 1 441 SER 441 460 460 SER SER A . n 
+A 1 442 LEU 442 461 461 LEU LEU A . n 
+A 1 443 VAL 443 462 462 VAL VAL A . n 
+A 1 444 ASP 444 463 463 ASP ASP A . n 
+A 1 445 PRO 445 464 464 PRO PRO A . n 
+A 1 446 LYS 446 465 465 LYS LYS A . n 
+A 1 447 ASN 447 466 466 ASN ASN A . n 
+A 1 448 LEU 448 467 467 LEU LEU A . n 
+A 1 449 ASP 449 468 468 ASP ASP A . n 
+A 1 450 THR 450 469 469 THR THR A . n 
+A 1 451 THR 451 470 470 THR THR A . n 
+A 1 452 PRO 452 471 471 PRO PRO A . n 
+A 1 453 VAL 453 472 472 VAL VAL A . n 
+A 1 454 VAL 454 473 473 VAL VAL A . n 
+A 1 455 ASN 455 474 474 ASN ASN A . n 
+A 1 456 GLY 456 475 475 GLY GLY A . n 
+A 1 457 PHE 457 476 476 PHE PHE A . n 
+A 1 458 ALA 458 477 477 ALA ALA A . n 
+A 1 459 SER 459 478 478 SER SER A . n 
+A 1 460 VAL 460 479 479 VAL VAL A . n 
+A 1 461 PRO 461 480 480 PRO PRO A . n 
+A 1 462 PRO 462 481 481 PRO PRO A . n 
+A 1 463 PHE 463 482 482 PHE PHE A . n 
+A 1 464 TYR 464 483 483 TYR TYR A . n 
+A 1 465 GLN 465 484 484 GLN GLN A . n 
+A 1 466 LEU 466 485 485 LEU LEU A . n 
+A 1 467 CYS 467 486 486 CYS CYS A . n 
+A 1 468 PHE 468 487 487 PHE PHE A . n 
+A 1 469 ILE 469 488 488 ILE ILE A . n 
+A 1 470 PRO 470 489 489 PRO PRO A . n 
+A 1 471 VAL 471 490 490 VAL VAL A . n 
+A 1 472 HIS 472 491 491 HIS HIS A . n 
+A 1 473 HIS 473 492 ?   ?   ?   A . n 
+A 1 474 HIS 474 493 ?   ?   ?   A . n 
+A 1 475 HIS 475 494 ?   ?   ?   A . n 
+B 1 1   MET 1   20  ?   ?   ?   B . n 
+B 1 2   ALA 2   21  ?   ?   ?   B . n 
+B 1 3   LYS 3   22  ?   ?   ?   B . n 
+B 1 4   LYS 4   23  ?   ?   ?   B . n 
+B 1 5   THR 5   24  ?   ?   ?   B . n 
+B 1 6   SER 6   25  ?   ?   ?   B . n 
+B 1 7   SER 7   26  ?   ?   ?   B . n 
+B 1 8   LYS 8   27  ?   ?   ?   B . n 
+B 1 9   GLY 9   28  ?   ?   ?   B . n 
+B 1 10  ARG 10  29  ?   ?   ?   B . n 
+B 1 11  PRO 11  30  30  PRO PRO B . n 
+B 1 12  PRO 12  31  31  PRO PRO B . n 
+B 1 13  GLY 13  32  32  GLY GLY B . n 
+B 1 14  PRO 14  33  33  PRO PRO B . n 
+B 1 15  THR 15  34  34  THR THR B . n 
+B 1 16  PRO 16  35  35  PRO PRO B . n 
+B 1 17  LEU 17  36  36  LEU LEU B . n 
+B 1 18  PRO 18  37  37  PRO PRO B . n 
+B 1 19  VAL 19  38  38  VAL VAL B . n 
+B 1 20  ILE 20  39  39  ILE ILE B . n 
+B 1 21  GLY 21  40  40  GLY GLY B . n 
+B 1 22  ASN 22  41  41  ASN ASN B . n 
+B 1 23  ILE 23  42  42  ILE ILE B . n 
+B 1 24  LEU 24  43  43  LEU LEU B . n 
+B 1 25  GLN 25  44  44  GLN GLN B . n 
+B 1 26  ILE 26  45  45  ILE ILE B . n 
+B 1 27  GLY 27  46  46  GLY GLY B . n 
+B 1 28  ILE 28  47  47  ILE ILE B . n 
+B 1 29  LYS 29  48  48  LYS LYS B . n 
+B 1 30  ASP 30  49  49  ASP ASP B . n 
+B 1 31  ILE 31  50  50  ILE ILE B . n 
+B 1 32  SER 32  51  51  SER SER B . n 
+B 1 33  LYS 33  52  52  LYS LYS B . n 
+B 1 34  SER 34  53  53  SER SER B . n 
+B 1 35  LEU 35  54  54  LEU LEU B . n 
+B 1 36  THR 36  55  55  THR THR B . n 
+B 1 37  ASN 37  56  56  ASN ASN B . n 
+B 1 38  LEU 38  57  57  LEU LEU B . n 
+B 1 39  SER 39  58  58  SER SER B . n 
+B 1 40  LYS 40  59  59  LYS LYS B . n 
+B 1 41  VAL 41  60  60  VAL VAL B . n 
+B 1 42  TYR 42  61  61  TYR TYR B . n 
+B 1 43  GLY 43  62  62  GLY GLY B . n 
+B 1 44  PRO 44  63  63  PRO PRO B . n 
+B 1 45  VAL 45  64  64  VAL VAL B . n 
+B 1 46  PHE 46  65  65  PHE PHE B . n 
+B 1 47  THR 47  66  66  THR THR B . n 
+B 1 48  LEU 48  67  67  LEU LEU B . n 
+B 1 49  TYR 49  68  68  TYR TYR B . n 
+B 1 50  PHE 50  69  69  PHE PHE B . n 
+B 1 51  GLY 51  70  70  GLY GLY B . n 
+B 1 52  LEU 52  71  71  LEU LEU B . n 
+B 1 53  LYS 53  72  72  LYS LYS B . n 
+B 1 54  PRO 54  73  73  PRO PRO B . n 
+B 1 55  ILE 55  74  74  ILE ILE B . n 
+B 1 56  VAL 56  75  75  VAL VAL B . n 
+B 1 57  VAL 57  76  76  VAL VAL B . n 
+B 1 58  LEU 58  77  77  LEU LEU B . n 
+B 1 59  HIS 59  78  78  HIS HIS B . n 
+B 1 60  GLY 60  79  79  GLY GLY B . n 
+B 1 61  TYR 61  80  80  TYR TYR B . n 
+B 1 62  GLU 62  81  81  GLU GLU B . n 
+B 1 63  ALA 63  82  82  ALA ALA B . n 
+B 1 64  VAL 64  83  83  VAL VAL B . n 
+B 1 65  LYS 65  84  84  LYS LYS B . n 
+B 1 66  GLU 66  85  85  GLU GLU B . n 
+B 1 67  ALA 67  86  86  ALA ALA B . n 
+B 1 68  LEU 68  87  87  LEU LEU B . n 
+B 1 69  ILE 69  88  88  ILE ILE B . n 
+B 1 70  ASP 70  89  89  ASP ASP B . n 
+B 1 71  LEU 71  90  90  LEU LEU B . n 
+B 1 72  GLY 72  91  91  GLY GLY B . n 
+B 1 73  GLU 73  92  92  GLU GLU B . n 
+B 1 74  GLU 74  93  93  GLU GLU B . n 
+B 1 75  PHE 75  94  94  PHE PHE B . n 
+B 1 76  SER 76  95  95  SER SER B . n 
+B 1 77  GLY 77  96  96  GLY GLY B . n 
+B 1 78  ARG 78  97  97  ARG ARG B . n 
+B 1 79  GLY 79  98  98  GLY GLY B . n 
+B 1 80  ILE 80  99  99  ILE ILE B . n 
+B 1 81  PHE 81  100 100 PHE PHE B . n 
+B 1 82  PRO 82  101 101 PRO PRO B . n 
+B 1 83  LEU 83  102 102 LEU LEU B . n 
+B 1 84  ALA 84  103 103 ALA ALA B . n 
+B 1 85  GLU 85  104 104 GLU GLU B . n 
+B 1 86  ARG 86  105 105 ARG ARG B . n 
+B 1 87  ALA 87  106 106 ALA ALA B . n 
+B 1 88  ASN 88  107 107 ASN ASN B . n 
+B 1 89  ARG 89  108 108 ARG ARG B . n 
+B 1 90  GLY 90  109 109 GLY GLY B . n 
+B 1 91  PHE 91  110 110 PHE PHE B . n 
+B 1 92  GLY 92  111 111 GLY GLY B . n 
+B 1 93  ILE 93  112 112 ILE ILE B . n 
+B 1 94  VAL 94  113 113 VAL VAL B . n 
+B 1 95  PHE 95  114 114 PHE PHE B . n 
+B 1 96  SER 96  115 115 SER SER B . n 
+B 1 97  ASN 97  116 116 ASN ASN B . n 
+B 1 98  GLY 98  117 117 GLY GLY B . n 
+B 1 99  LYS 99  118 118 LYS LYS B . n 
+B 1 100 LYS 100 119 119 LYS LYS B . n 
+B 1 101 TRP 101 120 120 TRP TRP B . n 
+B 1 102 LYS 102 121 121 LYS LYS B . n 
+B 1 103 GLU 103 122 122 GLU GLU B . n 
+B 1 104 ILE 104 123 123 ILE ILE B . n 
+B 1 105 ARG 105 124 124 ARG ARG B . n 
+B 1 106 ARG 106 125 125 ARG ARG B . n 
+B 1 107 PHE 107 126 126 PHE PHE B . n 
+B 1 108 SER 108 127 127 SER SER B . n 
+B 1 109 LEU 109 128 128 LEU LEU B . n 
+B 1 110 MET 110 129 129 MET MET B . n 
+B 1 111 THR 111 130 130 THR THR B . n 
+B 1 112 LEU 112 131 131 LEU LEU B . n 
+B 1 113 ARG 113 132 132 ARG ARG B . n 
+B 1 114 ASN 114 133 133 ASN ASN B . n 
+B 1 115 PHE 115 134 134 PHE PHE B . n 
+B 1 116 GLY 116 135 135 GLY GLY B . n 
+B 1 117 MET 117 136 136 MET MET B . n 
+B 1 118 GLY 118 137 137 GLY GLY B . n 
+B 1 119 LYS 119 138 138 LYS LYS B . n 
+B 1 120 ARG 120 139 139 ARG ARG B . n 
+B 1 121 SER 121 140 140 SER SER B . n 
+B 1 122 ILE 122 141 141 ILE ILE B . n 
+B 1 123 GLU 123 142 142 GLU GLU B . n 
+B 1 124 ASP 124 143 143 ASP ASP B . n 
+B 1 125 ARG 125 144 144 ARG ARG B . n 
+B 1 126 VAL 126 145 145 VAL VAL B . n 
+B 1 127 GLN 127 146 146 GLN GLN B . n 
+B 1 128 GLU 128 147 147 GLU GLU B . n 
+B 1 129 GLU 129 148 148 GLU GLU B . n 
+B 1 130 ALA 130 149 149 ALA ALA B . n 
+B 1 131 ARG 131 150 150 ARG ARG B . n 
+B 1 132 CYS 132 151 151 CYS CYS B . n 
+B 1 133 LEU 133 152 152 LEU LEU B . n 
+B 1 134 VAL 134 153 153 VAL VAL B . n 
+B 1 135 GLU 135 154 154 GLU GLU B . n 
+B 1 136 GLU 136 155 155 GLU GLU B . n 
+B 1 137 LEU 137 156 156 LEU LEU B . n 
+B 1 138 ARG 138 157 157 ARG ARG B . n 
+B 1 139 LYS 139 158 158 LYS LYS B . n 
+B 1 140 THR 140 159 159 THR THR B . n 
+B 1 141 LYS 141 160 160 LYS LYS B . n 
+B 1 142 ALA 142 161 161 ALA ALA B . n 
+B 1 143 SER 143 162 162 SER SER B . n 
+B 1 144 PRO 144 163 163 PRO PRO B . n 
+B 1 145 CYS 145 164 164 CYS CYS B . n 
+B 1 146 ASP 146 165 165 ASP ASP B . n 
+B 1 147 PRO 147 166 166 PRO PRO B . n 
+B 1 148 THR 148 167 167 THR THR B . n 
+B 1 149 PHE 149 168 168 PHE PHE B . n 
+B 1 150 ILE 150 169 169 ILE ILE B . n 
+B 1 151 LEU 151 170 170 LEU LEU B . n 
+B 1 152 GLY 152 171 171 GLY GLY B . n 
+B 1 153 CYS 153 172 172 CYS CYS B . n 
+B 1 154 ALA 154 173 173 ALA ALA B . n 
+B 1 155 PRO 155 174 174 PRO PRO B . n 
+B 1 156 CYS 156 175 175 CYS CYS B . n 
+B 1 157 ASN 157 176 176 ASN ASN B . n 
+B 1 158 VAL 158 177 177 VAL VAL B . n 
+B 1 159 ILE 159 178 178 ILE ILE B . n 
+B 1 160 CYS 160 179 179 CYS CYS B . n 
+B 1 161 SER 161 180 180 SER SER B . n 
+B 1 162 ILE 162 181 181 ILE ILE B . n 
+B 1 163 ILE 163 182 182 ILE ILE B . n 
+B 1 164 PHE 164 183 183 PHE PHE B . n 
+B 1 165 HIS 165 184 184 HIS HIS B . n 
+B 1 166 LYS 166 185 185 LYS LYS B . n 
+B 1 167 ARG 167 186 186 ARG ARG B . n 
+B 1 168 PHE 168 187 187 PHE PHE B . n 
+B 1 169 ASP 169 188 188 ASP ASP B . n 
+B 1 170 TYR 170 189 189 TYR TYR B . n 
+B 1 171 LYS 171 190 190 LYS LYS B . n 
+B 1 172 ASP 172 191 191 ASP ASP B . n 
+B 1 173 GLN 173 192 192 GLN GLN B . n 
+B 1 174 GLN 174 193 193 GLN GLN B . n 
+B 1 175 PHE 175 194 194 PHE PHE B . n 
+B 1 176 LEU 176 195 195 LEU LEU B . n 
+B 1 177 ASN 177 196 196 ASN ASN B . n 
+B 1 178 LEU 178 197 197 LEU LEU B . n 
+B 1 179 MET 179 198 198 MET MET B . n 
+B 1 180 GLU 180 199 199 GLU GLU B . n 
+B 1 181 LYS 181 200 200 LYS LYS B . n 
+B 1 182 LEU 182 201 201 LEU LEU B . n 
+B 1 183 ASN 183 202 202 ASN ASN B . n 
+B 1 184 GLU 184 203 203 GLU GLU B . n 
+B 1 185 ASN 185 204 204 ASN ASN B . n 
+B 1 186 ILE 186 205 205 ILE ILE B . n 
+B 1 187 GLU 187 206 206 GLU GLU B . n 
+B 1 188 ILE 188 207 207 ILE ILE B . n 
+B 1 189 LEU 189 208 208 LEU LEU B . n 
+B 1 190 SER 190 209 209 SER SER B . n 
+B 1 191 SER 191 210 210 SER SER B . n 
+B 1 192 PRO 192 211 211 PRO PRO B . n 
+B 1 193 TRP 193 212 212 TRP TRP B . n 
+B 1 194 ILE 194 213 213 ILE ILE B . n 
+B 1 195 GLN 195 214 214 GLN GLN B . n 
+B 1 196 VAL 196 215 215 VAL VAL B . n 
+B 1 197 TYR 197 216 216 TYR TYR B . n 
+B 1 198 ASN 198 217 217 ASN ASN B . n 
+B 1 199 ASN 199 218 218 ASN ASN B . n 
+B 1 200 PHE 200 219 219 PHE PHE B . n 
+B 1 201 PRO 201 220 220 PRO PRO B . n 
+B 1 202 ALA 202 221 221 ALA ALA B . n 
+B 1 203 LEU 203 222 222 LEU LEU B . n 
+B 1 204 LEU 204 223 223 LEU LEU B . n 
+B 1 205 ASP 205 224 224 ASP ASP B . n 
+B 1 206 TYR 206 225 225 TYR TYR B . n 
+B 1 207 PHE 207 226 226 PHE PHE B . n 
+B 1 208 PRO 208 227 227 PRO PRO B . n 
+B 1 209 GLY 209 228 228 GLY GLY B . n 
+B 1 210 THR 210 229 229 THR THR B . n 
+B 1 211 HIS 211 230 230 HIS HIS B . n 
+B 1 212 ASN 212 231 231 ASN ASN B . n 
+B 1 213 LYS 213 232 232 LYS LYS B . n 
+B 1 214 LEU 214 233 233 LEU LEU B . n 
+B 1 215 LEU 215 234 234 LEU LEU B . n 
+B 1 216 LYS 216 235 235 LYS LYS B . n 
+B 1 217 ASN 217 236 236 ASN ASN B . n 
+B 1 218 VAL 218 237 237 VAL VAL B . n 
+B 1 219 ALA 219 238 238 ALA ALA B . n 
+B 1 220 PHE 220 239 239 PHE PHE B . n 
+B 1 221 MET 221 240 240 MET MET B . n 
+B 1 222 LYS 222 241 241 LYS LYS B . n 
+B 1 223 SER 223 242 242 SER SER B . n 
+B 1 224 TYR 224 243 243 TYR TYR B . n 
+B 1 225 ILE 225 244 244 ILE ILE B . n 
+B 1 226 LEU 226 245 245 LEU LEU B . n 
+B 1 227 GLU 227 246 246 GLU GLU B . n 
+B 1 228 LYS 228 247 247 LYS LYS B . n 
+B 1 229 VAL 229 248 248 VAL VAL B . n 
+B 1 230 LYS 230 249 249 LYS LYS B . n 
+B 1 231 GLU 231 250 250 GLU GLU B . n 
+B 1 232 HIS 232 251 251 HIS HIS B . n 
+B 1 233 GLN 233 252 252 GLN GLN B . n 
+B 1 234 GLU 234 253 253 GLU GLU B . n 
+B 1 235 SER 235 254 254 SER SER B . n 
+B 1 236 MET 236 255 255 MET MET B . n 
+B 1 237 ASP 237 256 256 ASP ASP B . n 
+B 1 238 MET 238 257 257 MET MET B . n 
+B 1 239 ASN 239 258 258 ASN ASN B . n 
+B 1 240 ASN 240 259 259 ASN ASN B . n 
+B 1 241 PRO 241 260 260 PRO PRO B . n 
+B 1 242 GLN 242 261 261 GLN GLN B . n 
+B 1 243 ASP 243 262 262 ASP ASP B . n 
+B 1 244 PHE 244 263 263 PHE PHE B . n 
+B 1 245 ILE 245 264 264 ILE ILE B . n 
+B 1 246 ASP 246 265 265 ASP ASP B . n 
+B 1 247 CYS 247 266 266 CYS CYS B . n 
+B 1 248 PHE 248 267 267 PHE PHE B . n 
+B 1 249 LEU 249 268 268 LEU LEU B . n 
+B 1 250 MET 250 269 269 MET MET B . n 
+B 1 251 LYS 251 270 270 LYS LYS B . n 
+B 1 252 MET 252 271 271 MET MET B . n 
+B 1 253 GLU 253 272 272 GLU GLU B . n 
+B 1 254 LYS 254 273 273 LYS LYS B . n 
+B 1 255 GLU 255 274 274 GLU GLU B . n 
+B 1 256 LYS 256 275 275 LYS LYS B . n 
+B 1 257 HIS 257 276 276 HIS HIS B . n 
+B 1 258 ASN 258 277 277 ASN ASN B . n 
+B 1 259 GLN 259 278 278 GLN GLN B . n 
+B 1 260 PRO 260 279 279 PRO PRO B . n 
+B 1 261 SER 261 280 280 SER SER B . n 
+B 1 262 GLU 262 281 281 GLU GLU B . n 
+B 1 263 PHE 263 282 282 PHE PHE B . n 
+B 1 264 THR 264 283 283 THR THR B . n 
+B 1 265 ILE 265 284 284 ILE ILE B . n 
+B 1 266 GLU 266 285 285 GLU GLU B . n 
+B 1 267 SER 267 286 286 SER SER B . n 
+B 1 268 LEU 268 287 287 LEU LEU B . n 
+B 1 269 GLU 269 288 288 GLU GLU B . n 
+B 1 270 ASN 270 289 289 ASN ASN B . n 
+B 1 271 THR 271 290 290 THR THR B . n 
+B 1 272 ALA 272 291 291 ALA ALA B . n 
+B 1 273 VAL 273 292 292 VAL VAL B . n 
+B 1 274 ASP 274 293 293 ASP ASP B . n 
+B 1 275 LEU 275 294 294 LEU LEU B . n 
+B 1 276 PHE 276 295 295 PHE PHE B . n 
+B 1 277 GLY 277 296 296 GLY GLY B . n 
+B 1 278 ALA 278 297 297 ALA ALA B . n 
+B 1 279 GLY 279 298 298 GLY GLY B . n 
+B 1 280 THR 280 299 299 THR THR B . n 
+B 1 281 GLU 281 300 300 GLU GLU B . n 
+B 1 282 THR 282 301 301 THR THR B . n 
+B 1 283 THR 283 302 302 THR THR B . n 
+B 1 284 SER 284 303 303 SER SER B . n 
+B 1 285 THR 285 304 304 THR THR B . n 
+B 1 286 THR 286 305 305 THR THR B . n 
+B 1 287 LEU 287 306 306 LEU LEU B . n 
+B 1 288 ARG 288 307 307 ARG ARG B . n 
+B 1 289 TYR 289 308 308 TYR TYR B . n 
+B 1 290 ALA 290 309 309 ALA ALA B . n 
+B 1 291 LEU 291 310 310 LEU LEU B . n 
+B 1 292 LEU 292 311 311 LEU LEU B . n 
+B 1 293 LEU 293 312 312 LEU LEU B . n 
+B 1 294 LEU 294 313 313 LEU LEU B . n 
+B 1 295 LEU 295 314 314 LEU LEU B . n 
+B 1 296 LYS 296 315 315 LYS LYS B . n 
+B 1 297 HIS 297 316 316 HIS HIS B . n 
+B 1 298 PRO 298 317 317 PRO PRO B . n 
+B 1 299 GLU 299 318 318 GLU GLU B . n 
+B 1 300 VAL 300 319 319 VAL VAL B . n 
+B 1 301 THR 301 320 320 THR THR B . n 
+B 1 302 ALA 302 321 321 ALA ALA B . n 
+B 1 303 LYS 303 322 322 LYS LYS B . n 
+B 1 304 VAL 304 323 323 VAL VAL B . n 
+B 1 305 GLN 305 324 324 GLN GLN B . n 
+B 1 306 GLU 306 325 325 GLU GLU B . n 
+B 1 307 GLU 307 326 326 GLU GLU B . n 
+B 1 308 ILE 308 327 327 ILE ILE B . n 
+B 1 309 GLU 309 328 328 GLU GLU B . n 
+B 1 310 ARG 310 329 329 ARG ARG B . n 
+B 1 311 VAL 311 330 330 VAL VAL B . n 
+B 1 312 ILE 312 331 331 ILE ILE B . n 
+B 1 313 GLY 313 332 332 GLY GLY B . n 
+B 1 314 ARG 314 333 333 ARG ARG B . n 
+B 1 315 ASN 315 334 334 ASN ASN B . n 
+B 1 316 ARG 316 335 335 ARG ARG B . n 
+B 1 317 SER 317 336 336 SER SER B . n 
+B 1 318 PRO 318 337 337 PRO PRO B . n 
+B 1 319 CYS 319 338 338 CYS CYS B . n 
+B 1 320 MET 320 339 339 MET MET B . n 
+B 1 321 GLN 321 340 340 GLN GLN B . n 
+B 1 322 ASP 322 341 341 ASP ASP B . n 
+B 1 323 ARG 323 342 342 ARG ARG B . n 
+B 1 324 SER 324 343 343 SER SER B . n 
+B 1 325 HIS 325 344 344 HIS HIS B . n 
+B 1 326 MET 326 345 345 MET MET B . n 
+B 1 327 PRO 327 346 346 PRO PRO B . n 
+B 1 328 TYR 328 347 347 TYR TYR B . n 
+B 1 329 THR 329 348 348 THR THR B . n 
+B 1 330 ASP 330 349 349 ASP ASP B . n 
+B 1 331 ALA 331 350 350 ALA ALA B . n 
+B 1 332 VAL 332 351 351 VAL VAL B . n 
+B 1 333 VAL 333 352 352 VAL VAL B . n 
+B 1 334 HIS 334 353 353 HIS HIS B . n 
+B 1 335 GLU 335 354 354 GLU GLU B . n 
+B 1 336 VAL 336 355 355 VAL VAL B . n 
+B 1 337 GLN 337 356 356 GLN GLN B . n 
+B 1 338 ARG 338 357 357 ARG ARG B . n 
+B 1 339 TYR 339 358 358 TYR TYR B . n 
+B 1 340 ILE 340 359 359 ILE ILE B . n 
+B 1 341 ASP 341 360 360 ASP ASP B . n 
+B 1 342 LEU 342 361 361 LEU LEU B . n 
+B 1 343 LEU 343 362 362 LEU LEU B . n 
+B 1 344 PRO 344 363 363 PRO PRO B . n 
+B 1 345 THR 345 364 364 THR THR B . n 
+B 1 346 SER 346 365 365 SER SER B . n 
+B 1 347 LEU 347 366 366 LEU LEU B . n 
+B 1 348 PRO 348 367 367 PRO PRO B . n 
+B 1 349 HIS 349 368 368 HIS HIS B . n 
+B 1 350 ALA 350 369 369 ALA ALA B . n 
+B 1 351 VAL 351 370 370 VAL VAL B . n 
+B 1 352 THR 352 371 371 THR THR B . n 
+B 1 353 CYS 353 372 372 CYS CYS B . n 
+B 1 354 ASP 354 373 373 ASP ASP B . n 
+B 1 355 ILE 355 374 374 ILE ILE B . n 
+B 1 356 LYS 356 375 375 LYS LYS B . n 
+B 1 357 PHE 357 376 376 PHE PHE B . n 
+B 1 358 ARG 358 377 377 ARG ARG B . n 
+B 1 359 ASN 359 378 378 ASN ASN B . n 
+B 1 360 TYR 360 379 379 TYR TYR B . n 
+B 1 361 LEU 361 380 380 LEU LEU B . n 
+B 1 362 ILE 362 381 381 ILE ILE B . n 
+B 1 363 PRO 363 382 382 PRO PRO B . n 
+B 1 364 LYS 364 383 383 LYS LYS B . n 
+B 1 365 GLY 365 384 384 GLY GLY B . n 
+B 1 366 THR 366 385 385 THR THR B . n 
+B 1 367 THR 367 386 386 THR THR B . n 
+B 1 368 ILE 368 387 387 ILE ILE B . n 
+B 1 369 LEU 369 388 388 LEU LEU B . n 
+B 1 370 ILE 370 389 389 ILE ILE B . n 
+B 1 371 SER 371 390 390 SER SER B . n 
+B 1 372 LEU 372 391 391 LEU LEU B . n 
+B 1 373 THR 373 392 392 THR THR B . n 
+B 1 374 SER 374 393 393 SER SER B . n 
+B 1 375 VAL 375 394 394 VAL VAL B . n 
+B 1 376 LEU 376 395 395 LEU LEU B . n 
+B 1 377 HIS 377 396 396 HIS HIS B . n 
+B 1 378 ASP 378 397 397 ASP ASP B . n 
+B 1 379 ASN 379 398 398 ASN ASN B . n 
+B 1 380 LYS 380 399 399 LYS LYS B . n 
+B 1 381 GLU 381 400 400 GLU GLU B . n 
+B 1 382 PHE 382 401 401 PHE PHE B . n 
+B 1 383 PRO 383 402 402 PRO PRO B . n 
+B 1 384 ASN 384 403 403 ASN ASN B . n 
+B 1 385 PRO 385 404 404 PRO PRO B . n 
+B 1 386 GLU 386 405 405 GLU GLU B . n 
+B 1 387 MET 387 406 406 MET MET B . n 
+B 1 388 PHE 388 407 407 PHE PHE B . n 
+B 1 389 ASP 389 408 408 ASP ASP B . n 
+B 1 390 PRO 390 409 409 PRO PRO B . n 
+B 1 391 HIS 391 410 410 HIS HIS B . n 
+B 1 392 HIS 392 411 411 HIS HIS B . n 
+B 1 393 PHE 393 412 412 PHE PHE B . n 
+B 1 394 LEU 394 413 413 LEU LEU B . n 
+B 1 395 ASP 395 414 414 ASP ASP B . n 
+B 1 396 GLU 396 415 415 GLU GLU B . n 
+B 1 397 GLY 397 416 416 GLY GLY B . n 
+B 1 398 GLY 398 417 417 GLY GLY B . n 
+B 1 399 ASN 399 418 418 ASN ASN B . n 
+B 1 400 PHE 400 419 419 PHE PHE B . n 
+B 1 401 LYS 401 420 420 LYS LYS B . n 
+B 1 402 LYS 402 421 421 LYS LYS B . n 
+B 1 403 SER 403 422 422 SER SER B . n 
+B 1 404 LYS 404 423 423 LYS LYS B . n 
+B 1 405 TYR 405 424 424 TYR TYR B . n 
+B 1 406 PHE 406 425 425 PHE PHE B . n 
+B 1 407 MET 407 426 426 MET MET B . n 
+B 1 408 PRO 408 427 427 PRO PRO B . n 
+B 1 409 PHE 409 428 428 PHE PHE B . n 
+B 1 410 SER 410 429 429 SER SER B . n 
+B 1 411 ALA 411 430 430 ALA ALA B . n 
+B 1 412 GLY 412 431 431 GLY GLY B . n 
+B 1 413 LYS 413 432 432 LYS LYS B . n 
+B 1 414 ARG 414 433 433 ARG ARG B . n 
+B 1 415 ILE 415 434 434 ILE ILE B . n 
+B 1 416 CYS 416 435 435 CYS CYS B . n 
+B 1 417 VAL 417 436 436 VAL VAL B . n 
+B 1 418 GLY 418 437 437 GLY GLY B . n 
+B 1 419 GLU 419 438 438 GLU GLU B . n 
+B 1 420 ALA 420 439 439 ALA ALA B . n 
+B 1 421 LEU 421 440 440 LEU LEU B . n 
+B 1 422 ALA 422 441 441 ALA ALA B . n 
+B 1 423 GLY 423 442 442 GLY GLY B . n 
+B 1 424 MET 424 443 443 MET MET B . n 
+B 1 425 GLU 425 444 444 GLU GLU B . n 
+B 1 426 LEU 426 445 445 LEU LEU B . n 
+B 1 427 PHE 427 446 446 PHE PHE B . n 
+B 1 428 LEU 428 447 447 LEU LEU B . n 
+B 1 429 PHE 429 448 448 PHE PHE B . n 
+B 1 430 LEU 430 449 449 LEU LEU B . n 
+B 1 431 THR 431 450 450 THR THR B . n 
+B 1 432 SER 432 451 451 SER SER B . n 
+B 1 433 ILE 433 452 452 ILE ILE B . n 
+B 1 434 LEU 434 453 453 LEU LEU B . n 
+B 1 435 GLN 435 454 454 GLN GLN B . n 
+B 1 436 ASN 436 455 455 ASN ASN B . n 
+B 1 437 PHE 437 456 456 PHE PHE B . n 
+B 1 438 ASN 438 457 457 ASN ASN B . n 
+B 1 439 LEU 439 458 458 LEU LEU B . n 
+B 1 440 LYS 440 459 459 LYS LYS B . n 
+B 1 441 SER 441 460 460 SER SER B . n 
+B 1 442 LEU 442 461 461 LEU LEU B . n 
+B 1 443 VAL 443 462 462 VAL VAL B . n 
+B 1 444 ASP 444 463 463 ASP ASP B . n 
+B 1 445 PRO 445 464 464 PRO PRO B . n 
+B 1 446 LYS 446 465 465 LYS LYS B . n 
+B 1 447 ASN 447 466 466 ASN ASN B . n 
+B 1 448 LEU 448 467 467 LEU LEU B . n 
+B 1 449 ASP 449 468 468 ASP ASP B . n 
+B 1 450 THR 450 469 469 THR THR B . n 
+B 1 451 THR 451 470 470 THR THR B . n 
+B 1 452 PRO 452 471 471 PRO PRO B . n 
+B 1 453 VAL 453 472 472 VAL VAL B . n 
+B 1 454 VAL 454 473 473 VAL VAL B . n 
+B 1 455 ASN 455 474 474 ASN ASN B . n 
+B 1 456 GLY 456 475 475 GLY GLY B . n 
+B 1 457 PHE 457 476 476 PHE PHE B . n 
+B 1 458 ALA 458 477 477 ALA ALA B . n 
+B 1 459 SER 459 478 478 SER SER B . n 
+B 1 460 VAL 460 479 479 VAL VAL B . n 
+B 1 461 PRO 461 480 480 PRO PRO B . n 
+B 1 462 PRO 462 481 481 PRO PRO B . n 
+B 1 463 PHE 463 482 482 PHE PHE B . n 
+B 1 464 TYR 464 483 483 TYR TYR B . n 
+B 1 465 GLN 465 484 484 GLN GLN B . n 
+B 1 466 LEU 466 485 485 LEU LEU B . n 
+B 1 467 CYS 467 486 486 CYS CYS B . n 
+B 1 468 PHE 468 487 487 PHE PHE B . n 
+B 1 469 ILE 469 488 488 ILE ILE B . n 
+B 1 470 PRO 470 489 489 PRO PRO B . n 
+B 1 471 VAL 471 490 490 VAL VAL B . n 
+B 1 472 HIS 472 491 491 HIS HIS B . n 
+B 1 473 HIS 473 492 ?   ?   ?   B . n 
+B 1 474 HIS 474 493 ?   ?   ?   B . n 
+B 1 475 HIS 475 494 ?   ?   ?   B . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+C 2 HEC 1  501  501  HEC HEC A . 
+D 2 HEC 1  501  501  HEC HEC B . 
+E 3 HOH 1  2001 2001 HOH HOH A . 
+E 3 HOH 2  2002 2002 HOH HOH A . 
+E 3 HOH 3  2003 2003 HOH HOH A . 
+E 3 HOH 4  2004 2004 HOH HOH A . 
+E 3 HOH 5  2005 2005 HOH HOH A . 
+E 3 HOH 6  2006 2006 HOH HOH A . 
+E 3 HOH 7  2007 2007 HOH HOH A . 
+E 3 HOH 8  2008 2008 HOH HOH A . 
+E 3 HOH 9  2009 2009 HOH HOH A . 
+E 3 HOH 10 2010 2010 HOH HOH A . 
+E 3 HOH 11 2011 2011 HOH HOH A . 
+E 3 HOH 12 2012 2012 HOH HOH A . 
+E 3 HOH 13 2013 2013 HOH HOH A . 
+E 3 HOH 14 2014 2014 HOH HOH A . 
+E 3 HOH 15 2015 2015 HOH HOH A . 
+E 3 HOH 16 2016 2016 HOH HOH A . 
+E 3 HOH 17 2017 2017 HOH HOH A . 
+E 3 HOH 18 2018 2018 HOH HOH A . 
+E 3 HOH 19 2019 2019 HOH HOH A . 
+E 3 HOH 20 2020 2020 HOH HOH A . 
+E 3 HOH 21 2021 2021 HOH HOH A . 
+E 3 HOH 22 2022 2022 HOH HOH A . 
+E 3 HOH 23 2023 2023 HOH HOH A . 
+E 3 HOH 24 2024 2024 HOH HOH A . 
+E 3 HOH 25 2025 2025 HOH HOH A . 
+E 3 HOH 26 2026 2026 HOH HOH A . 
+E 3 HOH 27 2027 2027 HOH HOH A . 
+E 3 HOH 28 2028 2028 HOH HOH A . 
+E 3 HOH 29 2029 2029 HOH HOH A . 
+E 3 HOH 30 2030 2030 HOH HOH A . 
+E 3 HOH 31 2031 2031 HOH HOH A . 
+E 3 HOH 32 2032 2032 HOH HOH A . 
+E 3 HOH 33 2033 2033 HOH HOH A . 
+E 3 HOH 34 2034 2034 HOH HOH A . 
+E 3 HOH 35 2035 2035 HOH HOH A . 
+E 3 HOH 36 2036 2036 HOH HOH A . 
+E 3 HOH 37 2037 2037 HOH HOH A . 
+E 3 HOH 38 2038 2038 HOH HOH A . 
+E 3 HOH 39 2039 2039 HOH HOH A . 
+E 3 HOH 40 2040 2040 HOH HOH A . 
+E 3 HOH 41 2041 2041 HOH HOH A . 
+E 3 HOH 42 2042 2042 HOH HOH A . 
+E 3 HOH 43 2043 2043 HOH HOH A . 
+E 3 HOH 44 2044 2044 HOH HOH A . 
+E 3 HOH 45 2045 2045 HOH HOH A . 
+E 3 HOH 46 2046 2046 HOH HOH A . 
+E 3 HOH 47 2047 2047 HOH HOH A . 
+E 3 HOH 48 2048 2048 HOH HOH A . 
+E 3 HOH 49 2049 2049 HOH HOH A . 
+E 3 HOH 50 2050 2050 HOH HOH A . 
+E 3 HOH 51 2051 2051 HOH HOH A . 
+E 3 HOH 52 2052 2052 HOH HOH A . 
+E 3 HOH 53 2053 2053 HOH HOH A . 
+E 3 HOH 54 2054 2054 HOH HOH A . 
+E 3 HOH 55 2055 2055 HOH HOH A . 
+E 3 HOH 56 2056 2056 HOH HOH A . 
+E 3 HOH 57 2057 2057 HOH HOH A . 
+E 3 HOH 58 2058 2058 HOH HOH A . 
+E 3 HOH 59 2059 2059 HOH HOH A . 
+E 3 HOH 60 2060 2060 HOH HOH A . 
+E 3 HOH 61 2061 2061 HOH HOH A . 
+E 3 HOH 62 2062 2062 HOH HOH A . 
+E 3 HOH 63 2063 2063 HOH HOH A . 
+E 3 HOH 64 2064 2064 HOH HOH A . 
+E 3 HOH 65 2065 2065 HOH HOH A . 
+E 3 HOH 66 2066 2066 HOH HOH A . 
+E 3 HOH 67 2067 2067 HOH HOH A . 
+E 3 HOH 68 2068 2068 HOH HOH A . 
+E 3 HOH 69 2069 2069 HOH HOH A . 
+E 3 HOH 70 2070 2070 HOH HOH A . 
+E 3 HOH 71 2071 2071 HOH HOH A . 
+E 3 HOH 72 2072 2072 HOH HOH A . 
+E 3 HOH 73 2073 2073 HOH HOH A . 
+E 3 HOH 74 2074 2074 HOH HOH A . 
+E 3 HOH 75 2075 2075 HOH HOH A . 
+E 3 HOH 76 2076 2076 HOH HOH A . 
+E 3 HOH 77 2077 2077 HOH HOH A . 
+E 3 HOH 78 2078 2078 HOH HOH A . 
+E 3 HOH 79 2079 2079 HOH HOH A . 
+E 3 HOH 80 2080 2080 HOH HOH A . 
+E 3 HOH 81 2081 2081 HOH HOH A . 
+E 3 HOH 82 2082 2082 HOH HOH A . 
+E 3 HOH 83 2083 2083 HOH HOH A . 
+E 3 HOH 84 2084 2084 HOH HOH A . 
+F 3 HOH 1  2001 2001 HOH HOH B . 
+F 3 HOH 2  2002 2002 HOH HOH B . 
+F 3 HOH 3  2003 2003 HOH HOH B . 
+F 3 HOH 4  2004 2004 HOH HOH B . 
+F 3 HOH 5  2005 2005 HOH HOH B . 
+F 3 HOH 6  2006 2006 HOH HOH B . 
+F 3 HOH 7  2007 2007 HOH HOH B . 
+F 3 HOH 8  2008 2008 HOH HOH B . 
+F 3 HOH 9  2009 2009 HOH HOH B . 
+F 3 HOH 10 2010 2010 HOH HOH B . 
+F 3 HOH 11 2011 2011 HOH HOH B . 
+F 3 HOH 12 2012 2012 HOH HOH B . 
+F 3 HOH 13 2013 2013 HOH HOH B . 
+F 3 HOH 14 2014 2014 HOH HOH B . 
+F 3 HOH 15 2015 2015 HOH HOH B . 
+F 3 HOH 16 2016 2016 HOH HOH B . 
+F 3 HOH 17 2017 2017 HOH HOH B . 
+F 3 HOH 18 2018 2018 HOH HOH B . 
+F 3 HOH 19 2019 2019 HOH HOH B . 
+F 3 HOH 20 2020 2020 HOH HOH B . 
+F 3 HOH 21 2021 2021 HOH HOH B . 
+F 3 HOH 22 2022 2022 HOH HOH B . 
+F 3 HOH 23 2023 2023 HOH HOH B . 
+F 3 HOH 24 2024 2024 HOH HOH B . 
+F 3 HOH 25 2025 2025 HOH HOH B . 
+F 3 HOH 26 2026 2026 HOH HOH B . 
+F 3 HOH 27 2027 2027 HOH HOH B . 
+F 3 HOH 28 2028 2028 HOH HOH B . 
+F 3 HOH 29 2029 2029 HOH HOH B . 
+F 3 HOH 30 2030 2030 HOH HOH B . 
+F 3 HOH 31 2031 2031 HOH HOH B . 
+F 3 HOH 32 2032 2032 HOH HOH B . 
+F 3 HOH 33 2033 2033 HOH HOH B . 
+F 3 HOH 34 2034 2034 HOH HOH B . 
+F 3 HOH 35 2035 2035 HOH HOH B . 
+F 3 HOH 36 2036 2036 HOH HOH B . 
+F 3 HOH 37 2037 2037 HOH HOH B . 
+F 3 HOH 38 2038 2038 HOH HOH B . 
+F 3 HOH 39 2039 2039 HOH HOH B . 
+F 3 HOH 40 2040 2040 HOH HOH B . 
+F 3 HOH 41 2041 2041 HOH HOH B . 
+F 3 HOH 42 2042 2042 HOH HOH B . 
+F 3 HOH 43 2043 2043 HOH HOH B . 
+F 3 HOH 44 2044 2044 HOH HOH B . 
+F 3 HOH 45 2045 2045 HOH HOH B . 
+F 3 HOH 46 2046 2046 HOH HOH B . 
+F 3 HOH 47 2047 2047 HOH HOH B . 
+F 3 HOH 48 2048 2048 HOH HOH B . 
+F 3 HOH 49 2049 2049 HOH HOH B . 
+F 3 HOH 50 2050 2050 HOH HOH B . 
+F 3 HOH 51 2051 2051 HOH HOH B . 
+F 3 HOH 52 2052 2052 HOH HOH B . 
+F 3 HOH 53 2053 2053 HOH HOH B . 
+F 3 HOH 54 2054 2054 HOH HOH B . 
+F 3 HOH 55 2055 2055 HOH HOH B . 
+F 3 HOH 56 2056 2056 HOH HOH B . 
+F 3 HOH 57 2057 2057 HOH HOH B . 
+F 3 HOH 58 2058 2058 HOH HOH B . 
+F 3 HOH 59 2059 2059 HOH HOH B . 
+F 3 HOH 60 2060 2060 HOH HOH B . 
+F 3 HOH 61 2061 2061 HOH HOH B . 
+F 3 HOH 62 2062 2062 HOH HOH B . 
+F 3 HOH 63 2063 2063 HOH HOH B . 
+# 
+loop_
+_pdbx_struct_assembly.id 
+_pdbx_struct_assembly.details 
+_pdbx_struct_assembly.method_details 
+_pdbx_struct_assembly.oligomeric_details 
+_pdbx_struct_assembly.oligomeric_count 
+1 author_and_software_defined_assembly PISA monomeric 1 
+2 author_and_software_defined_assembly PISA monomeric 1 
+# 
+loop_
+_pdbx_struct_assembly_gen.assembly_id 
+_pdbx_struct_assembly_gen.oper_expression 
+_pdbx_struct_assembly_gen.asym_id_list 
+1 1 A,C,E 
+2 1 B,D,F 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+_pdbx_struct_special_symmetry.id              1 
+_pdbx_struct_special_symmetry.PDB_model_num   1 
+_pdbx_struct_special_symmetry.auth_asym_id    A 
+_pdbx_struct_special_symmetry.auth_comp_id    HOH 
+_pdbx_struct_special_symmetry.auth_seq_id     2047 
+_pdbx_struct_special_symmetry.PDB_ins_code    ? 
+_pdbx_struct_special_symmetry.label_asym_id   E 
+_pdbx_struct_special_symmetry.label_comp_id   HOH 
+_pdbx_struct_special_symmetry.label_seq_id    . 
+# 
+loop_
+_pdbx_struct_conn_angle.id 
+_pdbx_struct_conn_angle.ptnr1_label_atom_id 
+_pdbx_struct_conn_angle.ptnr1_label_alt_id 
+_pdbx_struct_conn_angle.ptnr1_label_asym_id 
+_pdbx_struct_conn_angle.ptnr1_label_comp_id 
+_pdbx_struct_conn_angle.ptnr1_label_seq_id 
+_pdbx_struct_conn_angle.ptnr1_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr1_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr1_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr1_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr1_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr1_symmetry 
+_pdbx_struct_conn_angle.ptnr2_label_atom_id 
+_pdbx_struct_conn_angle.ptnr2_label_alt_id 
+_pdbx_struct_conn_angle.ptnr2_label_asym_id 
+_pdbx_struct_conn_angle.ptnr2_label_comp_id 
+_pdbx_struct_conn_angle.ptnr2_label_seq_id 
+_pdbx_struct_conn_angle.ptnr2_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr2_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr2_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr2_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr2_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr2_symmetry 
+_pdbx_struct_conn_angle.ptnr3_label_atom_id 
+_pdbx_struct_conn_angle.ptnr3_label_alt_id 
+_pdbx_struct_conn_angle.ptnr3_label_asym_id 
+_pdbx_struct_conn_angle.ptnr3_label_comp_id 
+_pdbx_struct_conn_angle.ptnr3_label_seq_id 
+_pdbx_struct_conn_angle.ptnr3_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr3_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr3_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr3_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr3_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr3_symmetry 
+_pdbx_struct_conn_angle.value 
+_pdbx_struct_conn_angle.value_esd 
+1  O  ? E HOH .   ? A HOH 2031 ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 NA ? C HEC .   ? A HEC 501 ? 1_555 77.5  ? 
+2  O  ? E HOH .   ? A HOH 2031 ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 NB ? C HEC .   ? A HEC 501 ? 1_555 86.8  ? 
+3  NA ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 NB ? C HEC .   ? A HEC 501 ? 1_555 91.2  ? 
+4  O  ? E HOH .   ? A HOH 2031 ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 NC ? C HEC .   ? A HEC 501 ? 1_555 101.3 ? 
+5  NA ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 NC ? C HEC .   ? A HEC 501 ? 1_555 176.0 ? 
+6  NB ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 NC ? C HEC .   ? A HEC 501 ? 1_555 92.6  ? 
+7  O  ? E HOH .   ? A HOH 2031 ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 ND ? C HEC .   ? A HEC 501 ? 1_555 91.8  ? 
+8  NA ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 ND ? C HEC .   ? A HEC 501 ? 1_555 86.3  ? 
+9  NB ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 ND ? C HEC .   ? A HEC 501 ? 1_555 177.4 ? 
+10 NC ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 ND ? C HEC .   ? A HEC 501 ? 1_555 89.9  ? 
+11 O  ? E HOH .   ? A HOH 2031 ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 SG ? A CYS 416 ? A CYS 435 ? 1_555 175.0 ? 
+12 NA ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 SG ? A CYS 416 ? A CYS 435 ? 1_555 97.5  ? 
+13 NB ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 SG ? A CYS 416 ? A CYS 435 ? 1_555 92.7  ? 
+14 NC ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 SG ? A CYS 416 ? A CYS 435 ? 1_555 83.7  ? 
+15 ND ? C HEC .   ? A HEC 501  ? 1_555 FE ? C HEC . ? A HEC 501 ? 1_555 SG ? A CYS 416 ? A CYS 435 ? 1_555 88.5  ? 
+16 SG ? B CYS 416 ? B CYS 435  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 NA ? D HEC .   ? B HEC 501 ? 1_555 100.9 ? 
+17 SG ? B CYS 416 ? B CYS 435  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 NB ? D HEC .   ? B HEC 501 ? 1_555 91.5  ? 
+18 NA ? D HEC .   ? B HEC 501  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 NB ? D HEC .   ? B HEC 501 ? 1_555 92.7  ? 
+19 SG ? B CYS 416 ? B CYS 435  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 NC ? D HEC .   ? B HEC 501 ? 1_555 81.5  ? 
+20 NA ? D HEC .   ? B HEC 501  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 NC ? D HEC .   ? B HEC 501 ? 1_555 175.6 ? 
+21 NB ? D HEC .   ? B HEC 501  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 NC ? D HEC .   ? B HEC 501 ? 1_555 91.0  ? 
+22 SG ? B CYS 416 ? B CYS 435  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 ND ? D HEC .   ? B HEC 501 ? 1_555 90.1  ? 
+23 NA ? D HEC .   ? B HEC 501  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 ND ? D HEC .   ? B HEC 501 ? 1_555 87.5  ? 
+24 NB ? D HEC .   ? B HEC 501  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 ND ? D HEC .   ? B HEC 501 ? 1_555 178.3 ? 
+25 NC ? D HEC .   ? B HEC 501  ? 1_555 FE ? D HEC . ? B HEC 501 ? 1_555 ND ? D HEC .   ? B HEC 501 ? 1_555 88.8  ? 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 2003-07-17 
+2 'Structure model' 1 1 2011-11-09 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Derived calculations'      
+2 2 'Structure model' 'Non-polymer description'   
+3 2 'Structure model' Other                       
+4 2 'Structure model' 'Structure summary'         
+5 2 'Structure model' 'Version format compliance' 
+# 
+loop_
+_software.name 
+_software.classification 
+_software.version 
+_software.citation_id 
+_software.pdbx_ordinal 
+REFMAC refinement       5.1.24 ? 1 
+MOSFLM 'data reduction' .      ? 2 
+SCALA  'data scaling'   .      ? 3 
+AMoRE  phasing          .      ? 4 
+# 
+_pdbx_entry_details.entry_id             1OG2 
+_pdbx_entry_details.compound_details     
+;CYTOCHROMES P450 ARE HEME-THIOLATE MONOOXYGENASES THAT IN THE
+ LIVER MICROSOMES FORM PART OF THE NADPH-DEPENDENT ELECTRON
+ TRANSPORT PATHWAY. THE ENZYME OXIDIZES A VARIETY
+ OF STRUCTURALLY UNRELATED COMPOUNDS, INCLUDING STEROIDS, FATTY
+ ACIDS AND XENOBIOTICS.
+
+ENGINEERED RESIDUE IN CHAIN A, LYS 206 TO GLU
+ENGINEERED RESIDUE IN CHAIN A, ILE 215 TO VAL
+ENGINEERED RESIDUE IN CHAIN A, CYS 216 TO TYR
+ENGINEERED RESIDUE IN CHAIN A, SER 220 TO PRO
+ENGINEERED RESIDUE IN CHAIN A, PRO 221 TO ALA
+ENGINEERED RESIDUE IN CHAIN A, ILE 222 TO LEU
+ENGINEERED RESIDUE IN CHAIN A, ILE 223 TO LEU
+ENGINEERED RESIDUE IN CHAIN B, LYS 206 TO GLU
+ENGINEERED RESIDUE IN CHAIN B, ILE 215 TO VAL
+ENGINEERED RESIDUE IN CHAIN B, CYS 216 TO TYR
+ENGINEERED RESIDUE IN CHAIN B, SER 220 TO PRO
+ENGINEERED RESIDUE IN CHAIN B, PRO 221 TO ALA
+ENGINEERED RESIDUE IN CHAIN B, ILE 222 TO LEU
+ENGINEERED RESIDUE IN CHAIN B, ILE 223 TO LEU
+;
+_pdbx_entry_details.source_details       ? 
+_pdbx_entry_details.nonpolymer_details   ? 
+_pdbx_entry_details.sequence_details     
+;RESIDUES 1-29 OF THE FULL LENGTH PROTEIN WERE DELETED
+(THE PROPOSED TRANSMEMBRANE DOMAIN) AND A SHORT REGION OF
+SEQUENCE INTRODUCED TO ASSIST WITH EXPRESSION. A
+FOUR-HISTIDINE TAG WAS INTRODUCED AT THE C-TERMINUS FOR
+PURIFICATION PURPOSES
+;
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1 1 CB A ASP 49  ? ? CG A ASP 49  ? ? OD2 A ASP 49  ? ? 123.89 118.30 5.59 0.90 N 
+2 1 CB A ASP 191 ? ? CG A ASP 191 ? ? OD2 A ASP 191 ? ? 124.84 118.30 6.54 0.90 N 
+3 1 CB A ASP 414 ? ? CG A ASP 414 ? ? OD2 A ASP 414 ? ? 123.75 118.30 5.45 0.90 N 
+4 1 CB B ASP 49  ? ? CG B ASP 49  ? ? OD2 B ASP 49  ? ? 125.38 118.30 7.08 0.90 N 
+5 1 CB B ASP 89  ? ? CG B ASP 89  ? ? OD2 B ASP 89  ? ? 124.45 118.30 6.15 0.90 N 
+6 1 CB B ASP 188 ? ? CG B ASP 188 ? ? OD2 B ASP 188 ? ? 123.95 118.30 5.65 0.90 N 
+7 1 CB B ASP 293 ? ? CG B ASP 293 ? ? OD2 B ASP 293 ? ? 125.94 118.30 7.64 0.90 N 
+8 1 CB B ASP 373 ? ? CG B ASP 373 ? ? OD2 B ASP 373 ? ? 123.78 118.30 5.48 0.90 N 
+9 1 CB B ASP 414 ? ? CG B ASP 414 ? ? OD2 B ASP 414 ? ? 123.92 118.30 5.62 0.90 N 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1  1 LYS A 48  ? ? -82.55  -120.45 
+2  1 HIS A 78  ? ? -96.69  -80.52  
+3  1 LEU A 90  ? ? -109.14 46.59   
+4  1 ILE A 112 ? ? -136.18 -45.66  
+5  1 PHE A 134 ? ? -111.63 56.40   
+6  1 MET A 136 ? ? -169.08 79.98   
+7  1 HIS A 184 ? ? 61.80   -6.16   
+8  1 HIS A 230 ? ? 101.34  -41.22  
+9  1 ASN A 259 ? ? -150.06 51.70   
+10 1 HIS A 276 ? ? -77.25  -83.26  
+11 1 ASN A 277 ? ? -62.82  96.96   
+12 1 PRO A 279 ? ? -63.06  -70.46  
+13 1 SER A 280 ? ? 72.62   118.06  
+14 1 THR A 299 ? ? -108.15 -63.11  
+15 1 HIS A 316 ? ? -115.51 78.16   
+16 1 ASN A 334 ? ? -69.46  -87.79  
+17 1 SER A 365 ? ? 12.25   -117.24 
+18 1 LEU A 380 ? ? 58.20   107.16  
+19 1 ASN A 403 ? ? -118.30 78.06   
+20 1 SER A 429 ? ? 65.13   -150.76 
+21 1 CYS A 435 ? ? -36.59  128.27  
+22 1 ASP A 463 ? ? 66.51   114.24  
+23 1 ILE B 47  ? ? -157.39 -29.40  
+24 1 LYS B 48  ? ? -71.66  -97.35  
+25 1 ILE B 88  ? ? -105.74 -64.41  
+26 1 LEU B 90  ? ? -107.27 42.16   
+27 1 MET B 136 ? ? -163.06 103.05  
+28 1 HIS B 184 ? ? 77.78   -26.07  
+29 1 ASP B 191 ? ? -39.20  134.66  
+30 1 PHE B 219 ? ? -119.93 71.75   
+31 1 PHE B 226 ? ? -150.23 76.13   
+32 1 HIS B 230 ? ? 107.90  -27.69  
+33 1 SER B 254 ? ? -62.60  -76.28  
+34 1 MET B 255 ? ? 5.04    103.14  
+35 1 GLU B 274 ? ? 67.02   -2.40   
+36 1 THR B 299 ? ? -105.83 -61.26  
+37 1 HIS B 316 ? ? -118.35 74.42   
+38 1 ASN B 334 ? ? -74.84  -71.70  
+39 1 ASP B 360 ? ? 46.67   73.09   
+40 1 LEU B 362 ? ? -117.11 75.69   
+41 1 SER B 365 ? ? -43.42  165.69  
+42 1 LEU B 380 ? ? 59.55   80.88   
+43 1 PRO B 402 ? ? -19.72  -72.42  
+44 1 GLU B 415 ? ? -27.21  -65.00  
+45 1 ASN B 418 ? ? 59.95   120.97  
+46 1 SER B 429 ? ? 71.58   -159.37 
+47 1 ASP B 463 ? ? 71.97   138.31  
+# 
+_pdbx_validate_peptide_omega.id               1 
+_pdbx_validate_peptide_omega.PDB_model_num    1 
+_pdbx_validate_peptide_omega.auth_comp_id_1   GLN 
+_pdbx_validate_peptide_omega.auth_asym_id_1   A 
+_pdbx_validate_peptide_omega.auth_seq_id_1    278 
+_pdbx_validate_peptide_omega.PDB_ins_code_1   ? 
+_pdbx_validate_peptide_omega.label_alt_id_1   ? 
+_pdbx_validate_peptide_omega.auth_comp_id_2   PRO 
+_pdbx_validate_peptide_omega.auth_asym_id_2   A 
+_pdbx_validate_peptide_omega.auth_seq_id_2    279 
+_pdbx_validate_peptide_omega.PDB_ins_code_2   ? 
+_pdbx_validate_peptide_omega.label_alt_id_2   ? 
+_pdbx_validate_peptide_omega.omega            147.98 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_atoms.id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_model_num 
+_pdbx_unobs_or_zero_occ_atoms.polymer_flag 
+_pdbx_unobs_or_zero_occ_atoms.occupancy_flag 
+_pdbx_unobs_or_zero_occ_atoms.auth_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_atoms.auth_atom_id 
+_pdbx_unobs_or_zero_occ_atoms.label_alt_id 
+_pdbx_unobs_or_zero_occ_atoms.label_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.label_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.label_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.label_atom_id 
+1  1 Y 1 A HIS 491 ? CA  ? A HIS 472 CA  
+2  1 Y 1 A HIS 491 ? C   ? A HIS 472 C   
+3  1 Y 1 A HIS 491 ? O   ? A HIS 472 O   
+4  1 Y 1 A HIS 491 ? CB  ? A HIS 472 CB  
+5  1 Y 1 A HIS 491 ? CG  ? A HIS 472 CG  
+6  1 Y 1 A HIS 491 ? ND1 ? A HIS 472 ND1 
+7  1 Y 1 A HIS 491 ? CD2 ? A HIS 472 CD2 
+8  1 Y 1 A HIS 491 ? CE1 ? A HIS 472 CE1 
+9  1 Y 1 A HIS 491 ? NE2 ? A HIS 472 NE2 
+10 1 Y 1 B HIS 491 ? CA  ? B HIS 472 CA  
+11 1 Y 1 B HIS 491 ? C   ? B HIS 472 C   
+12 1 Y 1 B HIS 491 ? O   ? B HIS 472 O   
+13 1 Y 1 B HIS 491 ? CB  ? B HIS 472 CB  
+14 1 Y 1 B HIS 491 ? CG  ? B HIS 472 CG  
+15 1 Y 1 B HIS 491 ? ND1 ? B HIS 472 ND1 
+16 1 Y 1 B HIS 491 ? CD2 ? B HIS 472 CD2 
+17 1 Y 1 B HIS 491 ? CE1 ? B HIS 472 CE1 
+18 1 Y 1 B HIS 491 ? NE2 ? B HIS 472 NE2 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_residues.id 
+_pdbx_unobs_or_zero_occ_residues.PDB_model_num 
+_pdbx_unobs_or_zero_occ_residues.polymer_flag 
+_pdbx_unobs_or_zero_occ_residues.occupancy_flag 
+_pdbx_unobs_or_zero_occ_residues.auth_asym_id 
+_pdbx_unobs_or_zero_occ_residues.auth_comp_id 
+_pdbx_unobs_or_zero_occ_residues.auth_seq_id 
+_pdbx_unobs_or_zero_occ_residues.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_residues.label_asym_id 
+_pdbx_unobs_or_zero_occ_residues.label_comp_id 
+_pdbx_unobs_or_zero_occ_residues.label_seq_id 
+1  1 Y 1 A MET 20  ? A MET 1   
+2  1 Y 1 A ALA 21  ? A ALA 2   
+3  1 Y 1 A LYS 22  ? A LYS 3   
+4  1 Y 1 A LYS 23  ? A LYS 4   
+5  1 Y 1 A THR 24  ? A THR 5   
+6  1 Y 1 A SER 25  ? A SER 6   
+7  1 Y 1 A SER 26  ? A SER 7   
+8  1 Y 1 A LYS 27  ? A LYS 8   
+9  1 Y 1 A GLY 28  ? A GLY 9   
+10 1 Y 1 A ARG 29  ? A ARG 10  
+11 1 Y 1 A HIS 492 ? A HIS 473 
+12 1 Y 1 A HIS 493 ? A HIS 474 
+13 1 Y 1 A HIS 494 ? A HIS 475 
+14 1 Y 1 B MET 20  ? B MET 1   
+15 1 Y 1 B ALA 21  ? B ALA 2   
+16 1 Y 1 B LYS 22  ? B LYS 3   
+17 1 Y 1 B LYS 23  ? B LYS 4   
+18 1 Y 1 B THR 24  ? B THR 5   
+19 1 Y 1 B SER 25  ? B SER 6   
+20 1 Y 1 B SER 26  ? B SER 7   
+21 1 Y 1 B LYS 27  ? B LYS 8   
+22 1 Y 1 B GLY 28  ? B GLY 9   
+23 1 Y 1 B ARG 29  ? B ARG 10  
+24 1 Y 1 B HIS 492 ? B HIS 473 
+25 1 Y 1 B HIS 493 ? B HIS 474 
+26 1 Y 1 B HIS 494 ? B HIS 475 
+# 
+loop_
+_pdbx_entity_nonpoly.entity_id 
+_pdbx_entity_nonpoly.name 
+_pdbx_entity_nonpoly.comp_id 
+2 'HEME C' HEC 
+3 water    HOH 
+# 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Avoid `renderMarkingDepth` for fully transparent renderables
 - Remove `camera.far` doubeling workaround
 - Add `ModifiersKeys.areNone` helper function
+- Add "Zoom All", "Orient Axes", "Reset Axes" buttons to the "Reset Camera" button
 
 ## [v3.33.0] - 2023-04-02
 

--- a/src/mol-plugin-state/manager/camera.ts
+++ b/src/mol-plugin-state/manager/camera.ts
@@ -4,18 +4,22 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Ke Ma <mark.ma@rcsb.org>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { Sphere3D } from '../../mol-math/geometry';
-import { PluginContext } from '../../mol-plugin/context';
-import { PrincipalAxes } from '../../mol-math/linear-algebra/matrix/principal-axes';
 import { Camera } from '../../mol-canvas3d/camera';
-import { Loci } from '../../mol-model/loci';
-import { BoundaryHelper } from '../../mol-math/geometry/boundary-helper';
 import { GraphicsRenderObject } from '../../mol-gl/render-object';
-import { StructureElement } from '../../mol-model/structure';
+import { Sphere3D } from '../../mol-math/geometry';
+import { BoundaryHelper } from '../../mol-math/geometry/boundary-helper';
+import { Mat3 } from '../../mol-math/linear-algebra';
 import { Vec3 } from '../../mol-math/linear-algebra/3d/vec3';
+import { PrincipalAxes } from '../../mol-math/linear-algebra/matrix/principal-axes';
+import { Loci } from '../../mol-model/loci';
+import { Structure, StructureElement } from '../../mol-model/structure';
+import { PluginContext } from '../../mol-plugin/context';
+import { PluginStateObject } from '../objects';
 import { pcaFocus } from './focus-camera/focus-first-residue';
+import { changeCameraRotation, structureLayingTransform } from './focus-camera/orient-axes';
 
 // TODO: make this customizable somewhere?
 const DefaultCameraFocusOptions = {
@@ -123,6 +127,26 @@ export class CameraManager {
             const snapshot = canvas3d.camera.getFocus(sphere.center, radius);
             canvas3d.requestCameraReset({ durationMs, snapshot });
         }
+    }
+
+    /** Align PCA axes of `structures` (default: all loaded structures) to the screen axes. */
+    orientAxes(structures?: Structure[], durationMs?: number) {
+        if (!this.plugin.canvas3d) return;
+        if (!structures) {
+            const structCells = this.plugin.state.data.selectQ(q => q.ofType(PluginStateObject.Molecule.Structure));
+            const rootStructCells = structCells.filter(cell => cell.obj && !cell.transform.transformer.definition.isDecorator && !cell.obj.data.parent);
+            structures = rootStructCells.map(cell => cell.obj?.data).filter(struct => !!struct) as Structure[];
+        }
+        const { rotation } = structureLayingTransform(structures);
+        const newSnapshot = changeCameraRotation(this.plugin.canvas3d.camera.getSnapshot(), rotation);
+        this.setSnapshot(newSnapshot, durationMs);
+    }
+
+    /** Align Cartesian axes to the screen axes (X right, Y up). */
+    resetAxes(durationMs?: number) {
+        if (!this.plugin.canvas3d) return;
+        const newSnapshot = changeCameraRotation(this.plugin.canvas3d.camera.getSnapshot(), Mat3.identity());
+        this.setSnapshot(newSnapshot, durationMs);
     }
 
     setSnapshot(snapshot: Partial<Camera.Snapshot>, durationMs?: number) {

--- a/src/mol-plugin-state/manager/focus-camera/orient-axes.ts
+++ b/src/mol-plugin-state/manager/focus-camera/orient-axes.ts
@@ -1,59 +1,247 @@
+/**
+ * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Adam Midlik <midlik@gmail.com>
+ */
+
 import { Camera } from '../../../mol-canvas3d/camera';
 import { Mat3, Vec3 } from '../../../mol-math/linear-algebra';
-import { PluginCommands } from '../../../mol-plugin/commands';
-import { PluginContext } from '../../../mol-plugin/context';
-import { PluginStateObject } from '../../objects';
+import { PrincipalAxes } from '../../../mol-math/linear-algebra/matrix/principal-axes';
+import { Structure } from '../../../mol-model/structure';
 
 
-export function resetAxes(plugin: PluginContext) {
-    if (!plugin.canvas3d) return;
+/** Minimum number of atoms necessary for running PCA.
+ * If enough atoms cannot be selected, XYZ axes will be used instead of PCA axes. */
+const MIN_ATOMS_FOR_PCA = 3;
 
-    PluginCommands.Camera.SetSnapshot(plugin, { snapshot: cameraSetRotation(plugin.canvas3d.camera.getSnapshot(), Mat3.identity()) }); 
-    // will probably not work for Headless plugin because of asynchronicity!
+/** Rotation matrices for the basic rotations by 90 degrees */
+export const ROTATION_MATRICES = {
+    // The order of elements in the matrices in column-wise (F-style)
+    eye: Mat3.create(1, 0, 0, 0, 1, 0, 0, 0, 1),
+    rotX90: Mat3.create(1, 0, 0, 0, 0, 1, 0, -1, 0),
+    rotY90: Mat3.create(0, 0, -1, 0, 1, 0, 1, 0, 0),
+    rotZ90: Mat3.create(0, 1, 0, -1, 0, 0, 0, 0, 1),
+    rotX270: Mat3.create(1, 0, 0, 0, 0, -1, 0, 1, 0),
+    rotY270: Mat3.create(0, 0, 1, 0, 1, 0, -1, 0, 0),
+    rotZ270: Mat3.create(0, -1, 0, 1, 0, 0, 0, 0, 1),
+    rotX180: Mat3.create(1, 0, 0, 0, -1, 0, 0, 0, -1),
+    rotY180: Mat3.create(-1, 0, 0, 0, 1, 0, 0, 0, -1),
+    rotZ180: Mat3.create(-1, 0, 0, 0, -1, 0, 0, 0, 1),
+};
 
-    // adjustCamera(plugin, old => cameraSetRotation(old, Mat3.identity()), 0);
+
+/** Return transformation which will align the PCA axes of an atomic structure
+ * (or multiple structures) to the Cartesian axes x, y, z
+ * (transformed = rotation * (coords - origin)).
+ *
+ * There are always 4 equally good rotations to do this (4 flips).
+ * If `referenceRotation` is provided, select the one nearest to `referenceRotation`.
+ * Otherwise use arbitrary rules to ensure the orientation after transform does not depend on the original orientation.
+ */
+export function structureLayingTransform(structures: Structure[], referenceRotation?: Mat3): { rotation: Mat3, origin: Vec3 } {
+    const coords = selectCoords(structures, MIN_ATOMS_FOR_PCA);
+    return layingTransform(coords, referenceRotation);
 }
 
-export function orientAxes(plugin: PluginContext) {
-    const structs = plugin.state.data.selectQ(q => q.ofType(PluginStateObject.Molecule.Structure));
-    const rootStructs = structs.filter(s => s.obj && !s.obj?.data.parent);
-    console.log('structs:', structs);
-    console.log('rootStructs:', rootStructs);
-    adjustCamera;
+/** Return transformation which will align the PCA axes of a sequence
+ * of points to the Cartesian axes x, y, z
+ * (transformed = rotation * (coords - origin)).
+ *
+ * `coords` is a flattened array of 3D coordinates (i.e. the first 3 values are x, y, and z of the first point etc.).
+ *
+ * There are always 4 equally good rotations to do this (4 flips).
+ * If `referenceRotation` is provided, select the one nearest to `referenceRotation`.
+ * Otherwise use arbitrary rules to ensure the orientation after transform does not depend on the original orientation.
+ */
+export function layingTransform(coords: number[], referenceRotation?: Mat3): { rotation: Mat3, origin: Vec3 } {
+    if (coords.length === 0) {
+        console.warn('Skipping PCA, no atoms');
+        return { rotation: Mat3.identity(), origin: Vec3.zero() };
+    }
+    const axes = PrincipalAxes.calculateMomentsAxes(coords);
+    const normAxes = PrincipalAxes.calculateNormalizedAxes(axes);
+    const R = mat3FromRows(normAxes.dirA, normAxes.dirB, normAxes.dirC);
+    avoidMirrorRotation(R); // The SVD implementation seems to always provide proper rotation, but just to be sure
+    const flip = referenceRotation ? minimalFlip(R, referenceRotation) : canonicalFlip(coords, R, axes.origin);
+    Mat3.mul(R, flip, R);
+    return { rotation: R, origin: normAxes.origin };
 }
 
+/** Try these selection strategies until having at least `minAtoms` atoms:
+ * 1. only "polymer" atoms (e.g. C-alpha and O3')
+ * 2. all non-hydrogen atoms with exception of water (HOH)
+ * 3. all atoms
+ * Return the coordinates in a flattened array (in triples).
+ * If the total number of atoms is less than `minAtoms`, return only those. */
+function selectCoords(structs: Structure[], minAtoms: number): number[] {
+    let coords = selectCACoords(structs);
+    if (coords.length >= 3 * minAtoms) return coords;
 
+    coords = selectHeavyCoords(structs);
+    if (coords.length >= 3 * minAtoms) return coords;
+
+    coords = selectAllCoords(structs);
+    return coords;
+}
+
+/** Select coordinates of C-alpha and O3' atoms */
+function selectCACoords(structs: Structure[]): number[] {
+    const coords: number[] = [];
+    for (const struct of structs) {
+        for (const unit of struct.units) {
+            const { x, y, z } = unit.conformation;
+            for (let i = 0; i < unit.polymerElements.length; i++) {
+                const index = unit.polymerElements[i];
+                coords.push(x(index), y(index), z(index));
+            }
+        }
+    }
+    return coords;
+}
+
+/** Select coordinates of non-hydrogen atoms, excluding water */
+function selectHeavyCoords(structs: Structure[]): number[] {
+    const coords: number[] = [];
+    for (const struct of structs) {
+        for (const unit of struct.units) {
+            const { x, y, z } = unit.model.atomicConformation;
+            for (let i = 0; i < unit.elements.length; i++) {
+                const index = unit.elements[i];
+                const compound = unit.model.atomicHierarchy.atoms.label_comp_id.value(index);
+                const element = unit.model.atomicHierarchy.atoms.type_symbol.value(index);
+                if (element !== 'H' && compound !== 'HOH') {
+                    coords.push(x[index], y[index], z[index]);
+                }
+            }
+        }
+    }
+    return coords;
+}
+
+/** Select coordinates of all atoms */
+function selectAllCoords(structs: Structure[]): number[] {
+    const coords: number[] = [];
+    for (const struct of structs) {
+        for (const unit of struct.units) {
+            const { x, y, z } = unit.model.atomicConformation;
+            for (let i = 0; i < unit.elements.length; i++) {
+                const index = unit.elements[i];
+                coords.push(x[index], y[index], z[index]);
+            }
+        }
+    }
+    return coords;
+}
+
+/** Return a flip around XYZ axes which minimizes the difference between flip*rotation and referenceRotation. */
+function minimalFlip(rotation: Mat3, referenceRotation: Mat3): Mat3 {
+    let bestFlip = ROTATION_MATRICES.eye;
+    let bestScore = 0; // there will always be at least one positive score
+    const aux = Mat3();
+    for (const flip of [ROTATION_MATRICES.eye, ROTATION_MATRICES.rotX180, ROTATION_MATRICES.rotY180, ROTATION_MATRICES.rotZ180]) {
+        const score = mat3Dot(Mat3.mul(aux, flip, rotation), referenceRotation);
+        if (score > bestScore) {
+            bestFlip = flip;
+            bestScore = score;
+        }
+    }
+    return bestFlip;
+}
+
+/** Measure of how similar two rotation matrices are (dot product of flattened matrices) */
+function mat3Dot(a: Mat3, b: Mat3) {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3] + a[4] * b[4] + a[5] * b[5] + a[6] * b[6] + a[7] * b[7] + a[8] * b[8];
+}
+
+/** Return a rotation matrix (flip) that should be applied to `coords` (after being rotated by `rotation`)
+ * to ensure a deterministic "canonical" rotation.
+ * There are 4 flips to choose from (one identity and three 180-degree rotations around the X, Y, and Z axes).
+ * One of these 4 possible results is selected so that:
+ *   1) starting and ending coordinates tend to be more in front (z > 0), middle more behind (z < 0).
+ *   2) starting coordinates tend to be more left-top (x < y), ending more right-bottom (x > y).
+ * These rules are arbitrary, but try to avoid ties for at least some basic symmetries.
+ * Provided `origin` parameter MUST be the mean of the coordinates, otherwise it will not work!
+ */
+function canonicalFlip(coords: number[], rotation: Mat3, origin: Vec3): Mat3 {
+    const pcaX = Vec3.create(Mat3.getValue(rotation, 0, 0), Mat3.getValue(rotation, 0, 1), Mat3.getValue(rotation, 0, 2));
+    const pcaY = Vec3.create(Mat3.getValue(rotation, 1, 0), Mat3.getValue(rotation, 1, 1), Mat3.getValue(rotation, 1, 2));
+    const pcaZ = Vec3.create(Mat3.getValue(rotation, 2, 0), Mat3.getValue(rotation, 2, 1), Mat3.getValue(rotation, 2, 2));
+    const n = Math.floor(coords.length / 3);
+    const v = Vec3();
+    let xCum = 0;
+    let yCum = 0;
+    let zCum = 0;
+    for (let i = 0; i < n; i++) {
+        Vec3.fromArray(v, coords, 3 * i);
+        Vec3.sub(v, v, origin);
+        xCum += i * Vec3.dot(v, pcaX);
+        yCum += i * Vec3.dot(v, pcaY);
+        zCum += veeSlope(i, n) * Vec3.dot(v, pcaZ);
+        // Thanks to subtracting `origin` from `coords` the slope functions `i` and `veeSlope(i, n)`
+        // don't have to have zero sum (can be shifted up or down):
+        //     sum{(slope[i]+shift)*(coords[i]-origin).PCA} =
+        //     = sum{slope[i]*coords[i].PCA - slope[i]*origin.PCA + shift*coords[i].PCA - shift*origin.PCA} =
+        //     = sum{slope[i]*(coords[i]-origin).PCA} + shift*sum{coords[i]-origin}.PCA =
+        //     = sum{slope[i]*(coords[i]-origin).PCA}
+    }
+    const wrongFrontBack = zCum < 0;
+    const wrongLeftTopRightBottom = wrongFrontBack ? xCum + yCum < 0 : xCum - yCum < 0;
+    if (wrongLeftTopRightBottom && wrongFrontBack) {
+        return ROTATION_MATRICES.rotY180; // flip around Y = around X then Z
+    } else if (wrongFrontBack) {
+        return ROTATION_MATRICES.rotX180; // flip around X
+    } else if (wrongLeftTopRightBottom) {
+        return ROTATION_MATRICES.rotZ180; // flip around Z
+    } else {
+        return Mat3.identity(); // do not flip
+    }
+}
+
+/** Auxiliary function defined for i in [0, n), linearly decreasing from 0 to n/2
+ * and then increasing back from n/2 to n, resembling letter V. */
+function veeSlope(i: number, n: number) {
+    const mid = Math.floor(n / 2);
+    if (i < mid) {
+        if (n % 2) return mid - i;
+        else return mid - i - 1;
+    } else {
+        return i - mid;
+    }
+}
+
+function mat3FromRows(row0: Vec3, row1: Vec3, row2: Vec3): Mat3 {
+    const m = Mat3();
+    Mat3.setValue(m, 0, 0, row0[0]);
+    Mat3.setValue(m, 0, 1, row0[1]);
+    Mat3.setValue(m, 0, 2, row0[2]);
+    Mat3.setValue(m, 1, 0, row1[0]);
+    Mat3.setValue(m, 1, 1, row1[1]);
+    Mat3.setValue(m, 1, 2, row1[2]);
+    Mat3.setValue(m, 2, 0, row2[0]);
+    Mat3.setValue(m, 2, 1, row2[1]);
+    Mat3.setValue(m, 2, 2, row2[2]);
+    return m;
+}
+
+/** Check if a rotation matrix includes mirroring and invert Z axis in such case, to ensure a proper rotation (in-place). */
+function avoidMirrorRotation(rot: Mat3) {
+    if (Mat3.determinant(rot) < 0) {
+        Mat3.setValue(rot, 2, 0, -Mat3.getValue(rot, 2, 0));
+        Mat3.setValue(rot, 2, 1, -Mat3.getValue(rot, 2, 1));
+        Mat3.setValue(rot, 2, 2, -Mat3.getValue(rot, 2, 2));
+    }
+}
 
 /** Return a new camera snapshot with the same target and camera distance from the target as `old`
- * but with diferent orientation. 
- * The actual rotation applied to the camera is the invert of `rotation`, 
+ * but with diferent orientation.
+ * The actual rotation applied to the camera is the inverse of `rotation`,
  * which creates the same effect as if `rotation` were applied to the whole scene without moving the camera.
  * The rotation is relative to the default camera orientation (not to the current orientation). */
-function cameraSetRotation(old: Camera.Snapshot, rotation: Mat3): Camera.Snapshot {
+export function changeCameraRotation(old: Camera.Snapshot, rotation: Mat3): Camera.Snapshot {
     const cameraRotation = Mat3.invert(Mat3(), rotation);
     const dist = Vec3.distance(old.position, old.target);
     const relPosition = Vec3.transformMat3(Vec3(), Vec3.create(0, 0, dist), cameraRotation);
     const newUp = Vec3.transformMat3(Vec3(), Vec3.create(0, 1, 0), cameraRotation);
     const newPosition = Vec3.add(Vec3(), old.target, relPosition);
     return { ...old, position: newPosition, up: newUp };
-}
-
-/** Apply `change` to the camera snapshot (i.e. target, position, orientation) in a plugin.
- * The `change` function will get the current camera snapshot and the result of the function will be used as the new snapshot. */
-function adjustCamera(plugin: PluginContext, change: (old: Camera.Snapshot) => Camera.Snapshot, durationMs?: number) {
-    if (!plugin.canvas3d) throw new Error('plugin.canvas3d is undefined');
-    plugin.canvas3d.commit(true);
-    const oldSnapshot = plugin.canvas3d.camera.getSnapshot();
-    const newSnapshot = change(oldSnapshot);
-    // plugin.canvas3d.camera.setState(newSnapshot, durationMs);
-    plugin.managers.camera.setSnapshot(newSnapshot, durationMs);
-    const checkSnapshot = plugin.canvas3d.camera.getSnapshot();
-    if (durationMs && oldSnapshot.radius > 0 && !Camera.areSnapshotsEqual(newSnapshot, checkSnapshot)) {
-        console.error('Error: The camera has not been adjusted correctly.');
-        console.error('Required:');
-        console.error(newSnapshot);
-        console.error('Real:');
-        console.error(checkSnapshot);
-        throw new Error(`AssertionError: The camera has not been adjusted correctly.`);
-    }
 }

--- a/src/mol-plugin-state/manager/focus-camera/orient-axes.ts
+++ b/src/mol-plugin-state/manager/focus-camera/orient-axes.ts
@@ -1,0 +1,59 @@
+import { Camera } from '../../../mol-canvas3d/camera';
+import { Mat3, Vec3 } from '../../../mol-math/linear-algebra';
+import { PluginCommands } from '../../../mol-plugin/commands';
+import { PluginContext } from '../../../mol-plugin/context';
+import { PluginStateObject } from '../../objects';
+
+
+export function resetAxes(plugin: PluginContext) {
+    if (!plugin.canvas3d) return;
+
+    PluginCommands.Camera.SetSnapshot(plugin, { snapshot: cameraSetRotation(plugin.canvas3d.camera.getSnapshot(), Mat3.identity()) }); 
+    // will probably not work for Headless plugin because of asynchronicity!
+
+    // adjustCamera(plugin, old => cameraSetRotation(old, Mat3.identity()), 0);
+}
+
+export function orientAxes(plugin: PluginContext) {
+    const structs = plugin.state.data.selectQ(q => q.ofType(PluginStateObject.Molecule.Structure));
+    const rootStructs = structs.filter(s => s.obj && !s.obj?.data.parent);
+    console.log('structs:', structs);
+    console.log('rootStructs:', rootStructs);
+    adjustCamera;
+}
+
+
+
+/** Return a new camera snapshot with the same target and camera distance from the target as `old`
+ * but with diferent orientation. 
+ * The actual rotation applied to the camera is the invert of `rotation`, 
+ * which creates the same effect as if `rotation` were applied to the whole scene without moving the camera.
+ * The rotation is relative to the default camera orientation (not to the current orientation). */
+function cameraSetRotation(old: Camera.Snapshot, rotation: Mat3): Camera.Snapshot {
+    const cameraRotation = Mat3.invert(Mat3(), rotation);
+    const dist = Vec3.distance(old.position, old.target);
+    const relPosition = Vec3.transformMat3(Vec3(), Vec3.create(0, 0, dist), cameraRotation);
+    const newUp = Vec3.transformMat3(Vec3(), Vec3.create(0, 1, 0), cameraRotation);
+    const newPosition = Vec3.add(Vec3(), old.target, relPosition);
+    return { ...old, position: newPosition, up: newUp };
+}
+
+/** Apply `change` to the camera snapshot (i.e. target, position, orientation) in a plugin.
+ * The `change` function will get the current camera snapshot and the result of the function will be used as the new snapshot. */
+function adjustCamera(plugin: PluginContext, change: (old: Camera.Snapshot) => Camera.Snapshot, durationMs?: number) {
+    if (!plugin.canvas3d) throw new Error('plugin.canvas3d is undefined');
+    plugin.canvas3d.commit(true);
+    const oldSnapshot = plugin.canvas3d.camera.getSnapshot();
+    const newSnapshot = change(oldSnapshot);
+    // plugin.canvas3d.camera.setState(newSnapshot, durationMs);
+    plugin.managers.camera.setSnapshot(newSnapshot, durationMs);
+    const checkSnapshot = plugin.canvas3d.camera.getSnapshot();
+    if (durationMs && oldSnapshot.radius > 0 && !Camera.areSnapshotsEqual(newSnapshot, checkSnapshot)) {
+        console.error('Error: The camera has not been adjusted correctly.');
+        console.error('Required:');
+        console.error(newSnapshot);
+        console.error('Real:');
+        console.error(checkSnapshot);
+        throw new Error(`AssertionError: The camera has not been adjusted correctly.`);
+    }
+}

--- a/src/mol-plugin-ui/skin/base/components/viewport.scss
+++ b/src/mol-plugin-ui/skin/base/components/viewport.scss
@@ -7,7 +7,7 @@
     background: $default-background;
 
     .msp-btn-link {
-        background: rgba(0,0,0,0.2);
+        background: rgba(0, 0, 0, 0.2);
     }
 
 }
@@ -25,14 +25,14 @@
     bottom: 0;
     -webkit-user-select: none;
     user-select: none;
-    -webkit-tap-highlight-color: rgba(0,0,0,0);
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-touch-callout: none;
     touch-action: manipulation;
 
-    > canvas {
+    >canvas {
         background-color: $default-background;
         background-image: linear-gradient(45deg, lightgrey 25%, transparent 25%, transparent 75%, lightgrey 75%, lightgrey),
-        linear-gradient(45deg, lightgrey 25%, transparent 25%, transparent 75%, lightgrey 75%, lightgrey);
+            linear-gradient(45deg, lightgrey 25%, transparent 25%, transparent 75%, lightgrey 75%, lightgrey);
         background-size: 60px 60px;
         background-position: 0 0, 30px 30px;
     }
@@ -51,7 +51,7 @@
     // opacity: 0.5;
     // &:hover { opacity: 1.0; }
 
-    > div {
+    >div {
         position: relative;
         margin-bottom: 4px;
     }
@@ -80,6 +80,32 @@
     left: 0;
     width: 100%;
     height: 100%;
+}
+
+.msp-hover-box-wrapper {
+    position: relative;
+
+    .msp-hover-box-spacer {
+        visibility: hidden;
+        position: absolute;
+        right: $row-height;
+        top: 0;
+        width: 4px;
+        height: $row-height;
+    }
+    .msp-hover-box-body {
+        visibility: hidden;
+        position: absolute;
+        right: $row-height + 4px;
+        top: 0;
+        width: 145px;
+        background-color: $default-background;
+    }
+
+    &:hover .msp-hover-box-body, 
+    &:hover .msp-hover-box-spacer {
+        visibility: visible;
+    }
 }
 
 .msp-viewport-controls-panel {

--- a/src/mol-plugin-ui/viewport.tsx
+++ b/src/mol-plugin-ui/viewport.tsx
@@ -16,6 +16,7 @@ import { ToggleSelectionModeButton } from './structure/selection';
 import { ViewportCanvas } from './viewport/canvas';
 import { DownloadScreenshotControls } from './viewport/screenshot';
 import { SimpleSettingsControl } from './viewport/simple-settings';
+import { orientAxes, resetAxes } from '../mol-plugin-state/manager/focus-camera/orient-axes';
 
 interface ViewportControlsState {
     isSettingsExpanded: boolean,
@@ -85,7 +86,10 @@ export class ViewportControls extends PluginUIComponent<ViewportControlsProps, V
                     <div className='msp-hover-box-body'>
                         <div className='msp-flex-column'>
                             <div className='msp-flex-row'>
-                                <Button onClick={()=>console.log('Reset Axes clicked')} /*disabled={this.state.isDisabled}*/>Reset Axes</Button>
+                                <Button onClick={()=>resetAxes(this.plugin)} /*disabled={this.state.isDisabled}*/>Reset Axes</Button>
+                            </div>
+                            <div className='msp-flex-row'>
+                                <Button onClick={()=>orientAxes(this.plugin)} /*disabled={this.state.isDisabled}*/>Orient Axes</Button>
                             </div>
                         </div>
                     </div>

--- a/src/mol-plugin-ui/viewport.tsx
+++ b/src/mol-plugin-ui/viewport.tsx
@@ -10,7 +10,7 @@ import { PluginCommands } from '../mol-plugin/commands';
 import { PluginConfig } from '../mol-plugin/config';
 import { ParamDefinition as PD } from '../mol-util/param-definition';
 import { PluginUIComponent } from './base';
-import { ControlGroup, IconButton } from './controls/common';
+import { Button, ControlGroup, IconButton } from './controls/common';
 import { AutorenewSvg, BuildOutlinedSvg, CameraOutlinedSvg, CloseSvg, FullscreenSvg, TuneSvg } from './controls/icons';
 import { ToggleSelectionModeButton } from './structure/selection';
 import { ViewportCanvas } from './viewport/canvas';
@@ -79,10 +79,22 @@ export class ViewportControls extends PluginUIComponent<ViewportControlsProps, V
     render() {
         return <div className={'msp-viewport-controls'}>
             <div className='msp-viewport-controls-buttons'>
-                <div>
+                <div className='msp-hover-box-wrapper'>
                     <div className='msp-semi-transparent-background' />
                     {this.icon(AutorenewSvg, this.resetCamera, 'Reset Camera')}
+                    <div className='msp-hover-box-body'>
+                        <div className='msp-flex-column'>
+                            <div className='msp-flex-row'>
+                                <Button onClick={()=>console.log('Reset Axes clicked')} /*disabled={this.state.isDisabled}*/>Reset Axes</Button>
+                            </div>
+                        </div>
+                    </div>
+                    <div className='msp-hover-box-spacer'></div>
                 </div>
+                {/* <div>
+                    <div className='msp-semi-transparent-background' />
+                    {this.icon(AutorenewSvg, this.resetCamera, 'Reset Camera')}
+                </div> */}
                 <div>
                     <div className='msp-semi-transparent-background' />
                     {this.icon(CameraOutlinedSvg, this.toggleScreenshotExpanded, 'Screenshot / State Snapshot', this.state.isScreenshotExpanded)}

--- a/src/mol-plugin/behavior/static/camera.ts
+++ b/src/mol-plugin/behavior/static/camera.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { PluginContext } from '../../../mol-plugin/context';
@@ -11,6 +12,8 @@ export function registerDefault(ctx: PluginContext) {
     Reset(ctx);
     Focus(ctx);
     SetSnapshot(ctx);
+    OrientAxes(ctx);
+    ResetAxes(ctx);
 }
 
 export function Reset(ctx: PluginContext) {
@@ -29,5 +32,17 @@ export function Focus(ctx: PluginContext) {
     PluginCommands.Camera.Focus.subscribe(ctx, ({ center, radius, durationMs }) => {
         ctx.managers.camera.focusSphere({ center, radius }, { durationMs });
         ctx.events.canvas3d.settingsUpdated.next(void 0);
+    });
+}
+
+export function OrientAxes(ctx: PluginContext) {
+    PluginCommands.Camera.OrientAxes.subscribe(ctx, ({ structures, durationMs }) => {
+        ctx.managers.camera.orientAxes(structures, durationMs);
+    });
+}
+
+export function ResetAxes(ctx: PluginContext) {
+    PluginCommands.Camera.ResetAxes.subscribe(ctx, ({ durationMs }) => {
+        ctx.managers.camera.resetAxes(durationMs);
     });
 }

--- a/src/mol-plugin/commands.ts
+++ b/src/mol-plugin/commands.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Camera } from '../mol-canvas3d/camera';
@@ -10,7 +11,7 @@ import { PluginCommand } from './command';
 import { StateTransform, State, StateAction } from '../mol-state';
 import { Canvas3DProps } from '../mol-canvas3d/canvas3d';
 import { PluginLayoutStateProps } from './layout';
-import { StructureElement } from '../mol-model/structure';
+import { Structure, StructureElement } from '../mol-model/structure';
 import { PluginState } from './state';
 import { PluginToast } from './util/toast';
 import { Vec3 } from '../mol-math/linear-algebra';
@@ -62,7 +63,9 @@ export const PluginCommands = {
     Camera: {
         Reset: PluginCommand<{ durationMs?: number, snapshot?: Partial<Camera.Snapshot> }>(),
         SetSnapshot: PluginCommand<{ snapshot: Partial<Camera.Snapshot>, durationMs?: number }>(),
-        Focus: PluginCommand<{ center: Vec3, radius: number, durationMs?: number }>()
+        Focus: PluginCommand<{ center: Vec3, radius: number, durationMs?: number }>(),
+        OrientAxes: PluginCommand<{ structures?: Structure[], durationMs?: number }>(),
+        ResetAxes: PluginCommand<{ durationMs?: number }>(),
     },
     Canvas3D: {
         SetSettings: PluginCommand<{ settings: Partial<Canvas3DProps> | ((old: Canvas3DProps) => Partial<Canvas3DProps> | void) }>(),


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
I added "Zoom All", "Orient Axes", "Reset Axes" buttons. These will show when one hovers over the "Reset Camera" button. "Zoom All" does the same as "Reset Camera" (we might drop it).
"Orient Axes"/"Reset Axes" rotate camera to align with PCA/XYZ coordinates. I exposed the same functionality via `PluginCommands` and `plugin.manager.camera` as well.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`