### PR TITLE
add some elements name for `guessElementSymbolString` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
+- Add some elements support for `guessElementSymbolString` function
 
 ## [v3.38.3] - 2023-07-29
 

--- a/src/mol-model-formats/structure/util.ts
+++ b/src/mol-model-formats/structure/util.ts
@@ -46,8 +46,8 @@ export function guessElementSymbolTokens(tokens: Tokens, str: string, start: num
     TokenBuilder.add(tokens, s, s); // no reasonable guess, add empty token
 }
 
-const TwoCharElementNames = new Set(['NA', 'CL', 'FE', 'SI', 'BR', 'AS']);
-const OneCharElementNames = new Set(['C', 'H', 'N', 'O', 'P', 'S']);
+const TwoCharElementNames = new Set(['NA', 'CL', 'FE', 'SI', 'BR', 'AS', 'LI']);
+const OneCharElementNames = new Set(['C', 'H', 'N', 'O', 'P', 'S', 'F', 'B']);
 
 const reTrimSpacesAndNumbers = /^[\s\d]+|[\s\d]+$/g;
 export function guessElementSymbolString(atomId: string, compId: string) {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
In our scenario that simulate battery material include some elements like `Li`, `B`, `F` etc. But I noticed that molstar can not render those elements correctly.
[incorrect example here](https://github.com/molstar/molstar/issues/882)

So I added some elements that our scenario requires into the function `guessElementSymbolString`. But I'm not sure if there are any other elements that need to be added.

If there are any other elements that need to be added, please let me know, or perhaps the project's author could add them.

Thank you~

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`