### PR TITLE
Pass current colorTheme props to theme provider

### DIFF
--- a/src/mol-theme/theme.ts
+++ b/src/mol-theme/theme.ts
@@ -54,8 +54,8 @@ namespace Theme {
     }
 
     export async function ensureDependencies(ctx: CustomProperty.Context, theme: ThemeRegistryContext, data: ThemeDataContext, props: Props) {
-        await theme.colorThemeRegistry.get(props.colorTheme.name).ensureCustomProperties?.attach(ctx, data);
-        await theme.sizeThemeRegistry.get(props.sizeTheme.name).ensureCustomProperties?.attach(ctx, data);
+        await theme.colorThemeRegistry.get(props.colorTheme.name).ensureCustomProperties?.attach(ctx, data, props.colorTheme);
+        await theme.sizeThemeRegistry.get(props.sizeTheme.name).ensureCustomProperties?.attach(ctx, data, props.sizeTheme);
     }
 
     export function releaseDependencies(theme: ThemeRegistryContext, data: ThemeDataContext, props: Props) {
@@ -75,7 +75,7 @@ export interface ThemeProvider<T extends ColorTheme<P, G> | SizeTheme<P>, P exte
     readonly defaultValues: PD.Values<P>
     readonly isApplicable: (ctx: ThemeDataContext) => boolean
     readonly ensureCustomProperties?: {
-        attach: (ctx: CustomProperty.Context, data: ThemeDataContext) => Promise<void>,
+        attach: (ctx: CustomProperty.Context, data: ThemeDataContext, props?: PD.Values<P>) => Promise<void>,
         detach: (data: ThemeDataContext) => void
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

I am writing a colorTheme which allows the user to customize the underlying parameters of the CustomStructurePropertyProvider. I found that current implementations do not allow `props` to be passed from colorTheme to CustomStructurePropertyProvider, so I did the following modifications:

```typescript
    export async function ensureDependencies(ctx: CustomProperty.Context, theme: ThemeRegistryContext, data: ThemeDataContext, props: Props) {
        // old: await theme.colorThemeRegistry.get(props.colorTheme.name).ensureCustomProperties?.attach(ctx, data);
        // old: await theme.sizeThemeRegistry.get(props.sizeTheme.name).ensureCustomProperties?.attach(ctx, data);
        await theme.colorThemeRegistry.get(props.colorTheme.name).ensureCustomProperties?.attach(ctx, data, props.colorTheme);
        await theme.sizeThemeRegistry.get(props.sizeTheme.name).ensureCustomProperties?.attach(ctx, data, props.sizeTheme);
    }
```

This allows for more detailed control over property computation, for example:

```typescript
import { AccessibleSurfaceAreaProvider, AccessibleSurfaceAreaParams } from '../accessible-surface-area';
export const AccessibleSurfaceAreaColorThemeParams = {
    list: PD.ColorList('rainbow', { presetKind: 'scale' }),
    ...AccessibleSurfaceAreaParams // now user can modify AccessibleSurfaceAreaParams in color theme setting!
};

export const AccessibleSurfaceAreaColorThemeProvider: ColorTheme.Provider<AccessibleSurfaceAreaColorThemeParams, 'accessible-surface-area'> = {
    ...
    ensureCustomProperties: {
        attach: (ctx: CustomProperty.Context, data: ThemeDataContext, props?: Partial<PD.Values<AccessibleSurfaceAreaColorThemeParams>>) => {
            return data.structure ? AccessibleSurfaceAreaProvider.attach(ctx, data.structure, props, true) : Promise.resolve()
        },
        detach: (data) => data.structure && AccessibleSurfaceAreaProvider.ref(data.structure, false)
    }
};
```


## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`