### PR TITLE
CCD extension: Make visuals for aromatic bonds configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Do not call `updateFocusRepr` if default `StructureFocusRepresentation` isn't present.
 - Treat "tap" as a click in `InputObserver`
+- CCD extension: Make visuals for aromatic bonds configurable
 
 ## [v3.39.0] - 2023-09-02
 


### PR DESCRIPTION
# Description
Gives control over aromatic bonds: depict delocalized ring or actual bonds as annotated by the CCD.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`