### PR TITLE
compression-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix polymer-gap visual coloring with cartoon theme
 - Add formal-charge color theme (#328)
 - Add more coloring options to cartoon theme
+- Use `CompressionStream` Browser API when available
 
 ## [v4.5.0] - 2024-07-28
 

--- a/src/mol-util/zip/util.ts
+++ b/src/mol-util/zip/util.ts
@@ -7,17 +7,23 @@
  * MIT License, Copyright (c) 2018 Photopea
  */
 
-let hasCompressionStreamSupport: boolean | undefined = undefined;
-export function checkCompressionStreamSupport(format: 'deflate' | 'deflate-raw' | 'gzip'): boolean {
-    if (hasCompressionStreamSupport === undefined) {
+type CompressionStreamFormat = 'deflate' | 'deflate-raw' | 'gzip';
+
+const hasCompressionStreamSupport: { [k in CompressionStreamFormat]: boolean | undefined } = {
+    deflate: undefined,
+    'deflate-raw': undefined,
+    gzip: undefined
+};
+export function checkCompressionStreamSupport(format: CompressionStreamFormat): boolean {
+    if (hasCompressionStreamSupport[format] === undefined) {
         try {
             new CompressionStream(format);
-            hasCompressionStreamSupport = true;
+            hasCompressionStreamSupport[format] = true;
         } catch (e) {
-            hasCompressionStreamSupport = false;
+            hasCompressionStreamSupport[format] = false;
         }
     }
-    return hasCompressionStreamSupport;
+    return hasCompressionStreamSupport[format];
 }
 
 export const U = (function () {

--- a/src/mol-util/zip/util.ts
+++ b/src/mol-util/zip/util.ts
@@ -1,11 +1,24 @@
 /**
- * Copyright (c) 2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  *
  * ported from https://github.com/photopea/UZIP.js/blob/master/UZIP.js
  * MIT License, Copyright (c) 2018 Photopea
  */
+
+let hasCompressionStreamSupport: boolean | undefined = undefined;
+export function checkCompressionStreamSupport(format: 'deflate' | 'deflate-raw' | 'gzip'): boolean {
+    if (hasCompressionStreamSupport === undefined) {
+        try {
+            new CompressionStream(format);
+            hasCompressionStreamSupport = true;
+        } catch (e) {
+            hasCompressionStreamSupport = false;
+        }
+    }
+    return hasCompressionStreamSupport;
+}
 
 export const U = (function () {
     const u16 = Uint16Array, u32 = Uint32Array;


### PR DESCRIPTION
- Use `CompressionStream` Browser API when available

// inflating a 44 MB gzip file to 225 MB.

// Using JS
// inflate: 570.8759765625 ms
// inflate: 562.950927734375 ms
// inflate: 595.06591796875 ms
// inflate: 584.8740234375 ms
// inflate: 583.31396484375 ms

// Using DecompressionStream
// inflate: 502.001953125 ms
// inflate: 476.818115234375 ms
// inflate: 476.68701171875 ms
// inflate: 422.319091796875 ms
// inflate: 428.925048828125 ms

closes #580