### PR TITLE
Add `options` support for default bond labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Improve `distinctColors` function
     - Add `sort` and `sampleCountFactor` parameters
     - Fix clustering issues
+- Add `options` support for default bond labels
 
 ## [v3.41.0] - 2023-10-15
 

--- a/src/mol-theme/label.ts
+++ b/src/mol-theme/label.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -34,7 +34,7 @@ export function lociLabel(loci: Loci, options: Partial<LabelOptions> = {}): stri
             return structureElementStatsLabel(StructureElement.Stats.ofLoci(loci), options);
         case 'bond-loci':
             const bond = loci.bonds[0];
-            return bond ? bondLabel(bond) : '';
+            return bond ? bondLabel(bond, options) : '';
         case 'shape-loci':
             return loci.shape.name;
         case 'group-loci':


### PR DESCRIPTION
# Description
I would like to create `condensed` labels for bonds. This allows doing so with the default `lociLabel(loci, options)`.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`