### PR TITLE
BinaryCIF encoder fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file, following t
 
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
+## [Unreleased]
+
+- Fix BinaryCIF encoder edge cases caused by re-encoding an existing BinaryCIF file
+
 
 ## [v4.0.1] - 2023-02-19
 

--- a/src/mol-io/common/binary-cif/array-encoder.ts
+++ b/src/mol-io/common/binary-cif/array-encoder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * Adapted from CIFTools.js (https://github.com/dsehnal/CIFTools.js; MIT) and MMTF (https://github.com/rcsb/mmtf-javascript/; MIT)
  *
@@ -57,7 +57,10 @@ export namespace ArrayEncoder {
 
     export function fromEncoding(encoding: Encoding[]) {
         let e = by(getProvider(encoding[0]));
-        for (let i = 1; i < encoding.length; i++) e = e.and(getProvider(encoding[i]));
+        for (let i = 1; i < encoding.length; i++) {
+            if (encoding[i - 1].kind === 'IntegerPacking') break;
+            e = e.and(getProvider(encoding[i]));
+        }
         return e;
     }
 

--- a/src/mol-io/writer/cif/encoder/binary.ts
+++ b/src/mol-io/writer/cif/encoder/binary.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * Adapted from CIFTools.js (https://github.com/dsehnal/CIFTools.js)
  *
@@ -146,7 +146,15 @@ function encodeField(categoryName: string, field: Field, data: CategoryInstanceD
 
     const { array, allPresent, mask } = getFieldData(field, getArrayCtor(field, format), totalCount, data);
 
-    let encoder: ArrayEncoder | undefined = tryGetEncoder(categoryName, field, format, encoderProvider);
+    let encoder: ArrayEncoder | undefined;
+    if (field.type === Field.Type.Str) {
+        // Force string array encoding if field type is str to prevent conflicts between
+        // encoderProvider (determined by automatic classifier) and field type comming from a CIF schema
+        encoder = ArrayEncoder.by(E.stringArray);
+    } else {
+        encoder = tryGetEncoder(categoryName, field, format, encoderProvider);
+    }
+
     if (!encoder) {
         if (autoClassify) encoder = classify(field.type, array);
         else encoder = getDefaultEncoder(field.type);


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Fixes BinaryCIF encoder edge cases caused by re-encoding an existing BinaryCIF file. See #1040.

The issues:
- The `ArrayEncoder.fromEncoding` added extra `byte-array` encoding due to implementation details (`integer-packing` adds `byte-array` automatically).
- The automatic column encoding classifier could determine a column has a numeric type on per-entry basis (e.g. using the `cif2bcif` tool), but in the schema the column would be marked as `str`. This caused the encoder to apply numeric-only encoding to a string type, resulting a weird behavior (e.g. in `pdbx_chem_comp_identifier.program_version`)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files