### PR TITLE
Fixed drag and drop overlay on WebKit and Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Labels applied in one node
 - ModelServer SDF/MOL2 ligand export: fix atom indices when additional atoms are present
 - Avoid showing (and calculating) inter-unit bonds for huge structures
+- Fixed `DragOverlay` on WebKit/Safari browsers
 
 ## [v3.43.1] - 2023-12-04
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "Russell Parker <russell@benchling.com>",
     "Dominik Tichy <tichydominik451@gmail.com>",
     "Yana Rose <yana.v.rose@gmail.com>",
-    "Yakov Pechersky <ffxen158@gmail.com>"
+    "Yakov Pechersky <ffxen158@gmail.com>",
+    "Christian Dominguez <christian.99dominguez@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-plugin-ui/plugin.tsx
+++ b/src/mol-plugin-ui/plugin.tsx
@@ -170,22 +170,18 @@ class Layout extends PluginUIComponent {
     private showDragOverlay = new BehaviorSubject(false);
     onDragEnter = (ev: React.DragEvent<HTMLDivElement>) => {
         let hasFile = false;
-        if (ev.dataTransfer.items) {
+        if (ev.dataTransfer.items && ev.dataTransfer.items.length > 0) {
             for (let i = 0; i < ev.dataTransfer.items.length; i++) {
                 if (ev.dataTransfer.items[i].kind !== 'file') continue;
                 hasFile = true;
                 break;
             }
         } else {
-            for (let i = 0; i < ev.dataTransfer.files.length; i++) {
-                if (!ev.dataTransfer.files[i]) continue;
+            for (let i = 0; i < ev.dataTransfer.types.length; i++) {
+                if (ev.dataTransfer.types[i] !== 'Files') continue;
                 hasFile = true;
                 break;
             }
-        }
-
-        if (!navigator.userAgent.includes('Chrome') || navigator.userAgent.includes('Safari')) {
-            hasFile = true;
         }
 
         if (hasFile) {

--- a/src/mol-plugin-ui/plugin.tsx
+++ b/src/mol-plugin-ui/plugin.tsx
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Christian Dominguez <christian.99dominguez@gmail.com>
  */
 
 import { List } from 'immutable';

--- a/src/mol-plugin-ui/plugin.tsx
+++ b/src/mol-plugin-ui/plugin.tsx
@@ -184,6 +184,10 @@ class Layout extends PluginUIComponent {
             }
         }
 
+        if (!navigator.userAgent.includes('Chrome') || navigator.userAgent.includes('Safari')) {
+            hasFile = true;
+        }
+
         if (hasFile) {
             this.showDragOverlay.next(true);
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
On Safari, `dataTransfer` is not populated during the drag operation. Thus, the drag overlay of Mol* was never getting active.

This change checks if we are on a Safari browser by checking the `userAgent`, if so, then forces the `showDragOverlay` variable to true.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`