### PR TITLE
Resolution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Note that since we don't clearly distinguish between a public and private interf
 - Mol2 Reader: Fix mol2 status_bit read error (#1251)
 - Fix shadows with multiple lights
 - Fix impostor sphere interior normal when using orthographic projection
+- Add `resolutionMode` parameter to `Canvas3DContext`
+    - `scaled`, divides by `devicePixelRatio`
+    - `native`, no changes
 
 ## [v4.6.0] - 2024-08-28
 

--- a/src/mol-plugin-ui/viewport/simple-settings.tsx
+++ b/src/mol-plugin-ui/viewport/simple-settings.tsx
@@ -75,6 +75,7 @@ const SimpleSettingsParams = {
         hiZ: Canvas3DParams.hiZ,
         sharpening: Canvas3DParams.postprocessing.params.sharpening,
         bloom: Canvas3DParams.postprocessing.params.bloom,
+        resolutionMode: Canvas3DContext.Params.resolutionMode,
         pixelScale: Canvas3DContext.Params.pixelScale,
         transparency: Canvas3DContext.Params.transparency,
     }),
@@ -110,8 +111,8 @@ const SimpleSettingsMapping = ParamMapping({
         if (r.bottom !== 'hidden' && (!c || c.bottom !== 'none')) layout.push('log');
         if (r.left !== 'hidden' && (!c || c.left !== 'none')) layout.push('left');
         if (r.right !== 'hidden' && (!c || c.right !== 'none')) layout.push('right');
-        const { pixelScale, transparency } = ctx.canvas3dContext?.props!;
-        return { canvas: ctx.canvas3d?.props!, layout, pixelScale, transparency };
+        const { pixelScale, transparency, resolutionMode } = ctx.canvas3dContext?.props!;
+        return { canvas: ctx.canvas3d?.props!, layout, resolutionMode, pixelScale, transparency };
     }
 })({
     values(props, ctx) {
@@ -142,6 +143,7 @@ const SimpleSettingsMapping = ParamMapping({
                 hiZ: canvas.hiZ,
                 sharpening: canvas.postprocessing.sharpening,
                 bloom: canvas.postprocessing.bloom,
+                resolutionMode: props.resolutionMode,
                 pixelScale: props.pixelScale,
                 transparency: props.transparency,
             },
@@ -170,6 +172,7 @@ const SimpleSettingsMapping = ParamMapping({
         canvas.postprocessing.dof = s.lighting.dof;
 
         props.layout = s.layout;
+        props.resolutionMode = s.advanced.resolutionMode;
         props.pixelScale = s.advanced.pixelScale;
         props.transparency = s.advanced.transparency;
     },
@@ -190,6 +193,7 @@ const SimpleSettingsMapping = ParamMapping({
         }
 
         ctx.canvas3dContext?.setProps({
+            resolutionMode: props.resolutionMode,
             pixelScale: props.pixelScale,
             transparency: props.transparency,
         });

--- a/src/mol-plugin/context.ts
+++ b/src/mol-plugin/context.ts
@@ -332,7 +332,8 @@ export class PluginContext {
         const canvas = this.canvas3dContext?.canvas;
         const container = this.layout.root;
         if (container && canvas) {
-            resizeCanvas(canvas, container, this.canvas3dContext.props.pixelScale);
+            resizeCanvas(canvas, container, this.canvas3dContext.pixelScale);
+            this.canvas3dContext.syncPixelScale();
             this.canvas3d?.requestResize();
         }
     };

--- a/src/mol-plugin/util/headless-screenshot.ts
+++ b/src/mol-plugin/util/headless-screenshot.ts
@@ -59,12 +59,14 @@ export class HeadlessScreenshotHelper {
             const props = { ...Canvas3DContext.DefaultProps };
             const assetManager = new AssetManager();
             const passes = new Passes(webgl, assetManager, props);
+            const pixelScale = 1;
+            const syncPixelScale = () => {};
             const setProps = () => {};
             const dispose = () => {
                 input.dispose();
                 webgl.destroy();
             };
-            this.canvas3d = Canvas3D.create({ webgl, input, passes, attribs, props, assetManager, setProps, dispose }, options?.canvas ?? defaultCanvas3DParams());
+            this.canvas3d = Canvas3D.create({ webgl, input, passes, attribs, props, assetManager, pixelScale, syncPixelScale, setProps, dispose }, options?.canvas ?? defaultCanvas3DParams());
         }
 
         this.imagePass = this.canvas3d.getImagePass(options?.imagePass ?? defaultImagePassParams());


### PR DESCRIPTION
Add `resolutionMode` parameter to `Canvas3DContext`
    - `scaled`, divides by `devicePixelRatio`
    - `native`, no changes

The new default `scaled` helps greatly with rendering performance on high dpi displays and quality is still good enough.