### PR TITLE
ModelServer SDF/MOL2 ligand export: fix atom indices for atoms not present in the CCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 
 - Fix measurement label `offsetZ` default: not needed when `scaleByRadius` is enabled
-- ModelServer SDF/MOL2 ligand export: fix atom indices when additional hydrogen atoms are present
+- ModelServer SDF/MOL2 ligand export: fix atom indices when additional atoms are present
 
 ## [v3.43.1] - 2023-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
-- Fix measurement label `offsetZ` default: not needed when `scaleByRadius` is enbaled
+- Fix measurement label `offsetZ` default: not needed when `scaleByRadius` is enabled
+- ModelServer SDF/MOL2 ligand export: fix atom indices when additional hydrogen atoms are present
 
 ## [v3.43.1] - 2023-12-04
 

--- a/src/mol-io/writer/ligand-encoder.ts
+++ b/src/mol-io/writer/ligand-encoder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
@@ -111,11 +111,13 @@ export abstract class LigandEncoder implements Encoder<string> {
                 const key = it.move();
 
                 const lai = label_atom_id.value(key, data, index) as string;
+                // ignore all atoms not registered in the CCD
+                if (!ccdAtoms.has(lai)) continue;
                 // ignore all alternate locations after the first
                 if (atoms.has(lai)) continue;
 
                 const ts = type_symbol.value(key, data, index) as ElementSymbol;
-                if (this.skipHydrogen(ts, ccdAtoms.has(lai))) continue;
+                if (this.skipHydrogen(ts)) continue;
 
                 const a: { [k: string]: (string | number) } = {};
 
@@ -134,10 +136,11 @@ export abstract class LigandEncoder implements Encoder<string> {
         return atoms;
     }
 
-    // skip hydrogens if ignored globally or if observed in structure but unknown to CCD
-    protected skipHydrogen(ts: ElementSymbol, present: boolean) {
-        const isHydrogen = this.isHydrogen(ts);
-        return isHydrogen && (!this.hydrogens || !present);
+    protected skipHydrogen(type_symbol: ElementSymbol) {
+        if (this.hydrogens) {
+            return false;
+        }
+        return this.isHydrogen(type_symbol);
     }
 
     protected isHydrogen(type_symbol: ElementSymbol) {

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -34,7 +34,7 @@ export class MolEncoder extends LigandEncoder {
         let chiral = false;
 
         // traverse once to determine all actually present atoms
-        const atoms = this.getAtoms(instance, source);
+        const atoms = this.getAtoms(instance, source, atomMap.map);
         atoms.forEach((atom1, label_atom_id1) => {
             const { index: i1, type_symbol: type_symbol1 } = atom1;
             const atomMapData1 = atomMap.map.get(label_atom_id1);

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -36,7 +36,7 @@ export class Mol2Encoder extends LigandEncoder {
         let atomCount = 0;
         let bondCount = 0;
 
-        const atoms = this.getAtoms(instance, source);
+        const atoms = this.getAtoms(instance, source, atomMap.map);
         StringBuilder.writeSafe(a, '@<TRIPOS>ATOM\n');
         StringBuilder.writeSafe(b, '@<TRIPOS>BOND\n');
         atoms.forEach((atom1, label_atom_id1) => {

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2018-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export const VERSION = '0.9.10';
+export const VERSION = '0.9.11';


### PR DESCRIPTION
# Description
Some entries have additional (hydrogen) atoms that aren't present in the CCD. This may shift atom indices and can butcher bond information.
This PR addresses this by ignoring all atoms that aren't also registered in the CCD.

Example: https://models.rcsb.org/v1/5sak/ligand?auth_seq_id=404&label_asym_id=E&encoding=mol2

![additional-hydrogen](https://github.com/molstar/molstar/assets/9744615/89f894ba-9e74-4a06-9931-f116d895d448)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`