### PR TITLE
ModelServer & VolumeServer: add health-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix cartoon representation not updated when secondary structure changes
 - Add Zhang-Skolnick secondary-structure assignment method which handles coarse-grained models (#49)
 - Calculate bonds for coarse-grained models
+- VolumeServer: Add `health-check` endpoint + `healthCheckPath` config prop to report service health
 
 ## [v4.5.0] - 2024-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add Zhang-Skolnick secondary-structure assignment method which handles coarse-grained models (#49)
 - Calculate bonds for coarse-grained models
 - VolumeServer: Add `health-check` endpoint + `healthCheckPath` config prop to report service health
+- ModelServer: Add `health-check` endpoint + `healthCheckPath` config prop to report service health
 
 ## [v4.5.0] - 2024-07-28
 

--- a/src/servers/common/util.ts
+++ b/src/servers/common/util.ts
@@ -1,9 +1,13 @@
 /**
- * Copyright (c) 2018-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
+
+import * as express from 'express';
+import { promises, constants } from 'fs';
 
 import { ConsoleLogger } from '../../mol-util/console-logger';
 
@@ -18,4 +22,38 @@ export function getParam<T>(params: any, ...path: string[]): T | undefined {
     } catch (e) {
         ConsoleLogger.error('Config', `Unable to retrieve property ${path.join('.')} from ${JSON.stringify(params)}`);
     }
+}
+
+/**
+ * Used to define a dedicated endpoint to monitor service health. Optionally checks whether source data from file system is readable.
+ * @param res used to write response
+ * @param paths array of file paths to check, may be empty
+ */
+export async function healthCheck(res: express.Response, paths: string[]) {
+    if (paths.length === 0) {
+        healthCheckResponse(res, true);
+        return;
+    }
+
+    for (const path of paths) {
+        try {
+            // assert readable file
+            await promises.access(path, constants.R_OK);
+        } catch (e) {
+            ConsoleLogger.error(`Error accessing path ${path}:`, e);
+            healthCheckResponse(res, false, 'Failed to access data from file system.');
+            return;
+        }
+    }
+    healthCheckResponse(res, true);
+}
+
+function healthCheckResponse(res: express.Response, success: boolean, msg?: string) {
+    res.writeHead(success ? 200 : 500, {
+        'Content-Type': 'text/plain',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'X-Requested-With',
+    });
+    res.write(success ? msg || 'true' : msg || 'false');
+    res.end();
 }

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.12
+* add `health-check` endpoint + `healthCheckPath` config prop to report service health
+
+# 0.9.11
+# SDF/MOL2 ligand export: fix atom indices when additional atoms are present
+
 # 0.9.10
 * /ligand queries: fix atom count reported by SDF/MOL/MOL2 export
 

--- a/src/servers/model/config.ts
+++ b/src/servers/model/config.ts
@@ -1,7 +1,8 @@
 ﻿/**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
 
 import * as argparse from 'argparse';
@@ -106,7 +107,12 @@ const DefaultModelServerConfig = {
     sourceMap: [
         ['pdb-cif', 'e:/test/quick/${id}_updated.cif'],
         // ['pdb-bcif', 'e:/test/quick/${id}.bcif'],
-    ] as ([string, string] | [string, string, ModelServerFetchFormats])[]
+    ] as ([string, string] | [string, string, ModelServerFetchFormats])[],
+
+    /**
+     * Optionally point to files. The service health-check will assert that all are readable and fail otherwise.
+     */
+    healthCheckPath: [] as string[],
 };
 
 export const ModelServerFetchFormats = ['cif', 'bcif', 'cif.gz', 'bcif.gz'] as const;
@@ -197,6 +203,12 @@ function addServerArgs(parser: argparse.ArgumentParser) {
             'Example: \'pdb-cif "https://www.ebi.ac.uk/pdbe/entry-files/download/${id}_updated.cif" cif\'',
             `Supported formats: ${ModelServerFetchFormats.join(', ')}`
         ].join('\n'),
+    });
+    parser.add_argument('--healthCheckPath', {
+        default: DefaultModelServerConfig.healthCheckPath,
+        action: 'append',
+        metavar: 'PATH',
+        help: `File path(s) to use for health-checks. Will test if all files are accessible and report a failed health-check if that's not the case.`,
     });
 }
 

--- a/src/servers/model/server/api-web.ts
+++ b/src/servers/model/server/api-web.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */
@@ -19,6 +19,7 @@ import { swaggerUiAssetsHandler, swaggerUiIndexHandler } from '../../common/swag
 import { MultipleQuerySpec, getMultiQuerySpecFilename } from './api-web-multiple';
 import { SimpleResponseResultWriter, WebResutlWriter, TarballResponseResultWriter } from '../utils/writer';
 import { splitCamelCase } from '../../../mol-util/string';
+import { healthCheck } from '../../common/util';
 
 function makePath(p: string) {
     return Config.apiPrefix + '/' + p;
@@ -168,6 +169,9 @@ export function initWebApi(app: express.Express) {
     for (const q of QueryList) {
         mapQuery(app, q.name, q.definition);
     }
+
+    // Reports server health depending on `healthCheckPath` config prop
+    app.get(makePath('health-check'), (_, res) => healthCheck(res, ModelServerConfig.healthCheckPath));
 
     const schema = getApiSchema();
 

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export const VERSION = '0.9.11';
+export const VERSION = '0.9.12';

--- a/src/servers/volume/CHANGELOG.md
+++ b/src/servers/volume/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.6
+* Add `health-check` endpoint + `healthCheckPath` config prop to report service health.
+
 # 0.9.5
 * Better query response box resolution.
 

--- a/src/servers/volume/config.ts
+++ b/src/servers/volume/config.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  */
 
 import * as argparse from 'argparse';
@@ -15,7 +16,8 @@ const DefaultServerConfig = {
     defaultPort: 1337,
     shutdownTimeoutMinutes: 24 * 60, /* a day */
     shutdownTimeoutVarianceMinutes: 60,
-    idMap: [] as [string, string][]
+    idMap: [] as [string, string][],
+    healthCheckPath: [] as string[],
 };
 
 function addLimitsArgs(parser: argparse.ArgumentParser) {
@@ -80,6 +82,12 @@ function addServerArgs(parser: argparse.ArgumentParser) {
             '  - The `TYPE` variable (e.g. `x-ray`) is arbitrary and depends on how you plan to use the server.',
             '    By default, Mol* Viewer uses `x-ray` and `em`, but any particular use case may vary. '
         ].join('\n'),
+    });
+    parser.add_argument('--healthCheckPath', {
+        default: DefaultServerConfig.healthCheckPath,
+        action: 'append',
+        metavar: 'PATH',
+        help: `File path(s) to use for health-checks. Will test if all files are accessible and report a failed health-check if that's not the case.`,
     });
 }
 

--- a/src/servers/volume/server/version.ts
+++ b/src/servers/volume/server/version.ts
@@ -1,2 +1,2 @@
-export const VOLUME_SERVER_VERSION = '0.9.5';
-export const VOLUME_SERVER_HEADER = `VolumeServer ${VOLUME_SERVER_VERSION}, (c) 2018-2020, Mol* contributors`;
+export const VOLUME_SERVER_VERSION = '0.9.6';
+export const VOLUME_SERVER_HEADER = `VolumeServer ${VOLUME_SERVER_VERSION}, (c) 2018-2024, Mol* contributors`;


### PR DESCRIPTION
# Description
- adds a new endpoint to ModelServer & VolumeServer to report service health
- useful to monitor API status, a non-200 status code makes this easier when used e.g. in Kubernetes
- adds new optional `healthCheckPath` config prop, which can point to 1...n files to ensure that these are readable (i.e. asserting that e.g. both X-ray and EM data are available, depending on the setup)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`