### PR TITLE
Allow toggling of hydrogens as part of `LabelTextVisual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Add some elements support for `guessElementSymbolString` function
 - Faster bounding rectangle calculation for imposter spheres
+- Allow toggling of hydrogens as part of `LabelTextVisual`
 
 ## [v3.38.3] - 2023-07-29
 

--- a/src/mol-repr/structure/visual/label-text.ts
+++ b/src/mol-repr/structure/visual/label-text.ts
@@ -49,9 +49,9 @@ export function LabelTextVisual(materialId: number): ComplexVisual<LabelTextPara
                 newProps.level !== currentProps.level ||
                 (newProps.level === 'chain' && newProps.chainScale !== currentProps.chainScale) ||
                 (newProps.level === 'residue' && newProps.residueScale !== currentProps.residueScale) ||
-                (newProps.level === 'element' && newProps.elementScale !== currentProps.elementScale ||
+                (newProps.level === 'element' && newProps.elementScale !== currentProps.elementScale) ||
                 newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
-                newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant)
+                newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant
             );
         }
     }, materialId);


### PR DESCRIPTION
# Description
Allows toggling of hydrogen atoms for label representations.
Follow-up to https://github.com/molstar/molstar/pull/731#issuecomment-1558604204.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`