### PR TITLE
Update  `misc.scss` `msp-no-webgl` syntax to be in line with latest sass requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix DoF missing transparent depth
 - Fix trackball pinch zoom and add pan
 - Change trackball animate spin speed unit to radians per second
+- Fix `mol-plugin-ui/skin/base/components/misc.scss` syntax to be in line with latest Sass syntax
 
 ## [v4.4.1] - 2023-06-30
 

--- a/src/mol-plugin-ui/skin/base/components/misc.scss
+++ b/src/mol-plugin-ui/skin/base/components/misc.scss
@@ -40,11 +40,14 @@
         b {
             font-size: 120%;
         }
-        display: table-cell;
-        vertical-align: middle;
-        text-align: center;
-        width: 100%;
-        height: 100%;
+
+        & {
+            display: table-cell;
+            vertical-align: middle;
+            text-align: center;
+            width: 100%;
+            height: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Closes #1198 . On node builds, we currently get a Sass deprecation warning due to the latest version update on Sass,  where they started warning users to be more in line with traditional CSS semantics in .scss files.

NOTE: In draft to start, since I don't know how to ensure that this is fully resolved.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`