### PR TITLE
fix preset coloring in ME

### DIFF
--- a/src/apps/mesoscale-explorer/ui/states.tsx
+++ b/src/apps/mesoscale-explorer/ui/states.tsx
@@ -577,7 +577,7 @@ export class MesoQuickStyles extends PluginUIComponent {
         const loptions = { ignoreLight: true, materialStyle: { metalness: 0, roughness: 1.0, bumpiness: 0 } };
         const options = { ...loptions, celShaded: false, };
         await this.plugin.managers.structure.component.setOptions(loptions as StructureComponentManager.Options);
-        await updateColors(this.plugin, this.default_color_values, options, 'ent:');
+        await updateColors(this.plugin, this.default_color_values, options);
     }
 
     async celshading() {
@@ -628,7 +628,7 @@ export class MesoQuickStyles extends PluginUIComponent {
         const loptions = { ignoreLight: false, materialStyle: { metalness: 0, roughness: 1.0, bumpiness: 0 } };
         const options = { ...loptions, celShaded: true, };
         await this.plugin.managers.structure.component.setOptions(loptions as StructureComponentManager.Options);
-        await updateColors(this.plugin, this.default_color_values, options, 'ent:');
+        await updateColors(this.plugin, this.default_color_values, options);
     }
 
     async stylizedDof() {
@@ -689,7 +689,7 @@ export class MesoQuickStyles extends PluginUIComponent {
         const loptions = { ignoreLight: false, materialStyle: { metalness: 0, roughness: 0.2, bumpiness: 0 } };
         const options = { ...loptions, celShaded: false };
         await this.plugin.managers.structure.component.setOptions(loptions as StructureComponentManager.Options);
-        await updateColors(this.plugin, this.default_color_values, options, 'ent:');
+        await updateColors(this.plugin, this.default_color_values, options);
     }
 
     async illustrative() {
@@ -748,7 +748,7 @@ export class MesoQuickStyles extends PluginUIComponent {
         const loptions = { ignoreLight: true, materialStyle: { metalness: 0, roughness: 1.0, bumpiness: 0 } };
         const options = { ...loptions, celShaded: false, };
         await this.plugin.managers.structure.component.setOptions(loptions as StructureComponentManager.Options);
-        await updateColors(this.plugin, this.illustrative_color_values, options, 'ent:');
+        await updateColors(this.plugin, this.illustrative_color_values, options);
     }
 
     async shiny() {
@@ -792,7 +792,7 @@ export class MesoQuickStyles extends PluginUIComponent {
         const loptions = { ignoreLight: false, materialStyle: { metalness: 0, roughness: 0.2, bumpiness: 0 } };
         const options = { ...loptions, celShaded: false };
         await this.plugin.managers.structure.component.setOptions(loptions as StructureComponentManager.Options);
-        await updateColors(this.plugin, this.default_color_values, options, 'ent:');
+        await updateColors(this.plugin, this.default_color_values, options);
     }
 
     async stylized() {
@@ -851,7 +851,7 @@ export class MesoQuickStyles extends PluginUIComponent {
         const loptions = { ignoreLight: false, materialStyle: { metalness: 0, roughness: 0.2, bumpiness: 0 } };
         const options = { ...loptions, celShaded: false };
         await this.plugin.managers.structure.component.setOptions(loptions as StructureComponentManager.Options);
-        await updateColors(this.plugin, this.illustrative_color_values, options, 'ent:');
+        await updateColors(this.plugin, this.illustrative_color_values, options);
     }
 
     render() {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
I removed the argument 'ent:' which was breaking the quick style preset 

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`