### PR TITLE
Remove 2ICY from list

### DIFF
--- a/docs/interesting-pdb-entries.md
+++ b/docs/interesting-pdb-entries.md
@@ -27,7 +27,7 @@
     * Protein (1BRR, 5Z6Y)
     * DNA (5D3G)
     * Collagen (6JEC)
-* Multiple models with different sets of ligands or missing ligands (1J6T, 1VRC, 2ICY, 1O2F)
+* Multiple models with different sets of ligands or missing ligands (1J6T, 1VRC, 1O2F)
 * Long linear sugar chain (4HG6)
 * Anisotropic B-factors/Ellipsoids (1EJG)
 * NOS bridges (LYS-CSO in 7B0L, 6ZWJ, 6ZWH)


### PR DESCRIPTION
2ICY does not have different sets of ligands, or missing ligands in different models

<!-- Thank you for contributing to Mol* -->

# Description


## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`