### PR TITLE
Avoid calculating bonds for water units when `ignoreHydrogens` is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Fix missing Sequence UI update on state object removal (#1219)
 - Improved prmtop format support (CTITLE, %COMMENT)
+- Avoid calculating bonds for water units when `ignoreHydrogens` is on
+- Add `Water` trait to `Unit`
 
 ## [v4.5.0] - 2023-07-28
 

--- a/src/mol-geo/util/location-iterator.ts
+++ b/src/mol-geo/util/location-iterator.ts
@@ -115,6 +115,30 @@ export function LocationIterator(groupCount: number, instanceCount: number, stri
     };
 }
 
+export const EmptyLocationIterator: LocationIterator = {
+    get hasNext() { return false; },
+    get isNextNewInstance() { return false; },
+    groupCount: 0,
+    instanceCount: 0,
+    count: 0,
+    stride: 0,
+    nonInstanceable: false,
+    hasLocation2: false,
+    move() {
+        return {
+            location: NullLocation as Location,
+            location2: NullLocation as Location,
+            index: 0,
+            groupIndex: 0,
+            instanceIndex: 0,
+            isSecondary: false
+        };
+    },
+    reset() {},
+    skipInstance() {},
+    voidInstances() {}
+};
+
 //
 
 /** A position Location */

--- a/src/mol-model/structure/structure/unit.ts
+++ b/src/mol-model/structure/structure/unit.ts
@@ -130,6 +130,7 @@ namespace Unit {
         MultiChain = 0x1,
         Partitioned = 0x2,
         FastBoundary = 0x4,
+        Water = 0x8,
     }
     export namespace Traits {
         export const is: (t: Traits, f: Trait) => boolean = BitFlags.has;

--- a/src/mol-repr/structure/visual/bond-inter-unit-line.ts
+++ b/src/mol-repr/structure/visual/bond-inter-unit-line.ts
@@ -14,9 +14,10 @@ import { LinkStyle, createLinkLines, LinkBuilderProps } from './util/link';
 import { ComplexVisual, ComplexLinesVisual, ComplexLinesParams } from '../complex-visual';
 import { VisualUpdateState } from '../../util';
 import { BondType } from '../../../mol-model/structure/model/types';
-import { BondIterator, getInterBondLoci, eachInterBond, BondLineParams, makeInterBondIgnoreTest } from './util/bond';
+import { BondIterator, getInterBondLoci, eachInterBond, BondLineParams, makeInterBondIgnoreTest, hasStructureVisibleBonds } from './util/bond';
 import { Lines } from '../../../mol-geo/geometry/lines/lines';
 import { Sphere3D } from '../../../mol-math/geometry';
+import { EmptyLocationIterator } from '../../../mol-geo/util/location-iterator';
 
 const tmpRefPosBondIt = new Bond.ElementBondIterator();
 function setRefPosition(pos: Vec3, structure: Structure, unit: Unit.Atomic, index: StructureElement.UnitIndex) {
@@ -30,6 +31,8 @@ function setRefPosition(pos: Vec3, structure: Structure, unit: Unit.Atomic, inde
 }
 
 function createInterUnitBondLines(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<InterUnitBondLineParams>, lines?: Lines) {
+    if (!hasStructureVisibleBonds(structure, props)) return Lines.createEmpty(lines);
+
     const bonds = structure.interUnitBonds;
     const { edgeCount, edges } = bonds;
 
@@ -127,7 +130,11 @@ export function InterUnitBondLineVisual(materialId: number): ComplexVisual<Inter
     return ComplexLinesVisual<InterUnitBondLineParams>({
         defaultProps: PD.getDefaultValues(InterUnitBondLineParams),
         createGeometry: createInterUnitBondLines,
-        createLocationIterator: (structure: Structure) => BondIterator.fromStructure(structure),
+        createLocationIterator: (structure: Structure, props: PD.Values<InterUnitBondLineParams>) => {
+            return !hasStructureVisibleBonds(structure, props)
+                ? EmptyLocationIterator
+                : BondIterator.fromStructure(structure);
+        },
         getLoci: getInterBondLoci,
         eachLocation: eachInterBond,
         setUpdateState: (state: VisualUpdateState, newProps: PD.Values<InterUnitBondLineParams>, currentProps: PD.Values<InterUnitBondLineParams>, newTheme: Theme, currentTheme: Theme, newStructure: Structure, currentStructure: Structure) => {
@@ -144,7 +151,7 @@ export function InterUnitBondLineVisual(materialId: number): ComplexVisual<Inter
                 newProps.multipleBonds !== currentProps.multipleBonds
             );
 
-            if (newStructure.interUnitBonds !== currentStructure.interUnitBonds) {
+            if (hasStructureVisibleBonds(newStructure, newProps) && newStructure.interUnitBonds !== currentStructure.interUnitBonds) {
                 state.createGeometry = true;
                 state.updateTransform = true;
                 state.updateColor = true;

--- a/src/mol-repr/structure/visual/bond-intra-unit-cylinder.ts
+++ b/src/mol-repr/structure/visual/bond-intra-unit-cylinder.ts
@@ -18,7 +18,7 @@ import { createLinkCylinderImpostors, createLinkCylinderMesh, LinkBuilderProps, 
 import { UnitsMeshParams, UnitsVisual, UnitsMeshVisual, UnitsCylindersParams, UnitsCylindersVisual } from '../units-visual';
 import { VisualUpdateState } from '../../util';
 import { BondType } from '../../../mol-model/structure/model/types';
-import { BondCylinderParams, BondIterator, eachIntraBond, getIntraBondLoci, ignoreBondType, makeIntraBondIgnoreTest } from './util/bond';
+import { BondCylinderParams, BondIterator, eachIntraBond, getIntraBondLoci, hasUnitVisibleBonds, ignoreBondType, makeIntraBondIgnoreTest } from './util/bond';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { IntAdjacencyGraph } from '../../../mol-math/graph';
 import { WebGLContext } from '../../../mol-gl/webgl/context';
@@ -172,6 +172,7 @@ function getIntraUnitBondCylinderBuilderProps(unit: Unit.Atomic, structure: Stru
 
 function createIntraUnitBondCylinderImpostors(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: PD.Values<IntraUnitBondCylinderParams>, cylinders?: Cylinders): Cylinders {
     if (!Unit.isAtomic(unit)) return Cylinders.createEmpty(cylinders);
+    if (!hasUnitVisibleBonds(unit, props)) return Cylinders.createEmpty(cylinders);
     if (!unit.bonds.edgeCount) return Cylinders.createEmpty(cylinders);
 
     const { child } = structure;
@@ -193,6 +194,7 @@ function createIntraUnitBondCylinderImpostors(ctx: VisualContext, unit: Unit, st
 
 function createIntraUnitBondCylinderMesh(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: PD.Values<IntraUnitBondCylinderParams>, mesh?: Mesh): Mesh {
     if (!Unit.isAtomic(unit)) return Mesh.createEmpty(mesh);
+    if (!hasUnitVisibleBonds(unit, props)) return Mesh.createEmpty(mesh);
     if (!unit.bonds.edgeCount) return Mesh.createEmpty(mesh);
 
     const { child } = structure;

--- a/src/mol-repr/structure/visual/bond-intra-unit-line.ts
+++ b/src/mol-repr/structure/visual/bond-intra-unit-line.ts
@@ -14,7 +14,7 @@ import { LinkStyle, createLinkLines, LinkBuilderProps } from './util/link';
 import { UnitsVisual, UnitsLinesParams, UnitsLinesVisual } from '../units-visual';
 import { VisualUpdateState } from '../../util';
 import { BondType } from '../../../mol-model/structure/model/types';
-import { BondIterator, BondLineParams, getIntraBondLoci, eachIntraBond, makeIntraBondIgnoreTest, ignoreBondType } from './util/bond';
+import { BondIterator, BondLineParams, getIntraBondLoci, eachIntraBond, makeIntraBondIgnoreTest, ignoreBondType, hasUnitVisibleBonds } from './util/bond';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { Lines } from '../../../mol-geo/geometry/lines/lines';
 import { IntAdjacencyGraph } from '../../../mol-math/graph';
@@ -26,6 +26,7 @@ const isBondType = BondType.is;
 
 function createIntraUnitBondLines(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: PD.Values<IntraUnitBondLineParams>, lines?: Lines) {
     if (!Unit.isAtomic(unit)) return Lines.createEmpty(lines);
+    if (!hasUnitVisibleBonds(unit, props)) return Lines.createEmpty(lines);
 
     const { child } = structure;
     const childUnit = child?.unitMap.get(unit.id);

--- a/src/mol-repr/structure/visual/element-cross.ts
+++ b/src/mol-repr/structure/visual/element-cross.ts
@@ -76,18 +76,19 @@ export function createElementCross(ctx: VisualContext, unit: Unit, structure: St
         builder.add(s[0], s[1], s[2], e[0], e[1], e[2], i);
     }
 
-    const oldBoundingSphere = lines ? Sphere3D.clone(lines.boundingSphere) : undefined;
     const l = builder.getLines();
     if (count === 0) return l;
 
     // re-use boundingSphere if it has not changed much
+    let boundingSphere: Sphere3D;
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = lines ? Sphere3D.clone(lines.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
-        l.setBoundingSphere(oldBoundingSphere);
+        boundingSphere = oldBoundingSphere;
     } else {
-        const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, 1 * props.sizeFactor);
-        l.setBoundingSphere(sphere);
+        boundingSphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, 1 * props.sizeFactor);
     }
+    l.setBoundingSphere(boundingSphere);
 
     return l;
 }

--- a/src/mol-repr/structure/visual/element-cross.ts
+++ b/src/mol-repr/structure/visual/element-cross.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -16,8 +16,10 @@ import { Sphere3D } from '../../../mol-math/geometry';
 import { Lines } from '../../../mol-geo/geometry/lines/lines';
 import { LinesBuilder } from '../../../mol-geo/geometry/lines/lines-builder';
 import { bondCount } from '../../../mol-model-props/computed/chemistry/util';
+import { hasUnitVisibleBonds } from './util/bond';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
+const v3add = Vec3.add;
 const v3scaleAndAdd = Vec3.scaleAndAdd;
 const v3unitX = Vec3.unitX;
 const v3unitY = Vec3.unitY;
@@ -52,11 +54,17 @@ export function createElementCross(ctx: VisualContext, unit: Unit, structure: St
     const r = props.crossSize / 2;
     const lone = props.crosses === 'lone';
 
+    const center = Vec3();
+    let count = 0;
+
     for (let i = 0 as StructureElement.UnitIndex; i < n; ++i) {
         if (ignore && ignore(elements[i])) continue;
-        if (lone && Unit.isAtomic(unit) && bondCount(structure, unit, i) !== 0) continue;
+        if (lone && Unit.isAtomic(unit) && hasUnitVisibleBonds(unit, props) && bondCount(structure, unit, i) !== 0) continue;
 
         c.invariantPosition(elements[i], p);
+        v3add(center, center, p);
+        count += 1;
+
         v3scaleAndAdd(s, p, v3unitX, r);
         v3scaleAndAdd(e, p, v3unitX, -r);
         builder.add(s[0], s[1], s[2], e[0], e[1], e[2], i);
@@ -68,10 +76,18 @@ export function createElementCross(ctx: VisualContext, unit: Unit, structure: St
         builder.add(s[0], s[1], s[2], e[0], e[1], e[2], i);
     }
 
+    const oldBoundingSphere = lines ? Sphere3D.clone(lines.boundingSphere) : undefined;
     const l = builder.getLines();
+    if (count === 0) return l;
 
-    const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, 1 * props.sizeFactor);
-    l.setBoundingSphere(sphere);
+    // re-use boundingSphere if it has not changed much
+    Vec3.scale(center, center, 1 / count);
+    if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
+        l.setBoundingSphere(oldBoundingSphere);
+    } else {
+        const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, 1 * props.sizeFactor);
+        l.setBoundingSphere(sphere);
+    }
 
     return l;
 }

--- a/src/mol-repr/structure/visual/element-point.ts
+++ b/src/mol-repr/structure/visual/element-point.ts
@@ -65,13 +65,13 @@ export function createElementPoint(ctx: VisualContext, unit: Unit, structure: St
         }
     }
 
-    const oldBoundingSphere = points ? Sphere3D.clone(points.boundingSphere) : undefined;
     const pt = builder.getPoints();
     if (count === 0) return pt;
 
     // re-use boundingSphere if it has not changed much
     let boundingSphere: Sphere3D;
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = points ? Sphere3D.clone(points.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
         boundingSphere = oldBoundingSphere;
     } else {

--- a/src/mol-repr/structure/visual/util/bond.ts
+++ b/src/mol-repr/structure/visual/util/bond.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -123,6 +123,17 @@ export function makeInterBondIgnoreTest(structure: Structure, props: BondProps):
 
         return false;
     };
+}
+
+export function hasUnitVisibleBonds(unit: Unit.Atomic, props: { ignoreHydrogens: boolean }) {
+    return !(props.ignoreHydrogens && Unit.Traits.is(unit.traits, Unit.Trait.Water));
+}
+
+export function hasStructureVisibleBonds(structure: Structure, props: { ignoreHydrogens: boolean }) {
+    for (const { units } of structure.unitSymmetryGroups) {
+        if (Unit.isAtomic(units[0]) && hasUnitVisibleBonds(units[0], props)) return true;
+    }
+    return false;
 }
 
 export namespace BondIterator {

--- a/src/mol-repr/structure/visual/util/element.ts
+++ b/src/mol-repr/structure/visual/util/element.ts
@@ -97,13 +97,13 @@ export function createElementSphereMesh(ctx: VisualContext, unit: Unit, structur
         addSphere(builderState, v, size * sizeFactor, detail);
     }
 
-    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
     const m = MeshBuilder.getMesh(builderState);
     if (count === 0) return m;
 
     // re-use boundingSphere if it has not changed much
     let boundingSphere: Sphere3D;
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
         boundingSphere = oldBoundingSphere;
     } else {
@@ -158,13 +158,13 @@ export function createElementSphereImpostor(ctx: VisualContext, unit: Unit, stru
         maxSize = themeSize(l);
     }
 
-    const oldBoundingSphere = spheres ? Sphere3D.clone(spheres.boundingSphere) : undefined;
     const s = builder.getSpheres();
     if (count === 0) return s;
 
     // re-use boundingSphere if it has not changed much
     let boundingSphere: Sphere3D;
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = spheres ? Sphere3D.clone(spheres.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
         boundingSphere = oldBoundingSphere;
     } else {
@@ -261,13 +261,13 @@ export function createStructureElementSphereMesh(ctx: VisualContext, structure: 
         }
     }
 
-    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
     const m = MeshBuilder.getMesh(builderState);
     if (count === 0) return m;
 
     // re-use boundingSphere if it has not changed much
     let boundingSphere: Sphere3D;
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 1.0) {
         boundingSphere = oldBoundingSphere;
     } else {
@@ -329,13 +329,13 @@ export function createStructureElementSphereImpostor(ctx: VisualContext, structu
         }
     }
 
-    const oldBoundingSphere = spheres ? Sphere3D.clone(spheres.boundingSphere) : undefined;
     const s = builder.getSpheres();
     if (count === 0) return s;
 
     // re-use boundingSphere if it has not changed much
     let boundingSphere: Sphere3D;
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = spheres ? Sphere3D.clone(spheres.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 1.0) {
         boundingSphere = oldBoundingSphere;
     } else {

--- a/src/mol-repr/structure/visual/util/link.ts
+++ b/src/mol-repr/structure/visual/util/link.ts
@@ -246,12 +246,12 @@ export function createLinkCylinderMesh(ctx: VisualContext, linkBuilder: LinkBuil
         }
     }
 
-    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
     const m = MeshBuilder.getMesh(builderState);
     if (count === 0) return { mesh: m };
 
     // re-use boundingSphere if it has not changed much
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
         return { mesh: m, boundingSphere: oldBoundingSphere };
     } else {
@@ -359,12 +359,12 @@ export function createLinkCylinderImpostors(ctx: VisualContext, linkBuilder: Lin
         }
     }
 
-    const oldBoundingSphere = cylinders ? Sphere3D.clone(cylinders.boundingSphere) : undefined;
     const c = builder.getCylinders();
     if (count === 0) return { cylinders: c };
 
     // re-use boundingSphere if it has not changed much
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = cylinders ? Sphere3D.clone(cylinders.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
         return { cylinders: c, boundingSphere: oldBoundingSphere };
     } else {
@@ -469,12 +469,12 @@ export function createLinkLines(ctx: VisualContext, linkBuilder: LinkBuilderProp
         }
     }
 
-    const oldBoundingSphere = lines ? Sphere3D.clone(lines.boundingSphere) : undefined;
     const l = builder.getLines();
     if (count === 0) return { lines: l };
 
     // re-use boundingSphere if it has not changed much
     Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = lines ? Sphere3D.clone(lines.boundingSphere) : undefined;
     if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
         return { lines: l, boundingSphere: oldBoundingSphere };
     } else {


### PR DESCRIPTION
Avoid calculating bonds for water units when `ignoreHydrogens` is on

- Add `Water` trait to `Unit`
- Remove unsued code from `Structure.ofModel`
- Try reuse boundary in element-cross visual