### PR TITLE
Stop showing `computed` bonds if `chem_comp_bond` is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Wrong operator checks in `findPairBonds`
 - Fix SSAO artifacts (@corredD, #1082)
 - Fix bumpiness artifact (#1107)
+- Stop showing `computed` bonds if `chem_comp_bond` is defined
 
 ## [v4.1.0] - 2023-03-31
 

--- a/src/mol-model/structure/model/model.ts
+++ b/src/mol-model/structure/model/model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -426,5 +426,10 @@ export namespace Model {
                 ))
             )
         );
+    }
+
+    export function hasChemCompBond(model: Model): boolean {
+        if (!MmcifFormat.is(model.sourceData)) return false;
+        return model.sourceData.data.db.chem_comp_bond._rowCount > 0;
     }
 }

--- a/src/mol-model/structure/structure/structure.ts
+++ b/src/mol-model/structure/structure/structure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -158,6 +158,14 @@ class Structure {
      */
     get isCoarseGrained() {
         return this.models.some(m => Model.isCoarseGrained(m));
+    }
+
+    /**
+     * True if all models provide explicit bond information (i.e., `chem_comp_bond` is defined).
+     * @see Model.hasChemCompBond
+     */
+    get hasChemCompBond() {
+        return this.models.length && this.models.every(m => Model.hasChemCompBond(m));
     }
 
     get isEmpty() {

--- a/src/mol-model/structure/structure/structure.ts
+++ b/src/mol-model/structure/structure/structure.ts
@@ -165,7 +165,7 @@ class Structure {
      * @see Model.hasChemCompBond
      */
     get hasChemCompBond() {
-        return this.models.length && this.models.every(m => Model.hasChemCompBond(m));
+        return !!this.models.length && this.models.every(m => Model.hasChemCompBond(m));
     }
 
     get isEmpty() {

--- a/src/mol-plugin/behavior/dynamic/selection/structure-focus-representation.ts
+++ b/src/mol-plugin/behavior/dynamic/selection/structure-focus-representation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>

--- a/src/mol-plugin/behavior/dynamic/selection/structure-focus-representation.ts
+++ b/src/mol-plugin/behavior/dynamic/selection/structure-focus-representation.ts
@@ -116,9 +116,16 @@ class StructureFocusRepresentationBehavior extends PluginBehavior.WithSubscriber
         }
 
         if (components.indexOf('surroundings') >= 0 && !refs[StructureFocusRepresentationTags.SurrRepr]) {
+            const surroundingsParams = this.getReprParams(this.params.surroundingsParams);
+            // suppress computed bonds if bond order and aromaticity flags are known from chem_comp_bond
+            if (cell.obj!.data.hasChemCompBond) {
+                const i = surroundingsParams.type.params.includeTypes.indexOf('computed');
+                if (i !== -1) surroundingsParams.type.params.includeTypes.splice(i, 1);
+            }
+
             refs[StructureFocusRepresentationTags.SurrRepr] = builder
                 .to(refs[StructureFocusRepresentationTags.SurrSel]!)
-                .apply(StateTransforms.Representation.StructureRepresentation3D, this.getReprParams(this.params.surroundingsParams), { tags: StructureFocusRepresentationTags.SurrRepr }).ref;
+                .apply(StateTransforms.Representation.StructureRepresentation3D, surroundingsParams, { tags: StructureFocusRepresentationTags.SurrRepr }).ref;
         }
 
         if (components.indexOf('interactions') >= 0 && !refs[StructureFocusRepresentationTags.SurrNciRepr] && cell.obj && InteractionsRepresentationProvider.isApplicable(cell.obj?.data)) {

--- a/src/mol-repr/structure/representation/ball-and-stick.ts
+++ b/src/mol-repr/structure/representation/ball-and-stick.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -43,7 +43,12 @@ export function getBallAndStickParams(ctx: ThemeRegistryContext, structure: Stru
         params.visuals.defaultValue = ['element-sphere', 'intra-bond'];
         return params;
     } else {
-        return BallAndStickParams;
+        if (!structure.hasChemCompBond) return BallAndStickParams;
+
+        // suppress computed bonds if bond order and aromaticity flags are known from chem_comp_bond
+        const params = PD.clone(BallAndStickParams);
+        params.excludeTypes.defaultValue = ['computed'];
+        return params;
     }
 }
 

--- a/src/mol-repr/structure/representation/line.ts
+++ b/src/mol-repr/structure/representation/line.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -45,7 +45,12 @@ export function getLineParams(ctx: ThemeRegistryContext, structure: Structure) {
         params.visuals.defaultValue = ['intra-bond', 'element-point', 'element-cross'];
         return params;
     } else {
-        return LineParams;
+        if (!structure.hasChemCompBond) return LineParams;
+
+        // suppress computed bonds if bond order and aromaticity flags are known from chem_comp_bond
+        const params = PD.clone(LineParams);
+        params.excludeTypes.defaultValue = ['computed'];
+        return params;
     }
 }
 


### PR DESCRIPTION
# Description
Follow-up to #641, implementing Alex' proposal.

Works for standard ball-and-stick but doesn't play nicely with focus, which includes `computed` interactions by default (and adding it to `excludeTypes` removes other bonds, but removing it from `includeTypes` gives the visuals I'd like, at least for [1t2c](https://molstar.org/viewer/?load-pdb=1t2c)).

Do you have an idea for that? All archive mmCIF will have `chem_comp_bond` by the end of the year, currently available for ~160k.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`