### PR TITLE
Support for AlphaFold DB BinaryCIF files and 4-character PDB-Dev IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note that since we don't clearly distinguish between a public and private interf
 - Avoid calculating bonds for water units when `ignoreHydrogens` is on
 - Add `Water` trait to `Unit`
 - Improve entity-id coloring for structures with multiple models from the same source (#1221)
+- AlphaFold DB: Add BinaryCIF support when fetching data
+- PDB-Dev: Add support for 4-character PDB IDs (e.g., 8ZZC)
 
 ## [v4.5.0] - 2024-07-28
 

--- a/src/apps/viewer/app.ts
+++ b/src/apps/viewer/app.ts
@@ -318,7 +318,10 @@ export class Viewer {
             source: {
                 name: 'alphafolddb' as const,
                 params: {
-                    id: afdb,
+                    provider: {
+                        id: afdb,
+                        encoding: 'bcif'
+                    },
                     options: {
                         ...params.source.params.options,
                         representation: 'preset-structure-representation-ma-quality-assessment-plddt'

--- a/src/mol-plugin-state/actions/structure.ts
+++ b/src/mol-plugin-state/actions/structure.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -40,7 +40,7 @@ export const PdbDownloadProvider = {
         encoding: PD.Select('bcif', PD.arrayToOptions(['cif', 'bcif'] as const)),
     }, { label: 'RCSB PDB', isFlat: true }),
     'pdbe': PD.Group({
-        variant: PD.Select('updated-bcif', [['updated-bcif', 'Updated (bcif)'], ['updated', 'Updated'], ['archival', 'Archival']] as ['updated' | 'updtaed-bcif' | 'archival', string][]),
+        variant: PD.Select('updated-bcif', [['updated-bcif', 'Updated (bcif)'], ['updated', 'Updated'], ['archival', 'Archival']] as ['updated' | 'updated-bcif' | 'archival', string][]),
     }, { label: 'PDBe', isFlat: true }),
     'pdbj': PD.EmptyGroup({ label: 'PDBj' }),
 };


### PR DESCRIPTION
# Description
- add option to fetch BinaryCIF from AlphaFold DB and make that the default
  - I saw @midlik starting to use these files, so I'm assuming that AlphaFold DB finally fully supports BinaryCIF
- PDB-Dev now uses PDB-style identifiers alongside the old style (e.g., PDBDEV_00000012 = 8ZZC)
  - future depositions will only have PDB-style identifiers but not the old PDBDEV_00000012 style
  - this PR ensures support for both styles
  - also note that PDB-Dev currently fails to serve data via the old identifiers but this will be fixed by next Wednesday (in the meantime, [pdb-dev-beta.wwpdb.org](https://pdb-dev-beta.wwpdb.org/bcif/PDBDEV_00000001.bcif) works for testing)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`