### PR TITLE
doNotDisposeCanvas3DContext option in PluginContext.dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - `celShaded` geometry parameter
     - `celSteps` renderer parameter
 - Add the ability to customize the Snapshot Description component via `PluginUISpec.components.viewport.snapshotDescription`
+- Add `doNotDisposeCanvas3DContext` option to `PluginContext.dispose` 
 
 ## [v4.3.0] - 2023-05-26
 

--- a/src/mol-plugin/context.ts
+++ b/src/mol-plugin/context.ts
@@ -374,7 +374,7 @@ export class PluginContext {
         return PluginCommands.State.RemoveObject(this, { state: this.state.data, ref: StateTransform.RootRef });
     }
 
-    dispose(options?: { doNotForceWebGLContextLoss?: boolean }) {
+    dispose(options?: { doNotForceWebGLContextLoss?: boolean, doNotDisposeCanvas3DContext?: boolean }) {
         if (this.disposed) return;
 
         for (const s of this.subs) {
@@ -385,7 +385,9 @@ export class PluginContext {
         this.animationLoop.stop();
         this.commands.dispose();
         this.canvas3d?.dispose();
-        this.canvas3dContext?.dispose(options);
+        if (!options?.doNotDisposeCanvas3DContext) {
+            this.canvas3dContext?.dispose(options);
+        }
         this.ev.dispose();
         this.state.dispose();
         this.helpers.substructureParent.dispose();

--- a/src/mol-plugin/context.ts
+++ b/src/mol-plugin/context.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Allow sharing single canvas3d context with multiple plugins that need to be disposed.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files