### PR TITLE
Fix layout typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 
 - Add `PluginContext.initialized` promise & support for it in the `Plugin` UI component.
+- Fix undesired interaction between settings panel and the panel on the right
 
 ## [v3.40.1] - 2023-09-30
 

--- a/src/mol-plugin-ui/viewport/simple-settings.tsx
+++ b/src/mol-plugin-ui/viewport/simple-settings.tsx
@@ -100,7 +100,7 @@ const SimpleSettingsMapping = ParamMapping({
         if (r.top !== 'hidden' && (!c || c.top !== 'none')) layout.push('sequence');
         if (r.bottom !== 'hidden' && (!c || c.bottom !== 'none')) layout.push('log');
         if (r.left !== 'hidden' && (!c || c.left !== 'none')) layout.push('left');
-        if (r.right !== 'hidden' && (!c || c.left !== 'none')) layout.push('right');
+        if (r.right !== 'hidden' && (!c || c.right !== 'none')) layout.push('right');
         return { canvas: ctx.canvas3d?.props!, layout };
     }
 })({


### PR DESCRIPTION
# Description
Probably just copy-and-paste. Causes the panel on the right to disappear forever if interacting with the Settings panel and `components.controls.left = 'none'`.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`