### PR TITLE
Fix outlines on volume and surface reps that do not disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Fix outlines on volume and surface reps that do not disappear (#1326)
 - Add example `glb-export`
 - Fix set fenceSync to null after deleteSync.
 - Fix operator key-based `IndexPairBonds` assignment

--- a/src/mol-canvas3d/passes/postprocessing.ts
+++ b/src/mol-canvas3d/passes/postprocessing.ts
@@ -164,7 +164,7 @@ export class PostprocessingPass {
     }
 
     static isTransparentOutlineEnabled(props: PostprocessingProps) {
-        return OutlinePass.isEnabled(props) && (props.outline.params as OutlineProps).includeTransparent;
+        return OutlinePass.isEnabled(props) && ((props.outline.params as OutlineProps).includeTransparent ?? true);
     }
 
     static isTransparentSsaoEnabled(scene: Scene, props: PostprocessingProps) {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
A fix for outlines on volume and surface reps not disappearing when includeTransparent is not defined (#1326)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`