### PR TITLE
Fix rendering of NtC tube when some of the required atoms are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Avoid `renderMarkingDepth` for fully transparent renderables
 - Remove `camera.far` doubeling workaround
 - Add `ModifiersKeys.areNone` helper function
+- Do not render NtC tube segments unless all required atoms are present in the structure
 
 ## [v3.33.0] - 2023-04-02
 


### PR DESCRIPTION
I recently ran into a structure that is missing C5' atoms in a few places. C5' atoms are control points of the NtC tube spline and without them it's not possible to render the segment. The most reasonable thing to do seems to be to just skip any segments for which we cannot construct the NtC tube spline.

4v4t example:
Broken:
![4v4t_wrong](https://user-images.githubusercontent.com/1009657/230354447-ba0217b0-c346-4d20-961a-838334526241.png)
The long spokes are the result of the point coordinates defaulting to [0,0,0] when the requested atom cannot be found.

Ok:
![4v4t_ok](https://user-images.githubusercontent.com/1009657/230354421-1f31c382-04d1-4ef8-8102-8e3ff4db15b9.png)

