### PR TITLE
Structure visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix operator key-based `IndexPairBonds` assignment
     - Don't add bonds twice
     - Add `IndexPairs.bySameOperator` to avoid looping over all bonds for each unit
+- Add `Structure.intraUnitBondMapping`
 
 ## [v4.8.0] - 2024-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Note that since we don't clearly distinguish between a public and private interf
     - Don't add bonds twice
     - Add `IndexPairs.bySameOperator` to avoid looping over all bonds for each unit
 - Add `Structure.intraUnitBondMapping`
+- Add more structure-based visuals to avoid too many (small) render-objects
+    - `structure-intra-bond`, `structure-ellipsoid-mesh`, `structure-element-point`, `structure-element-cross`
 
 ## [v4.8.0] - 2024-10-27
 

--- a/src/mol-model/structure/structure/mapping.ts
+++ b/src/mol-model/structure/structure/mapping.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { OrderedSet } from '../../../mol-data/int/ordered-set';
+import { ElementIndex } from '../model/indexing';
+import { Structure } from './structure';
+import { Unit } from './unit';
+
+/** Serial index of an element in the structure across all units */
+export type SerialIndex = { readonly '@type': 'serial-index' } & number
+
+export interface SerialMapping {
+    /** Cumulative count of preceding elements for each unit */
+    cumulativeUnitElementCount: ArrayLike<number>
+    /** Unit index for each serial element in the structure */
+    unitIndices: ArrayLike<number>
+    /** Element index for each serial element in the structure */
+    elementIndices: ArrayLike<ElementIndex>
+    /** Get serial index of element in the structure */
+    getSerialIndex: (unit: Unit, element: ElementIndex) => SerialIndex
+}
+
+export function getSerialMapping(structure: Structure): SerialMapping {
+    const { units, elementCount, unitIndexMap } = structure;
+    const cumulativeUnitElementCount = new Uint32Array(units.length);
+    const unitIndices = new Uint32Array(elementCount);
+    const elementIndices = new Uint32Array(elementCount) as unknown as ElementIndex[];
+    for (let i = 0, m = 0, il = units.length; i < il; ++i) {
+        cumulativeUnitElementCount[i] = m;
+        const { elements } = units[i];
+        for (let j = 0, jl = elements.length; j < jl; ++j) {
+            const mj = m + j;
+            unitIndices[mj] = i;
+            elementIndices[mj] = elements[j];
+        }
+        m += elements.length;
+    }
+    return {
+        cumulativeUnitElementCount,
+        unitIndices,
+        elementIndices,
+
+        getSerialIndex: (unit, element) => cumulativeUnitElementCount[unitIndexMap.get(unit.id)] + OrderedSet.indexOf(unit.elements, element) as SerialIndex
+    };
+}
+
+//
+
+export interface IntraUnitBondMapping {
+    bondCount: number
+    unitIndex: ArrayLike<number>
+    unitEdgeIndex: ArrayLike<number>
+    unitGroupIndex: ArrayLike<number>
+}
+
+export function getIntraUnitBondMapping(structure: Structure): IntraUnitBondMapping {
+    let bondCount = 0;
+
+    for (const ug of structure.unitSymmetryGroups) {
+        const unit = ug.units[0];
+        if (Unit.isAtomic(unit)) {
+            bondCount += unit.bonds.edgeCount * 2 * ug.units.length;
+        }
+    }
+
+    const unitIndex = new Uint32Array(bondCount);
+    const unitEdgeIndex = new Uint32Array(bondCount);
+    const unitGroupIndex = new Uint32Array(bondCount);
+
+    let idx = 0;
+    let unitIdx = 0;
+    for (const ug of structure.unitSymmetryGroups) {
+        const unit = ug.units[0];
+        if (Unit.isAtomic(unit)) {
+            const edgeCount = unit.bonds.edgeCount * 2;
+            for (let i = 0, il = ug.units.length; i < il; ++i) {
+                for (let j = 0, jl = edgeCount; j < jl; ++j) {
+                    unitIndex[idx] = unitIdx;
+                    unitEdgeIndex[idx] = j;
+                    unitGroupIndex[idx] = i;
+                    idx += 1;
+                }
+            }
+        }
+        unitIdx += 1;
+    }
+
+    return { bondCount, unitIndex, unitEdgeIndex, unitGroupIndex };
+}

--- a/src/mol-model/structure/structure/unit/bonds.ts
+++ b/src/mol-model/structure/structure/unit/bonds.ts
@@ -165,9 +165,11 @@ namespace Bond {
 
     export function getIntraUnitBondCount(structure: Structure) {
         let count = 0;
-        for (let i = 0, il = structure.units.length; i < il; ++i) {
-            const u = structure.units[i];
-            if (Unit.isAtomic(u)) count += u.bonds.edgeCount;
+        for (const ug of structure.unitSymmetryGroups) {
+            const u = ug.units[0];
+            if (Unit.isAtomic(u)) {
+                count += u.bonds.edgeCount * ug.units.length;
+            }
         }
         return count;
     }

--- a/src/mol-repr/structure/complex-visual.ts
+++ b/src/mol-repr/structure/complex-visual.ts
@@ -32,7 +32,7 @@ import { Text } from '../../mol-geo/geometry/text/text';
 import { SizeTheme } from '../../mol-theme/size';
 import { DirectVolume } from '../../mol-geo/geometry/direct-volume/direct-volume';
 import { createMarkers } from '../../mol-geo/geometry/marker-data';
-import { StructureParams, StructureMeshParams, StructureTextParams, StructureDirectVolumeParams, StructureLinesParams, StructureCylindersParams, StructureTextureMeshParams, StructureSpheresParams } from './params';
+import { StructureParams, StructureMeshParams, StructureTextParams, StructureDirectVolumeParams, StructureLinesParams, StructureCylindersParams, StructureTextureMeshParams, StructureSpheresParams, StructurePointsParams } from './params';
 import { Clipping } from '../../mol-theme/clipping';
 import { TextureMesh } from '../../mol-geo/geometry/texture-mesh/texture-mesh';
 import { WebGLContext } from '../../mol-gl/webgl/context';
@@ -40,6 +40,7 @@ import { isPromiseLike } from '../../mol-util/type-helpers';
 import { Substance } from '../../mol-theme/substance';
 import { Spheres } from '../../mol-geo/geometry/spheres/spheres';
 import { Emissive } from '../../mol-theme/emissive';
+import { Points } from '../../mol-geo/geometry/points/points';
 
 export interface ComplexVisual<P extends StructureParams> extends Visual<Structure, P> { }
 
@@ -386,6 +387,24 @@ export function ComplexCylindersVisual<P extends ComplexCylindersParams>(builder
             if (!SizeTheme.areEqual(newTheme.size, currentTheme.size)) state.updateSize = true;
         },
         geometryUtils: Cylinders.Utils
+    }, materialId);
+}
+
+// points
+
+export const ComplexPointsParams = { ...StructurePointsParams, ...StructureParams };
+export type ComplexPointsParams = typeof ComplexPointsParams
+
+export interface ComplexPointsVisualBuilder<P extends ComplexPointsParams> extends ComplexVisualBuilder<P, Points> { }
+
+export function ComplexPointsVisual<P extends ComplexPointsParams>(builder: ComplexPointsVisualBuilder<P>, materialId: number): ComplexVisual<P> {
+    return ComplexVisual<Points, P>({
+        ...builder,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<P>, currentProps: PD.Values<P>, newTheme: Theme, currentTheme: Theme, newStructure: Structure, currentStructure: Structure) => {
+            builder.setUpdateState(state, newProps, currentProps, newTheme, currentTheme, newStructure, currentStructure);
+            if (!SizeTheme.areEqual(newTheme.size, currentTheme.size)) state.updateSize = true;
+        },
+        geometryUtils: Points.Utils
     }, materialId);
 }
 

--- a/src/mol-repr/structure/representation/ball-and-stick.ts
+++ b/src/mol-repr/structure/representation/ball-and-stick.ts
@@ -4,9 +4,9 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { IntraUnitBondCylinderVisual, IntraUnitBondCylinderParams } from '../visual/bond-intra-unit-cylinder';
+import { IntraUnitBondCylinderVisual, IntraUnitBondCylinderParams, StructureIntraUnitBondCylinderParams, StructureIntraUnitBondCylinderVisual } from '../visual/bond-intra-unit-cylinder';
 import { InterUnitBondCylinderParams, InterUnitBondCylinderVisual } from '../visual/bond-inter-unit-cylinder';
-import { ElementSphereVisual, ElementSphereParams } from '../visual/element-sphere';
+import { ElementSphereVisual, ElementSphereParams, StructureElementSphereVisual } from '../visual/element-sphere';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
 import { UnitsRepresentation } from '../units-representation';
 import { ComplexRepresentation } from '../complex-representation';
@@ -21,6 +21,8 @@ const BallAndStickVisuals = {
     'element-sphere': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, ElementSphereParams>) => UnitsRepresentation('Element sphere', ctx, getParams, ElementSphereVisual),
     'intra-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, IntraUnitBondCylinderParams>) => UnitsRepresentation('Intra-unit bond cylinder', ctx, getParams, IntraUnitBondCylinderVisual),
     'inter-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, InterUnitBondCylinderParams>) => ComplexRepresentation('Inter-unit bond cylinder', ctx, getParams, InterUnitBondCylinderVisual),
+    'structure-element-sphere': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, ElementSphereParams>) => ComplexRepresentation('Structure element sphere', ctx, getParams, StructureElementSphereVisual),
+    'structure-intra-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureIntraUnitBondCylinderParams>) => ComplexRepresentation('Structure intra-unit bond cylinder', ctx, getParams, StructureIntraUnitBondCylinderVisual),
 };
 
 export const BallAndStickParams = {
@@ -38,14 +40,16 @@ export const BallAndStickParams = {
 };
 export type BallAndStickParams = typeof BallAndStickParams
 export function getBallAndStickParams(ctx: ThemeRegistryContext, structure: Structure) {
+    let params = BallAndStickParams;
     const size = Structure.getSize(structure);
     if (size >= Structure.Size.Huge) {
         const params = PD.clone(BallAndStickParams);
         params.visuals.defaultValue = ['element-sphere', 'intra-bond'];
-        return params;
-    } else {
-        return BallAndStickParams;
+    } else if (structure.unitSymmetryGroups.length > 5000) {
+        params = PD.clone(params);
+        params.visuals.defaultValue = ['structure-element-sphere', 'structure-intra-bond'];
     }
+    return params;
 }
 
 export type BallAndStickRepresentation = StructureRepresentation<BallAndStickParams>

--- a/src/mol-repr/structure/representation/ellipsoid.ts
+++ b/src/mol-repr/structure/representation/ellipsoid.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -9,9 +9,9 @@ import { RepresentationParamsGetter, RepresentationContext, Representation } fro
 import { ThemeRegistryContext } from '../../../mol-theme/theme';
 import { Structure } from '../../../mol-model/structure';
 import { UnitsRepresentation, StructureRepresentation, StructureRepresentationStateBuilder, StructureRepresentationProvider, ComplexRepresentation } from '../../../mol-repr/structure/representation';
-import { EllipsoidMeshParams, EllipsoidMeshVisual } from '../visual/ellipsoid-mesh';
+import { EllipsoidMeshParams, EllipsoidMeshVisual, StructureEllipsoidMeshParams, StructureEllipsoidMeshVisual } from '../visual/ellipsoid-mesh';
 import { AtomSiteAnisotrop } from '../../../mol-model-formats/structure/property/anisotropic';
-import { IntraUnitBondCylinderParams, IntraUnitBondCylinderVisual } from '../visual/bond-intra-unit-cylinder';
+import { IntraUnitBondCylinderParams, IntraUnitBondCylinderVisual, StructureIntraUnitBondCylinderParams, StructureIntraUnitBondCylinderVisual } from '../visual/bond-intra-unit-cylinder';
 import { InterUnitBondCylinderVisual, InterUnitBondCylinderParams } from '../visual/bond-inter-unit-cylinder';
 import { getUnitKindsParam } from '../params';
 import { BaseGeometry } from '../../../mol-geo/geometry/base';
@@ -20,6 +20,8 @@ const EllipsoidVisuals = {
     'ellipsoid-mesh': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, EllipsoidMeshParams>) => UnitsRepresentation('Ellipsoid Mesh', ctx, getParams, EllipsoidMeshVisual),
     'intra-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, IntraUnitBondCylinderParams>) => UnitsRepresentation('Intra-unit bond cylinder', ctx, getParams, IntraUnitBondCylinderVisual),
     'inter-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, InterUnitBondCylinderParams>) => ComplexRepresentation('Inter-unit bond cylinder', ctx, getParams, InterUnitBondCylinderVisual),
+    'structure-ellipsoid-mesh': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureEllipsoidMeshParams>) => ComplexRepresentation('Structure Ellipsoid Mesh', ctx, getParams, StructureEllipsoidMeshVisual),
+    'structure-intra-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureIntraUnitBondCylinderParams>) => ComplexRepresentation('Structure intra-unit bond cylinder', ctx, getParams, StructureIntraUnitBondCylinderVisual),
 };
 
 export const EllipsoidParams = {
@@ -37,7 +39,16 @@ export const EllipsoidParams = {
 };
 export type EllipsoidParams = typeof EllipsoidParams
 export function getEllipsoidParams(ctx: ThemeRegistryContext, structure: Structure) {
-    return EllipsoidParams;
+    let params = EllipsoidParams;
+    const size = Structure.getSize(structure);
+    if (size >= Structure.Size.Huge) {
+        const params = PD.clone(EllipsoidParams);
+        params.visuals.defaultValue = ['ellipsoid-mesh', 'intra-bond'];
+    } else if (structure.unitSymmetryGroups.length > 5000) {
+        params = PD.clone(params);
+        params.visuals.defaultValue = ['structure-ellipsoid-mesh', 'structure-intra-bond'];
+    }
+    return params;
 }
 
 export type EllipsoidRepresentation = StructureRepresentation<EllipsoidParams>

--- a/src/mol-repr/structure/representation/line.ts
+++ b/src/mol-repr/structure/representation/line.ts
@@ -4,7 +4,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { IntraUnitBondLineVisual, IntraUnitBondLineParams } from '../visual/bond-intra-unit-line';
+import { IntraUnitBondLineVisual, IntraUnitBondLineParams, StructureIntraUnitBondLineParams, StructureIntraUnitBondLineVisual } from '../visual/bond-intra-unit-line';
 import { InterUnitBondLineVisual, InterUnitBondLineParams } from '../visual/bond-inter-unit-line';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
 import { UnitsRepresentation } from '../units-representation';
@@ -14,8 +14,8 @@ import { Representation, RepresentationParamsGetter, RepresentationContext } fro
 import { ThemeRegistryContext } from '../../../mol-theme/theme';
 import { Structure } from '../../../mol-model/structure';
 import { getUnitKindsParam } from '../params';
-import { ElementPointParams, ElementPointVisual } from '../visual/element-point';
-import { ElementCrossParams, ElementCrossVisual } from '../visual/element-cross';
+import { ElementPointParams, ElementPointVisual, StructureElementPointParams, StructureElementPointVisual } from '../visual/element-point';
+import { ElementCrossParams, ElementCrossVisual, StructureElementCrossParams, StructureElementCrossVisual } from '../visual/element-cross';
 import { Points } from '../../../mol-geo/geometry/points/points';
 import { BaseGeometry } from '../../../mol-geo/geometry/base';
 
@@ -24,6 +24,9 @@ const LineVisuals = {
     'inter-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, InterUnitBondLineParams>) => ComplexRepresentation('Inter-unit bond line', ctx, getParams, InterUnitBondLineVisual),
     'element-point': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, ElementPointParams>) => UnitsRepresentation('Points', ctx, getParams, ElementPointVisual),
     'element-cross': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, ElementCrossParams>) => UnitsRepresentation('Crosses', ctx, getParams, ElementCrossVisual),
+    'structure-intra-bond': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureIntraUnitBondLineParams>) => ComplexRepresentation('Structure intra-unit bond line', ctx, getParams, StructureIntraUnitBondLineVisual),
+    'structure-element-point': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureElementPointParams>) => ComplexRepresentation('Structure element points', ctx, getParams, StructureElementPointVisual),
+    'structure-element-cross': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureElementCrossParams>) => ComplexRepresentation('Structure element crosses', ctx, getParams, StructureElementCrossVisual),
 };
 
 export const LineParams = {
@@ -41,14 +44,16 @@ export const LineParams = {
 };
 export type LineParams = typeof LineParams
 export function getLineParams(ctx: ThemeRegistryContext, structure: Structure) {
+    let params = LineParams;
     const size = Structure.getSize(structure);
     if (size >= Structure.Size.Huge) {
         const params = PD.clone(LineParams);
         params.visuals.defaultValue = ['intra-bond', 'element-point', 'element-cross'];
-        return params;
-    } else {
-        return LineParams;
+    } else if (structure.unitSymmetryGroups.length > 5000) {
+        params = PD.clone(params);
+        params.visuals.defaultValue = ['structure-intra-bond', 'structure-element-point', 'structure-element-cross'];
     }
+    return params;
 }
 
 export type LineRepresentation = StructureRepresentation<LineParams>

--- a/src/mol-repr/structure/representation/point.ts
+++ b/src/mol-repr/structure/representation/point.ts
@@ -4,26 +4,33 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { ElementPointVisual, ElementPointParams } from '../visual/element-point';
+import { ElementPointVisual, ElementPointParams, StructureElementPointVisual, StructureElementPointParams } from '../visual/element-point';
 import { UnitsRepresentation } from '../units-representation';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
-import { StructureRepresentation, StructureRepresentationProvider, StructureRepresentationStateBuilder } from '../representation';
+import { ComplexRepresentation, StructureRepresentation, StructureRepresentationProvider, StructureRepresentationStateBuilder } from '../representation';
 import { Representation, RepresentationParamsGetter, RepresentationContext } from '../../../mol-repr/representation';
 import { ThemeRegistryContext } from '../../../mol-theme/theme';
 import { Structure } from '../../../mol-model/structure';
 import { BaseGeometry } from '../../../mol-geo/geometry/base';
 
 const PointVisuals = {
-    'element-point': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, ElementPointParams>) => UnitsRepresentation('Points', ctx, getParams, ElementPointVisual),
+    'element-point': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, ElementPointParams>) => UnitsRepresentation('Element points', ctx, getParams, ElementPointVisual),
+    'structure-element-point': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureElementPointParams>) => ComplexRepresentation('Structure element points', ctx, getParams, StructureElementPointVisual),
 };
 
 export const PointParams = {
     ...ElementPointParams,
     density: PD.Numeric(0.1, { min: 0, max: 1, step: 0.01 }, BaseGeometry.ShadingCategory),
+    visuals: PD.MultiSelect(['element-point'], PD.objectToOptions(PointVisuals)),
 };
 export type PointParams = typeof PointParams
 export function getPointParams(ctx: ThemeRegistryContext, structure: Structure) {
-    return PointParams;
+    let params = PointParams;
+    if (structure.unitSymmetryGroups.length > 5000) {
+        params = PD.clone(params);
+        params.visuals.defaultValue = ['structure-element-point'];
+    }
+    return params;
 }
 
 export type PointRepresentation = StructureRepresentation<PointParams>

--- a/src/mol-repr/structure/representation/spacefill.ts
+++ b/src/mol-repr/structure/representation/spacefill.ts
@@ -36,7 +36,7 @@ export function getSpacefillParams(ctx: ThemeRegistryContext, structure: Structu
         }
         params = CoarseGrainedSpacefillParams;
     }
-    if (structure.units.length > 5000) {
+    if (structure.unitSymmetryGroups.length > 5000) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-sphere'];
     }

--- a/src/mol-repr/structure/visual/bond-inter-unit-line.ts
+++ b/src/mol-repr/structure/visual/bond-inter-unit-line.ts
@@ -30,13 +30,9 @@ function setRefPosition(pos: Vec3, structure: Structure, unit: Unit.Atomic, inde
     return null;
 }
 
-function createInterUnitBondLines(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<InterUnitBondLineParams>, lines?: Lines) {
-    if (!hasStructureVisibleBonds(structure, props)) return Lines.createEmpty(lines);
-
+export function getInterUnitBondLineBuilderProps(structure: Structure, theme: Theme, props: PD.Values<InterUnitBondLineParams>): LinkBuilderProps {
     const bonds = structure.interUnitBonds;
     const { edgeCount, edges } = bonds;
-
-    if (!edgeCount) return Lines.createEmpty(lines);
 
     const { sizeFactor, aromaticBonds, multipleBonds } = props;
 
@@ -46,7 +42,7 @@ function createInterUnitBondLines(ctx: VisualContext, structure: Structure, them
     const ref = Vec3();
     const loc = StructureElement.Location.create();
 
-    const builderProps: LinkBuilderProps = {
+    return {
         linkCount: edgeCount,
         referencePosition: (edgeIndex: number) => {
             const b = edges[edgeIndex];
@@ -105,6 +101,13 @@ function createInterUnitBondLines(ctx: VisualContext, structure: Structure, them
         },
         ignore: makeInterBondIgnoreTest(structure, props)
     };
+}
+
+function createInterUnitBondLines(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<InterUnitBondLineParams>, lines?: Lines) {
+    if (!hasStructureVisibleBonds(structure, props)) return Lines.createEmpty(lines);
+    if (!structure.interUnitBonds.edgeCount) return Lines.createEmpty(lines);
+
+    const builderProps = getInterUnitBondLineBuilderProps(structure, theme, props);
 
     const { lines: l, boundingSphere } = createLinkLines(ctx, builderProps, props, lines);
 
@@ -112,7 +115,7 @@ function createInterUnitBondLines(ctx: VisualContext, structure: Structure, them
         l.setBoundingSphere(boundingSphere);
     } else if (l.lineCount > 0) {
         const { child } = structure;
-        const sphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * sizeFactor);
+        const sphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * props.sizeFactor);
         l.setBoundingSphere(sphere);
     }
 

--- a/src/mol-repr/structure/visual/bond-intra-unit-cylinder.ts
+++ b/src/mol-repr/structure/visual/bond-intra-unit-cylinder.ts
@@ -14,11 +14,11 @@ import { Theme } from '../../../mol-theme/theme';
 import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { Vec3 } from '../../../mol-math/linear-algebra';
 import { arrayEqual } from '../../../mol-util';
-import { createLinkCylinderImpostors, createLinkCylinderMesh, LinkBuilderProps, LinkStyle } from './util/link';
+import { createLinkCylinderImpostors, createLinkCylinderMesh, EmptyLinkBuilderProps, LinkBuilderProps, LinkStyle } from './util/link';
 import { UnitsMeshParams, UnitsVisual, UnitsMeshVisual, UnitsCylindersParams, UnitsCylindersVisual } from '../units-visual';
 import { VisualUpdateState } from '../../util';
 import { BondType } from '../../../mol-model/structure/model/types';
-import { BondCylinderParams, BondIterator, eachIntraBond, getIntraBondLoci, hasUnitVisibleBonds, ignoreBondType, makeIntraBondIgnoreTest } from './util/bond';
+import { BondCylinderParams, BondIterator, eachIntraBond, eachStructureGroupsBond, getIntraBondLoci, getStructureGroupsBondLoci, hasStructureVisibleBonds, hasUnitVisibleBonds, ignoreBondType, makeIntraBondIgnoreTest } from './util/bond';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { IntAdjacencyGraph } from '../../../mol-math/graph';
 import { WebGLContext } from '../../../mol-gl/webgl/context';
@@ -27,6 +27,8 @@ import { SortedArray } from '../../../mol-data/int';
 import { arrayIntersectionSize } from '../../../mol-util/array';
 import { StructureGroup } from './util/common';
 import { SizeTheme } from '../../../mol-theme/size';
+import { ComplexCylindersParams, ComplexMeshParams, ComplexCylindersVisual, ComplexMeshVisual, ComplexVisual } from '../complex-visual';
+import { EmptyLocationIterator } from '../../../mol-geo/util/location-iterator';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const isBondType = BondType.is;
@@ -328,6 +330,211 @@ export function IntraUnitBondCylinderMeshVisual(materialId: number): UnitsVisual
             }
         },
         mustRecreate: (structureGroup: StructureGroup, props: PD.Values<IntraUnitBondCylinderParams>, webgl?: WebGLContext) => {
+            return props.tryUseImpostor && !!webgl;
+        }
+    }, materialId);
+}
+
+//
+
+function getStructureIntraUnitBondCylinderBuilderProps(structure: Structure, theme: Theme, props: PD.Values<StructureIntraUnitBondCylinderParams>): LinkBuilderProps {
+    const intraUnitProps: { group: Unit.SymmetryGroup, props: LinkBuilderProps}[] = [];
+
+    const { bondCount, unitIndex, unitEdgeIndex, unitGroupIndex } = structure.intraUnitBondMapping;
+
+    for (const ug of structure.unitSymmetryGroups) {
+        const unit = ug.units[0];
+        const p = Unit.isAtomic(unit) ? getIntraUnitBondCylinderBuilderProps(unit, structure, theme, props) : EmptyLinkBuilderProps;
+        intraUnitProps.push({ group: ug, props: p });
+    }
+
+    return {
+        linkCount: bondCount,
+        referencePosition: (edgeIndex: number) => {
+            const { group, props } = intraUnitProps[unitIndex[edgeIndex]];
+            if (!props.referencePosition) return null;
+
+            const v = props.referencePosition(unitEdgeIndex[edgeIndex]);
+            if (!v) return null;
+
+            const u = group.units[unitGroupIndex[edgeIndex]];
+            Vec3.transformMat4(v, v, u.conformation.operator.matrix);
+            return v;
+        },
+        position: (posA: Vec3, posB: Vec3, edgeIndex: number, adjust: boolean) => {
+            const { group, props } = intraUnitProps[unitIndex[edgeIndex]];
+            props.position(posA, posB, unitEdgeIndex[edgeIndex], adjust);
+            const u = group.units[unitGroupIndex[edgeIndex]];
+            Vec3.transformMat4(posA, posA, u.conformation.operator.matrix);
+            Vec3.transformMat4(posB, posB, u.conformation.operator.matrix);
+        },
+        style: (edgeIndex: number) => {
+            const { props } = intraUnitProps[unitIndex[edgeIndex]];
+            return props.style ? props.style(unitEdgeIndex[edgeIndex]) : LinkStyle.Solid;
+        },
+        radius: (edgeIndex: number) => {
+            const { props } = intraUnitProps[unitIndex[edgeIndex]];
+            return props.radius(unitEdgeIndex[edgeIndex]);
+        },
+        ignore: (edgeIndex: number) => {
+            const { props } = intraUnitProps[unitIndex[edgeIndex]];
+            return props.ignore ? props.ignore(unitEdgeIndex[edgeIndex]) : false;
+        },
+        stub: (edgeIndex: number) => {
+            const { props } = intraUnitProps[unitIndex[edgeIndex]];
+            return props.stub ? props.stub(unitEdgeIndex[edgeIndex]) : false;
+        }
+    };
+}
+
+function createStructureIntraUnitBondCylinderImpostors(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<StructureIntraUnitBondCylinderParams>, cylinders?: Cylinders) {
+    if (!hasStructureVisibleBonds(structure, props)) return Cylinders.createEmpty(cylinders);
+    if (!structure.intraUnitBondMapping.bondCount) return Cylinders.createEmpty(cylinders);
+
+    const builderProps = getStructureIntraUnitBondCylinderBuilderProps(structure, theme, props);
+    const { cylinders: c, boundingSphere } = createLinkCylinderImpostors(ctx, builderProps, props, cylinders);
+
+    if (boundingSphere) {
+        c.setBoundingSphere(boundingSphere);
+    } else if (c.cylinderCount > 0) {
+        const { child } = structure;
+        const sphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * props.sizeFactor);
+        c.setBoundingSphere(sphere);
+    }
+
+    return c;
+}
+
+function createStructureIntraUnitBondCylinderMesh(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<StructureIntraUnitBondCylinderParams>, mesh?: Mesh) {
+    if (!hasStructureVisibleBonds(structure, props)) return Mesh.createEmpty(mesh);
+    if (!structure.intraUnitBondMapping.bondCount) return Mesh.createEmpty(mesh);
+
+    const builderProps = getStructureIntraUnitBondCylinderBuilderProps(structure, theme, props);
+    const { mesh: m, boundingSphere } = createLinkCylinderMesh(ctx, builderProps, props, mesh);
+
+    if (boundingSphere) {
+        m.setBoundingSphere(boundingSphere);
+    } else if (m.triangleCount > 0) {
+        const { child } = structure;
+        const sphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * props.sizeFactor);
+        m.setBoundingSphere(sphere);
+    }
+
+    return m;
+}
+
+export const StructureIntraUnitBondCylinderParams = {
+    ...ComplexMeshParams,
+    ...ComplexCylindersParams,
+    ...BondCylinderParams,
+    sizeFactor: PD.Numeric(0.3, { min: 0, max: 10, step: 0.01 }),
+    sizeAspectRatio: PD.Numeric(2 / 3, { min: 0, max: 3, step: 0.01 }),
+    tryUseImpostor: PD.Boolean(true),
+    includeParent: PD.Boolean(false),
+};
+export type StructureIntraUnitBondCylinderParams = typeof StructureIntraUnitBondCylinderParams
+
+export function StructureIntraUnitBondCylinderVisual(materialId: number, structure: Structure, props: PD.Values<StructureIntraUnitBondCylinderParams>, webgl?: WebGLContext) {
+    return props.tryUseImpostor && webgl && webgl.extensions.fragDepth
+        ? StructureIntraUnitBondCylinderImpostorVisual(materialId)
+        : StructureIntraUnitBondCylinderMeshVisual(materialId);
+}
+
+export function StructureIntraUnitBondCylinderImpostorVisual(materialId: number): ComplexVisual<StructureIntraUnitBondCylinderParams> {
+    return ComplexCylindersVisual<StructureIntraUnitBondCylinderParams>({
+        defaultProps: PD.getDefaultValues(StructureIntraUnitBondCylinderParams),
+        createGeometry: createStructureIntraUnitBondCylinderImpostors,
+        createLocationIterator: (structure: Structure, props: PD.Values<StructureIntraUnitBondCylinderParams>) => {
+            return !hasStructureVisibleBonds(structure, props)
+                ? EmptyLocationIterator
+                : BondIterator.fromStructureGroups(structure, { includeLocation2: props.colorMode === 'interpolate' });
+        },
+        getLoci: getStructureGroupsBondLoci,
+        eachLocation: eachStructureGroupsBond,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureIntraUnitBondCylinderParams>, currentProps: PD.Values<StructureIntraUnitBondCylinderParams>, newTheme: Theme, currentTheme: Theme, newStructure: Structure, currentStructure: Structure) => {
+            state.createGeometry = (
+                newProps.sizeFactor !== currentProps.sizeFactor ||
+                newProps.sizeAspectRatio !== currentProps.sizeAspectRatio ||
+                newProps.linkScale !== currentProps.linkScale ||
+                newProps.linkSpacing !== currentProps.linkSpacing ||
+                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
+                newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+                newProps.linkCap !== currentProps.linkCap ||
+                newProps.aromaticScale !== currentProps.aromaticScale ||
+                newProps.aromaticSpacing !== currentProps.aromaticSpacing ||
+                newProps.aromaticDashCount !== currentProps.aromaticDashCount ||
+                newProps.dashCount !== currentProps.dashCount ||
+                newProps.dashScale !== currentProps.dashScale ||
+                newProps.dashCap !== currentProps.dashCap ||
+                newProps.stubCap !== currentProps.stubCap ||
+                !arrayEqual(newProps.includeTypes, currentProps.includeTypes) ||
+                !arrayEqual(newProps.excludeTypes, currentProps.excludeTypes) ||
+                newProps.adjustCylinderLength !== currentProps.adjustCylinderLength ||
+                newProps.multipleBonds !== currentProps.multipleBonds
+            );
+
+            if (newProps.colorMode !== currentProps.colorMode) {
+                state.createGeometry = true;
+                state.updateTransform = true;
+                state.updateColor = true;
+            }
+
+            if (hasStructureVisibleBonds(newStructure, newProps) && newStructure.interUnitBonds !== currentStructure.interUnitBonds) {
+                state.createGeometry = true;
+                state.updateTransform = true;
+                state.updateColor = true;
+                state.updateSize = true;
+            }
+        },
+        mustRecreate: (structure: Structure, props: PD.Values<StructureIntraUnitBondCylinderParams>, webgl?: WebGLContext) => {
+            return !props.tryUseImpostor || !webgl;
+        }
+    }, materialId);
+}
+
+export function StructureIntraUnitBondCylinderMeshVisual(materialId: number): ComplexVisual<StructureIntraUnitBondCylinderParams> {
+    return ComplexMeshVisual<StructureIntraUnitBondCylinderParams>({
+        defaultProps: PD.getDefaultValues(StructureIntraUnitBondCylinderParams),
+        createGeometry: createStructureIntraUnitBondCylinderMesh,
+        createLocationIterator: (structure: Structure, props: PD.Values<StructureIntraUnitBondCylinderParams>) => {
+            return !hasStructureVisibleBonds(structure, props)
+                ? EmptyLocationIterator
+                : BondIterator.fromStructureGroups(structure);
+        },
+        getLoci: getStructureGroupsBondLoci,
+        eachLocation: eachStructureGroupsBond,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureIntraUnitBondCylinderParams>, currentProps: PD.Values<StructureIntraUnitBondCylinderParams>, newTheme: Theme, currentTheme: Theme, newStructure: Structure, currentStructure: Structure) => {
+            state.createGeometry = (
+                newProps.sizeFactor !== currentProps.sizeFactor ||
+                newProps.sizeAspectRatio !== currentProps.sizeAspectRatio ||
+                newProps.radialSegments !== currentProps.radialSegments ||
+                newProps.linkScale !== currentProps.linkScale ||
+                newProps.linkSpacing !== currentProps.linkSpacing ||
+                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
+                newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+                newProps.linkCap !== currentProps.linkCap ||
+                newProps.aromaticScale !== currentProps.aromaticScale ||
+                newProps.aromaticSpacing !== currentProps.aromaticSpacing ||
+                newProps.aromaticDashCount !== currentProps.aromaticDashCount ||
+                newProps.dashCount !== currentProps.dashCount ||
+                newProps.dashScale !== currentProps.dashScale ||
+                newProps.dashCap !== currentProps.dashCap ||
+                newProps.stubCap !== currentProps.stubCap ||
+                !arrayEqual(newProps.includeTypes, currentProps.includeTypes) ||
+                !arrayEqual(newProps.excludeTypes, currentProps.excludeTypes) ||
+                newProps.adjustCylinderLength !== currentProps.adjustCylinderLength ||
+                newProps.multipleBonds !== currentProps.multipleBonds ||
+                newProps.adjustCylinderLength && !SizeTheme.areEqual(newTheme.size, currentTheme.size)
+            );
+
+            if (hasStructureVisibleBonds(newStructure, newProps) && newStructure.interUnitBonds !== currentStructure.interUnitBonds) {
+                state.createGeometry = true;
+                state.updateTransform = true;
+                state.updateColor = true;
+                state.updateSize = true;
+            }
+        },
+        mustRecreate: (structure: Structure, props: PD.Values<StructureIntraUnitBondCylinderParams>, webgl?: WebGLContext) => {
             return props.tryUseImpostor && !!webgl;
         }
     }, materialId);

--- a/src/mol-repr/structure/visual/element-cross.ts
+++ b/src/mol-repr/structure/visual/element-cross.ts
@@ -10,13 +10,14 @@ import { VisualContext } from '../../visual';
 import { Unit, Structure, StructureElement } from '../../../mol-model/structure';
 import { Theme } from '../../../mol-theme/theme';
 import { Vec3 } from '../../../mol-math/linear-algebra';
-import { ElementIterator, getElementLoci, eachElement, makeElementIgnoreTest } from './util/element';
+import { ElementIterator, getElementLoci, eachElement, makeElementIgnoreTest, getSerialElementLoci, eachSerialElement } from './util/element';
 import { VisualUpdateState } from '../../util';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { Lines } from '../../../mol-geo/geometry/lines/lines';
 import { LinesBuilder } from '../../../mol-geo/geometry/lines/lines-builder';
 import { bondCount } from '../../../mol-model-props/computed/chemistry/util';
 import { hasUnitVisibleBonds } from './util/bond';
+import { ComplexLinesParams, ComplexLinesVisual, ComplexVisual } from '../complex-visual';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3add = Vec3.add;
@@ -101,6 +102,102 @@ export function ElementCrossVisual(materialId: number): UnitsVisual<ElementCross
         getLoci: getElementLoci,
         eachLocation: eachElement,
         setUpdateState: (state: VisualUpdateState, newProps: PD.Values<ElementCrossParams>, currentProps: PD.Values<ElementCrossParams>) => {
+            state.createGeometry = (
+                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
+                newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+                newProps.traceOnly !== currentProps.traceOnly ||
+                newProps.crosses !== currentProps.crosses ||
+                newProps.crossSize !== currentProps.crossSize
+            );
+        }
+    }, materialId);
+}
+
+//
+
+export function createStructureElementCross(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<StructureElementCrossParams>, lines?: Lines): Lines {
+    const { child } = structure;
+
+    const { getSerialIndex } = structure.serialMapping;
+    const structureElementCount = structure.elementCount;
+    const builder = LinesBuilder.create(structureElementCount, structureElementCount / 2, lines);
+
+    const p = Vec3();
+    const s = Vec3();
+    const e = Vec3();
+
+    const r = props.crossSize / 2;
+    const lone = props.crosses === 'lone';
+
+    const center = Vec3();
+    let count = 0;
+
+    for (const unit of structure.units) {
+        const childUnit = child?.unitMap.get(unit.id);
+        if (child && !childUnit) return Lines.createEmpty(lines);
+
+        const { elements, conformation: c } = unit;
+        const elementCount = elements.length;
+
+        const ignore = makeElementIgnoreTest(structure, unit, props);
+
+        for (let i = 0 as StructureElement.UnitIndex; i < elementCount; i++) {
+            if (ignore && ignore(elements[i])) continue;
+            if (lone && Unit.isAtomic(unit) && hasUnitVisibleBonds(unit, props) && bondCount(structure, unit, i) !== 0) continue;
+
+            c.position(elements[i], p);
+            v3add(center, center, p);
+            count += 1;
+
+            const si = getSerialIndex(unit, elements[i]);
+            v3scaleAndAdd(s, p, v3unitX, r);
+            v3scaleAndAdd(e, p, v3unitX, -r);
+            builder.add(s[0], s[1], s[2], e[0], e[1], e[2], si);
+            v3scaleAndAdd(s, p, v3unitY, r);
+            v3scaleAndAdd(e, p, v3unitY, -r);
+            builder.add(s[0], s[1], s[2], e[0], e[1], e[2], si);
+            v3scaleAndAdd(s, p, v3unitZ, r);
+            v3scaleAndAdd(e, p, v3unitZ, -r);
+            builder.add(s[0], s[1], s[2], e[0], e[1], e[2], si);
+        }
+    }
+
+    const l = builder.getLines();
+    if (count === 0) return l;
+
+    // re-use boundingSphere if it has not changed much
+    let boundingSphere: Sphere3D;
+    Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = lines ? Sphere3D.clone(lines.boundingSphere) : undefined;
+    if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 1.0) {
+        boundingSphere = oldBoundingSphere;
+    } else {
+        boundingSphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * props.sizeFactor);
+    }
+    l.setBoundingSphere(boundingSphere);
+
+    return l;
+}
+
+export const StructureElementCrossParams = {
+    ...ComplexLinesParams,
+    lineSizeAttenuation: PD.Boolean(false),
+    ignoreHydrogens: PD.Boolean(false),
+    ignoreHydrogensVariant: PD.Select('all', PD.arrayToOptions(['all', 'non-polar'] as const)),
+    traceOnly: PD.Boolean(false),
+    crosses: PD.Select('lone', PD.arrayToOptions(['lone', 'all'] as const)),
+    crossSize: PD.Numeric(0.35, { min: 0, max: 2, step: 0.01 }),
+};
+export type StructureElementCrossParams = typeof StructureElementCrossParams
+
+export function StructureElementCrossVisual(materialId: number): ComplexVisual<StructureElementCrossParams> {
+    return ComplexLinesVisual<StructureElementCrossParams>({
+        defaultProps: PD.getDefaultValues(StructureElementCrossParams),
+        createGeometry: createStructureElementCross,
+        createLocationIterator: ElementIterator.fromStructure,
+        getLoci: getSerialElementLoci,
+        eachLocation: eachSerialElement,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureElementCrossParams>, currentProps: PD.Values<StructureElementCrossParams>) => {
             state.createGeometry = (
                 newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
                 newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||

--- a/src/mol-repr/structure/visual/element-point.ts
+++ b/src/mol-repr/structure/visual/element-point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -13,9 +13,10 @@ import { Theme } from '../../../mol-theme/theme';
 import { Points } from '../../../mol-geo/geometry/points/points';
 import { PointsBuilder } from '../../../mol-geo/geometry/points/points-builder';
 import { Vec3 } from '../../../mol-math/linear-algebra';
-import { ElementIterator, getElementLoci, eachElement, makeElementIgnoreTest } from './util/element';
+import { ElementIterator, getElementLoci, eachElement, makeElementIgnoreTest, getSerialElementLoci, eachSerialElement } from './util/element';
 import { VisualUpdateState } from '../../util';
 import { Sphere3D } from '../../../mol-math/geometry';
+import { ComplexPointsParams, ComplexPointsVisual, ComplexVisual } from '../complex-visual';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3add = Vec3.add;
@@ -38,6 +39,8 @@ export function createElementPoint(ctx: VisualContext, unit: Unit, structure: St
     const { child } = structure;
     if (child && !child.unitMap.get(unit.id)) return Points.createEmpty(points);
 
+    const { stride } = props;
+
     const elements = unit.elements;
     const n = elements.length;
     const builder = PointsBuilder.create(n, n / 10, points);
@@ -48,9 +51,10 @@ export function createElementPoint(ctx: VisualContext, unit: Unit, structure: St
     const center = Vec3();
     let count = 0;
 
-    if (ignore) {
+    if ((stride && stride > 1) || ignore) {
         for (let i = 0; i < n; ++i) {
-            if (ignore(elements[i])) continue;
+            if (stride && i % stride !== 0) continue;
+            if (ignore && ignore(elements[i])) continue;
             c.invariantPosition(elements[i], p);
             v3add(center, center, p);
             count += 1;
@@ -90,6 +94,98 @@ export function ElementPointVisual(materialId: number): UnitsVisual<ElementPoint
         getLoci: getElementLoci,
         eachLocation: eachElement,
         setUpdateState: (state: VisualUpdateState, newProps: PD.Values<ElementPointParams>, currentProps: PD.Values<ElementPointParams>) => {
+            state.createGeometry = (
+                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
+                newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+                newProps.traceOnly !== currentProps.traceOnly ||
+                newProps.stride !== currentProps.stride
+            );
+        }
+    }, materialId);
+}
+
+//
+
+export function createStructureElementPoint(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<StructureElementPointParams>, points?: Points): Points {
+    // TODO sizeFactor
+
+    const { child } = structure;
+    const { stride } = props;
+
+    const { getSerialIndex } = structure.serialMapping;
+    const structureElementCount = structure.elementCount;
+    const builder = PointsBuilder.create(structureElementCount, structureElementCount / 2, points);
+
+    const center = Vec3();
+    let count = 0;
+
+    for (const unit of structure.units) {
+        const childUnit = child?.unitMap.get(unit.id);
+        if (child && !childUnit) return Points.createEmpty(points);
+
+        const { elements, conformation: c } = unit;
+        const elementCount = elements.length;
+
+        const v = Vec3();
+        const ignore = makeElementIgnoreTest(structure, unit, props);
+
+        if ((stride && stride > 1) || ignore) {
+            for (let i = 0; i < elementCount; i++) {
+                const eI = elements[i];
+                if (stride && i % stride !== 0) continue;
+                if (ignore && ignore(eI)) continue;
+
+                c.position(eI, v);
+                builder.add(v[0], v[1], v[2], getSerialIndex(unit, eI));
+                v3add(center, center, v);
+                count += 1;
+            }
+        } else {
+            for (let i = 0; i < elementCount; i++) {
+                const eI = elements[i];
+                c.position(eI, v);
+                builder.add(v[0], v[1], v[2], getSerialIndex(unit, eI));
+                v3add(center, center, v);
+            }
+            count += elementCount;
+        }
+    }
+
+    const pt = builder.getPoints();
+    if (count === 0) return pt;
+
+    // re-use boundingSphere if it has not changed much
+    let boundingSphere: Sphere3D;
+    Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = points ? Sphere3D.clone(points.boundingSphere) : undefined;
+    if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 1.0) {
+        boundingSphere = oldBoundingSphere;
+    } else {
+        boundingSphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * props.sizeFactor);
+    }
+    pt.setBoundingSphere(boundingSphere);
+
+    return pt;
+}
+
+export const StructureElementPointParams = {
+    ...ComplexPointsParams,
+    pointSizeAttenuation: PD.Boolean(false),
+    ignoreHydrogens: PD.Boolean(false),
+    ignoreHydrogensVariant: PD.Select('all', PD.arrayToOptions(['all', 'non-polar'] as const)),
+    traceOnly: PD.Boolean(false),
+    stride: PD.Numeric(1, { min: 1, max: 100, step: 1 }),
+};
+export type StructureElementPointParams = typeof StructureElementPointParams
+
+export function StructureElementPointVisual(materialId: number): ComplexVisual<StructureElementPointParams> {
+    return ComplexPointsVisual<StructureElementPointParams>({
+        defaultProps: PD.getDefaultValues(StructureElementPointParams),
+        createGeometry: createStructureElementPoint,
+        createLocationIterator: ElementIterator.fromStructure,
+        getLoci: getSerialElementLoci,
+        eachLocation: eachSerialElement,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureElementPointParams>, currentProps: PD.Values<StructureElementPointParams>) => {
             state.createGeometry = (
                 newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
                 newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||

--- a/src/mol-repr/structure/visual/ellipsoid-mesh.ts
+++ b/src/mol-repr/structure/visual/ellipsoid-mesh.ts
@@ -1,12 +1,12 @@
 /**
- * Copyright (c) 2019-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
 import { UnitsMeshParams, UnitsVisual, UnitsMeshVisual } from '../../../mol-repr/structure/units-visual';
-import { ElementIterator, getElementLoci, eachElement } from '../../../mol-repr/structure/visual/util/element';
+import { ElementIterator, getElementLoci, eachElement, getSerialElementLoci, eachSerialElement, makeElementIgnoreTest } from '../../../mol-repr/structure/visual/util/element';
 import { VisualUpdateState } from '../../../mol-repr/util';
 import { VisualContext } from '../../../mol-repr/visual';
 import { Unit, Structure, StructureElement } from '../../../mol-model/structure';
@@ -15,46 +15,23 @@ import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { sphereVertexCount } from '../../../mol-geo/primitive/sphere';
 import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
 import { Vec3, Mat3, Tensor, EPSILON } from '../../../mol-math/linear-algebra';
-import { isH } from '../../../mol-repr/structure/visual/util/common';
 import { addEllipsoid } from '../../../mol-geo/geometry/mesh/builder/ellipsoid';
 import { AtomSiteAnisotrop } from '../../../mol-model-formats/structure/property/anisotropic';
 import { equalEps } from '../../../mol-math/linear-algebra/3d/common';
 import { addSphere } from '../../../mol-geo/geometry/mesh/builder/sphere';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { BaseGeometry } from '../../../mol-geo/geometry/base';
-import { SortedArray } from '../../../mol-data/int/sorted-array';
+import { ComplexMeshParams, ComplexVisual, ComplexMeshVisual } from '../complex-visual';
 
-export const EllipsoidMeshParams = {
-    ...UnitsMeshParams,
-    sizeFactor: PD.Numeric(1, { min: 0, max: 10, step: 0.1 }),
-    detail: PD.Numeric(0, { min: 0, max: 3, step: 1 }, BaseGeometry.CustomQualityParamInfo),
-    ignoreHydrogens: PD.Boolean(false),
-};
-export type EllipsoidMeshParams = typeof EllipsoidMeshParams
-
-export function EllipsoidMeshVisual(materialId: number): UnitsVisual<EllipsoidMeshParams> {
-    return UnitsMeshVisual<EllipsoidMeshParams>({
-        defaultProps: PD.getDefaultValues(EllipsoidMeshParams),
-        createGeometry: createEllipsoidMesh,
-        createLocationIterator: ElementIterator.fromGroup,
-        getLoci: getElementLoci,
-        eachLocation: eachElement,
-        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<EllipsoidMeshParams>, currentProps: PD.Values<EllipsoidMeshParams>) => {
-            state.createGeometry = (
-                newProps.sizeFactor !== currentProps.sizeFactor ||
-                newProps.detail !== currentProps.detail ||
-                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens
-            );
-        }
-    }, materialId);
-}
-
-//
+// avoiding namespace lookup improved performance in Chrome (Aug 2020)
+const v3add = Vec3.add;
 
 export interface EllipsoidMeshProps {
     detail: number,
     sizeFactor: number,
     ignoreHydrogens: boolean,
+    ignoreHydrogensVariant: 'all' | 'non-polar',
+    traceOnly: boolean,
 }
 
 export function createEllipsoidMesh(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: EllipsoidMeshProps, mesh?: Mesh): Mesh {
@@ -62,10 +39,9 @@ export function createEllipsoidMesh(ctx: VisualContext, unit: Unit, structure: S
     const childUnit = child?.unitMap.get(unit.id);
     if (child && !childUnit) return Mesh.createEmpty(mesh);
 
-    const { detail, sizeFactor, ignoreHydrogens } = props;
+    const { detail, sizeFactor } = props;
 
     const { elements, model } = unit;
-    const { atomicNumber } = unit.model.atomicHierarchy.derived.atom;
     const elementCount = elements.length;
     const vertexCount = elementCount * sphereVertexCount(detail);
     const builderState = MeshBuilder.createState(vertexCount, vertexCount / 2, mesh);
@@ -85,15 +61,20 @@ export function createEllipsoidMesh(ctx: VisualContext, unit: Unit, structure: S
     const l = StructureElement.Location.create(structure);
     l.unit = unit;
 
+    const ignore = makeElementIgnoreTest(structure, unit, props);
+    const center = Vec3();
+    let count = 0;
+
     for (let i = 0; i < elementCount; i++) {
         const ei = elements[i];
         const ai = elementToAnsiotrop[ei];
         if (ai === -1) continue;
-        if (((!!childUnit && !SortedArray.has(childUnit.elements, ei))) ||
-            (ignoreHydrogens && isH(atomicNumber, ei))) continue;
+        if (ignore && ignore(elements[i])) continue;
 
         l.element = ei;
         c.invariantPosition(ei, v);
+        v3add(center, center, v);
+        count += 1;
 
         builderState.currentGroup = i;
         Tensor.toMat3(mat, space, U.value(ai));
@@ -116,9 +97,180 @@ export function createEllipsoidMesh(ctx: VisualContext, unit: Unit, structure: S
     }
 
     const m = MeshBuilder.getMesh(builderState);
+    if (count === 0) return m;
 
-    const sphere = Sphere3D.expand(Sphere3D(), (childUnit || unit).boundary.sphere, 1 * sizeFactor);
-    m.setBoundingSphere(sphere);
+    // re-use boundingSphere if it has not changed much
+    let boundingSphere: Sphere3D;
+    Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
+    if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 0.1) {
+        boundingSphere = oldBoundingSphere;
+    } else {
+        boundingSphere = Sphere3D.expand(Sphere3D(), (childUnit ?? unit).boundary.sphere, 1 * sizeFactor * 2);
+    }
+    m.setBoundingSphere(boundingSphere);
 
     return m;
+}
+
+export const EllipsoidMeshParams = {
+    ...UnitsMeshParams,
+    sizeFactor: PD.Numeric(1, { min: 0, max: 10, step: 0.1 }),
+    detail: PD.Numeric(0, { min: 0, max: 3, step: 1 }, BaseGeometry.CustomQualityParamInfo),
+    ignoreHydrogens: PD.Boolean(false),
+    ignoreHydrogensVariant: PD.Select('all', PD.arrayToOptions(['all', 'non-polar'] as const)),
+    traceOnly: PD.Boolean(false),
+};
+export type EllipsoidMeshParams = typeof EllipsoidMeshParams
+
+export function EllipsoidMeshVisual(materialId: number): UnitsVisual<EllipsoidMeshParams> {
+    return UnitsMeshVisual<EllipsoidMeshParams>({
+        defaultProps: PD.getDefaultValues(EllipsoidMeshParams),
+        createGeometry: createEllipsoidMesh,
+        createLocationIterator: ElementIterator.fromGroup,
+        getLoci: getElementLoci,
+        eachLocation: eachElement,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<EllipsoidMeshParams>, currentProps: PD.Values<EllipsoidMeshParams>) => {
+            state.createGeometry = (
+                newProps.sizeFactor !== currentProps.sizeFactor ||
+                newProps.detail !== currentProps.detail ||
+                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens
+            );
+        }
+    }, materialId);
+}
+
+//
+
+export function createStructureEllipsoidMesh(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<StructureEllipsoidMeshParams>, mesh?: Mesh): Mesh {
+    const { child } = structure;
+
+    const { detail, sizeFactor } = props;
+    const { getSerialIndex } = structure.serialMapping;
+    const structureElementCount = structure.elementCount;
+    const vertexCount = structureElementCount * sphereVertexCount(detail);
+    const builderState = MeshBuilder.createState(vertexCount, vertexCount / 2, mesh);
+
+    const v = Vec3();
+    const mat = Mat3();
+    const eigvals = Vec3();
+    const eigvec1 = Vec3();
+    const eigvec2 = Vec3();
+
+    const center = Vec3();
+    let count = 0;
+
+    for (const unit of structure.units) {
+        const childUnit = child?.unitMap.get(unit.id);
+        if (child && !childUnit) return Mesh.createEmpty(mesh);
+
+        const { elements, model } = unit;
+        const elementCount = elements.length;
+
+        const atomSiteAnisotrop = AtomSiteAnisotrop.Provider.get(model);
+        if (!atomSiteAnisotrop) return Mesh.createEmpty(mesh);
+
+        const ignore = makeElementIgnoreTest(structure, unit, props);
+
+        const { elementToAnsiotrop, data } = atomSiteAnisotrop;
+        const { U } = data;
+        const space = data._schema.U.space;
+        const c = unit.conformation;
+        const l = StructureElement.Location.create(structure);
+        l.unit = unit;
+
+        // for (let i = 0 as StructureElement.UnitIndex; i < elementCount; i++) {
+        //     if (ignore && ignore(elements[i])) continue;
+        //     if (lone && Unit.isAtomic(unit) && hasUnitVisibleBonds(unit, props) && bondCount(structure, unit, i) !== 0) continue;
+
+        //     c.position(elements[i], p);
+        //     v3add(center, center, p);
+        //     count += 1;
+
+        //     const si = getSerialIndex(unit, elements[i]);
+        //     v3scaleAndAdd(s, p, v3unitX, r);
+        //     v3scaleAndAdd(e, p, v3unitX, -r);
+        //     builder.add(s[0], s[1], s[2], e[0], e[1], e[2], si);
+        //     v3scaleAndAdd(s, p, v3unitY, r);
+        //     v3scaleAndAdd(e, p, v3unitY, -r);
+        //     builder.add(s[0], s[1], s[2], e[0], e[1], e[2], si);
+        //     v3scaleAndAdd(s, p, v3unitZ, r);
+        //     v3scaleAndAdd(e, p, v3unitZ, -r);
+        //     builder.add(s[0], s[1], s[2], e[0], e[1], e[2], si);
+        // }
+
+        for (let i = 0 as StructureElement.UnitIndex; i < elementCount; i++) {
+            const ei = elements[i];
+            const ai = elementToAnsiotrop[ei];
+            if (ai === -1) continue;
+            if (ignore && ignore(elements[i])) continue;
+
+            l.element = ei;
+            c.position(ei, v);
+            v3add(center, center, v);
+            count += 1;
+
+            builderState.currentGroup = getSerialIndex(unit, elements[i]);
+            Tensor.toMat3(mat, space, U.value(ai));
+            Mat3.symmtricFromLower(mat, mat);
+            Mat3.symmetricEigenvalues(eigvals, mat);
+            Mat3.eigenvector(eigvec1, mat, eigvals[1]);
+            Mat3.eigenvector(eigvec2, mat, eigvals[2]);
+            for (let j = 0; j < 3; ++j) {
+                // show 50% probability surface, needs sqrt as U matrix is in angstrom-squared
+                // take abs of eigenvalue to avoid reflection
+                // multiply by given size-factor
+                eigvals[j] = sizeFactor * 1.5958 * Math.sqrt(Math.abs(eigvals[j]));
+            }
+
+            if (equalEps(eigvals[0], eigvals[1], EPSILON) && equalEps(eigvals[1], eigvals[2], EPSILON)) {
+                addSphere(builderState, v, eigvals[0], detail);
+            } else {
+                addEllipsoid(builderState, v, eigvec2, eigvec1, eigvals, detail);
+            }
+        }
+    }
+
+    const m = MeshBuilder.getMesh(builderState);
+    if (count === 0) return m;
+
+    // re-use boundingSphere if it has not changed much
+    let boundingSphere: Sphere3D;
+    Vec3.scale(center, center, 1 / count);
+    const oldBoundingSphere = mesh ? Sphere3D.clone(mesh.boundingSphere) : undefined;
+    if (oldBoundingSphere && Vec3.distance(center, oldBoundingSphere.center) / oldBoundingSphere.radius < 1.0) {
+        boundingSphere = oldBoundingSphere;
+    } else {
+        boundingSphere = Sphere3D.expand(Sphere3D(), (child ?? structure).boundary.sphere, 1 * sizeFactor * 2);
+    }
+    m.setBoundingSphere(boundingSphere);
+
+    return m;
+}
+
+export const StructureEllipsoidMeshParams = {
+    ...ComplexMeshParams,
+    sizeFactor: PD.Numeric(1, { min: 0, max: 10, step: 0.1 }),
+    detail: PD.Numeric(0, { min: 0, max: 3, step: 1 }, BaseGeometry.CustomQualityParamInfo),
+    ignoreHydrogens: PD.Boolean(false),
+    ignoreHydrogensVariant: PD.Select('all', PD.arrayToOptions(['all', 'non-polar'] as const)),
+    traceOnly: PD.Boolean(false),
+};
+export type StructureEllipsoidMeshParams = typeof StructureEllipsoidMeshParams
+
+export function StructureEllipsoidMeshVisual(materialId: number): ComplexVisual<StructureEllipsoidMeshParams> {
+    return ComplexMeshVisual<StructureEllipsoidMeshParams>({
+        defaultProps: PD.getDefaultValues(StructureEllipsoidMeshParams),
+        createGeometry: createStructureEllipsoidMesh,
+        createLocationIterator: ElementIterator.fromStructure,
+        getLoci: getSerialElementLoci,
+        eachLocation: eachSerialElement,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureEllipsoidMeshParams>, currentProps: PD.Values<StructureEllipsoidMeshParams>) => {
+            state.createGeometry = (
+                newProps.sizeFactor !== currentProps.sizeFactor ||
+                newProps.detail !== currentProps.detail ||
+                newProps.ignoreHydrogens !== currentProps.ignoreHydrogens
+            );
+        }
+    }, materialId);
 }

--- a/src/mol-repr/structure/visual/util/element.ts
+++ b/src/mol-repr/structure/visual/util/element.ts
@@ -247,7 +247,6 @@ export function createStructureElementSphereMesh(ctx: VisualContext, structure: 
             if (stride && i % stride !== 0) continue;
             if (ignore && ignore(eI)) continue;
 
-
             c.position(eI, v);
             v3add(center, center, v);
             count += 1;

--- a/src/mol-repr/structure/visual/util/link.ts
+++ b/src/mol-repr/structure/visual/util/link.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Zhenyu Zhang <jump2cn@gmail.com>
@@ -88,6 +88,12 @@ export interface LinkBuilderProps {
     ignore?: (edgeIndex: number) => boolean
     stub?: (edgeIndex: number) => boolean
 }
+
+export const EmptyLinkBuilderProps: LinkBuilderProps = {
+    linkCount: 0,
+    position: () => { },
+    radius: () => 0
+};
 
 export const enum LinkStyle {
     Solid = 0,


### PR DESCRIPTION
- Add `Structure.intraUnitBondMapping`
- Add more structure-based visuals to avoid too many (small) render-objects
    - `structure-intra-bond`, `structure-ellipsoid-mesh`, `structure-element-point`, `structure-element-cross`