### PR TITLE
fixes for SSAO edge artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fixes SSAO edge artifacts (#1122)
     - Add `reuseOcclusion` parameter to multi-sample pass
     - Add `blurBias` parameter to occlusion pass
+    - Handle near clip in ssao-blur
 
 ## [v4.2.0] - 2023-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Add depth of field (dof) postprocessing effect
 - Add `SbNcbrTunnels` extension for for visualizing tunnels in molecular structures from ChannelsDB (more info in [tunnels.md](./docs/docs/extensions/tunnels.md))
+- Fixes SSAO edge artifacts (#1122)
+    - Add `reuseOcclusion` parameter to multi-sample pass
+    - Add `blurBias` parameter to occlusion pass
 
 ## [v4.2.0] - 2023-04-05
 

--- a/src/apps/docking-viewer/viewport.tsx
+++ b/src/apps/docking-viewer/viewport.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -46,6 +46,7 @@ function occlusionStyle(plugin: PluginContext) {
             ...plugin.canvas3d!.props.postprocessing,
             occlusion: { name: 'on', params: {
                 blurKernelSize: 15,
+                blurBias: 0.5,
                 multiScale: { name: 'off', params: {} },
                 radius: 5,
                 bias: 0.8,

--- a/src/apps/mesoscale-explorer/ui/states.tsx
+++ b/src/apps/mesoscale-explorer/ui/states.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -77,6 +77,7 @@ function adjustPluginProps(ctx: PluginContext) {
                     radius: 5,
                     bias: 1,
                     blurKernelSize: 11,
+                    blurBias: 0.5,
                     resolutionScale: 1,
                     color: Color(0x000000),
                 }

--- a/src/examples/lighting/index.ts
+++ b/src/examples/lighting/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -33,6 +33,7 @@ const Canvas3DPresets = {
                         radius: 5,
                         bias: 0.8,
                         blurKernelSize: 15,
+                        blurBias: 0.5,
                         resolutionScale: 1,
                         color: Color(0x000000),
                     }

--- a/src/mol-canvas3d/passes/multi-sample.ts
+++ b/src/mol-canvas3d/passes/multi-sample.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -54,6 +54,7 @@ export const MultiSampleParams = {
     mode: PD.Select('temporal', [['off', 'Off'], ['on', 'On'], ['temporal', 'Temporal']]),
     sampleLevel: PD.Numeric(2, { min: 0, max: 5, step: 1 }, { description: 'Take level^2 samples.' }),
     reduceFlicker: PD.Boolean(true, { description: 'Reduce flicker in "temporal" mode.' }),
+    reuseOcclusion: PD.Boolean(true, { description: 'Reuse occlusion data. It is faster but has some artefacts.' }),
 };
 export type MultiSampleProps = PD.Values<typeof MultiSampleParams>
 
@@ -161,7 +162,7 @@ export class MultiSamplePass {
             ValueCell.update(compose.values.uWeight, sampleWeight);
 
             // render scene
-            if (i === 0) {
+            if (i === 0 || !props.multiSample.reuseOcclusion) {
                 drawPass.postprocessing.setOcclusionOffset(0, 0);
             } else {
                 drawPass.postprocessing.setOcclusionOffset(
@@ -252,7 +253,7 @@ export class MultiSamplePass {
                 camera.update();
 
                 // render scene
-                if (sampleIndex === 0) {
+                if (sampleIndex === 0 || !props.multiSample.reuseOcclusion) {
                     drawPass.postprocessing.setOcclusionOffset(0, 0);
                 } else {
                     drawPass.postprocessing.setOcclusionOffset(

--- a/src/mol-canvas3d/passes/postprocessing.ts
+++ b/src/mol-canvas3d/passes/postprocessing.ts
@@ -206,6 +206,7 @@ const SsaoBlurSchema = {
 
     uKernel: UniformSpec('f[]'),
     dOcclusionKernelSize: DefineSpec('number'),
+    uBlurBias: UniformSpec('f'),
 
     uBlurDirectionX: UniformSpec('f'),
     uBlurDirectionY: UniformSpec('f'),
@@ -227,6 +228,7 @@ function getSsaoBlurRenderable(ctx: WebGLContext, ssaoDepthTexture: Texture, dir
 
         uKernel: ValueCell.create(getBlurKernel(15)),
         dOcclusionKernelSize: ValueCell.create(15),
+        uBlurBias: ValueCell.create(0.5),
 
         uBlurDirectionX: ValueCell.create(direction === 'horizontal' ? 1 : 0),
         uBlurDirectionY: ValueCell.create(direction === 'vertical' ? 1 : 0),
@@ -374,6 +376,7 @@ export const PostprocessingParams = {
             radius: PD.Numeric(5, { min: 0, max: 20, step: 0.1 }, { description: 'Final occlusion radius is 2^x', hideIf: p => p?.multiScale.name === 'on' }),
             bias: PD.Numeric(0.8, { min: 0, max: 3, step: 0.1 }),
             blurKernelSize: PD.Numeric(15, { min: 1, max: 25, step: 2 }),
+            blurBias: PD.Numeric(0.5, { min: 0, max: 1, step: 0.01 }),
             resolutionScale: PD.Numeric(1, { min: 0.1, max: 1, step: 0.05 }, { description: 'Adjust resolution of occlusion calculation' }),
             color: PD.Color(Color(0x000000)),
         }),
@@ -649,6 +652,9 @@ export class PostprocessingPass {
 
             ValueCell.update(this.ssaoBlurFirstPassRenderable.values.uInvProjection, invProjection);
             ValueCell.update(this.ssaoBlurSecondPassRenderable.values.uInvProjection, invProjection);
+
+            ValueCell.update(this.ssaoBlurFirstPassRenderable.values.uBlurBias, props.occlusion.params.blurBias);
+            ValueCell.update(this.ssaoBlurSecondPassRenderable.values.uBlurBias, props.occlusion.params.blurBias);
 
             if (this.ssaoBlurFirstPassRenderable.values.dOrthographic.ref.value !== orthographic) {
                 needsUpdateSsaoBlur = true;

--- a/src/mol-gl/shader/ssao-blur.frag.ts
+++ b/src/mol-gl/shader/ssao-blur.frag.ts
@@ -16,6 +16,7 @@ uniform vec2 uTexSize;
 uniform vec4 uBounds;
 
 uniform float uKernel[dOcclusionKernelSize];
+uniform float uBlurBias;
 
 uniform float uBlurDirectionX;
 uniform float uBlurDirectionY;
@@ -68,7 +69,7 @@ void main(void) {
     float selfViewZ = getViewZ(selfDepth);
     float pixelSize = getPixelSize(coords, selfDepth);
     // max diff depth between two pixels
-    float maxDiffViewZ = 1.0;
+    float maxDiffViewZ = 0.1;
 
     vec2 offset = vec2(uBlurDirectionX, uBlurDirectionY) / uTexSize;
 
@@ -91,7 +92,7 @@ void main(void) {
         }
 
         float sampleViewZ = getViewZ(sampleDepth);
-        if (abs(selfViewZ - sampleViewZ) > maxDiffViewZ) {
+        if (abs(selfViewZ - sampleViewZ) >= uBlurBias) {
             continue;
         }
 

--- a/src/mol-plugin-ui/structure/quick-styles.tsx
+++ b/src/mol-plugin-ui/structure/quick-styles.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -70,6 +70,7 @@ export class QuickStyles extends PurePluginUIComponent {
                             radius: 5,
                             bias: 0.8,
                             blurKernelSize: 15,
+                            blurBias: 0.5,
                             samples: 32,
                             resolutionScale: 1,
                             color: Color(0x000000),
@@ -108,6 +109,7 @@ export class QuickStyles extends PurePluginUIComponent {
                                 radius: 5,
                                 bias: 0.8,
                                 blurKernelSize: 15,
+                                blurBias: 0.5,
                                 samples: 32,
                                 resolutionScale: 1,
                                 color: Color(0x000000),

--- a/src/mol-plugin/util/headless-screenshot.ts
+++ b/src/mol-plugin/util/headless-screenshot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Jesse Liang <jesse.liang@rcsb.org>
@@ -209,6 +209,7 @@ export function defaultImagePassParams(): Partial<ImageProps> {
             ...DefaultCanvas3DParams.multiSample,
             mode: 'on',
             sampleLevel: 4,
+            reuseOcclusion: false,
         }
     };
 }
@@ -221,6 +222,7 @@ export const STYLIZED_POSTPROCESSING: Partial<PostprocessingProps> = {
             radius: 5,
             bias: 0.8,
             blurKernelSize: 15,
+            blurBias: 0.5,
             resolutionScale: 1,
             color: ColorNames.black,
         }

--- a/src/mol-plugin/util/viewport-screenshot.ts
+++ b/src/mol-plugin/util/viewport-screenshot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -116,6 +116,7 @@ class ViewportScreenshotHelper extends PluginComponent {
                 ...c.props.multiSample,
                 mode: multisample ? 'on' : 'off',
                 sampleLevel: colorBufferFloat && textureFloat ? 4 : 2,
+                reuseOcclusion: false,
             },
             postprocessing: {
                 ...c.props.postprocessing,


### PR DESCRIPTION
Reported in #1122.

Add `reuseOcclusion` parameter to multi-sample pass. This helps with the first artifact reported. It happens because we reuse the occlusion data in the multi-sample pass for performance. We try to correct for the jitter but apparently it dos not (fully) work. As an alternative/workaround we can disable by default in screenshots.

Add `blurBias` parameter to occlusion pass. Not sure if there is an automatic way to calculate a "correct" value but 0.5 seems to work well. There was a previous issue related to that value in the synaptic gap model, @giagitom, can you check?