### PR TITLE
Take into account explicit hydrogens when creating and representing Hydrogen bonds (regular and weak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Take into account explicit hydrogens when computing hydrogen bonds
 
 ## [v4.4.1] - 2023-06-30
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "Cai Huiyu <szmun.caihy@gmail.com>",
     "Ryan DiRisio <rjdiris@gmail.com>",
     "Dušan Veľký <dvelky@mail.muni.cz>",
-    "Neli Fonseca <neli@ebi.ac.uk>"
+    "Neli Fonseca <neli@ebi.ac.uk>",
+    "Paul Pillot <paul.pillot@tandemai.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-model-props/computed/chemistry/geometry.ts
+++ b/src/mol-model-props/computed/chemistry/geometry.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2017-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Fred Ludlow <Fred.Ludlow@astx.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { degToRad } from '../../../mol-math/misc';

--- a/src/mol-model-props/computed/interactions/halogen-bonds.ts
+++ b/src/mol-model-props/computed/interactions/halogen-bonds.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Fred Ludlow <Fred.Ludlow@astx.com>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  *
  * based in part on NGL (https://github.com/arose/ngl)
  */

--- a/src/mol-model-props/computed/interactions/halogen-bonds.ts
+++ b/src/mol-model-props/computed/interactions/halogen-bonds.ts
@@ -97,12 +97,12 @@ function testHalogenBond(structure: Structure, infoA: Features.Info, infoB: Feat
     const donIndex = don.members[don.offsets[don.feature]];
     const accIndex = acc.members[acc.offsets[acc.feature]];
 
-    const halogenAngles = calcAngles(structure, don.unit, donIndex, acc.unit, accIndex);
+    const [halogenAngles] = calcAngles(structure, don.unit, donIndex, acc.unit, accIndex);
     // Singly bonded halogen only (not bromide ion for example)
     if (halogenAngles.length !== 1) return;
     if (OptimalHalogenAngle - halogenAngles[0] > opts.angleMax) return;
 
-    const acceptorAngles = calcAngles(structure, acc.unit, accIndex, don.unit, donIndex);
+    const [acceptorAngles] = calcAngles(structure, acc.unit, accIndex, don.unit, donIndex);
     // Angle must be defined. Excludes water as acceptor. Debatable
     if (acceptorAngles.length === 0) return;
     if (acceptorAngles.some(acceptorAngle => OptimalAcceptorAngle - acceptorAngle > opts.angleMax)) return;

--- a/src/mol-model-props/computed/interactions/hydrogen-bonds.ts
+++ b/src/mol-model-props/computed/interactions/hydrogen-bonds.ts
@@ -248,12 +248,12 @@ function checkGeometry(structure: Structure, don: Features.Info, acc: Features.I
         if (outOfPlane !== undefined && outOfPlane > opts.maxDonOutOfPlaneAngle) return;
     }
 
-    let donnorIndex = donIndex;
+    let donorIndex = donIndex;
     if (!opts.ignoreHydrogens && donHAngles.length > 0) {
-        donnorIndex = closestHydrogenIndex(structure, don.unit, donIndex, acc.unit, accIndex);
+        donorIndex = closestHydrogenIndex(structure, don.unit, donIndex, acc.unit, accIndex);
     }
 
-    const [accAngles, accHAngles] = calcAngles(structure, acc.unit, accIndex, don.unit, donnorIndex, opts.ignoreHydrogens);
+    const [accAngles, accHAngles] = calcAngles(structure, acc.unit, accIndex, don.unit, donorIndex, opts.ignoreHydrogens);
     const idealAccAngle = AtomGeometryAngles.get(acc.idealGeometry[accIndex]) || deg120InRad;
 
     // Do not limit large acceptor angles

--- a/src/mol-model-props/computed/interactions/hydrogen-bonds.ts
+++ b/src/mol-model-props/computed/interactions/hydrogen-bonds.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2019-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Fred Ludlow <Fred.Ludlow@astx.com>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  *
  * based in part on NGL (https://github.com/arose/ngl)
  */

--- a/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
@@ -54,7 +54,7 @@ function createInterUnitInteractionCylinderMesh(ctx: VisualContext, structure: S
             const uB = structure.unitMap.get(unitB) as Unit.Atomic;
 
             if ((!ignoreHydrogens || ignoreHydrogensVariant !== 'all') && (
-                t === InteractionType.HydrogenBond || t === InteractionType.WeakHydrogenBond)
+                t === InteractionType.HydrogenBond || (t === InteractionType.WeakHydrogenBond && ignoreHydrogensVariant !== 'non-polar'))
             ) {
                 const idxA = fA.members[fA.offsets[indexA]];
                 const idxB = fB.members[fB.offsets[indexB]];
@@ -64,11 +64,12 @@ function createInterUnitInteractionCylinderMesh(ctx: VisualContext, structure: S
                 let minDistB = minDistA;
                 Vec3.copy(posA, pA);
                 Vec3.copy(posB, pB);
-                const isHydrogenDonorA = fA.types[fA.offsets[indexA]] === FeatureType.HydrogenDonor;
+                const donorType = t === InteractionType.HydrogenBond ? FeatureType.HydrogenDonor : FeatureType.WeakHydrogenDonor;
+                const isHydrogenDonorA = fA.types[fA.offsets[indexA]] === donorType;
 
                 if (isHydrogenDonorA) eachBondedAtom(structure, uA, idxA, (u, idx) => {
                     const eI = u.elements[idx];
-                    if (isHydrogen(structure, u, eI, 'polar')) {
+                    if (isHydrogen(structure, u, eI, 'all')) {
                         u.conformation.position(eI, p);
                         const dist = Vec3.distance(p, pB);
                         if (dist < minDistA) {
@@ -80,7 +81,7 @@ function createInterUnitInteractionCylinderMesh(ctx: VisualContext, structure: S
 
                 else eachBondedAtom(structure, uB, idxB, (u, idx) => {
                     const eI = u.elements[idx];
-                    if (isHydrogen(structure, u, eI, 'polar')) {
+                    if (isHydrogen(structure, u, eI, 'all')) {
                         u.conformation.position(eI, p);
                         const dist = Vec3.distance(p, pA);
                         if (dist < minDistB) {

--- a/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2019-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';

--- a/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
@@ -68,29 +68,31 @@ function createInterUnitInteractionCylinderMesh(ctx: VisualContext, structure: S
                 const donorType = t === InteractionType.HydrogenBond ? FeatureType.HydrogenDonor : FeatureType.WeakHydrogenDonor;
                 const isHydrogenDonorA = fA.types[fA.offsets[indexA]] === donorType;
 
-                if (isHydrogenDonorA) eachBondedAtom(structure, uA, idxA, (u, idx) => {
-                    const eI = u.elements[idx];
-                    if (isHydrogen(structure, u, eI, 'all')) {
-                        u.conformation.position(eI, p);
-                        const dist = Vec3.distance(p, pB);
-                        if (dist < minDistA) {
-                            minDistA = dist;
-                            Vec3.copy(posA, p);
+                if (isHydrogenDonorA) {
+                    eachBondedAtom(structure, uA, idxA, (u, idx) => {
+                        const eI = u.elements[idx];
+                        if (isHydrogen(structure, u, eI, 'all')) {
+                            u.conformation.position(eI, p);
+                            const dist = Vec3.distance(p, pB);
+                            if (dist < minDistA) {
+                                minDistA = dist;
+                                Vec3.copy(posA, p);
+                            }
                         }
-                    }
-                });
-
-                else eachBondedAtom(structure, uB, idxB, (u, idx) => {
-                    const eI = u.elements[idx];
-                    if (isHydrogen(structure, u, eI, 'all')) {
-                        u.conformation.position(eI, p);
-                        const dist = Vec3.distance(p, pA);
-                        if (dist < minDistB) {
-                            minDistB = dist;
-                            Vec3.copy(posB, p);
+                    });
+                } else {
+                    eachBondedAtom(structure, uB, idxB, (u, idx) => {
+                        const eI = u.elements[idx];
+                        if (isHydrogen(structure, u, eI, 'all')) {
+                            u.conformation.position(eI, p);
+                            const dist = Vec3.distance(p, pA);
+                            if (dist < minDistB) {
+                                minDistB = dist;
+                                Vec3.copy(posB, p);
+                            }
                         }
-                    }
-                });
+                    });
+                }
             } else {
                 Vec3.set(posA, fA.x[indexA], fA.y[indexA], fA.z[indexA]);
                 Vec3.transformMat4(posA, posA, uA.conformation.operator.matrix);

--- a/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-inter-unit-cylinder.ts
@@ -19,7 +19,7 @@ import { Interval, OrderedSet, SortedArray } from '../../../mol-data/int';
 import { Interactions } from '../interactions/interactions';
 import { InteractionsProvider } from '../interactions';
 import { LocationIterator } from '../../../mol-geo/util/location-iterator';
-import { InteractionFlag, InteractionType } from '../interactions/common';
+import { FeatureType, InteractionFlag, InteractionType } from '../interactions/common';
 import { Unit } from '../../../mol-model/structure/structure';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { assertUnreachable } from '../../../mol-util/type-helpers';
@@ -64,8 +64,9 @@ function createInterUnitInteractionCylinderMesh(ctx: VisualContext, structure: S
                 let minDistB = minDistA;
                 Vec3.copy(posA, pA);
                 Vec3.copy(posB, pB);
+                const isHydrogenDonorA = fA.types[fA.offsets[indexA]] === FeatureType.HydrogenDonor;
 
-                eachBondedAtom(structure, uA, idxA, (u, idx) => {
+                if (isHydrogenDonorA) eachBondedAtom(structure, uA, idxA, (u, idx) => {
                     const eI = u.elements[idx];
                     if (isHydrogen(structure, u, eI, 'polar')) {
                         u.conformation.position(eI, p);
@@ -77,7 +78,7 @@ function createInterUnitInteractionCylinderMesh(ctx: VisualContext, structure: S
                     }
                 });
 
-                eachBondedAtom(structure, uB, idxB, (u, idx) => {
+                else eachBondedAtom(structure, uB, idxB, (u, idx) => {
                     const eI = u.elements[idx];
                     if (isHydrogen(structure, u, eI, 'polar')) {
                         u.conformation.position(eI, p);

--- a/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
@@ -19,7 +19,7 @@ import { UnitsMeshParams, UnitsVisual, UnitsMeshVisual } from '../../../mol-repr
 import { VisualUpdateState } from '../../../mol-repr/util';
 import { LocationIterator } from '../../../mol-geo/util/location-iterator';
 import { Interactions } from '../interactions/interactions';
-import { InteractionFlag } from '../interactions/common';
+import { FeatureType, InteractionFlag } from '../interactions/common';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { StructureGroup, isHydrogen } from '../../../mol-repr/structure/visual/util/common';
 import { assertUnreachable } from '../../../mol-util/type-helpers';
@@ -40,7 +40,7 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
     const features = interactions.unitsFeatures.get(unit.id);
     const contacts = interactions.unitsContacts.get(unit.id);
 
-    const { x, y, z, members, offsets } = features;
+    const { x, y, z, members, offsets, types } = features;
     const { edgeCount, a, b, edgeProps: { flag, type } } = contacts;
     const { sizeFactor, ignoreHydrogens, ignoreHydrogensVariant, parentDisplay } = props;
 
@@ -66,8 +66,9 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
                 let minDistB = minDistA;
                 Vec3.copy(posA, pA);
                 Vec3.copy(posB, pB);
+                const isHydrogeDonorA = types[offsets[a[edgeIndex]]] === FeatureType.HydrogenDonor;
 
-                eachIntraBondedAtom(unit, idxA, (_, idx) => {
+                if (isHydrogeDonorA) eachIntraBondedAtom(unit, idxA, (_, idx) => {
                     if (isHydrogen(structure, unit, elements[idx], 'polar')) {
                         c.invariantPosition(elements[idx], p);
                         const dist = Vec3.distance(p, pB);
@@ -78,7 +79,7 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
                     }
                 });
 
-                eachIntraBondedAtom(unit, idxB, (_, idx) => {
+                else eachIntraBondedAtom(unit, idxB, (_, idx) => {
                     if (isHydrogen(structure, unit, elements[idx], 'polar')) {
                         c.invariantPosition(elements[idx], p);
                         const dist = Vec3.distance(p, pA);

--- a/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2019-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { Unit, Structure, StructureElement } from '../../../mol-model/structure';

--- a/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
@@ -70,27 +70,29 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
                 const donorType = t === InteractionType.HydrogenBond ? FeatureType.HydrogenDonor : FeatureType.WeakHydrogenDonor;
                 const isHydrogenDonorA = types[offsets[a[edgeIndex]]] === donorType;
 
-                if (isHydrogenDonorA) eachIntraBondedAtom(unit, idxA, (_, idx) => {
-                    if (isHydrogen(structure, unit, elements[idx], 'all')) {
-                        c.invariantPosition(elements[idx], p);
-                        const dist = Vec3.distance(p, pB);
-                        if (dist < minDistA) {
-                            minDistA = dist;
-                            Vec3.copy(posA, p);
+                if (isHydrogenDonorA) {
+                    eachIntraBondedAtom(unit, idxA, (_, idx) => {
+                        if (isHydrogen(structure, unit, elements[idx], 'all')) {
+                            c.invariantPosition(elements[idx], p);
+                            const dist = Vec3.distance(p, pB);
+                            if (dist < minDistA) {
+                                minDistA = dist;
+                                Vec3.copy(posA, p);
+                            }
                         }
-                    }
-                });
-
-                else eachIntraBondedAtom(unit, idxB, (_, idx) => {
-                    if (isHydrogen(structure, unit, elements[idx], 'all')) {
-                        c.invariantPosition(elements[idx], p);
-                        const dist = Vec3.distance(p, pA);
-                        if (dist < minDistB) {
-                            minDistB = dist;
-                            Vec3.copy(posB, p);
+                    });
+                } else {
+                    eachIntraBondedAtom(unit, idxB, (_, idx) => {
+                        if (isHydrogen(structure, unit, elements[idx], 'all')) {
+                            c.invariantPosition(elements[idx], p);
+                            const dist = Vec3.distance(p, pA);
+                            if (dist < minDistB) {
+                                minDistB = dist;
+                                Vec3.copy(posB, p);
+                            }
                         }
-                    }
-                });
+                    });
+                }
             } else {
                 Vec3.set(posA, x[a[edgeIndex]], y[a[edgeIndex]], z[a[edgeIndex]]);
                 Vec3.set(posB, x[b[edgeIndex]], y[b[edgeIndex]], z[b[edgeIndex]]);

--- a/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
+++ b/src/mol-model-props/computed/representations/interactions-intra-unit-cylinder.ts
@@ -56,7 +56,7 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
         position: (posA: Vec3, posB: Vec3, edgeIndex: number) => {
             const t = type[edgeIndex];
             if ((!ignoreHydrogens || ignoreHydrogensVariant !== 'all') && (
-                t === InteractionType.HydrogenBond || t === InteractionType.WeakHydrogenBond)
+                t === InteractionType.HydrogenBond || (t === InteractionType.WeakHydrogenBond && ignoreHydrogensVariant !== 'non-polar'))
             ) {
                 const idxA = members[offsets[a[edgeIndex]]];
                 const idxB = members[offsets[b[edgeIndex]]];
@@ -66,10 +66,11 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
                 let minDistB = minDistA;
                 Vec3.copy(posA, pA);
                 Vec3.copy(posB, pB);
-                const isHydrogeDonorA = types[offsets[a[edgeIndex]]] === FeatureType.HydrogenDonor;
+                const donorType = t === InteractionType.HydrogenBond ? FeatureType.HydrogenDonor : FeatureType.WeakHydrogenDonor;
+                const isHydrogenDonorA = types[offsets[a[edgeIndex]]] === donorType;
 
-                if (isHydrogeDonorA) eachIntraBondedAtom(unit, idxA, (_, idx) => {
-                    if (isHydrogen(structure, unit, elements[idx], 'polar')) {
+                if (isHydrogenDonorA) eachIntraBondedAtom(unit, idxA, (_, idx) => {
+                    if (isHydrogen(structure, unit, elements[idx], 'all')) {
                         c.invariantPosition(elements[idx], p);
                         const dist = Vec3.distance(p, pB);
                         if (dist < minDistA) {
@@ -80,7 +81,7 @@ async function createIntraUnitInteractionsCylinderMesh(ctx: VisualContext, unit:
                 });
 
                 else eachIntraBondedAtom(unit, idxB, (_, idx) => {
-                    if (isHydrogen(structure, unit, elements[idx], 'polar')) {
+                    if (isHydrogen(structure, unit, elements[idx], 'all')) {
                         c.invariantPosition(elements[idx], p);
                         const dist = Vec3.distance(p, pA);
                         if (dist < minDistB) {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Fixes #1163 
This PR refines the way Hydrogen bonds are created and represented when explicit hydrogen atoms atoms are present:
- Donors: the angle between H-Donor-Acceptor must be below the Donor Deviation angle value. This ensures that when H atoms are present on the donor, there is at least one atom positioned in a conic region of angle 90º between the donor and the acceptor
- Acceptors: the H atoms are taken into account to satisfy the geometry of the bond towards the donor. This is the same criteria as for heavy atoms bonded to the acceptor. It ensures that there are no hydrogen atoms on the acceptor that are "in the way" of the hydrogen bond. In other words, the hydrogen bonds is anchored on an unoccupied area of the acceptor.
- Representations: links are made using the closest hydrogen atom of the donor atom (not on the acceptor) when hydrogen atoms are represented. If only polar hydrogens are represented, they are used for regular hydrogen bonds, but weak hydrogens bonds are anchored on the C donor directly.
- A new geometry option has been added "Ignore Hydrogens". This takes into account the hydrogen atoms position for calculating the interactions. It is set to `false` by default. My understanding is that this option is different than the one that controls the display of the hydrogen atoms, as I can think that someone might wish to hide the hydrogen atoms but still benefit from using the explicit hydrogens to display only the most "realistic" hydrogen bonds. And in some cases, if the hydrogens atoms have been places arbitrarily, one might wish to not base interactions on their positions.
<img width="293" alt="Screenshot 2024-06-25 at 11 30 12" src="https://github.com/molstar/molstar/assets/116235895/5fc619f7-3cc8-4d4b-a75e-d17caa4711f4">


## Comparison with other implementations
Using PDB code 1GJ5 and looking at the interactions with ligand [130] (using PDB file as input)
| Viewers   | Total HBonds | Water Hbonds | Sulfur HBond |
|-----------|--------------|----------------|--------------|
| MolStar     | 7                    | 2                        | 1                      |
| ChimeraX | 5                     | 1                        | 0                     |
| PyMol       | 5                     | 2                        | 0                    |
|MolStar 4.3| 13                  | 4                        | 1                     |

The most dubious one is this water hydrogen bond:
<img width="290" alt="image" src="https://github.com/molstar/molstar/assets/116235895/f5c2c132-201d-43a0-b42e-f7e08ad8a70a">
(note that the covalent bond from the ligand oxygen is not in the PDB file, and not represented in the other viewers)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`