### PR TITLE
Add a uniform color theme for NtC tube that still paints the residue and segment dividers in a different color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
+- Add a uniform color theme for NtC tube that still paints residue and segment dividers in a different color
 
 ## [v3.34.0] - 2023-04-16
 

--- a/src/extensions/dnatco/ntc-tube/color.ts
+++ b/src/extensions/dnatco/ntc-tube/color.ts
@@ -31,7 +31,8 @@ type NtCTubeColors = typeof NtCTubeColors;
 export const NtCTubeColorThemeParams = {
     colors: PD.MappedStatic('default', {
         'default': PD.EmptyGroup(),
-        'custom': PD.Group(getColorMapParams(NtCTubeColors))
+        'custom': PD.Group(getColorMapParams(NtCTubeColors)),
+        'uniform': PD.Color(Color(0xEEEEEE)),
     }),
     markResidueBoundaries: PD.Boolean(true),
     markSegmentBoundaries: PD.Boolean(true),
@@ -43,7 +44,15 @@ export function getNtCTubeColorThemeParams(ctx: ThemeDataContext) {
 }
 
 export function NtCTubeColorTheme(ctx: ThemeDataContext, props: PD.Values<NtCTubeColorThemeParams>): ColorTheme<NtCTubeColorThemeParams> {
-    const colorMap = props.colors.name === 'default' ? NtCTubeColors : props.colors.params;
+    const colorMap = props.colors.name === 'default'
+        ? NtCTubeColors
+        : props.colors.name === 'custom'
+            ? props.colors.params
+            : ColorMap({
+                ...Object.fromEntries(ObjectKeys(NtCTubeColors).map(item => [item, props.colors.params])),
+                residueMarker: NtCTubeColors.residueMarker,
+                stepBoundaryMarker: NtCTubeColors.stepBoundaryMarker
+            }) as NtCTubeColors;
 
     function color(location: Location, isSecondary: boolean): Color {
         if (NTT.isLocation(location)) {


### PR DESCRIPTION
With some practical experience we found out that having the NtC tube painted accordingly to NtCs could make the structure look "busy" and difficult to read in some situations. This patch adds an alternative color theme where everything but the residue and step boundaries are painted in uniform color.

![image](https://user-images.githubusercontent.com/1009657/233425245-417620ad-8f4e-4699-8ff6-a242026f9fab.png)
vs.
![image](https://user-images.githubusercontent.com/1009657/233425329-877eab29-31f5-483d-aeae-2c89f6a0a708.png)
