### PR TITLE
Adjust VolumeRepresentation#setState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 
 - Optimize inter unit bond compute
+- Ensure consistent state for volume representation (#210)
 
 ## [v3.35.0] - 2023-05-14
 

--- a/src/mol-repr/structure/units-representation.ts
+++ b/src/mol-repr/structure/units-representation.ts
@@ -258,9 +258,9 @@ export function UnitsRepresentation<P extends StructureParams>(label: string, ct
         const { visible, alphaFactor, pickable, overpaint, transparency, substance, clipping, themeStrength, transform, unitTransforms, syncManually, markerActions } = state;
         const newState: Partial<StructureRepresentationState> = {};
 
-        if (visible !== _state.visible) newState.visible = visible;
-        if (alphaFactor !== _state.alphaFactor) newState.alphaFactor = alphaFactor;
-        if (pickable !== _state.pickable) newState.pickable = pickable;
+        if (visible !== undefined) newState.visible = visible;
+        if (alphaFactor !== undefined) newState.alphaFactor = alphaFactor;
+        if (pickable !== undefined) newState.pickable = pickable;
         if (overpaint !== undefined && _structure) {
             newState.overpaint = Overpaint.remap(overpaint, _structure);
         }
@@ -281,8 +281,8 @@ export function UnitsRepresentation<P extends StructureParams>(label: string, ct
             newState.unitTransforms = unitTransforms;
             _state.unitTransformsVersion = unitTransforms ? unitTransforms?.version : -1;
         }
-        if (syncManually !== _state.syncManually) newState.syncManually = syncManually;
-        if (markerActions !== _state.markerActions) newState.markerActions = markerActions;
+        if (syncManually !== undefined) newState.syncManually = syncManually;
+        if (markerActions !== undefined) newState.markerActions = markerActions;
 
         visuals.forEach(({ visual, group }) => setVisualState(visual, group, newState));
 

--- a/src/mol-repr/structure/units-representation.ts
+++ b/src/mol-repr/structure/units-representation.ts
@@ -277,7 +277,7 @@ export function UnitsRepresentation<P extends StructureParams>(label: string, ct
         if (transform !== undefined && !Mat4.areEqual(transform, _state.transform, EPSILON)) {
             newState.transform = transform;
         }
-        if (unitTransforms !== _state.unitTransforms || unitTransforms?.version !== state.unitTransformsVersion) {
+        if (unitTransforms !== _state.unitTransforms || unitTransforms?.version !== _state.unitTransformsVersion) {
             newState.unitTransforms = unitTransforms;
             _state.unitTransformsVersion = unitTransforms ? unitTransforms?.version : -1;
         }

--- a/src/mol-repr/volume/representation.ts
+++ b/src/mol-repr/volume/representation.ts
@@ -385,9 +385,9 @@ export function VolumeRepresentation<P extends VolumeParams>(label: string, ctx:
         const { visible, alphaFactor, pickable, overpaint, transparency, substance, clipping, transform, themeStrength, syncManually, markerActions } = state;
         const newState: Partial<Representation.State> = {};
 
-        if (visible !== _state.visible) newState.visible = visible;
-        if (alphaFactor !== _state.alphaFactor) newState.alphaFactor = alphaFactor;
-        if (pickable !== _state.pickable) newState.pickable = pickable;
+        if (visible !== undefined) newState.visible = visible;
+        if (alphaFactor !== undefined) newState.alphaFactor = alphaFactor;
+        if (pickable !== undefined) newState.pickable = pickable;
         if (overpaint !== undefined) newState.overpaint = overpaint;
         if (transparency !== undefined) newState.transparency = transparency;
         if (substance !== undefined) newState.substance = substance;
@@ -396,8 +396,8 @@ export function VolumeRepresentation<P extends VolumeParams>(label: string, ctx:
         if (transform !== undefined && !Mat4.areEqual(transform, _state.transform, EPSILON)) {
             newState.transform = transform;
         }
-        if (syncManually !== _state.syncManually) newState.syncManually = syncManually;
-        if (markerActions !== _state.markerActions) newState.markerActions = markerActions;
+        if (syncManually !== undefined) newState.syncManually = syncManually;
+        if (markerActions !== undefined) newState.markerActions = markerActions;
 
         visuals.forEach(visual => setVisualState(visual, newState));
 


### PR DESCRIPTION
# Description
This brings back the behavior where one can hide volume certain channels and they won't reappear later on, e.g. when focusing on a residue.
Adjusts other properties as well. Let me know if this has any implications.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`