### PR TITLE
Add `blockIndex` parameter to TrajectoryFromMmCif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - `EXT_clip_control`
 - Add `MultiSampleParams.reduceFlicker` (to be able to switch it off)
 - Add `alphaThickness` parameter to adjust alpha of spheres for radius
+- Add `blockIndex` parameter to TrajectoryFromMmCif
 
 ## [v3.39.0] - 2023-09-02
 


### PR DESCRIPTION
# Description

I added an optional parameter `blockIndex` to TrajectoryFromMmCif transformer. Defaults to 0 and only applies when `blockHeader` is undefined or empty string.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`