### PR TITLE
ModelServer ligand queries: fix atom count reported by SDF/MOL/MOL2 export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Do not call `updateFocusRepr` if default `StructureFocusRepresentation` isn't present.
 - Treat "tap" as a click in `InputObserver`
+- ModelServer ligand queries: fix atom count reported by SDF/MOL/MOL2 export
 
 ## [v3.39.0] - 2023-09-02
 

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
@@ -29,6 +29,7 @@ export class MolEncoder extends LigandEncoder {
         // happens for the unknown ligands (UNL)
         if (!atomMap) throw Error(`The Chemical Component Dictionary doesn't hold any atom data for ${name}`);
 
+        let atomCount = 0;
         let bondCount = 0;
         let chiral = false;
 
@@ -55,6 +56,7 @@ export class MolEncoder extends LigandEncoder {
             StringBuilder.writeSafe(ctab, '  0');
             StringBuilder.writeIntegerPadLeft(ctab, this.mapCharge(charge), 3);
             StringBuilder.writeSafe(ctab, '  0  0  0  0  0  0  0  0  0  0\n');
+            atomCount++;
             if (stereo_config !== 'n') chiral = true;
 
             // no data for metal ions
@@ -76,7 +78,7 @@ export class MolEncoder extends LigandEncoder {
         });
 
         // write counts line
-        StringBuilder.writeIntegerPadLeft(this.builder, atoms.size, 3);
+        StringBuilder.writeIntegerPadLeft(this.builder, atomCount, 3);
         StringBuilder.writeIntegerPadLeft(this.builder, bondCount, 3);
         StringBuilder.writeSafe(this.builder, `  0  0  ${chiral ? 1 : 0}  0  0  0  0  0  0\n`);
 

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
@@ -33,6 +33,7 @@ export class Mol2Encoder extends LigandEncoder {
         const bondMap = this.componentBondData.entries.get(name)!;
         // happens for the unknown ligands (UNL)
         if (!atomMap) throw Error(`The Chemical Component Dictionary doesn't hold any atom data for ${name}`);
+        let atomCount = 0;
         let bondCount = 0;
 
         const atoms = this.getAtoms(instance, source);
@@ -67,10 +68,11 @@ export class Mol2Encoder extends LigandEncoder {
 
             const sybyl = bondMap?.map ? this.mapToSybyl(label_atom_id1, type_symbol1, bondMap) : type_symbol1;
             StringBuilder.writeSafe(a, `${i1 + 1} ${label_atom_id1} ${atom1.Cartn_x.toFixed(3)} ${atom1.Cartn_y.toFixed(3)} ${atom1.Cartn_z.toFixed(3)} ${sybyl} 1 ${name} 0.000\n`);
+            atomCount++;
         });
 
         // could write something like 'SMALL\nNO_CHARGES', for now let's write **** indicating non-optional, yet missing, string values
-        StringBuilder.writeSafe(this.out, `@<TRIPOS>MOLECULE\n${name}\n${atoms.size} ${bondCount} 1\n****\n****\n\n`);
+        StringBuilder.writeSafe(this.out, `@<TRIPOS>MOLECULE\n${name}\n${atomCount} ${bondCount} 1\n****\n****\n\n`);
         StringBuilder.writeSafe(this.out, StringBuilder.getString(a));
         StringBuilder.writeSafe(this.out, StringBuilder.getString(b));
         StringBuilder.writeSafe(this.out, `@<TRIPOS>SUBSTRUCTURE\n1 ${name} 1\n`);

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.10
+* /ligand queries: fix atom count reported by SDF/MOL/MOL2 export
+
 # 0.9.9
 * /ligand queries: fix behavior for alternate locations
 * /ligand queries: handle additional atoms more gracefully

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -4,4 +4,4 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export const VERSION = '0.9.9';
+export const VERSION = '0.9.10';


### PR DESCRIPTION
# Description
Atom count reported as part of SDF/MOL/MOL2 export may not match the actual file content. Exported file won't open in RDKit/OpenBabel/etc.

Happens e.g. for 6t6x: https://models.rcsb.org/v1/6t6x/ligand?auth_seq_id=301&label_asym_id=B&encoding=cif. This instance of MQW contains `H462`, an atom that isn't described by the CCD and can't get exported.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`