### PR TITLE
add approximate option for spheres rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Fix display issue with SIFTS mapping
 - Properly switch-off fog
+- Add `approximate` option for spheres rendering
 
 ## [v3.37.1] - 2023-06-20
 

--- a/src/mol-geo/geometry/spheres/spheres.ts
+++ b/src/mol-geo/geometry/spheres/spheres.ts
@@ -131,6 +131,7 @@ export namespace Spheres {
         xrayShaded: PD.Select<boolean | 'inverted'>(false, [[false, 'Off'], [true, 'On'], ['inverted', 'Inverted']], BaseGeometry.ShadingCategory),
         transparentBackfaces: PD.Select('off', PD.arrayToOptions(['off', 'on', 'opaque']), BaseGeometry.ShadingCategory),
         solidInterior: PD.Boolean(true, BaseGeometry.ShadingCategory),
+        approximate: PD.Boolean(false, { ...BaseGeometry.ShadingCategory, description: 'Faster rendering, but has artifacts.' }),
         bumpFrequency: PD.Numeric(0, { min: 0, max: 10, step: 0.1 }, BaseGeometry.ShadingCategory),
         bumpAmplitude: PD.Numeric(1, { min: 0, max: 5, step: 0.1 }, BaseGeometry.ShadingCategory),
     };
@@ -214,6 +215,7 @@ export namespace Spheres {
             dXrayShaded: ValueCell.create(props.xrayShaded === 'inverted' ? 'inverted' : props.xrayShaded === true ? 'on' : 'off'),
             dTransparentBackfaces: ValueCell.create(props.transparentBackfaces),
             dSolidInterior: ValueCell.create(props.solidInterior),
+            dApproximate: ValueCell.create(props.approximate),
             uBumpFrequency: ValueCell.create(props.bumpFrequency),
             uBumpAmplitude: ValueCell.create(props.bumpAmplitude),
         };
@@ -233,6 +235,7 @@ export namespace Spheres {
         ValueCell.updateIfChanged(values.dXrayShaded, props.xrayShaded === 'inverted' ? 'inverted' : props.xrayShaded === true ? 'on' : 'off');
         ValueCell.updateIfChanged(values.dTransparentBackfaces, props.transparentBackfaces);
         ValueCell.updateIfChanged(values.dSolidInterior, props.solidInterior);
+        ValueCell.updateIfChanged(values.dApproximate, props.approximate);
         ValueCell.updateIfChanged(values.uBumpFrequency, props.bumpFrequency);
         ValueCell.updateIfChanged(values.uBumpAmplitude, props.bumpAmplitude);
     }

--- a/src/mol-gl/renderable/spheres.ts
+++ b/src/mol-gl/renderable/spheres.ts
@@ -25,6 +25,7 @@ export const SpheresSchema = {
     dXrayShaded: DefineSpec('string', ['off', 'on', 'inverted']),
     dTransparentBackfaces: DefineSpec('string', ['off', 'on', 'opaque']),
     dSolidInterior: DefineSpec('boolean'),
+    dApproximate: DefineSpec('boolean'),
     uBumpFrequency: UniformSpec('f', 'material'),
     uBumpAmplitude: UniformSpec('f', 'material'),
 };

--- a/src/mol-gl/shader/chunks/common-clip.glsl.ts
+++ b/src/mol-gl/shader/chunks/common-clip.glsl.ts
@@ -65,7 +65,7 @@ export const common_clip = `
 
     #if __VERSION__ == 100
         // 8-bit
-        int bitwiseAnd(const in int a, const in int b) {
+        int bitwiseAnd(in int a, in int b) {
             int d = 128;
             int result = 0;
             for (int i = 0; i < 8; ++i) {

--- a/src/mol-gl/shader/spheres.frag.ts
+++ b/src/mol-gl/shader/spheres.frag.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -88,16 +88,30 @@ void main(void){
     vec3 cameraNormal;
     float fragmentDepth;
     bool clipped = false;
-    bool hit = SphereImpostor(modelPos, cameraPos, cameraNormal, interior, fragmentDepth);
-    if (!hit) discard;
 
-    if (fragmentDepth < 0.0) discard;
-    if (fragmentDepth > 1.0) discard;
+    #ifdef dApproximate
+        vec3 pointDir = -vPointViewPosition - vPoint;
+        if (dot(pointDir, pointDir) > vRadius * vRadius) discard;
+        cameraPos = -vPointViewPosition;
+        modelPos = vPoint;
+        fragmentDepth = gl_FragCoord.z;
+        #ifndef dIgnoreLight
+            pointDir.z += length(pointDir) - vRadius;
+            cameraNormal = -normalize(pointDir / vRadius);
+        #endif
+        interior = false;
+    #else
+        bool hit = SphereImpostor(modelPos, cameraPos, cameraNormal, interior, fragmentDepth);
+        if (!hit) discard;
+
+        if (fragmentDepth < 0.0) discard;
+        if (fragmentDepth > 1.0) discard;
+
+        gl_FragDepthEXT = fragmentDepth;
+    #endif
 
     vec3 vViewPosition = cameraPos;
     vec3 vModelPosition = modelPos;
-
-    gl_FragDepthEXT = fragmentDepth;
 
     #include clip_pixel
     #include assign_material_color

--- a/src/mol-gl/shader/spheres.frag.ts
+++ b/src/mol-gl/shader/spheres.frag.ts
@@ -96,7 +96,7 @@ void main(void){
         modelPos = vPoint;
         fragmentDepth = gl_FragCoord.z;
         #ifndef dIgnoreLight
-            pointDir.z += length(pointDir) - vRadius;
+            pointDir.z -= cos(length(pointDir) / vRadius);
             cameraNormal = -normalize(pointDir / vRadius);
         #endif
         interior = false;

--- a/src/mol-gl/shader/spheres.frag.ts
+++ b/src/mol-gl/shader/spheres.frag.ts
@@ -83,8 +83,6 @@ bool SphereImpostor(out vec3 modelPos, out vec3 cameraPos, out vec3 cameraNormal
 }
 
 void main(void){
-    vec3 modelPos;
-    vec3 cameraPos;
     vec3 cameraNormal;
     float fragmentDepth;
     bool clipped = false;
@@ -92,8 +90,7 @@ void main(void){
     #ifdef dApproximate
         vec3 pointDir = -vPointViewPosition - vPoint;
         if (dot(pointDir, pointDir) > vRadius * vRadius) discard;
-        cameraPos = -vPointViewPosition;
-        modelPos = vPoint;
+        vec3 vViewPosition = -vPointViewPosition;
         fragmentDepth = gl_FragCoord.z;
         #ifndef dIgnoreLight
             pointDir.z -= cos(length(pointDir) / vRadius);
@@ -101,6 +98,8 @@ void main(void){
         #endif
         interior = false;
     #else
+        vec3 modelPos;
+        vec3 cameraPos;
         bool hit = SphereImpostor(modelPos, cameraPos, cameraNormal, interior, fragmentDepth);
         if (!hit) discard;
 
@@ -108,10 +107,10 @@ void main(void){
         if (fragmentDepth > 1.0) discard;
 
         gl_FragDepthEXT = fragmentDepth;
-    #endif
 
-    vec3 vViewPosition = cameraPos;
-    vec3 vModelPosition = modelPos;
+        vec3 vModelPosition = modelPos;
+        vec3 vViewPosition = cameraPos;
+    #endif
 
     #include clip_pixel
     #include assign_material_color

--- a/src/mol-gl/shader/spheres.vert.ts
+++ b/src/mol-gl/shader/spheres.vert.ts
@@ -86,8 +86,14 @@ void main(void){
     vec4 position4 = vec4(aPosition, 1.0);
     vec4 mvPosition = uModelView * aTransform * position4;
 
-    gl_Position = uProjection * vec4(mvPosition.xyz, 1.0);
-    quadraticProjection(size, aPosition);
+    #ifdef dApproximate
+        vec4 mvCorner = vec4(mvPosition.xyz, 1.0);
+        mvCorner.xy += aMapping * vRadius;
+        gl_Position = uProjection * mvCorner;
+    #else
+        gl_Position = uProjection * vec4(mvPosition.xyz, 1.0);
+        quadraticProjection(vRadius, aPosition);
+    #endif
 
     vRadiusSq = vRadius * vRadius;
     vec4 vPoint4 = uInvProjection * gl_Position;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

To get more performance when rendering many spheres at the expense of artefacts. Best used when geometry does not overlap or when there is no lighting and uniform coloring.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`