### PR TITLE
MVS: Primitives MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix StructureElement.Loci.isSubset() only considers common units (#1292)
 - Fix `Scene.opacityAverage` calculation never 1
 - MolViewSpec: Support for transparency and custom properties
-- MolViewSpec: MVP Support for geometrical primitives (mesh, line, label, distance measurement)
+- MolViewSpec: MVP Support for geometrical primitives (mesh, lines, line, label, distance measurement)
 
 
 ## [v4.7.1] - 2024-09-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
-- MolViewSpec: Support for transparency and custom properties
 - Default to `blended` transparency on iOS due to `wboit` not being supported.
 - Fix direct-volume with fog off (and on with `dpoit`) and transparent background on (#1286)
 - Fix missing pre-multiplied alpha for `blended` & `wboit` with no fog (#1284)
 - Fix backfaces visible using blended transparency on impostors (#1285)
 - Fix StructureElement.Loci.isSubset() only considers common units (#1292)
 - Fix `Scene.opacityAverage` calculation never 1
+- MolViewSpec: Support for transparency and custom properties
+- MolViewSpec: MVP Support for geometrical primitives (mesh, line, label, distance measurement)
+
 
 ## [v4.7.1] - 2024-09-30
 

--- a/src/extensions/mvs/camera.ts
+++ b/src/extensions/mvs/camera.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { Camera } from '../../mol-canvas3d/camera';
@@ -53,35 +54,54 @@ export async function setCamera(plugin: PluginContext, params: ParamsOfKind<Mols
     await PluginCommands.Camera.SetSnapshot(plugin, { snapshot });
 }
 
+async function focusBoundingSphere(plugin: PluginContext, params: ParamsOfKind<MolstarTree, 'focus'>, boundingSphere: Sphere3D | undefined, extraRadius: number) {
+    if (!plugin.canvas3d || !boundingSphere) return;
+
+    const direction = Vec3.create(...params.direction);
+    const up = Vec3.create(...params.up);
+    Vec3.orthogonalize(up, direction, up);
+    const snapshot = snapshotFromSphereAndDirections(plugin.canvas3d.camera, {
+        center: boundingSphere.center,
+        radius: boundingSphere.radius + extraRadius,
+        up,
+        direction,
+    });
+    resetSceneRadiusFactor(plugin);
+    await PluginCommands.Camera.SetSnapshot(plugin, { snapshot });
+}
+
+function getRenderObjectsBoundary(objects: ReadonlyArray<GraphicsRenderObject>) {
+    const spheres: Sphere3D[] = [];
+    for (const o of objects) {
+        const s = o.values.boundingSphere.ref.value;
+        if (s.radius === 0) continue;
+        spheres.push(s);
+    }
+    if (spheres.length === 0) return;
+    if (spheres.length === 1) return spheres[0];
+    return boundingSphereOfSpheres(spheres);
+}
+
 /** Focus the camera on the bounding sphere of a (sub)structure (or on the whole scene if `structureNodeSelector` is null).
- * Orient the camera based on a focus node params. */
+  * Orient the camera based on a focus node params.
+  **/
 export async function setFocus(plugin: PluginContext, structureNodeSelector: StateObjectSelector | undefined, params: ParamsOfKind<MolstarTree, 'focus'> = MVSDefaults.focus) {
-    let structure: Structure | undefined = undefined;
+    let boundingSphere: Sphere3D | undefined = undefined;
     if (structureNodeSelector) {
         const cell = plugin.state.data.cells.get(structureNodeSelector.ref);
-        structure = cell?.obj?.data;
-        if (!structure) console.warn('Focus: no structure');
-        // TODO: support non-structure focus
-        if (!(structure instanceof Structure)) {
-            console.warn('Focus: cannot apply to a non-structure node');
-            structure = undefined;
+        const data = cell?.obj?.data;
+        if (!data) console.warn('Focus: no structure');
+        if (data instanceof Structure) {
+            boundingSphere = Loci.getBoundingSphere(Structure.Loci(data));
+        } else if (typeof data === 'object' && Array.isArray(data.repr?.renderObjects)) {
+            boundingSphere = getRenderObjectsBoundary(data.repr?.renderObjects);
+        } else {
+            console.warn('Focus: cannot apply to the specified node type');
         }
     }
-    const boundingSphere = structure ? Loci.getBoundingSphere(Structure.Loci(structure)) : getPluginBoundingSphere(plugin);
-    if (boundingSphere && plugin.canvas3d) {
-        const extraRadius = structure ? DefaultFocusOptions.extraRadiusForFocus : DefaultFocusOptions.extraRadiusForZoomAll;
-        const direction = Vec3.create(...params.direction);
-        const up = Vec3.create(...params.up);
-        Vec3.orthogonalize(up, direction, up);
-        const snapshot = snapshotFromSphereAndDirections(plugin.canvas3d.camera, {
-            center: boundingSphere.center,
-            radius: boundingSphere.radius + extraRadius,
-            up,
-            direction,
-        });
-        resetSceneRadiusFactor(plugin);
-        await PluginCommands.Camera.SetSnapshot(plugin, { snapshot });
-    }
+    const extraRadius = boundingSphere ? DefaultFocusOptions.extraRadiusForFocus : DefaultFocusOptions.extraRadiusForZoomAll;
+    boundingSphere ??= getPluginBoundingSphere(plugin);
+    return focusBoundingSphere(plugin, params, boundingSphere, extraRadius);
 }
 
 /** Adjust `sceneRadiusFactor` property so that the current scene is not cropped */

--- a/src/extensions/mvs/camera.ts
+++ b/src/extensions/mvs/camera.ts
@@ -61,6 +61,7 @@ export async function setFocus(plugin: PluginContext, structureNodeSelector: Sta
         const cell = plugin.state.data.cells.get(structureNodeSelector.ref);
         structure = cell?.obj?.data;
         if (!structure) console.warn('Focus: no structure');
+        // TODO: support non-structure focus
         if (!(structure instanceof Structure)) {
             console.warn('Focus: cannot apply to a non-structure node');
             structure = undefined;

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -150,7 +150,7 @@ function buildPrimitiveMesh(context: MVSPrimitiveBuilderContext, primives: MVSPr
 
     const { colors, tooltips } = state;
     const tooltip = context.globalOptions?.default_tooltip ?? '';
-    const color = decodeColor(context.globalOptions?.default_color as string | undefined) ?? 0x0;
+    const color = decodeColor(context.globalOptions?.default_color) ?? 0x0;
 
     return Shape.create(
         'Mesh',
@@ -175,12 +175,14 @@ function buildPrimitiveLabels(context: MVSPrimitiveBuilderContext, primives: MVS
         b[1](context, state, p);
     }
 
+    const color = decodeColor(context.globalOptions?.default_label_color) ?? 0x0;
     const { colors, sizes } = state;
+
     return Shape.create(
         'Labels',
         primives,
         labelsBuilder.getText(),
-        (g) => colors.get(g) as Color ?? 0x0 as Color,
+        (g) => colors.get(g) as Color ?? color as Color,
         (g) => sizes.get(g) ?? 1,
         (g) => '',
     );

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author David Sehnal <david.sehnal@gmail.com>
+ */
+
+import { addSimpleCylinder } from '../../../mol-geo/geometry/mesh/builder/cylinder';
+import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
+import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
+import { Vec3 } from '../../../mol-math/linear-algebra';
+import { Shape } from '../../../mol-model/shape';
+import { Structure } from '../../../mol-model/structure';
+import { PluginStateObject as SO } from '../../../mol-plugin-state/objects';
+import { Color } from '../../../mol-util/color';
+import { ParamDefinition as PD } from '../../../mol-util/param-definition';
+import { decodeColor } from '../helpers/utils';
+import { ValueFor } from '../tree/generic/params-schema';
+import { MVSNode } from '../tree/mvs/mvs-tree';
+import { ComponentExpressionT } from '../tree/mvs/param-types';
+import { MVSTransform } from './annotation-structure-component';
+
+export interface PrimitiveComponentExpression extends ValueFor<typeof ComponentExpressionT> {
+    structure_ref?: string;
+}
+
+export type PositionT = [number, number, number] | PrimitiveComponentExpression | PrimitiveComponentExpression[]
+
+export interface PrimitiveOptions {
+    color?: string;
+    transparency?: number;
+    tooltip?: string;
+}
+
+export type Primitive =
+    | { kind: 'mesh', params: MVSNode<'mesh'>['params'] }
+    | { kind: 'line', params: MVSNode<'line'>['params'] };
+
+export interface PrimitiveBuilderContext {
+    mesh?: Mesh;
+    defaultStructure?: Structure;
+    structureRefs: Record<string, Structure | undefined>;
+    globalOptions: PrimitiveOptions;
+}
+
+interface BuilderState {
+    builder: MeshBuilder.State;
+    colors: Map<number, number>;
+    tooltips: Map<number, string>;
+}
+
+export function getPrimitiveStructureRefs(primitives: Primitive[]) {
+    const refs = new Set<string>();
+    for (const p of primitives) {
+        const b = Builders[p.kind];
+        if (b) b[1](p, refs);
+    }
+    return refs;
+}
+
+function addRef(position: PositionT, refs: Set<string>) {
+    if (Array.isArray(position)) {
+        if (typeof position[0] === 'number') {
+            return;
+        }
+        for (const p of position as PrimitiveComponentExpression[]) {
+            if (p.structure_ref) refs.add(p.structure_ref);
+        }
+    }
+    if ((position as PrimitiveComponentExpression).structure_ref) {
+        refs.add((position as PrimitiveComponentExpression).structure_ref!);
+    }
+}
+
+function resolvePosition(context: PrimitiveBuilderContext, position: PositionT, target: Vec3) {
+    if (Array.isArray(position)) {
+        if (typeof position[0] === 'number') {
+            return Vec3.copy(target, position as Vec3);
+        }
+    }
+
+    throw new Error('not yet implemented');
+}
+
+function buildPrimitiveMesh(context: PrimitiveBuilderContext, primives: Primitive[]): Shape<Mesh> {
+    const builder = MeshBuilder.createState(1024, 1024, context.mesh);
+    const state: BuilderState = { builder, colors: new Map(), tooltips: new Map() };
+    builder.currentGroup = -1;
+
+    for (const p of primives) {
+        const b = Builders[p.kind];
+        if (!b) throw new Error(`Primitive ${p.kind} not supported`);
+        b[0](context, state, p.params as any);
+    }
+
+    const { colors, tooltips } = state;
+    const tooltip = context.globalOptions.tooltip ?? '';
+    const color = decodeColor(context.globalOptions.color) ?? 0x0;
+
+    return Shape.create(
+        'Mesh',
+        primives,
+        MeshBuilder.getMesh(builder),
+        (g) => colors.get(g) as Color ?? color as Color,
+        () => 1,
+        (g) => tooltips.get(g) ?? tooltip,
+    );
+}
+
+const Builders: Record<Primitive['kind'], [
+    build: (context: PrimitiveBuilderContext, state: BuilderState, params: any) => void,
+    resolveRefs: (params: any, refs: Set<string>) => void
+]> = {
+    mesh: [addMesh, () => {}],
+    line: [addLine, (params: MVSNode<'line'>['params'], refs) => {
+        addRef(params.start, refs);
+        addRef(params.end, refs);
+    }],
+};
+
+function addMesh(context: PrimitiveBuilderContext, { builder, colors, tooltips }: BuilderState, params: MVSNode<'mesh'>['params']) {
+    const a = Vec3.zero();
+    const b = Vec3.zero();
+    const c = Vec3.zero();
+
+    const { indices, vertices, triangle_colors, triangle_groups, group_colors, group_tooltips } = params;
+
+    const baseGroup = builder.currentGroup;
+    const groupOffsets = new Map<number, number>();
+    if (triangle_groups) {
+        for (const g of triangle_groups) {
+            if (groupOffsets.has(g)) continue;
+            groupOffsets.set(g, groupOffsets.size + 1);
+        }
+        builder.currentGroup += groupOffsets.size + 1;
+    }
+
+
+    for (let i = 0, _i = indices.length / 3; i < _i; i++) {
+        let group: number;
+        let color: number | undefined;
+        let tooltip: string | undefined;
+
+        if (triangle_groups) {
+            const grp = triangle_groups[i];
+            builder.currentGroup = baseGroup + groupOffsets.get(grp)!;
+            group = builder.currentGroup;
+            color = decodeColor(group_colors?.[grp]);
+            tooltip = group_tooltips?.[grp];
+        } else {
+            group = ++builder.currentGroup;
+            color = decodeColor(triangle_colors?.[i]);
+        }
+
+        if (typeof color !== 'undefined') colors.set(group, color);
+        if (tooltip) tooltips.set(group, tooltip);
+
+        Vec3.fromArray(a, vertices, 3 * indices[3 * i]);
+        Vec3.fromArray(b, vertices, 3 * indices[3 * i + 1]);
+        Vec3.fromArray(c, vertices, 3 * indices[3 * i + 2]);
+
+        MeshBuilder.addTriangle(builder, a, b, c);
+    }
+}
+
+const lStart = Vec3.zero();
+const lEnd = Vec3.zero();
+
+function addLine(context: PrimitiveBuilderContext, { builder, colors, tooltips }: BuilderState, params: MVSNode<'line'>['params']) {
+    const group = ++builder.currentGroup;
+    resolvePosition(context, params.start, lStart);
+    resolvePosition(context, params.end, lEnd);
+    const radius = params.thickness ?? 0.05;
+    // TODO: support dashes etc
+    addSimpleCylinder(builder, lStart, lEnd, { radiusBottom: radius, radiusTop: radius, topCap: true, bottomCap: true });
+    const color = decodeColor(params?.color as string);
+    if (typeof color !== 'undefined') colors.set(group, color);
+    if (params.tooltip) tooltips.set(group, params.tooltip);
+}
+
+export type MVSInlinePrimitives = typeof MVSInlinePrimitives
+export const MVSInlinePrimitives = MVSTransform({ // TODO: move MVSTransform to a common file
+    name: 'mvs-inline-primitives',
+    display: { name: 'MVS Primitives' },
+    from: [SO.Root, SO.Molecule.Structure],
+    to: SO.Shape.Provider,
+    params: {
+        primitives: PD.Value<Primitive[]>([], { isHidden: true }),
+        options: PD.Value<PrimitiveOptions>({} as any, { isHidden: true }),
+    },
+})({
+    apply({ params, dependencies }) {
+        return new SO.Shape.Provider({
+            label: 'Primitives',
+            data: params,
+            params: Mesh.Params,
+            getShape: (_, data: typeof params) => {
+                const mesh = buildPrimitiveMesh({
+                    structureRefs: {},
+                    globalOptions: data.options,
+                }, data.primitives);
+                return mesh;
+            },
+            geometryUtils: Mesh.Utils
+        }, { label: 'Box' });
+    }
+});

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -4,9 +4,11 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-import { addSimpleCylinder } from '../../../mol-geo/geometry/mesh/builder/cylinder';
+import { addFixedCountDashedCylinder, addSimpleCylinder, BasicCylinderProps } from '../../../mol-geo/geometry/mesh/builder/cylinder';
 import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
+import { Text } from '../../../mol-geo/geometry/text/text';
+import { TextBuilder } from '../../../mol-geo/geometry/text/text-builder';
 import { Vec3 } from '../../../mol-math/linear-algebra';
 import { Loci } from '../../../mol-model/loci';
 import { Shape } from '../../../mol-model/shape';
@@ -14,8 +16,10 @@ import { Structure, StructureSelection } from '../../../mol-model/structure';
 import { StructureQueryHelper } from '../../../mol-plugin-state/helpers/structure-query';
 import { PluginStateObject as SO } from '../../../mol-plugin-state/objects';
 import { Expression } from '../../../mol-script/language/expression';
+import { StateObject } from '../../../mol-state';
 import { Color } from '../../../mol-util/color';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
+import { capitalize } from '../../../mol-util/string';
 import { rowsToExpression, rowToExpression } from '../helpers/selections';
 import { collectMVSReferences, decodeColor } from '../helpers/utils';
 import { ValueFor } from '../tree/generic/params-schema';
@@ -36,11 +40,14 @@ export interface PrimitiveOptions {
 }
 
 export type Primitive =
-    | { kind: 'mesh', params: MVSNode<'mesh'>['params'] }
-    | { kind: 'line', params: MVSNode<'line'>['params'] };
+    | { kind: 'primitive_mesh', params: MVSNode<'primitive_mesh'>['params'] }
+    | { kind: 'primitive_line', params: MVSNode<'primitive_line'>['params'] }
+    | { kind: 'primitive_distance_measurement', params: MVSNode<'primitive_distance_measurement'>['params'] };
 
 export interface PrimitiveBuilderContext {
     mesh?: Mesh;
+    labels?: Text;
+
     defaultStructure?: Structure;
     structureRefs: Record<string, Structure | undefined>;
     globalOptions: PrimitiveOptions;
@@ -48,7 +55,8 @@ export interface PrimitiveBuilderContext {
 }
 
 interface BuilderState {
-    builder: MeshBuilder.State;
+    mesh: MeshBuilder.State;
+    labels: TextBuilder;
     colors: Map<number, number>;
     tooltips: Map<number, string>;
 }
@@ -120,10 +128,24 @@ function resolvePosition(context: PrimitiveBuilderContext, position: PositionT, 
     context.positionCache.set(cackeKey, Vec3.clone(target));
 }
 
-function buildPrimitiveMesh(context: PrimitiveBuilderContext, primives: Primitive[]): Shape<Mesh> {
-    const builder = MeshBuilder.createState(1024, 1024, context.mesh);
-    const state: BuilderState = { builder, colors: new Map(), tooltips: new Map() };
-    builder.currentGroup = -1;
+const LabelProps: PD.Values<Text.Params> = {
+    ...PD.getDefaultValues(Text.Params),
+    attachment: 'middle-center',
+    fontQuality: 3,
+    fontWeight: 'normal',
+    borderWidth: 0.3,
+    borderColor: Color(0x0),
+    background: false,
+    backgroundOpacity: 0.5,
+    tether: false,
+};
+
+function buildPrimitiveShapes(context: PrimitiveBuilderContext, primives: Primitive[]): { mesh?: Shape<Mesh>, labels?: Shape<Text> } {
+    const meshBuilder = MeshBuilder.createState(1024, 1024, context.mesh);
+    const labelsBuilder = TextBuilder.create(LabelProps, 1024, 1024, context.labels);
+    const state: BuilderState = { mesh: meshBuilder, labels: labelsBuilder, colors: new Map(), tooltips: new Map() };
+
+    meshBuilder.currentGroup = -1;
 
     for (const p of primives) {
         const b = Builders[p.kind];
@@ -135,44 +157,59 @@ function buildPrimitiveMesh(context: PrimitiveBuilderContext, primives: Primitiv
     const tooltip = context.globalOptions.tooltip ?? '';
     const color = decodeColor(context.globalOptions.color) ?? 0x0;
 
-    return Shape.create(
+    const mesh = meshBuilder.currentGroup !== -1 ? Shape.create(
         'Mesh',
         primives,
-        MeshBuilder.getMesh(builder),
+        MeshBuilder.getMesh(meshBuilder),
         (g) => colors.get(g) as Color ?? color as Color,
         () => 1,
         (g) => tooltips.get(g) ?? tooltip,
-    );
+    ) : undefined;
+
+    // TODO
+    const labels = !labelsBuilder.isEmpty ? Shape.create(
+        'Labels',
+        primives,
+        labelsBuilder.getText(),
+        (g) => color as Color,
+        () => 1,
+        (g) => '',
+    ) : undefined;
+
+    return { mesh, labels };
 }
 
 const Builders: Record<Primitive['kind'], [
     build: (context: PrimitiveBuilderContext, state: BuilderState, params: any) => void,
     resolveRefs: (params: any, refs: Set<string>) => void
 ]> = {
-    mesh: [addMesh, () => {}],
-    line: [addLine, (params: MVSNode<'line'>['params'], refs) => {
+    primitive_mesh: [addMesh, () => {}],
+    primitive_line: [addLine, (params: MVSNode<'primitive_line'>['params'], refs) => {
+        addRef(params.start, refs);
+        addRef(params.end, refs);
+    }],
+    primitive_distance_measurement: [addLine, (params: MVSNode<'primitive_distance_measurement'>['params'], refs) => {
         addRef(params.start, refs);
         addRef(params.end, refs);
     }],
 };
 
-function addMesh(context: PrimitiveBuilderContext, { builder, colors, tooltips }: BuilderState, params: MVSNode<'mesh'>['params']) {
+function addMesh(context: PrimitiveBuilderContext, { mesh, colors, tooltips }: BuilderState, params: MVSNode<'primitive_mesh'>['params']) {
     const a = Vec3.zero();
     const b = Vec3.zero();
     const c = Vec3.zero();
 
     const { indices, vertices, triangle_colors, triangle_groups, group_colors, group_tooltips } = params;
 
-    const baseGroup = builder.currentGroup;
+    const baseGroup = mesh.currentGroup;
     const groupOffsets = new Map<number, number>();
     if (triangle_groups) {
         for (const g of triangle_groups) {
             if (groupOffsets.has(g)) continue;
             groupOffsets.set(g, groupOffsets.size + 1);
         }
-        builder.currentGroup += groupOffsets.size + 1;
+        mesh.currentGroup += groupOffsets.size + 1;
     }
-
 
     for (let i = 0, _i = indices.length / 3; i < _i; i++) {
         let group: number;
@@ -181,12 +218,12 @@ function addMesh(context: PrimitiveBuilderContext, { builder, colors, tooltips }
 
         if (triangle_groups) {
             const grp = triangle_groups[i];
-            builder.currentGroup = baseGroup + groupOffsets.get(grp)!;
-            group = builder.currentGroup;
+            mesh.currentGroup = baseGroup + groupOffsets.get(grp)!;
+            group = mesh.currentGroup;
             color = decodeColor(group_colors?.[grp]);
             tooltip = group_tooltips?.[grp];
         } else {
-            group = ++builder.currentGroup;
+            group = ++mesh.currentGroup;
             color = decodeColor(triangle_colors?.[i]);
         }
 
@@ -197,53 +234,104 @@ function addMesh(context: PrimitiveBuilderContext, { builder, colors, tooltips }
         Vec3.fromArray(b, vertices, 3 * indices[3 * i + 1]);
         Vec3.fromArray(c, vertices, 3 * indices[3 * i + 2]);
 
-        MeshBuilder.addTriangle(builder, a, b, c);
+        MeshBuilder.addTriangle(mesh, a, b, c);
     }
 }
 
 const lStart = Vec3.zero();
 const lEnd = Vec3.zero();
 
-function addLine(context: PrimitiveBuilderContext, { builder, colors, tooltips }: BuilderState, params: MVSNode<'line'>['params']) {
-    const group = ++builder.currentGroup;
+function addLine(context: PrimitiveBuilderContext, { mesh, colors, tooltips }: BuilderState, params: MVSNode<'primitive_line'>['params']) {
+    const group = ++mesh.currentGroup;
     resolvePosition(context, params.start, lStart);
     resolvePosition(context, params.end, lEnd);
     const radius = params.thickness ?? 0.05;
-    // TODO: support dashes etc
-    addSimpleCylinder(builder, lStart, lEnd, { radiusBottom: radius, radiusTop: radius, topCap: true, bottomCap: true });
+
+    const cylinderProps: BasicCylinderProps = {
+        radiusBottom: radius,
+        radiusTop: radius,
+        topCap: true,
+        bottomCap: true,
+    };
+
+    if (params.dash_length) {
+        // TODO: support other dash params
+        const dist = Vec3.distance(lStart, lEnd);
+        const count = Math.ceil(dist / (2 * params.dash_length));
+        addFixedCountDashedCylinder(mesh, lStart, lEnd, 1.0, count, true, cylinderProps);
+    } else {
+        addSimpleCylinder(mesh, lStart, lEnd, cylinderProps);
+    }
+
     const color = decodeColor(params?.color as string);
     if (typeof color !== 'undefined') colors.set(group, color);
     if (params.tooltip) tooltips.set(group, params.tooltip);
 }
 
-export type MVSInlinePrimitives = typeof MVSInlinePrimitives
-export const MVSInlinePrimitives = MVSTransform({ // TODO: move MVSTransform to a common file
-    name: 'mvs-inline-primitives',
+/** ========== Plugin transforms ============== */
+
+export class MVSPrimitivesData extends SO.Create<{ structure?: Structure, primitives: Primitive[], options: PrimitiveOptions }>({ name: 'Primitive Data', typeClass: 'Object' }) { }
+export class MVSPrimitiveShapes extends SO.Create<{ mesh?: Shape<Mesh>, labels?: Shape<Text> }>({ name: 'Primitive Shapes', typeClass: 'Object' }) { }
+
+export type MVSInlinePrimitiveData = typeof MVSInlinePrimitiveData
+export const MVSInlinePrimitiveData = MVSTransform({
+    name: 'mvs-inline-primitive-data',
     display: { name: 'MVS Primitives' },
     from: [SO.Root, SO.Molecule.Structure],
-    to: SO.Shape.Provider,
+    to: MVSPrimitivesData,
     params: {
         primitives: PD.Value<Primitive[]>([], { isHidden: true }),
         options: PD.Value<PrimitiveOptions>({} as any, { isHidden: true }),
     },
 })({
-    apply({ a, params, dependencies }) {
-        const structureRefs = dependencies ? collectMVSReferences([SO.Molecule.Structure], dependencies) : {};
+    apply({ a, params }) {
+        return new MVSPrimitivesData({
+            structure: SO.Molecule.Structure.is(a) ? a.data : undefined,
+            primitives: params.primitives,
+            options: params.options,
+        }, { label: 'Primitive Data' });
+    }
+})
 
+export type MVSBuildPrimitiveShapes = typeof MVSBuildPrimitiveShapes
+export const MVSBuildPrimitiveShapes = MVSTransform({
+    name: 'mvs-build-primitive-shapes',
+    display: { name: 'MVS Primitives' },
+    from: MVSPrimitivesData,
+    to: MVSPrimitiveShapes,
+})({
+    apply({ a, dependencies }) {
+        const structureRefs = dependencies ? collectMVSReferences([SO.Molecule.Structure], dependencies) : {};
+        const context: PrimitiveBuilderContext = {
+            defaultStructure: a.data.structure,
+            structureRefs,
+            globalOptions: a.data.options,
+            positionCache: new Map(),
+        };
+        const shapes = buildPrimitiveShapes(context, a.data.primitives);
+        return new MVSPrimitiveShapes(shapes, { label: 'Primitive Shapes ' });
+    }
+});
+
+export type MVSBuildPrimitiveShapeProvider = typeof MVSBuildPrimitiveShapes
+export const MVSBuildPrimitiveShapeProvider = MVSTransform({
+    name: 'mvs-build-primitive-shape-provider',
+    display: { name: 'MVS Primitives' },
+    from: MVSPrimitiveShapes,
+    to: SO.Shape.Provider,
+    params: {
+        kind: PD.Text<'mesh' | 'labels'>('mesh')
+    }
+})({
+    apply({ a, params }) {
+        if (!a.data[params.kind]) return StateObject.Null;
+        const geo = params.kind === 'mesh' ? Mesh : Text;
         return new SO.Shape.Provider({
-            label: 'Primitives',
-            data: params,
-            params: Mesh.Params,
-            getShape: (_, data: typeof params) => {
-                const mesh = buildPrimitiveMesh({
-                    defaultStructure: SO.Molecule.Structure.is(a) ? a.data : undefined,
-                    structureRefs,
-                    globalOptions: data.options,
-                    positionCache: new Map(),
-                }, data.primitives);
-                return mesh;
-            },
-            geometryUtils: Mesh.Utils
-        }, { label: 'Primitives Provider' });
+            label: capitalize(params.kind),
+            data: a.data[params.kind],
+            params: geo.Params,
+            getShape: (_, data: any) => data,
+            geometryUtils: geo.Utils
+        }, { label: capitalize(params.kind) });
     }
 });

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -122,7 +122,7 @@ export const MVSBuildPrimitiveShape = MVSTransform({
                 label,
                 data: context,
                 params: PD.withDefaults(Mesh.Params, { alpha: a.data.options?.transparency ?? 1 }),
-                getShape: (_, data, __, prev: any) => buildPrimitiveMesh(data, prev),
+                getShape: (_, data, __, prev: any) => buildPrimitiveMesh(data, prev?.geometry),
                 geometryUtils: Mesh.Utils,
             }, { label });
         } else if (params.kind === 'labels') {
@@ -132,7 +132,7 @@ export const MVSBuildPrimitiveShape = MVSTransform({
                 label,
                 data: context,
                 params: PD.withDefaults(DefaultLabelParams, { alpha: a.data.options?.label_transparency ?? 1 }),
-                getShape: (_, data, __, prev: any) => buildPrimitiveLabels(data, prev),
+                getShape: (_, data, __, prev: any) => buildPrimitiveLabels(data, prev?.geometry),
                 geometryUtils: Text.Utils,
             }, { label });
         }

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -228,6 +228,7 @@ function resolvePosition(context: PrimitiveBuilderContext, position: MVSPosition
 
         expr = rowsToExpression(position as any);
     } else {
+        pivotRef = position.structure_ref;
         expr = rowToExpression(position as any);
     }
 
@@ -236,14 +237,14 @@ function resolvePosition(context: PrimitiveBuilderContext, position: MVSPosition
         throw new Error(`Structure with ref '${pivotRef ?? '<default>'}' not found.`);
     }
 
-    if (!context.defaultStructure) return Vec3.set(target, 0, 0, 0);
+    if (!pivot) return Vec3.set(target, 0, 0, 0);
 
     const cackeKey = JSON.stringify(position);
     if (context.positionCache.has(cackeKey)) {
         return Vec3.copy(target, context.positionCache.get(cackeKey)!);
     }
 
-    const { selection } = StructureQueryHelper.createAndRun(context.defaultStructure, expr);
+    const { selection } = StructureQueryHelper.createAndRun(pivot, expr);
 
     if (StructureSelection.isEmpty(selection)) {
         Vec3.set(target, 0, 0, 0);
@@ -443,7 +444,7 @@ function addDistanceLabel(context: PrimitiveBuilderContext, state: LabelBuilderS
     Vec3.add(labelPos, lStart, lEnd);
     Vec3.scale(labelPos, labelPos, 0.5);
 
-    labels.add(label, labelPos[0], labelPos[1], labelPos[2], 0.5, 1, group);
+    labels.add(label, labelPos[0], labelPos[1], labelPos[2], 1.05 * (params.thickness ?? 0.05), 1, group);
 }
 
 function resolveLabelRefs(params: MVSPrimitiveParams<'label'>, refs: Set<string>) {

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -75,6 +75,16 @@ export function getPrimitiveStructureRefs(primitives: MVSPrimitive[]) {
     return refs;
 }
 
+const Builders: Record<MVSPrimitive['kind'], [
+    mesh: (context: MVSPrimitiveBuilderContext, state: MeshBuilderState, params: any) => void,
+    label: (context: MVSPrimitiveBuilderContext, state: LabelBuilderState, params: any) => void,
+    resolveRefs: (params: any, refs: Set<string>) => void
+]> = {
+    mesh: [addMesh, noOp, noOp],
+    line: [addLineMesh, noOp, resolveLineRefs],
+    distance_measurement: [addDistanceMesh, addDistanceLabel, resolveLineRefs],
+};
+
 function addRef(position: MVSPositionT, refs: Set<string>) {
     if (Array.isArray(position)) {
         if (typeof position[0] === 'number') {
@@ -187,16 +197,6 @@ function buildPrimitiveLabels(context: MVSPrimitiveBuilderContext, primives: MVS
         (g) => '',
     );
 }
-
-const Builders: Record<MVSPrimitive['kind'], [
-    mesh: (context: MVSPrimitiveBuilderContext, state: MeshBuilderState, params: any) => void,
-    label: (context: MVSPrimitiveBuilderContext, state: LabelBuilderState, params: any) => void,
-    resolveRefs: (params: any, refs: Set<string>) => void
-]> = {
-    mesh: [addMesh, noOp, noOp],
-    line: [addLineMesh, noOp, resolveLineRefs],
-    distance_measurement: [addDistanceMesh, addDistanceLabel, resolveLineRefs],
-};
 
 function noOp() { }
 

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -9,7 +9,7 @@ import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
 import { Text } from '../../../mol-geo/geometry/text/text';
 import { TextBuilder } from '../../../mol-geo/geometry/text/text-builder';
-import { Vec3 } from '../../../mol-math/linear-algebra';
+import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
 import { Loci } from '../../../mol-model/loci';
 import { Shape } from '../../../mol-model/shape';
 import { Structure, StructureSelection } from '../../../mol-model/structure';
@@ -255,6 +255,11 @@ function resolvePosition(context: PrimitiveBuilderContext, position: MVSPosition
     context.positionCache.set(cackeKey, Vec3.clone(target));
 }
 
+function getInstances(context: PrimitiveBuilderContext): Mat4[] | undefined {
+    if (!context.options?.instances?.length) return undefined;
+    return context.options?.instances.map(i => Mat4.fromArray(Mat4(), i, 0));
+}
+
 function buildPrimitiveMesh(context: PrimitiveBuilderContext, primitives: MVSPrimitive[], prev?: Mesh): Shape<Mesh> {
     const meshBuilder = MeshBuilder.createState(1024, 1024, prev);
     const state: MeshBuilderState = { mesh: meshBuilder, colors: new Map(), tooltips: new Map() };
@@ -281,6 +286,7 @@ function buildPrimitiveMesh(context: PrimitiveBuilderContext, primitives: MVSPri
         (g) => colors.get(g) as Color ?? color as Color,
         (g) => 1,
         (g) => tooltips.get(g) ?? tooltip,
+        getInstances(context),
     );
 }
 
@@ -307,6 +313,7 @@ function buildPrimitiveLabels(context: PrimitiveBuilderContext, primitives: MVSP
         (g) => colors.get(g) as Color ?? color as Color,
         (g) => sizes.get(g) ?? 1,
         (g) => '',
+        getInstances(context),
     );
 }
 

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -11,7 +11,6 @@ import { Text } from '../../../mol-geo/geometry/text/text';
 import { TextBuilder } from '../../../mol-geo/geometry/text/text-builder';
 import { Box3D, Sphere3D } from '../../../mol-math/geometry';
 import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
-import { Loci } from '../../../mol-model/loci';
 import { Shape } from '../../../mol-model/shape';
 import { Structure, StructureElement, StructureSelection } from '../../../mol-model/structure';
 import { StructureQueryHelper } from '../../../mol-plugin-state/helpers/structure-query';
@@ -27,11 +26,10 @@ import { ParamDefinition as PD } from '../../../mol-util/param-definition';
 import { capitalize } from '../../../mol-util/string';
 import { rowsToExpression, rowToExpression } from '../helpers/selections';
 import { collectMVSReferences, decodeColor } from '../helpers/utils';
-import { ValueFor } from '../tree/generic/params-schema';
 import { MolstarNode, MolstarSubtree } from '../tree/molstar/molstar-tree';
 import { MVSPrimitive, MVSPrimitiveOptions, MVSPrimitiveParams } from '../tree/mvs/mvs-primitives';
 import { MVSNode } from '../tree/mvs/mvs-tree';
-import { isComponentExpression, isPrimitiveComponentExpressions, isVector3, PrimitiveComponentExpressionT, PrimitivePositionT } from '../tree/mvs/param-types';
+import { isComponentExpression, isPrimitiveComponentExpressions, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
 import { MVSTransform } from './annotation-structure-component';
 
 export function getPrimitiveStructureRefs(primitives: MolstarSubtree<'primitives'>) {

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -201,6 +201,6 @@ export const MVSInlinePrimitives = MVSTransform({ // TODO: move MVSTransform to 
                 return mesh;
             },
             geometryUtils: Mesh.Utils
-        }, { label: 'Box' });
+        }, { label: 'Primitives Provider' });
     }
 });

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -184,7 +184,7 @@ class GroupManager {
 }
 
 interface PrimitiveBuilderContext {
-    node: MolstarNode<'primitives'>,
+    node: MolstarNode<'primitives'>;
     defaultStructure?: Structure;
     structureRefs: Record<string, Structure | undefined>;
     primitives: MolstarNode<'primitive'>[];
@@ -403,7 +403,7 @@ function addMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBuilder
         if (groupSet) {
             const grp = triangle_groups![i];
             mesh.currentGroup = groupSet.get(grp)!;
-            groups.updateColor(mesh.currentGroup, group_colors?.[grp])
+            groups.updateColor(mesh.currentGroup, group_colors?.[grp]);
             groups.updateTooltip(mesh.currentGroup, group_tooltips?.[grp]);
         } else {
             mesh.currentGroup = groups.allocateSingle(node);

--- a/src/extensions/mvs/helpers/selections.ts
+++ b/src/extensions/mvs/helpers/selections.ts
@@ -311,6 +311,7 @@ export function rowToExpression(row: MVSAnnotationRow): Expression {
 /** Convert multiple annotation rows into a MolScript expression.
  * (with union semantics, i.e. an atom qualifies if it qualifies for at least one of the rows) */
 export function rowsToExpression(rows: readonly MVSAnnotationRow[]): Expression {
+    if (rows.length === 1) return rowToExpression(rows[0]);
     return unionExpression(rows.map(rowToExpression));
 }
 

--- a/src/extensions/mvs/helpers/utils.ts
+++ b/src/extensions/mvs/helpers/utils.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { hashString } from '../../../mol-data/util';

--- a/src/extensions/mvs/helpers/utils.ts
+++ b/src/extensions/mvs/helpers/utils.ts
@@ -98,7 +98,7 @@ export type ElementOfSet<S> = S extends Set<infer T> ? T : never
 /** Convert `colorString` (either X11 color name like 'magenta' or hex code like '#ff00ff') to Color.
  * Return `undefined` if `colorString` cannot be converted. */
 export function decodeColor(colorString: string | undefined): Color | undefined {
-    if (colorString === undefined) return undefined;
+    if (colorString === undefined || colorString === null) return undefined;
     let result: Color | undefined;
     if (HexColor.is(colorString)) {
         if (colorString.length === 4) {

--- a/src/extensions/mvs/helpers/utils.ts
+++ b/src/extensions/mvs/helpers/utils.ts
@@ -5,6 +5,7 @@
  */
 
 import { hashString } from '../../../mol-data/util';
+import { StateObject } from '../../../mol-state';
 import { Color } from '../../../mol-util/color';
 import { ColorNames } from '../../../mol-util/color/names';
 
@@ -125,3 +126,27 @@ export const HexColor = {
         return typeof str === 'string' && hexColorRegex.test(str);
     },
 };
+
+export function collectMVSReferences<T extends StateObject.Ctor>(type: T[], dependencies: Record<string, StateObject>): Record<string, StateObject.From<T>['data']> {
+    const ret: any = {};
+
+    for (const key of Object.keys(dependencies)) {
+        const o = dependencies[key];
+        let okType = false;
+        for (const t of type) {
+            if (t.is(o)) {
+                okType = true;
+                break;
+            }
+        }
+        if (!okType || !o.tags) continue;
+        for (const tag of o.tags) {
+            if (tag.startsWith('mvs-ref:')) {
+                ret[tag.substring(8)] = o.data;
+                break;
+            }
+        }
+    }
+
+    return ret;
+}

--- a/src/extensions/mvs/helpers/utils.ts
+++ b/src/extensions/mvs/helpers/utils.ts
@@ -98,7 +98,7 @@ export type ElementOfSet<S> = S extends Set<infer T> ? T : never
 
 /** Convert `colorString` (either X11 color name like 'magenta' or hex code like '#ff00ff') to Color.
  * Return `undefined` if `colorString` cannot be converted. */
-export function decodeColor(colorString: string | undefined): Color | undefined {
+export function decodeColor(colorString: string | undefined | null): Color | undefined {
     if (colorString === undefined || colorString === null) return undefined;
     let result: Color | undefined;
     if (HexColor.is(colorString)) {

--- a/src/extensions/mvs/load-generic.ts
+++ b/src/extensions/mvs/load-generic.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { StructureRepresentation3D } from '../../mol-plugin-state/transforms/representation';

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -253,7 +253,7 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         const meshVisual = UpdateTarget.apply(mesh, ShapeRepresentation3D);
         if (hasPrimitiveLabels(primitives)) {
             const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
-            UpdateTarget.apply(labels, ShapeRepresentation3D, MVSLabelProps);
+            UpdateTarget.apply(labels, ShapeRepresentation3D);
         }
 
         return meshVisual;
@@ -266,7 +266,7 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
         const meshVisual = UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
         const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
-        UpdateTarget.apply(labels, ShapeRepresentation3D, MVSLabelProps);
+        UpdateTarget.apply(labels, ShapeRepresentation3D);
 
         return meshVisual;
     },

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -246,9 +246,8 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         return updateParent;
     },
     primitives(updateParent: UpdateTarget, tree: MolstarSubtree<'primitives'>, context: MolstarLoadingContext): UpdateTarget {
-        const primitives: MVSPrimitive[] = tree.children?.filter(c => c.kind === 'primitive').map(c => c.params) as MVSPrimitive[] | undefined ?? [];
-        const refs = getPrimitiveStructureRefs(primitives);
-        const data = UpdateTarget.apply(updateParent, MVSInlinePrimitiveData, { primitives, options: { ...tree.params } });
+        const refs = getPrimitiveStructureRefs(tree);
+        const data = UpdateTarget.apply(updateParent, MVSInlinePrimitiveData, { node: tree });
         return applyPrimitiveVisuals(data, refs);
     },
     primitives_from_uri(updateParent: UpdateTarget, tree: MolstarNode<'primitives_from_uri'>, context: MolstarLoadingContext): UpdateTarget {

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -28,7 +28,6 @@ import { MVSData } from './mvs-data';
 import { validateTree } from './tree/generic/tree-schema';
 import { convertMvsToMolstar, mvsSanityCheck } from './tree/molstar/conversion';
 import { MolstarNode, MolstarNodeParams, MolstarSubtree, MolstarTree, MolstarTreeSchema } from './tree/molstar/molstar-tree';
-import { MVSPrimitive } from './tree/mvs/mvs-primitives';
 import { MVSTreeSchema } from './tree/mvs/mvs-tree';
 
 

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -257,10 +257,12 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
 
 function applyPrimitiveVisuals(data: UpdateTarget, refs: Set<string>) {
     const mesh = UpdateTarget.setMvsDependencies(UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } }), refs);
-    const meshVisual = UpdateTarget.apply(mesh, ShapeRepresentation3D);
+    UpdateTarget.apply(mesh, ShapeRepresentation3D);
     const labels = UpdateTarget.setMvsDependencies(UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } }), refs);
     UpdateTarget.apply(labels, ShapeRepresentation3D);
-    return meshVisual;
+    const lines = UpdateTarget.setMvsDependencies(UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'lines' }, { state: { isGhost: true } }), refs);
+    UpdateTarget.apply(lines, ShapeRepresentation3D);
+    return data;
 }
 
 export type MolstarLoadingExtension<TExtensionContext> = LoadingExtension<MolstarTree, MolstarLoadingContext, TExtensionContext>;

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -20,13 +20,13 @@ import { MVSAnnotationTooltipsProvider } from './components/annotation-tooltips-
 import { CustomLabelProps, CustomLabelRepresentationProvider } from './components/custom-label/representation';
 import { CustomTooltipsProvider } from './components/custom-tooltips-prop';
 import { IsMVSModelProps, IsMVSModelProvider } from './components/is-mvs-model-prop';
-import { MVSLabelProps, MVSBuildPrimitiveShape, MVSInlinePrimitiveData, MVSPrimitive, MVSPrimitiveOptions } from './components/primitives';
+import { MVSLabelProps, MVSBuildPrimitiveShape, MVSInlinePrimitiveData } from './components/primitives';
 import { AnnotationFromSourceKind, AnnotationFromUriKind, collectAnnotationReferences, collectAnnotationTooltips, collectInlineLabels, collectInlineTooltips, colorThemeForNode, componentFromXProps, componentPropsFromSelector, isPhantomComponent, labelFromXProps, LoadingActions, loadTree, makeNearestReprMap, prettyNameFromSelector, representationProps, structureProps, transformProps, UpdateTarget } from './load-helpers';
 import { MVSData } from './mvs-data';
 import { ParamsOfKind, SubTreeOfKind, validateTree } from './tree/generic/tree-schema';
 import { convertMvsToMolstar, mvsSanityCheck } from './tree/molstar/conversion';
 import { MolstarNode, MolstarTree, MolstarTreeSchema } from './tree/molstar/molstar-tree';
-import { MVSTreeSchema } from './tree/mvs/mvs-tree';
+import { MVSPrimitive, MVSPrimitiveOptions, MVSTreeSchema } from './tree/mvs/mvs-tree';
 
 
 /** Load a MolViewSpec (MVS) tree into the Mol* plugin.
@@ -243,21 +243,14 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
     },
     primitives(updateParent: UpdateTarget, tree: SubTreeOfKind<MolstarTree, 'primitives'>, context: MolstarLoadingContext): UpdateTarget {
         const primitives: MVSPrimitive[] = [];
-        const options: MVSPrimitiveOptions = {};
-
-        let optionsNode: SubTreeOfKind<MolstarTree, 'primitives_options'> | undefined;
+        const options: MVSPrimitiveOptions = { ...tree.params };
 
         for (const node of tree.children ?? []) {
-            if (node.kind.startsWith('primitive_')) primitives.push({ kind: node.kind, params: node.params } as any);
-            if (node.kind === 'primitives_options') optionsNode = node as any;
+            if (node.kind === 'primitive') primitives.push(node.params as any);
+            // TODO: support focus
         }
 
-        for (const node of optionsNode?.children ?? []) {
-            if (node.kind === 'color') options.color = node.params.color;
-            if (node.kind === 'tooltip') options.tooltip = node.params.text;
-            // TODO: transparency
-        }
-
+        // TODO
         // const refs = getPrimitiveStructureRefs(primitives);
 
         const data = UpdateTarget.apply(updateParent, MVSInlinePrimitiveData, { primitives, options });
@@ -268,6 +261,4 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
 
         return updateParent;
     },
-    primitive_mesh: undefined,
-    primitive_line: undefined,
 };

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -20,7 +20,7 @@ import { MVSAnnotationTooltipsProvider } from './components/annotation-tooltips-
 import { CustomLabelProps, CustomLabelRepresentationProvider } from './components/custom-label/representation';
 import { CustomTooltipsProvider } from './components/custom-tooltips-prop';
 import { IsMVSModelProps, IsMVSModelProvider } from './components/is-mvs-model-prop';
-import { MVSLabelProps, MVSBuildPrimitiveShape, MVSInlinePrimitiveData } from './components/primitives';
+import { MVSLabelProps, MVSBuildPrimitiveShape, MVSInlinePrimitiveData, MVSDownloadPrimitiveData } from './components/primitives';
 import { AnnotationFromSourceKind, AnnotationFromUriKind, collectAnnotationReferences, collectAnnotationTooltips, collectInlineLabels, collectInlineTooltips, colorThemeForNode, componentFromXProps, componentPropsFromSelector, isPhantomComponent, labelFromXProps, LoadingActions, loadTree, makeNearestReprMap, prettyNameFromSelector, representationProps, structureProps, transformProps, UpdateTarget } from './load-helpers';
 import { MVSData } from './mvs-data';
 import { ParamsOfKind, SubTreeOfKind, validateTree } from './tree/generic/tree-schema';
@@ -254,6 +254,19 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         // const refs = getPrimitiveStructureRefs(primitives);
 
         const data = UpdateTarget.apply(updateParent, MVSInlinePrimitiveData, { primitives, options });
+        const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
+        UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
+        const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
+        UpdateTarget.apply(labels, ShapeRepresentation3D, MVSLabelProps);
+
+        return updateParent;
+    },
+
+    primitives_from_uri(updateParent: UpdateTarget, tree: SubTreeOfKind<MolstarTree, 'primitives_from_uri'>, context: MolstarLoadingContext): UpdateTarget {
+        // TODO
+        // const refs = ...
+
+        const data = UpdateTarget.apply(updateParent, MVSDownloadPrimitiveData, { uri: tree.params.uri, format: tree.params.format });
         const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
         UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
         const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -255,23 +255,22 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
 
         const data = UpdateTarget.apply(updateParent, MVSInlinePrimitiveData, { primitives, options });
         const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
-        UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
+        const meshVisual = UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
         const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
         UpdateTarget.apply(labels, ShapeRepresentation3D, MVSLabelProps);
 
-        return updateParent;
+        return meshVisual;
     },
-
     primitives_from_uri(updateParent: UpdateTarget, tree: SubTreeOfKind<MolstarTree, 'primitives_from_uri'>, context: MolstarLoadingContext): UpdateTarget {
         // TODO
         // const refs = ...
 
         const data = UpdateTarget.apply(updateParent, MVSDownloadPrimitiveData, { uri: tree.params.uri, format: tree.params.format });
         const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
-        UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
+        const meshVisual = UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
         const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
         UpdateTarget.apply(labels, ShapeRepresentation3D, MVSLabelProps);
 
-        return updateParent;
+        return meshVisual;
     },
 };

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -20,13 +20,13 @@ import { MVSAnnotationTooltipsProvider } from './components/annotation-tooltips-
 import { CustomLabelProps, CustomLabelRepresentationProvider } from './components/custom-label/representation';
 import { CustomTooltipsProvider } from './components/custom-tooltips-prop';
 import { IsMVSModelProps, IsMVSModelProvider } from './components/is-mvs-model-prop';
-import { MVSBuildPrimitiveShapeProvider, MVSBuildPrimitiveShapes, MVSInlinePrimitiveData, Primitive, PrimitiveOptions } from './components/primitives';
+import { MVSLabelProps, MVSBuildPrimitiveShape, MVSInlinePrimitiveData, MVSPrimitive, MVSPrimitiveOptions } from './components/primitives';
 import { AnnotationFromSourceKind, AnnotationFromUriKind, collectAnnotationReferences, collectAnnotationTooltips, collectInlineLabels, collectInlineTooltips, colorThemeForNode, componentFromXProps, componentPropsFromSelector, isPhantomComponent, labelFromXProps, LoadingActions, loadTree, makeNearestReprMap, prettyNameFromSelector, representationProps, structureProps, transformProps, UpdateTarget } from './load-helpers';
 import { MVSData } from './mvs-data';
 import { ParamsOfKind, SubTreeOfKind, validateTree } from './tree/generic/tree-schema';
 import { convertMvsToMolstar, mvsSanityCheck } from './tree/molstar/conversion';
 import { MolstarNode, MolstarTree, MolstarTreeSchema } from './tree/molstar/molstar-tree';
-import { MVSPrimitives, MVSTreeSchema } from './tree/mvs/mvs-tree';
+import { MVSTreeSchema } from './tree/mvs/mvs-tree';
 
 
 /** Load a MolViewSpec (MVS) tree into the Mol* plugin.
@@ -242,13 +242,13 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         return updateParent;
     },
     primitives(updateParent: UpdateTarget, tree: SubTreeOfKind<MolstarTree, 'primitives'>, context: MolstarLoadingContext): UpdateTarget {
-        const primitives: Primitive[] = [];
-        const options: PrimitiveOptions = {};
+        const primitives: MVSPrimitive[] = [];
+        const options: MVSPrimitiveOptions = {};
 
         let optionsNode: SubTreeOfKind<MolstarTree, 'primitives_options'> | undefined;
 
         for (const node of tree.children ?? []) {
-            if (MVSPrimitives.has(node.kind as any)) primitives.push({ kind: node.kind, params: node.params } as any);
+            if (node.kind.startsWith('primitive_')) primitives.push({ kind: node.kind, params: node.params } as any);
             if (node.kind === 'primitives_options') optionsNode = node as any;
         }
 
@@ -261,11 +261,10 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         // const refs = getPrimitiveStructureRefs(primitives);
 
         const data = UpdateTarget.apply(updateParent, MVSInlinePrimitiveData, { primitives, options });
-        const shapes = UpdateTarget.apply(data, MVSBuildPrimitiveShapes, { }, { state: { isGhost: true } });
-        const mesh = UpdateTarget.apply(shapes, MVSBuildPrimitiveShapeProvider, { kind: 'mesh' }, { state: { isGhost: true } });
+        const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
         UpdateTarget.apply(mesh, ShapeRepresentation3D, { });
-        const labels = UpdateTarget.apply(shapes, MVSBuildPrimitiveShapeProvider, { kind: 'labels' }, { state: { isGhost: true } });
-        UpdateTarget.apply(labels, ShapeRepresentation3D, { });
+        const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
+        UpdateTarget.apply(labels, ShapeRepresentation3D, MVSLabelProps);
 
         return updateParent;
     },

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -258,10 +258,9 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
 };
 
 function applyPrimitiveVisuals(data: UpdateTarget, refs: Set<string>) {
-    // TODO: refs
-    const mesh = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } });
+    const mesh = UpdateTarget.setMvsDependencies(UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'mesh' }, { state: { isGhost: true } }), refs);
     const meshVisual = UpdateTarget.apply(mesh, ShapeRepresentation3D);
-    const labels = UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } });
+    const labels = UpdateTarget.setMvsDependencies(UpdateTarget.apply(data, MVSBuildPrimitiveShape, { kind: 'labels' }, { state: { isGhost: true } }), refs);
     UpdateTarget.apply(labels, ShapeRepresentation3D);
     return meshVisual;
 }

--- a/src/extensions/mvs/tree/generic/params-schema.ts
+++ b/src/extensions/mvs/tree/generic/params-schema.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import * as iots from 'io-ts';

--- a/src/extensions/mvs/tree/generic/params-schema.ts
+++ b/src/extensions/mvs/tree/generic/params-schema.ts
@@ -134,8 +134,8 @@ export function paramsValidationIssues<P extends ParamsSchema, V extends { [k: s
         const paramDef = schema[key];
 
         // Special handling of "union" param type
+        // TODO: figure out how to do this properly, ignoring the validation for now
         if (key === '_union_') {
-            // TODO: figure out how to do this
             return undefined;
         }
 

--- a/src/extensions/mvs/tree/generic/params-schema.ts
+++ b/src/extensions/mvs/tree/generic/params-schema.ts
@@ -45,6 +45,10 @@ export function literal<V extends string | number | boolean>(...values: V[]) {
         value => value
     );
 }
+/** Mapping between two types */
+export function mapping<A extends iots.Type<any>, B extends iots.Type<any>>(from: A, to: B) {
+    return iots.record(from, to);
+}
 
 
 /** Schema for one field in params (i.e. a value in a top-level key-value pair) */

--- a/src/extensions/mvs/tree/generic/params-schema.ts
+++ b/src/extensions/mvs/tree/generic/params-schema.ts
@@ -28,6 +28,11 @@ export const tuple = iots.tuple;
 export const list = iots.array;
 /** Type definition for union types, e.g. `union([str, int])` means string or integer  */
 export const union = iots.union;
+/** Type definition used to create objects */
+export const obj = iots.type;
+/** Type definition used to create partial objects */
+export const partial = iots.partial;
+
 /** Type definition for nullable types, e.g. `nullable(str)` means string or `null`  */
 export function nullable<T extends iots.Type<any>>(type: T) {
     return union([type, iots.null]);
@@ -126,6 +131,13 @@ export function paramsValidationIssues<P extends ParamsSchema, V extends { [k: s
     if (!isPlainObject(values)) return [`Parameters must be an object, not ${values}`];
     for (const key in schema) {
         const paramDef = schema[key];
+
+        // Special handling of "union" param type
+        if (key === '_union_') {
+            // TODO: figure out how to do this
+            return undefined;
+        }
+
         if (Object.hasOwn(values, key)) {
             const value = values[key];
             const issues = fieldValidationIssues(paramDef, value);

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -105,6 +105,7 @@ export const MVSDefaults = {
         default_label_color: null,
         default_tooltip: null,
         transparency: null,
+        label_transparency: null,
     },
     primitives_from_uri: {
         references: null,

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -105,6 +105,9 @@ export const MVSDefaults = {
         default_tooltip: null,
         transparency: null,
     },
+    primitives_from_uri: {
+        references: null,
+    },
     primitive: { },
 } satisfies DefaultsForTree<typeof MVSTreeSchema>;
 

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -101,8 +101,18 @@ export const MVSDefaults = {
     },
     primitives: { },
     primitives_options: { },
-    mesh: { triangle_colors: null, group_colors: null, triangle_groups: null, group_tooltips: null },
-    line: { thickness: 0.05, color: null, tooltip: null },
+    mesh: {
+        triangle_colors: null,
+        group_colors: null,
+        triangle_groups: null,
+        group_tooltips: null
+    },
+    line: {
+        thickness: 0.05,
+        color: null,
+        tooltip: null
+        // TODO: remaining params
+    },
 } satisfies DefaultsForTree<typeof MVSTreeSchema>;
 
 /** Color to be used e.g. for representations without 'color' node */

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -104,8 +104,8 @@ export const MVSDefaults = {
         default_color: null,
         default_label_color: null,
         default_tooltip: null,
-        transparency: null,
-        label_transparency: null,
+        default_transparency: null,
+        default_label_transparency: null,
     },
     primitives_from_uri: {
         references: null,

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { DefaultsForTree } from '../generic/tree-schema';

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -123,7 +123,8 @@ export const MVSDefaults = {
         color: null,
         label_template: '{{distance}}',
         label_size: 'auto',
-        label_auto_size_scale: 0.2,
+        label_auto_size_scale: 0.1,
+        label_auto_size_min: 0.2,
         label_color: 'black',
     }
 } satisfies DefaultsForTree<typeof MVSTreeSchema>;

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -101,18 +101,31 @@ export const MVSDefaults = {
     },
     primitives: { },
     primitives_options: { },
-    mesh: {
+    primitive_mesh: {
         triangle_colors: null,
         group_colors: null,
         triangle_groups: null,
         group_tooltips: null
     },
-    line: {
+    primitive_line: {
         thickness: 0.05,
+        dash_start: null,
+        dash_length: null,
+        gap_length: null,
         color: null,
         tooltip: null
-        // TODO: remaining params
     },
+    primitive_distance_measurement: {
+        thickness: 0.05,
+        dash_start: 0,
+        dash_length: 0.05,
+        gap_length: 0.05,
+        color: null,
+        label_template: '{{distance}}',
+        label_size: 'auto',
+        label_auto_size_scale: 0.2,
+        label_color: 'black',
+    }
 } satisfies DefaultsForTree<typeof MVSTreeSchema>;
 
 /** Color to be used e.g. for representations without 'color' node */

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -106,6 +106,7 @@ export const MVSDefaults = {
         tooltip: null,
         transparency: null,
         label_transparency: null,
+        instances: null,
     },
     primitives_from_uri: {
         references: null,

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -101,11 +101,11 @@ export const MVSDefaults = {
         up: [0, 1, 0],
     },
     primitives: {
-        default_color: null,
-        default_label_color: null,
-        default_tooltip: null,
-        default_transparency: null,
-        default_label_transparency: null,
+        color: null,
+        label_color: null,
+        tooltip: null,
+        transparency: null,
+        label_transparency: null,
     },
     primitives_from_uri: {
         references: null,

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -99,34 +99,13 @@ export const MVSDefaults = {
     camera: {
         up: [0, 1, 0],
     },
-    primitives: { },
-    primitives_options: { },
-    primitive_mesh: {
-        triangle_colors: null,
-        group_colors: null,
-        triangle_groups: null,
-        group_tooltips: null
+    primitives: {
+        default_color: null,
+        default_label_color: null,
+        default_tooltip: null,
+        transparency: null,
     },
-    primitive_line: {
-        thickness: 0.05,
-        dash_start: null,
-        dash_length: null,
-        gap_length: null,
-        color: null,
-        tooltip: null
-    },
-    primitive_distance_measurement: {
-        thickness: 0.05,
-        dash_start: 0,
-        dash_length: 0.05,
-        gap_length: 0.05,
-        color: null,
-        label_template: '{{distance}}',
-        label_size: 'auto',
-        label_auto_size_scale: 0.1,
-        label_auto_size_min: 0.2,
-        label_color: 'black',
-    }
+    primitive: { },
 } satisfies DefaultsForTree<typeof MVSTreeSchema>;
 
 /** Color to be used e.g. for representations without 'color' node */

--- a/src/extensions/mvs/tree/mvs/mvs-defaults.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-defaults.ts
@@ -99,6 +99,10 @@ export const MVSDefaults = {
     camera: {
         up: [0, 1, 0],
     },
+    primitives: { },
+    primitives_options: { },
+    mesh: { triangle_colors: null, group_colors: null, triangle_groups: null, group_tooltips: null },
+    line: { thickness: 0.05, color: null, tooltip: null },
 } satisfies DefaultsForTree<typeof MVSTreeSchema>;
 
 /** Color to be used e.g. for representations without 'color' node */

--- a/src/extensions/mvs/tree/mvs/mvs-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-primitives.ts
@@ -15,9 +15,7 @@ const _LineBase = {
     end: PrimitivePositionT,
     thickness: nullable(float),
     color: nullable(ColorT),
-    dash_start: nullable(float),
     dash_length: nullable(float),
-    gap_length: nullable(float),
 };
 
 const MeshParams = obj({
@@ -31,8 +29,23 @@ const MeshParams = obj({
     tooltip: nullable(str),
     show_triangles: nullable(bool),
     show_wireframe: nullable(bool),
+    color: nullable(ColorT),
     wireframe_radius: nullable(float),
     wireframe_color: nullable(ColorT),
+});
+
+const LinesParams = obj({
+    kind: literal('lines'),
+    vertices: FloatList,
+    indices: IntList,
+    line_colors: nullable(StrList),
+    line_groups: nullable(IntList),
+    group_colors: nullable(mapping(int, ColorT)),
+    group_tooltips: nullable(mapping(int, str)),
+    group_radius: nullable(mapping(int, float)),
+    tooltip: nullable(str),
+    color: nullable(ColorT),
+    line_radius: nullable(float),
 });
 
 const LineParams = obj({
@@ -60,7 +73,7 @@ const PrimitiveLabelParams = obj({
     label_offset: nullable(float),
 });
 
-export const MVSPrimitiveParams = union([MeshParams, LineParams, DistanceMeasurementParams, PrimitiveLabelParams]);
+export const MVSPrimitiveParams = union([MeshParams, LinesParams, LineParams, DistanceMeasurementParams, PrimitiveLabelParams]);
 
 export type MVSPrimitive = ValueFor<typeof MVSPrimitiveParams>
 export type MVSPrimitiveKind = MVSPrimitive['kind']

--- a/src/extensions/mvs/tree/mvs/mvs-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-primitives.ts
@@ -4,7 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-import { float, int, literal, mapping, nullable, obj, str, union, ValueFor } from '../generic/params-schema';
+import { bool, float, int, literal, mapping, nullable, obj, str, union, ValueFor } from '../generic/params-schema';
 import type { MVSNode } from './mvs-tree';
 import { ColorT, FloatList, IntList, PrimitivePositionT, StrList } from './param-types';
 
@@ -29,6 +29,10 @@ const MeshParams = obj({
     group_colors: nullable(mapping(int, ColorT)),
     group_tooltips: nullable(mapping(int, str)),
     tooltip: nullable(str),
+    show_triangles: nullable(bool),
+    show_wireframe: nullable(bool),
+    wireframe_radius: nullable(float),
+    wireframe_color: nullable(ColorT),
 });
 
 const LineParams = obj({
@@ -61,4 +65,4 @@ export const MVSPrimitiveParams = union([MeshParams, LineParams, DistanceMeasure
 export type MVSPrimitive = ValueFor<typeof MVSPrimitiveParams>
 export type MVSPrimitiveKind = MVSPrimitive['kind']
 export type MVSPrimitiveOptions = MVSNode<'primitives'>['params']
-export type MVSPrimitiveParams<T extends MVSPrimitiveKind> = Extract<MVSPrimitive, { kind: T }>
+export type MVSPrimitiveParams<T extends MVSPrimitiveKind = MVSPrimitiveKind> = Extract<MVSPrimitive, { kind: T }>

--- a/src/extensions/mvs/tree/mvs/mvs-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-primitives.ts
@@ -6,13 +6,13 @@
 
 import { float, int, literal, mapping, nullable, obj, str, union, ValueFor } from '../generic/params-schema';
 import type { MVSNode } from './mvs-tree';
-import { ColorT, FloatList, IntList, PositionT, StrList } from './param-types';
+import { ColorT, FloatList, IntList, PrimitivePositionT, StrList } from './param-types';
 
 // TODO: Figure out validation and default values for these
 
 const _LineBase = {
-    start: PositionT,
-    end: PositionT,
+    start: PrimitivePositionT,
+    end: PrimitivePositionT,
     thickness: nullable(float),
     color: nullable(ColorT),
     dash_start: nullable(float),
@@ -49,7 +49,7 @@ const DistanceMeasurementParams = obj({
 
 const PrimitiveLabelParams = obj({
     kind: literal('label'),
-    position: PositionT,
+    position: PrimitivePositionT,
     text: str,
     label_size: nullable(float),
     label_color: nullable(ColorT),

--- a/src/extensions/mvs/tree/mvs/mvs-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-primitives.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author David Sehnal <david.sehnal@gmail.com>
+ */
+
+import { float, int, literal, mapping, nullable, obj, str, union, ValueFor } from '../generic/params-schema';
+import type { MVSNode } from './mvs-tree';
+import { ColorT, FloatList, IntList, PositionT, StrList } from './param-types';
+
+// TODO: Figure out validation and default values for these
+
+const _LineBase = {
+    start: PositionT,
+    end: PositionT,
+    thickness: nullable(float),
+    color: nullable(ColorT),
+    dash_start: nullable(float),
+    dash_length: nullable(float),
+    gap_length: nullable(float),
+};
+
+const MeshParams = obj({
+    kind: literal('mesh'),
+    vertices: FloatList,
+    indices: IntList,
+    triangle_colors: nullable(StrList),
+    triangle_groups: nullable(IntList),
+    group_colors: nullable(mapping(int, ColorT)),
+    group_tooltips: nullable(mapping(int, str)),
+    tooltip: nullable(str),
+});
+
+const LineParams = obj({
+    kind: literal('line'),
+    ..._LineBase,
+    tooltip: nullable(str),
+});
+
+const DistanceMeasurementParams = obj({
+    kind: literal('distance_measurement'),
+    ..._LineBase,
+    label_template: nullable(str),
+    label_size: nullable(union([float, literal('auto')])),
+    label_auto_size_scale: nullable(float),
+    label_auto_size_min: nullable(float),
+    label_color: nullable(ColorT),
+});
+
+const PrimitiveLabelParams = obj({
+    kind: literal('label'),
+    position: PositionT,
+    text: str,
+    label_size: nullable(float),
+    label_color: nullable(ColorT),
+    label_offset: nullable(float),
+});
+
+export const MVSPrimitiveParams = union([MeshParams, LineParams, DistanceMeasurementParams, PrimitiveLabelParams]);
+
+export type MVSPrimitive = ValueFor<typeof MVSPrimitiveParams>
+export type MVSPrimitiveKind = MVSPrimitive['kind']
+export type MVSPrimitiveOptions = MVSNode<'primitives'>['params']
+export type MVSPrimitiveParams<T extends MVSPrimitiveKind> = Extract<MVSPrimitive, { kind: T }>

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -4,7 +4,7 @@
  * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { OptionalField, RequiredField, float, int, list, mapping, nullable, str, tuple, union } from '../generic/params-schema';
+import { OptionalField, RequiredField, float, int, list, literal, mapping, nullable, str, tuple, union } from '../generic/params-schema';
 import { NodeFor, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
 import { ColorT, ComponentExpressionT, ComponentSelectorT, FloatList, IntList, Matrix, ParseFormatT, PositionT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
 
@@ -38,6 +38,16 @@ const _DataFromSourceParams = {
     /** Name of the column in CIF or field name (key) in JSON that contains the dependent variable (color/label/tooltip/component_id...). The default value is 'color'/'label'/'tooltip'/'component' depending on the node type */
     field_name: OptionalField(str, 'Name of the column in CIF or field name (key) in JSON that contains the dependent variable (color/label/tooltip/component_id...).'),
 };
+
+const _LineBase = {
+    start: RequiredField(PositionT),
+    end: RequiredField(PositionT),
+    thickness: OptionalField(nullable(float)),
+    color: OptionalField(nullable(ColorT)),
+    dash_start: OptionalField(nullable(float)),
+    dash_length: OptionalField(nullable(float)),
+    gap_length: OptionalField(nullable(float)),
+}
 
 
 /** Schema for `MVSTree` (MolViewSpec tree) */
@@ -261,7 +271,7 @@ export const MVSTreeSchema = TreeSchema({
             parent: ['primitives'],
             params: { },
         },
-        mesh: {
+        primitive_mesh: {
             description: 'This node represents a mesh primitive',
             parent: ['primitives'],
             params: {
@@ -273,16 +283,23 @@ export const MVSTreeSchema = TreeSchema({
                 group_tooltips: OptionalField(nullable(mapping(int, str))),
             },
         },
-        line: {
+        primitive_line: {
             description: 'This node represents a line primitive',
             parent: ['primitives'],
             params: {
-                start: RequiredField(PositionT),
-                end: RequiredField(PositionT),
-                thickness: OptionalField(nullable(float)),
-                color: OptionalField(nullable(ColorT)),
+                ..._LineBase,
                 tooltip: OptionalField(nullable(str)),
-                // TODO: remaining properties
+            },
+        },
+        primitive_distance_measurement: {
+            description: 'This node represents a distance measurement primitive',
+            parent: ['primitives'],
+            params: {
+                ..._LineBase,
+                label_template: OptionalField(str),
+                label_size: OptionalField(union([float, literal('auto')])),
+                label_auto_size_scale: OptionalField(float),
+                label_color: OptionalField(ColorT),
             },
         }
 
@@ -305,3 +322,6 @@ export const FullMVSTreeSchema = TreeSchemaWithAllRequired(MVSTreeSchema);
 
 /** MolViewSpec tree with all params provided */
 export type FullMVSTree = TreeFor<typeof FullMVSTreeSchema>
+
+/** A set of primitive node kinds */
+export const MVSPrimitives = new Set<MVSKind>(['primitive_mesh', 'primitive_line', 'primitive_distance_measurement']);

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -306,6 +306,15 @@ export const MVSTreeSchema = TreeSchema({
                 transparency: OptionalField(nullable(float)),
             },
         },
+        primitives_from_uri: {
+            description: 'This node loads a list of primitives from URI',
+            parent: ['structure', 'root'],
+            params: {
+                uri: RequiredField(str),
+                format: RequiredField(literal('json')),
+                references: OptionalField(nullable(StrList)),
+            },
+        },
         primitive: {
             description: 'This node represents a geometrical primitive',
             parent: ['primitives'],

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -278,7 +278,7 @@ export const MVSTreeSchema = TreeSchema({
             parent: ['structure', 'root'],
             params: {
                 uri: RequiredField(str),
-                format: RequiredField(literal('json')),
+                format: RequiredField(literal('mvs-node-json')),
                 references: OptionalField(nullable(StrList)),
             },
         },

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -79,7 +79,16 @@ const DistanceMeasurementParams = obj({
     label_color: nullable(ColorT),
 });
 
-const PrimitiveParams = union([MeshParams, LineParams, DistanceMeasurementParams]);
+const PrimitiveLabelParams = obj({
+    kind: literal('label'),
+    position: PositionT,
+    text: str,
+    label_size: nullable(float),
+    label_color: nullable(ColorT),
+    label_offset: nullable(float),
+});
+
+const PrimitiveParams = union([MeshParams, LineParams, DistanceMeasurementParams, PrimitiveLabelParams]);
 
 export type MVSPrimitive = ValueFor<typeof PrimitiveParams>
 export type MVSPrimitiveKind = MVSPrimitive['kind']
@@ -305,6 +314,7 @@ export const MVSTreeSchema = TreeSchema({
                 default_label_color: OptionalField(nullable(ColorT)),
                 default_tooltip: OptionalField(nullable(str)),
                 transparency: OptionalField(nullable(float)),
+                label_transparency: OptionalField(nullable(float)),
             },
         },
         primitives_from_uri: {

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -5,9 +5,10 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-import { OptionalField, RequiredField, float, int, list, literal, mapping, nullable, str, tuple, union, obj, ValueFor } from '../generic/params-schema';
+import { float, int, list, literal, nullable, OptionalField, RequiredField, str, tuple, union } from '../generic/params-schema';
 import { NodeFor, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
-import { ColorT, ComponentExpressionT, ComponentSelectorT, FloatList, IntList, Matrix, ParseFormatT, PositionT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
+import { MVSPrimitiveParams } from './mvs-primitives';
+import { ColorT, ComponentExpressionT, ComponentSelectorT, Matrix, ParseFormatT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
 
 
 const _DataFromUriParams = {
@@ -39,61 +40,6 @@ const _DataFromSourceParams = {
     /** Name of the column in CIF or field name (key) in JSON that contains the dependent variable (color/label/tooltip/component_id...). The default value is 'color'/'label'/'tooltip'/'component' depending on the node type */
     field_name: OptionalField(str, 'Name of the column in CIF or field name (key) in JSON that contains the dependent variable (color/label/tooltip/component_id...).'),
 };
-
-
-
-const _LineBase = {
-    start: PositionT,
-    end: PositionT,
-    thickness: nullable(float),
-    color: nullable(ColorT),
-    dash_start: nullable(float),
-    dash_length: nullable(float),
-    gap_length: nullable(float),
-};
-
-const MeshParams = obj({
-    kind: literal('mesh'),
-    vertices: FloatList,
-    indices: IntList,
-    triangle_colors: nullable(StrList),
-    triangle_groups: nullable(IntList),
-    group_colors: nullable(mapping(int, ColorT)),
-    group_tooltips: nullable(mapping(int, str)),
-    tooltip: nullable(str),
-});
-
-const LineParams = obj({
-    kind: literal('line'),
-    ..._LineBase,
-    tooltip: nullable(str),
-});
-
-const DistanceMeasurementParams = obj({
-    kind: literal('distance_measurement'),
-    ..._LineBase,
-    label_template: nullable(str),
-    label_size: nullable(union([float, literal('auto')])),
-    label_auto_size_scale: nullable(float),
-    label_auto_size_min: nullable(float),
-    label_color: nullable(ColorT),
-});
-
-const PrimitiveLabelParams = obj({
-    kind: literal('label'),
-    position: PositionT,
-    text: str,
-    label_size: nullable(float),
-    label_color: nullable(ColorT),
-    label_offset: nullable(float),
-});
-
-const PrimitiveParams = union([MeshParams, LineParams, DistanceMeasurementParams, PrimitiveLabelParams]);
-
-export type MVSPrimitive = ValueFor<typeof PrimitiveParams>
-export type MVSPrimitiveKind = MVSPrimitive['kind']
-export type MVSPrimitiveOptions = MVSNode<'primitives'>['params']
-export type MVSPrimitiveParams<T extends MVSPrimitiveKind> = Extract<MVSPrimitive, { kind: T }>
 
 /** Schema for `MVSTree` (MolViewSpec tree) */
 export const MVSTreeSchema = TreeSchema({
@@ -310,11 +256,11 @@ export const MVSTreeSchema = TreeSchema({
             description: 'This node groups a list of geometrical primitives',
             parent: ['structure', 'root'],
             params: {
-                default_color: OptionalField(nullable(ColorT)),
-                default_label_color: OptionalField(nullable(ColorT)),
-                default_tooltip: OptionalField(nullable(str)),
-                default_transparency: OptionalField(nullable(float)),
-                default_label_transparency: OptionalField(nullable(float)),
+                color: OptionalField(nullable(ColorT)),
+                label_color: OptionalField(nullable(ColorT)),
+                tooltip: OptionalField(nullable(str)),
+                transparency: OptionalField(nullable(float)),
+                label_transparency: OptionalField(nullable(float)),
             },
         },
         primitives_from_uri: {
@@ -330,8 +276,8 @@ export const MVSTreeSchema = TreeSchema({
             description: 'This node represents a geometrical primitive',
             parent: ['primitives'],
             params: {
-                // TODO: proper validation
-                _union_: RequiredField(PrimitiveParams),
+                // TODO: validation
+                _union_: RequiredField(MVSPrimitiveParams),
             },
         },
     }

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -261,6 +261,7 @@ export const MVSTreeSchema = TreeSchema({
                 tooltip: OptionalField(nullable(str)),
                 transparency: OptionalField(nullable(float)),
                 label_transparency: OptionalField(nullable(float)),
+                instances: OptionalField(nullable(list(Matrix)))
             },
         },
         primitives_from_uri: {

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -6,7 +6,7 @@
 
 import { OptionalField, RequiredField, float, int, list, mapping, nullable, str, tuple, union } from '../generic/params-schema';
 import { NodeFor, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
-import { ColorT, ComponentExpressionT, ComponentSelectorT, FloatList, IntList, Matrix, ParseFormatT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
+import { ColorT, ComponentExpressionT, ComponentSelectorT, FloatList, IntList, Matrix, ParseFormatT, PositionT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
 
 
 const _DataFromUriParams = {
@@ -277,8 +277,8 @@ export const MVSTreeSchema = TreeSchema({
             description: 'This node represents a line primitive',
             parent: ['primitives'],
             params: {
-                start: RequiredField(Vector3),
-                end: RequiredField(Vector3),
+                start: RequiredField(PositionT),
+                end: RequiredField(PositionT),
                 thickness: OptionalField(nullable(float)),
                 color: OptionalField(nullable(ColorT)),
                 tooltip: OptionalField(nullable(str)),

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { OptionalField, RequiredField, float, int, list, literal, mapping, nullable, str, tuple, union, obj, ValueFor } from '../generic/params-schema';

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -4,9 +4,9 @@
  * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { OptionalField, RequiredField, float, int, list, nullable, str, tuple, union } from '../generic/params-schema';
+import { OptionalField, RequiredField, float, int, list, mapping, nullable, str, tuple, union } from '../generic/params-schema';
 import { NodeFor, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
-import { ColorT, ComponentExpressionT, ComponentSelectorT, Matrix, ParseFormatT, RepresentationTypeT, SchemaFormatT, SchemaT, StructureTypeT, Vector3 } from './param-types';
+import { ColorT, ComponentExpressionT, ComponentSelectorT, FloatList, IntList, Matrix, ParseFormatT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
 
 
 const _DataFromUriParams = {
@@ -144,7 +144,7 @@ export const MVSTreeSchema = TreeSchema({
         /** This node instructs to apply color to a visual representation. */
         color: {
             description: 'This node instructs to apply color to a visual representation.',
-            parent: ['representation'],
+            parent: ['representation', 'primitives_options'],
             params: {
                 /** Color to apply to the representation. Can be either an X11 color name (e.g. `"red"`) or a hexadecimal code (e.g. `"#FF0011"`). */
                 color: RequiredField(ColorT, 'Color to apply to the representation. Can be either an X11 color name (e.g. `"red"`) or a hexadecimal code (e.g. `"#FF0011"`).'),
@@ -196,7 +196,7 @@ export const MVSTreeSchema = TreeSchema({
         /** This node instructs to add a tooltip to a component. "Tooltip" is a text which is not a part of the visualization but should be presented to the users when they interact with the component (typically, the tooltip will be shown somewhere on the screen when the user hovers over a visual representation of the component). */
         tooltip: {
             description: 'This node instructs to add a tooltip to a component. "Tooltip" is a text which is not a part of the visualization but should be presented to the users when they interact with the component (typically, the tooltip will be shown somewhere on the screen when the user hovers over a visual representation of the component).',
-            parent: ['component', 'component_from_uri', 'component_from_source'],
+            parent: ['component', 'component_from_uri', 'component_from_source', 'primitives_options'],
             params: {
                 /** Content of the shown tooltip. */
                 text: RequiredField(str, 'Content of the shown tooltip.'),
@@ -251,6 +251,41 @@ export const MVSTreeSchema = TreeSchema({
                 background_color: RequiredField(ColorT, 'Color of the canvas background. Can be either an X11 color name (e.g. `"red"`) or a hexadecimal code (e.g. `"#FF0011"`).'),
             },
         },
+        primitives: {
+            description: 'This node groups a list of geometrical primitives',
+            parent: ['structure', 'root'],
+            params: { },
+        },
+        primitives_options: {
+            description: 'This node groups a list of geometrical primitives',
+            parent: ['primitives'],
+            params: { },
+        },
+        mesh: {
+            description: 'This node represents a mesh primitive',
+            parent: ['primitives'],
+            params: {
+                vertices: RequiredField(FloatList),
+                indices: RequiredField(IntList),
+                triangle_colors: OptionalField(nullable(StrList)),
+                triangle_groups: OptionalField(nullable(IntList)),
+                group_colors: OptionalField(nullable(mapping(int, ColorT))),
+                group_tooltips: OptionalField(nullable(mapping(int, str))),
+            },
+        },
+        line: {
+            description: 'This node represents a line primitive',
+            parent: ['primitives'],
+            params: {
+                start: RequiredField(Vector3),
+                end: RequiredField(Vector3),
+                thickness: OptionalField(nullable(float)),
+                color: OptionalField(nullable(ColorT)),
+                tooltip: OptionalField(nullable(str)),
+                // TODO: remaining properties
+            },
+        }
+
     }
 });
 

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -270,7 +270,7 @@ export const MVSTreeSchema = TreeSchema({
                 tooltip: OptionalField(nullable(str)),
                 transparency: OptionalField(nullable(float)),
                 label_transparency: OptionalField(nullable(float)),
-                instances: OptionalField(nullable(list(Matrix)))
+                instances: OptionalField(nullable(list(Matrix))),
             },
         },
         primitives_from_uri: {

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -47,8 +47,7 @@ const _LineBase = {
     dash_start: OptionalField(nullable(float)),
     dash_length: OptionalField(nullable(float)),
     gap_length: OptionalField(nullable(float)),
-}
-
+};
 
 /** Schema for `MVSTree` (MolViewSpec tree) */
 export const MVSTreeSchema = TreeSchema({
@@ -299,6 +298,7 @@ export const MVSTreeSchema = TreeSchema({
                 label_template: OptionalField(str),
                 label_size: OptionalField(union([float, literal('auto')])),
                 label_auto_size_scale: OptionalField(float),
+                label_auto_size_min: OptionalField(float),
                 label_color: OptionalField(ColorT),
             },
         }
@@ -322,6 +322,3 @@ export const FullMVSTreeSchema = TreeSchemaWithAllRequired(MVSTreeSchema);
 
 /** MolViewSpec tree with all params provided */
 export type FullMVSTree = TreeFor<typeof FullMVSTreeSchema>
-
-/** A set of primitive node kinds */
-export const MVSPrimitives = new Set<MVSKind>(['primitive_mesh', 'primitive_line', 'primitive_distance_measurement']);

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -5,16 +5,10 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-<<<<<<< HEAD
 import { float, int, list, literal, nullable, OptionalField, RequiredField, str, tuple, union } from '../generic/params-schema';
-import { NodeFor, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
+import { NodeFor, ParamsOfKind, SubtreeOfKind, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
 import { MVSPrimitiveParams } from './mvs-primitives';
 import { ColorT, ComponentExpressionT, ComponentSelectorT, Matrix, ParseFormatT, RepresentationTypeT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
-=======
-import { OptionalField, RequiredField, float, int, list, nullable, str, tuple, union } from '../generic/params-schema';
-import { NodeFor, ParamsOfKind, SubtreeOfKind, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
-import { ColorT, ComponentExpressionT, ComponentSelectorT, Matrix, ParseFormatT, RepresentationTypeT, SchemaFormatT, SchemaT, StructureTypeT, Vector3 } from './param-types';
->>>>>>> c19130c9eba2342b9f0636abb82cc9c274b5ce38
 
 
 const _DataFromUriParams = {

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -266,7 +266,7 @@ export const MVSTreeSchema = TreeSchema({
         /** This node instructs to set the camera focus to a component (zoom in). */
         focus: {
             description: 'This node instructs to set the camera focus to a component (zoom in).',
-            parent: ['component', 'component_from_uri', 'component_from_source'],
+            parent: ['component', 'component_from_uri', 'component_from_source', 'primitives', 'primitives_from_uri'],
             params: {
                 /** Vector describing the direction of the view (camera position -> focused target). */
                 direction: OptionalField(Vector3, 'Vector describing the direction of the view (camera position -> focused target).'),

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -313,8 +313,8 @@ export const MVSTreeSchema = TreeSchema({
                 default_color: OptionalField(nullable(ColorT)),
                 default_label_color: OptionalField(nullable(ColorT)),
                 default_tooltip: OptionalField(nullable(str)),
-                transparency: OptionalField(nullable(float)),
-                label_transparency: OptionalField(nullable(float)),
+                default_transparency: OptionalField(nullable(float)),
+                default_label_transparency: OptionalField(nullable(float)),
             },
         },
         primitives_from_uri: {

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -26,7 +26,7 @@ export const StructureTypeT = literal('model', 'assembly', 'symmetry', 'symmetry
 export const ComponentSelectorT = literal('all', 'polymer', 'protein', 'nucleic', 'branched', 'ligand', 'ion', 'water');
 
 /** `selector` parameter values for `component` node in MVS tree */
-const _ComponentBase = {
+export const ComponentExpressionT = iots.partial({
     label_entity_id: str,
     label_asym_id: str,
     auth_asym_id: str,
@@ -42,9 +42,8 @@ const _ComponentBase = {
     type_symbol: str,
     atom_id: int,
     atom_index: int,
-};
-
-export const ComponentExpressionT = iots.partial(_ComponentBase);
+});
+export type ComponentExpressionT = ValueFor<typeof ComponentExpressionT>
 
 /** `type` parameter values for `representation` node in MVS tree */
 export const RepresentationTypeT = literal('ball_and_stick', 'cartoon', 'surface');
@@ -57,16 +56,21 @@ export const SchemaFormatT = literal('cif', 'bcif', 'json');
 
 /** Parameter values for vector params, e.g. `position` */
 export const Vector3 = tuple([float, float, float]);
+export type Vector3 = ValueFor<typeof Vector3>
 
 /** Parameter values for matrix params, e.g. `rotation` */
 export const Matrix = list(float);
 
 /** Primitives-related types */
-export const PrimitiveComponentExpressionT = iots.partial({ structure_ref: str, ..._ComponentBase });
-export const PositionT = iots.union([Vector3, PrimitiveComponentExpressionT, list(PrimitiveComponentExpressionT)]);
+export const PrimitiveComponentExpressionT = iots.partial({ structure_ref: str, expression_schema: SchemaT, expressions: list(ComponentExpressionT) });
+export type PrimitiveComponentExpressionT = ValueFor<typeof PrimitiveComponentExpressionT>
+export const PrimitivePositionT = iots.union([Vector3, ComponentExpressionT, list(PrimitiveComponentExpressionT)]);
+export type PrimitivePositionT = ValueFor<typeof PrimitivePositionT>
+
 export const FloatList = list(float);
 export const IntList = list(int);
 export const StrList = list(str);
+
 
 /** `color` parameter values for `color` node in MVS tree */
 export const HexColorT = new iots.Type<HexColor>(
@@ -81,3 +85,16 @@ export const ColorNamesT = literal(...Object.keys(ColorNames) as (keyof ColorNam
 
 /** `color` parameter values for `color` node in MVS tree */
 export const ColorT = union([HexColorT, ColorNamesT]);
+
+/** Type helpers */
+export function isVector3(x: any): x is Vector3 {
+    return !!x && Array.isArray(x) && x.length === 3 && typeof x[0] === 'number';
+}
+
+export function isPrimitiveComponentExpressions(x: any): x is PrimitiveComponentExpressionT {
+    return !!x && Array.isArray(x.expressions);
+}
+
+export function isComponentExpression(x: any): x is ComponentExpressionT {
+    return !!x && typeof x === 'object' && !x.expressions;
+}

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import * as iots from 'io-ts';

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -58,6 +58,11 @@ export const Vector3 = tuple([float, float, float]);
 /** Parameter values for matrix params, e.g. `rotation` */
 export const Matrix = list(float);
 
+/** Primitives-related types */
+export const FloatList = list(float);
+export const IntList = list(int);
+export const StrList = list(str);
+
 /** `color` parameter values for `color` node in MVS tree */
 export const HexColorT = new iots.Type<HexColor>(
     'HexColor',

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -25,7 +25,7 @@ export const StructureTypeT = literal('model', 'assembly', 'symmetry', 'symmetry
 export const ComponentSelectorT = literal('all', 'polymer', 'protein', 'nucleic', 'branched', 'ligand', 'ion', 'water');
 
 /** `selector` parameter values for `component` node in MVS tree */
-export const ComponentExpressionT = iots.partial({
+const _ComponentBase = {
     label_entity_id: str,
     label_asym_id: str,
     auth_asym_id: str,
@@ -41,7 +41,9 @@ export const ComponentExpressionT = iots.partial({
     type_symbol: str,
     atom_id: int,
     atom_index: int,
-});
+};
+
+export const ComponentExpressionT = iots.partial(_ComponentBase);
 
 /** `type` parameter values for `representation` node in MVS tree */
 export const RepresentationTypeT = literal('ball_and_stick', 'cartoon', 'surface');
@@ -59,6 +61,8 @@ export const Vector3 = tuple([float, float, float]);
 export const Matrix = list(float);
 
 /** Primitives-related types */
+export const PrimitiveComponentExpressionT = iots.partial({ structure_ref: str, ..._ComponentBase });
+export const PositionT = iots.union([Vector3, PrimitiveComponentExpressionT, list(PrimitiveComponentExpressionT)]);
 export const FloatList = list(float);
 export const IntList = list(int);
 export const StrList = list(str);

--- a/src/mol-geo/geometry/text/text-builder.ts
+++ b/src/mol-geo/geometry/text/text-builder.ts
@@ -21,7 +21,6 @@ const caAdd2 = ChunkedArray.add2;
 const caAdd = ChunkedArray.add;
 
 export interface TextBuilder {
-    isEmpty: boolean
     add(str: string, x: number, y: number, z: number, depth: number, scale: number, group: number): void
     getText(): Text
 }
@@ -50,14 +49,8 @@ export namespace TextBuilder {
             caAdd(groups, group);
         };
 
-        let isEmpty = true;
-
         return {
-            get isEmpty() {
-                return isEmpty;
-            },
             add: (str: string, x: number, y: number, z: number, depth: number, scale: number, group: number) => {
-                isEmpty = false;
                 let bWidth = 0;
                 const nChar = str.length;
 

--- a/src/mol-geo/geometry/text/text-builder.ts
+++ b/src/mol-geo/geometry/text/text-builder.ts
@@ -21,6 +21,7 @@ const caAdd2 = ChunkedArray.add2;
 const caAdd = ChunkedArray.add;
 
 export interface TextBuilder {
+    isEmpty: boolean
     add(str: string, x: number, y: number, z: number, depth: number, scale: number, group: number): void
     getText(): Text
 }
@@ -49,8 +50,14 @@ export namespace TextBuilder {
             caAdd(groups, group);
         };
 
+        let isEmpty = true;
+
         return {
+            get isEmpty() {
+                return isEmpty;
+            },
             add: (str: string, x: number, y: number, z: number, depth: number, scale: number, group: number) => {
+                isEmpty = false;
                 let bWidth = 0;
                 const nChar = str.length;
 

--- a/src/mol-math/geometry/primitives/box3d.ts
+++ b/src/mol-math/geometry/primitives/box3d.ts
@@ -27,6 +27,12 @@ namespace Box3D {
         return out;
     }
 
+    export function set(out: Box3D, min: Vec3, max: Vec3): Box3D {
+        Vec3.copy(out.min, min);
+        Vec3.copy(out.max, max);
+        return out;
+    }
+
     export function clone(a: Box3D): Box3D {
         return copy(zero(), a);
     }

--- a/src/mol-state/transform.ts
+++ b/src/mol-state/transform.ts
@@ -142,6 +142,16 @@ namespace Transform {
         return { ...t, tags, version: UUID.create22() };
     }
 
+    export function withDependsOn(t: Transform, newDependsOn?: string | string[]): Transform {
+        let dependsOn: string[] | undefined = void 0;
+        if (newDependsOn) {
+            dependsOn = typeof newDependsOn === 'string' ? [newDependsOn] : newDependsOn;
+            if (dependsOn.length === 0) dependsOn = void 0;
+            else dependsOn.sort();
+        }
+        return { ...t, dependsOn, version: UUID.create22() };
+    }
+
     export function withParent(t: Transform, parent: Ref): Transform {
         return { ...t, parent, version: UUID.create22() };
     }

--- a/src/mol-state/tree/transient.ts
+++ b/src/mol-state/tree/transient.ts
@@ -203,6 +203,25 @@ class TransientTree implements StateTree {
         return true;
     }
 
+    setDependsOn(ref: StateTransform.Ref, dependsOn: string | string[] | undefined) {
+        ensurePresent(this.transforms, ref);
+
+        const transform = this.transforms.get(ref)!;
+
+        const withDependsOn = StateTransform.withDependsOn(transform, dependsOn);
+        if (arrayEqual(transform.dependsOn, withDependsOn.dependsOn)) {
+            return false;
+        }
+
+        if (!this.changedNodes) {
+            this.changedNodes = true;
+            this.transforms = this.transforms.asMutable();
+        }
+
+        this.transforms.set(transform.ref, withDependsOn);
+        return true;
+    }
+
     assignState(ref: StateTransform.Ref, state?: Partial<StateTransform.State>) {
         ensurePresent(this.transforms, ref);
 

--- a/src/mol-util/param-definition.ts
+++ b/src/mol-util/param-definition.ts
@@ -686,4 +686,14 @@ export namespace ParamDefinition {
         }
         return options.length > 0 ? options[0][0] : void 0 as any as T;
     }
+
+    export function withDefaults<T extends Params>(schema: T, updates: Partial<ValuesFor<T>>): T {
+        const next: any = {};
+        for (const k of Object.keys(updates)) {
+            const v = (updates as any)[k];
+            if (!schema[k] || v === null || v === undefined || schema[k].defaultValue === v) continue;
+            next[k] = { ...schema[k], defaultValue: v };
+        }
+        return { ...schema, ...next };
+    }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Adds the ability to define primitives via MVS. See https://github.com/molstar/mol-view-spec/pull/36 for Python builder implementation.

- [x] Support `mesh`, `lines`, `line`, `label`, `distance measurement` primitives
- [x] Support resolving positions from structure coordinates (e.g., `label_seq_id: 300` resolves to centroid of the residue)
- [x] Support loading primitives from JSON objects
- [x] Focus support
- [x] Primitive group instancing support
- [x] Support resolving structure references

Followup PR(s) will include:
- Additional primitives (e.g., box, arrow, angle, ...)
- TypeScript builder for primitives
- Validation and default values for primitive params

## Examples

### Cube 

```py
builder = create_builder()
builder.primitives().mesh(
    vertices=[
        0.0, 0.0, 0.0,
        1.0, 0.0, 0.0,
        1.0, 1.0, 0.0,
        0.0, 1.0, 0.0,
        0.0, 0.0, 1.0,
        1.0, 0.0, 1.0,
        1.0, 1.0, 1.0,
        0.0, 1.0, 1.0,
    ],
    indices=[
        # bottom
        0, 2, 1, 0, 3, 2,
        # top
        4, 5, 6, 4, 6, 7,
        # front
        0, 1, 5, 0, 5, 4,
        # back
        2, 3, 7, 2, 7, 6,
        # left
        0, 7, 3, 0, 4, 7,
        # right
        1, 2, 6, 1, 6, 5,
    ],
    triangle_groups=[0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
    group_colors={0: "red", 1: "green", 2: "blue", 3: "yellow", 4: "magenta", 5: "cyan"},
    group_tooltips={0: "### Side\nbottom", 1: "### Side\ntop", 2: "### Side\nfront", 3: "### Side\nback", 4: "### Side\nleft", 5: "### Side\nright"},
    show_wireframe=True,
    wireframe_radius=2,
    wireframe_color="black",
)
# let's throw in some lines and labels that intersect each face in the middle
(
    builder.primitives(color="blue", label_color="blue", tooltip="Generic Axis", transparency=0.5)
    # chain primitives to create desired visuals
    .line(start=(-0.5, 0.5, 0.5), end=(1.5, 0.5, 0.5), thickness=0.05, color="red", tooltip="### Axis\nX")
    .label(position=(-0.5, 0.5, 0.5), text="X", label_size=0.33, label_color="red")
    .line(start=(0.5, -0.5, 0.5), end=(0.5, 1.5, 0.5), thickness=0.05, color="green", tooltip="### Axis\nY")
    .label(position=(0.5, -0.5, 0.5), text="Y", label_size=0.33, label_color="green")
    .line(start=(0.5, 0.5, -0.5), end=(0.5, 0.5, 1.5), thickness=0.05)
    .label(position=(0.5, 0.5, -0.5), text="Z", label_size=0.33)
)
```

![image](https://github.com/user-attachments/assets/d9ee6185-5f91-451c-9f1b-e2dcbaa3bdd0)


### Distance within a single structure

```py
builder = create_builder()
structure = (
    builder.download(url=_url_for_mmcif("1tqn"))
    .parse(format="mmcif")
    .model_structure()
)
(
    structure.component(selector="polymer")
    .representation()
    .color(color="blue")
)
(
    structure.component(selector=[
        ComponentExpression(auth_seq_id=258),
        ComponentExpression(auth_seq_id=508)
    ])
    .representation(type="ball_and_stick")
    .color(color="green")
)
(
    structure.primitives()
    .distance(
        start=ComponentExpression(auth_seq_id=258),
        end=ComponentExpression(auth_seq_id=508),
        color="red",
        thickness=0.1,
        dash_length=0.1,
        label_template="Distance: {{distance}}",
        label_color="red",
    ).focus()
)
```

![image](https://github.com/user-attachments/assets/28b21664-127b-4275-92d4-2a1675cb1e3b)

### Loading from separate data

```py
# /data/basic-primitives
builder = create_builder().primitives(
    tooltip="Triangle",
    instances=[
        # Translate Z by -0.5 and 0.5
        (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, -0.5, 1),
        (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0.5, 1),
    ],
)
(
    builder
    .line(start=(0, 0, 0), end=(1, 0, 0), color="red", tooltip="A")
    .line(start=(0, 0, 0), end=(0.5, (1 - 0.5**2) ** 0.5, 0), color="green", tooltip="B")
    .line(start=(1, 0, 0), end=(0.5, (1 - 0.5**2) ** 0.5, 0), color="blue")
)
return JSONResponse(builder.as_data().dict())

# MVS
builder = create_builder()
builder.primitives_from_uri(uri="http://localhost:9000/api/v1/examples/data/basic-primitives")
```

![image](https://github.com/user-attachments/assets/08b09e12-0408-44a6-a66e-7fccfd5701b8)


### Distance between two different structures

```py
builder = create_builder()
_1tqn = builder.download(url=_url_for_mmcif("1tqn")).parse(format="mmcif").model_structure(ref="X")
_1tqn.component(selector="polymer").representation().color(color="blue")
(
    _1tqn.component(selector=ComponentExpression(auth_seq_id=508))
    .representation(type="ball_and_stick")
    .color(color="green")
)

_1cbs = builder.download(url=_url_for_mmcif("1cbs")).parse(format="mmcif").model_structure(ref="Y")
_1cbs.component(selector="polymer").representation().color(color="blue")
(
    _1cbs.component(selector=ComponentExpression(auth_seq_id=200))
    .representation(type="ball_and_stick")
    .color(color="green")
)
(
    builder.primitives().distance(
        start=PrimitiveComponentExpressions(structure_ref="X", expressions=[ComponentExpression(auth_seq_id=508)]),
        end=PrimitiveComponentExpressions(structure_ref="Y", expressions=[ComponentExpression(auth_seq_id=200)]),
        color="red",
        thickness=1,
        dash_length=1,
        label_template="Ligand Distance: {{distance}}",
        label_color="red",
    )
)
```

![image](https://github.com/user-attachments/assets/46776eb9-39f2-4428-83e0-928c2ddc6da7)

### Lines primitives

```py
builder = create_builder()
primitives = builder.primitives()
(
    primitives.lines(
        vertices=[
            0, 0, 0,
            1, 0, 0,
            1, 1, 0,
            0, 1, 0
        ],
        indices=[
            0, 1,
            1, 2,
            2, 3,
            3, 0
        ],
        line_colors=[
            "red",
            "green",
            "blue",
            "black"
        ],
        line_radius=1.5,
        tooltip="Square",
    )
)
```

![image](https://github.com/user-attachments/assets/874ceab9-0c3e-48f8-8d72-973f11390049)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`