### PR TITLE
Enable dXrayShaded define when using depth variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Enables dXrayShaded define when rendering depth
 - Fix handling of PDB files that have chains with same id separated by TER record (#1245)
 - Sequence Panel: Improve visuals of unmodeled sequence positions (#1248)
 

--- a/src/mol-gl/shader-code.ts
+++ b/src/mol-gl/shader-code.ts
@@ -170,11 +170,14 @@ function ignoreDefine(name: string, variant: string, defines: ShaderDefines): bo
     } else {
         const ignore = [
             'dColorType', 'dUsePalette',
-            'dLightCount', 'dXrayShaded',
             'dOverpaintType', 'dOverpaint',
             'dSubstanceType', 'dSubstance',
-            'dColorMarker', 'dCelShaded'
+            'dColorMarker', 'dCelShaded',
+            'dLightCount',
         ];
+        if (variant !== 'depth') {
+            ignore.push('dXrayShaded');
+        }
         if (variant !== 'emissive') {
             ignore.push('dEmissiveType', 'dEmissive');
         }

--- a/src/mol-gl/shader-code.ts
+++ b/src/mol-gl/shader-code.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ValueCell } from '../mol-util';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Enables dXrayShaded define when rendering depth. Fixes outlines not showing on opaque representation with xRayShading (on / inverted) 

![image](https://github.com/user-attachments/assets/bf012877-594c-49bc-ae66-17f57c810700)

![image](https://github.com/user-attachments/assets/6b8d495e-1a01-4c34-b642-76b4aab801a5)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`