### PR TITLE
Make Loci.isSubset() strict on units comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Default to `blended` transparency on iOS due to `wboit` not being supported.
 - Fix direct-volume with fog off (and on with `dpoit`) and transparent background on (#1286)
 - Fix missing pre-multiplied alpha for `blended` & `wboit` with no fog (#1284)
+- Fix StructureElement.Loci.isSubset() only considers common units (#1292)
 
 ## [v4.7.1] - 2024-09-30
 

--- a/src/mol-model/structure/structure/element/loci.ts
+++ b/src/mol-model/structure/structure/element/loci.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { UniqueArray } from '../../../../mol-data/generic';
@@ -265,7 +266,7 @@ export namespace Loci {
 
         let isSubset = false;
         for (const e of ys.elements) {
-            if (!map.has(e.unit.id)) continue;
+            if (!map.has(e.unit.id)) return false;
             if (!OrderedSet.isSubset(map.get(e.unit.id)!, e.indices)) return false;
             else isSubset = true;
         }


### PR DESCRIPTION
# Description
Loci.isSubest could return true for a Loci that is a superset of the reference Loci. This was happening when the second Loci contains units that are not matched in the reference Loci. See #1292


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`