### PR TITLE
Membrane orientation: improve `isApplicable` check and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 - Add example `glb-export`
+- Membrane orientation: Improve `isApplicable` check and error handling (#1316)
 
 ## [v4.8.0] - 2024-10-27
 

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -15,7 +15,6 @@ import { Vec3 } from '../../mol-math/linear-algebra';
 import { QuerySymbolRuntime } from '../../mol-script/runtime/query/base';
 import { CustomPropSymbol } from '../../mol-script/language/symbol';
 import { Type } from '../../mol-script/language/type';
-import { str } from '../mvs/tree/generic/params-schema';
 
 export const MembraneOrientationParams = {
     ...ANVILParams

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -83,11 +83,13 @@ export const MembraneOrientationProvider: CustomStructureProperty.Provider<Membr
 function isApplicable(structure: Structure) {
     if (!structure.isAtomic) return false;
 
-    const { byEntityKey } = structure.model.sequence;
-    for (const key of Object.keys(byEntityKey)) {
-        const { kind, length } = byEntityKey[+key].sequence;
-        if (kind !== 'protein') continue; // can only process protein chains
-        if (length >= 15) return true; // short peptides might fail
+    for (const model of structure.models) {
+        const { byEntityKey } = model.sequence;
+        for (const key of Object.keys(byEntityKey)) {
+            const { kind, length } = byEntityKey[+key].sequence;
+            if (kind !== 'protein') continue; // can only process protein chains
+            if (length >= 15) return true; // short peptides might fail
+        }
     }
     return false;
 }

--- a/src/extensions/anvil/prop.ts
+++ b/src/extensions/anvil/prop.ts
@@ -81,6 +81,8 @@ export const MembraneOrientationProvider: CustomStructureProperty.Provider<Membr
 });
 
 function isApplicable(structure: Structure) {
+    if (!structure.isAtomic) return false;
+
     const { byEntityKey } = structure.model.sequence;
     for (const key of Object.keys(byEntityKey)) {
         const { kind, length } = byEntityKey[+key].sequence;

--- a/src/extensions/anvil/representation.ts
+++ b/src/extensions/anvil/representation.ts
@@ -81,7 +81,7 @@ export const MembraneOrientationRepresentationProvider = StructureRepresentation
     defaultValues: PD.getDefaultValues(MembraneOrientationParams),
     defaultColorTheme: { name: 'shape-group' },
     defaultSizeTheme: { name: 'shape-group' },
-    isApplicable: (structure: Structure) => structure.elementCount > 0,
+    isApplicable(structure: Structure) { return MembraneOrientationProvider.isApplicable(structure); },
     ensureCustomProperties: {
         attach: (ctx: CustomProperty.Context, structure: Structure) => MembraneOrientationProvider.attach(ctx, structure, void 0, true),
         detach: (data) => MembraneOrientationProvider.ref(data, false)


### PR DESCRIPTION
# Description
- turns out adjusting the `isApplicable()` method isn't enough as selection symbols don't check that
- checking based on entity data seemed pretty cheap
- tested for 5xes, 5bna ("Membrane Orientation" hidden, selection symbol returns console warning) and 1brr, 6w6l

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`