### PR TITLE
Add 'Chain Instance' and 'Uniform' options for 'Carbon Color' param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Pull position and group from texture
 - Add `Euler` math primitive
 - Add stride option to element sphere & point visuals
+- Add 'Chain Instance' and 'Uniform' options for 'Carbon Color' param (in Color Theme: Element Symbol)
 
 ## [v3.37.1] - 2023-06-20
 

--- a/src/mol-theme/color/element-symbol.ts
+++ b/src/mol-theme/color/element-symbol.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { ElementSymbol } from '../../mol-model/structure/model/types';
@@ -22,6 +23,8 @@ import { EntitySourceColorTheme, EntitySourceColorThemeParams } from './entity-s
 import { ModelIndexColorTheme, ModelIndexColorThemeParams } from './model-index';
 import { StructureIndexColorTheme, StructureIndexColorThemeParams } from './structure-index';
 import { ColorThemeCategory } from './categories';
+import { UnitIndexColorTheme, UnitIndexColorThemeParams } from './unit-index';
+import { UniformColorTheme, UniformColorThemeParams } from './uniform';
 
 // from Jmol http://jmol.sourceforge.net/jscolors/ (or 0xFFFFFF)
 export const ElementSymbolColors = ColorMap({
@@ -35,12 +38,14 @@ const Description = 'Assigns a color to every atom according to its chemical ele
 export const ElementSymbolColorThemeParams = {
     carbonColor: PD.MappedStatic('chain-id', {
         'chain-id': PD.Group(ChainIdColorThemeParams),
+        'unit-index': PD.Group(UnitIndexColorThemeParams, { label: 'Chain Instance' }),
         'entity-id': PD.Group(EntityIdColorThemeParams),
         'entity-source': PD.Group(EntitySourceColorThemeParams),
         'operator-name': PD.Group(OperatorNameColorThemeParams),
         'model-index': PD.Group(ModelIndexColorThemeParams),
         'structure-index': PD.Group(StructureIndexColorThemeParams),
-        'element-symbol': PD.EmptyGroup()
+        'uniform': PD.Group(UniformColorThemeParams),
+        'element-symbol': PD.EmptyGroup(),
     }, { description: 'Use chain-id coloring for carbon atoms.' }),
     saturation: PD.Numeric(0, { min: -6, max: 6, step: 0.1 }),
     lightness: PD.Numeric(0.2, { min: -6, max: 6, step: 0.1 }),
@@ -64,11 +69,13 @@ export function elementSymbolColor(colorMap: ElementSymbolColors, element: Eleme
 function getCarbonTheme(ctx: ThemeDataContext, props: ElementSymbolColorThemeProps['carbonColor']) {
     switch (props.name) {
         case 'chain-id': return ChainIdColorTheme(ctx, props.params);
+        case 'unit-index': return UnitIndexColorTheme(ctx, props.params);
         case 'entity-id': return EntityIdColorTheme(ctx, props.params);
         case 'entity-source': return EntitySourceColorTheme(ctx, props.params);
         case 'operator-name': return OperatorNameColorTheme(ctx, props.params);
         case 'model-index': return ModelIndexColorTheme(ctx, props.params);
         case 'structure-index': return StructureIndexColorTheme(ctx, props.params);
+        case 'uniform': return UniformColorTheme(ctx, props.params);
         case 'element-symbol': return undefined;
         default: assertUnreachable(props);
     }
@@ -101,7 +108,7 @@ export function ElementSymbolColorTheme(ctx: ThemeDataContext, props: PD.Values<
         return DefaultElementSymbolColor;
     }
 
-    const granularity = props.carbonColor.name === 'operator-name' ? 'groupInstance' : 'group';
+    const granularity = (props.carbonColor.name === 'operator-name' || props.carbonColor.name === 'unit-index') ? 'groupInstance' : 'group';
 
     return {
         factory: ElementSymbolColorTheme,


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

I added 'Chain Instance' and 'Uniform' options for 'Carbon Color' param (in Color Theme: Element Symbol)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`