### PR TITLE
Fix logic for trajectoryFromCCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Don't rely solely on `chem_comp_atom` when detecting CCD files (#877)
+
 ## [v3.38.1] - 2023-07-22
 
 - Fix pixel-scale not updated in SSAO pass

--- a/src/mol-plugin-state/transforms/model.ts
+++ b/src/mol-plugin-state/transforms/model.ts
@@ -303,7 +303,8 @@ const TrajectoryFromMmCif = PluginStateTransform.BuiltIn({
                 const header = params.blockHeader || a.data.blocks[0].header;
                 const block = a.data.blocks.find(b => b.header === header);
                 if (!block) throw new Error(`Data block '${[header]}' not found.`);
-                trajectory = block.categoryNames.includes('chem_comp_atom') ? await trajectoryFromCCD(block).runInContext(ctx) : await trajectoryFromMmCIF(block).runInContext(ctx);
+                const isCcd = block.categoryNames.includes('chem_comp_atom') && !block.categoryNames.includes('atom_site') && !block.categoryNames.includes('ihm_sphere_obj_site') && !block.categoryNames.includes('ihm_gaussian_obj_site');
+                trajectory = isCcd ? await trajectoryFromCCD(block).runInContext(ctx) : await trajectoryFromMmCIF(block).runInContext(ctx);
             }
             if (trajectory.frameCount === 0) throw new Error('No models found.');
             const props = trajectoryProps(trajectory);


### PR DESCRIPTION
# Description
Proposal to fix #877 by ensuring that the CCD route only triggers if `chem_comp_atom` is defined and, simultaneously, no conventional coordinates are present.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`