### PR TITLE
Membrane Server to generate MolViewSpec data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix bonds not shown with `ignoreHydrogens` on (#1315)
     - Better handle mmCIF files with no entities defined by using `label_asym_id`
     - Show bonds in water chains when `ignoreHydorgensVariant` is `non-polar`
+- Add MembraneServer API, generating data to be consumed in the context of MolViewSpec
 
 ## [v4.8.0] - 2024-10-27
 

--- a/src/servers/membrane-orientation/config.ts
+++ b/src/servers/membrane-orientation/config.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ */
+
+import * as argparse from 'argparse';
+import { VERSION } from './version';
+import { ObjectKeys } from '../../mol-util/type-helpers';
+
+const DefaultMembraneServerConfig = {
+    /**
+     * Node (V8) sometimes exhibits GC related issues  that significantly slow down the execution
+     * (https://github.com/nodejs/node/issues/8670).
+     *
+     * Therefore an option is provided that automatically shuts down the server.
+     * For this to work, the server must be run using a deamon (i.e. forever.js on Linux
+     * or IISnode on Windows) so that the server is automatically restarted when the shutdown happens.
+     */
+
+    // 0 for off, server will shut down after this amount of minutes.
+    shutdownTimeoutMinutes: 24 * 60, /* a day */
+    // modifies the shutdown timer by +/- timeoutVarianceMinutes (to avoid multiple instances shutting at the same time)
+    shutdownTimeoutVarianceMinutes: 60,
+
+    defaultPort: 1340,
+
+    /**
+     * Specify the prefix of the API, i.e.
+     * <host>/<apiPrefix>/<API queries>
+     */
+    apiPrefix: '/MembraneServer',
+
+    /**
+     * The maximum number of ms the server spends on a request
+     */
+    requestTimeoutMs: 60 * 1000,
+
+    /**
+     * Default URL from which BinaryCIF data will be pulled.
+     */
+    bcifSource: (id: string) => `https://models.rcsb.org/${id}.bcif`,
+};
+
+function addServerArgs(parser: argparse.ArgumentParser) {
+    parser.add_argument('--apiPrefix', {
+        default: DefaultMembraneServerConfig.apiPrefix,
+        metavar: 'PREFIX',
+        help: `Specify the prefix of the API, i.e. <host>/<apiPrefix>/<API queries>`
+    });
+    parser.add_argument('--defaultPort', {
+        default: DefaultMembraneServerConfig.defaultPort,
+        metavar: 'PORT',
+        type: 'int',
+        help: `Specify the port the server is running on`
+    });
+    parser.add_argument('--shutdownTimeoutMinutes', {
+        default: DefaultMembraneServerConfig.shutdownTimeoutMinutes,
+        metavar: 'TIME',
+        type: 'int',
+        help: `0 for off, server will shut down after this amount of minutes.`
+    });
+    parser.add_argument('--shutdownTimeoutVarianceMinutes', {
+        default: DefaultMembraneServerConfig.shutdownTimeoutVarianceMinutes,
+        metavar: 'VARIANCE',
+        type: 'int',
+        help: `modifies the shutdown timer by +/- timeoutVarianceMinutes (to avoid multiple instances shutting at the same time)`
+    });
+    parser.add_argument('--bcifSource', {
+        default: DefaultMembraneServerConfig.bcifSource,
+        metavar: 'DEFAULT_SOURCE',
+        help: `Where 3D structure data is loaded from.`
+    });
+}
+
+export type MembraneServerConfig = typeof DefaultMembraneServerConfig
+export const MembraneServerConfig = { ...DefaultMembraneServerConfig };
+
+function setConfig(config: MembraneServerConfig) {
+    for (const k of ObjectKeys(MembraneServerConfig)) {
+        if (config[k] !== void 0) (MembraneServerConfig as any)[k] = config[k];
+    }
+}
+
+function parseConfigArguments() {
+    const parser = new argparse.ArgumentParser({
+        add_help: true,
+        description: `Mol* MembraneServer ${VERSION}, (c) 2024, Mol* contributors`
+    });
+    addServerArgs(parser);
+    return parser.parse_args() as MembraneServerConfig;
+}
+
+export function configureServer() {
+    const config = parseConfigArguments();
+    setConfig(config); // sets the config for global use
+}

--- a/src/servers/membrane-orientation/server.ts
+++ b/src/servers/membrane-orientation/server.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ */
+
+import compression from 'compression';
+import express from 'express';
+import { VERSION } from './version';
+import { configureServer, MembraneServerConfig } from './config';
+import { ConsoleLogger } from '../../mol-util/console-logger';
+import { PerformanceMonitor } from '../../mol-util/performance-monitor';
+import { initWebApi } from './web-api';
+
+function setupShutdown() {
+    if (MembraneServerConfig.shutdownTimeoutVarianceMinutes > MembraneServerConfig.shutdownTimeoutMinutes) {
+        ConsoleLogger.log('Server', 'Shutdown timeout variance is greater than the timer itself, ignoring.');
+    } else {
+        let tVar = 0;
+        if (MembraneServerConfig.shutdownTimeoutVarianceMinutes > 0) {
+            tVar = 2 * (Math.random() - 0.5) * MembraneServerConfig.shutdownTimeoutVarianceMinutes;
+        }
+        const tMs = (MembraneServerConfig.shutdownTimeoutMinutes + tVar) * 60 * 1000;
+
+        console.log(`----------------------------------------------------------------------------`);
+        console.log(`  The server will shut down in ${PerformanceMonitor.format(tMs)} to prevent slow performance.`);
+        console.log(`  Please make sure a daemon is running that will automatically restart it.`);
+        console.log(`----------------------------------------------------------------------------`);
+        console.log();
+
+        setTimeout(() => {
+            ConsoleLogger.log('Server', `Shut down due to timeout.`);
+            process.exit(0);
+        }, tMs);
+    }
+}
+
+configureServer();
+
+function startServer() {
+    const app = express();
+    app.use(compression({
+        level: 6, memLevel: 9, chunkSize: 16 * 16384,
+        filter: (req, res) => {
+            const ct = res.getHeader('Content-Type');
+            if (typeof ct === 'string' && ct.indexOf('tar+gzip') > 0) return false;
+            return true;
+        }
+    }));
+
+    initWebApi(app);
+
+    const port = process.env.port || MembraneServerConfig.defaultPort;
+    app.listen(port).setTimeout(MembraneServerConfig.requestTimeoutMs);
+
+    console.log(`Mol* Membrane Server ${VERSION}`);
+    console.log(``);
+    console.log(`The server is running on port ${port}.`);
+    console.log(``);
+}
+
+startServer();
+
+if (MembraneServerConfig.shutdownTimeoutMinutes > 0) {
+    setupShutdown();
+}

--- a/src/servers/membrane-orientation/version.ts
+++ b/src/servers/membrane-orientation/version.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ */
+
+export const VERSION = '0.0.1';

--- a/src/servers/membrane-orientation/web-api.ts
+++ b/src/servers/membrane-orientation/web-api.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ */
+
+import * as express from 'express';
+import { MembraneServerConfig } from './config';
+import { swaggerUiAssetsHandler, swaggerUiIndexHandler } from '../common/swagger-ui';
+import { getSchema, shortcutIconLink } from './web-schema';
+import { MembraneOrientationProvider } from '../../extensions/anvil/prop';
+import { SyncRuntimeContext } from '../../mol-task/execution/synchronous';
+import { AssetManager } from '../../mol-util/assets';
+import { CIF, CifFrame } from '../../mol-io/reader/cif';
+import { Model, Structure, StructureSymmetry } from '../../mol-model/structure';
+import { trajectoryFromMmCIF } from '../../mol-model-formats/structure/mmcif';
+import { ANVILParams, ANVILProps } from '../../extensions/anvil/algorithm';
+import { ParamDefinition as PD } from '../../mol-util/param-definition';
+import { ConsoleLogger } from '../../mol-util/console-logger';
+
+const assetManager = new AssetManager();
+
+export function initWebApi(app: express.Express) {
+    function makePath(p: string) {
+        return MembraneServerConfig.apiPrefix + '/' + p;
+    }
+
+    app.get(makePath('predict/:id/'), async (req, res) => predictMembraneOrientation(req, res));
+
+    app.get(makePath('openapi.json'), (_, res) => {
+        res.writeHead(200, {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': 'X-Requested-With'
+        });
+        res.end(JSON.stringify(getSchema()));
+    });
+
+    app.use(makePath(''), swaggerUiAssetsHandler());
+    app.get(makePath(''), swaggerUiIndexHandler({
+        openapiJsonUrl: makePath('openapi.json'),
+        apiPrefix: MembraneServerConfig.apiPrefix,
+        title: 'MembraneServer API',
+        shortcutIconLink
+    }));
+}
+
+async function predictMembraneOrientation(req: express.Request, res: express.Response) {
+    const ctx = { runtime: SyncRuntimeContext, assetManager };
+
+    const entryId = req.params.id;
+    const assemblyId = req.query.assemblyId as string ?? '1';
+    const p = parseParams(req);
+    ConsoleLogger.log('predictMembraneOrientation', `${entryId}-${assemblyId} with params: ${JSON.stringify(p)}`);
+
+    const cif = await downloadFromPdb(entryId);
+    const models = await getModels(cif);
+    const structure = await getStructure(models.representative, assemblyId);
+
+    await MembraneOrientationProvider.attach(ctx, structure, p);
+    const data = MembraneOrientationProvider.get(structure).value;
+
+    res.writeHead(200, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'X-Requested-With'
+    });
+    res.write(JSON.stringify(data));
+    res.end();
+}
+
+const defaults = PD.getDefaultValues(ANVILParams);
+function parseParams(req: express.Request): ANVILProps {
+    const {
+        numberOfSpherePoints = defaults.numberOfSpherePoints,
+        stepSize = defaults.stepSize,
+        minThickness = defaults.minThickness,
+        maxThickness = defaults.maxThickness,
+        asaCutoff = defaults.asaCutoff,
+        adjust = defaults.adjust,
+        tmdetDefinition = defaults.tmdetDefinition,
+    } = req.query;
+    return {
+        numberOfSpherePoints: Number(numberOfSpherePoints),
+        stepSize: Number(stepSize),
+        minThickness: Number(minThickness),
+        maxThickness: Number(maxThickness),
+        asaCutoff: Number(asaCutoff),
+        adjust: Number(adjust),
+        tmdetDefinition: tmdetDefinition === 'true',
+    };
+}
+
+async function parseCif(data: string | Uint8Array) {
+    const comp = CIF.parse(data);
+    const parsed = await comp.run();
+    if (parsed.isError) throw parsed;
+    return parsed.result;
+}
+
+async function downloadCif(url: string, isBinary: boolean) {
+    const data = await fetch(url);
+    return parseCif(isBinary ? new Uint8Array(await data.arrayBuffer()) : await data.text());
+}
+
+async function downloadFromPdb(pdb: string) {
+    const parsed = await downloadCif(MembraneServerConfig.bcifSource(pdb), true);
+    return parsed.blocks[0];
+}
+
+async function getModels(frame: CifFrame) {
+    return await trajectoryFromMmCIF(frame).run();
+}
+
+async function getStructure(model: Model, assemblyId: string) {
+    const modelStructure = Structure.ofModel(model);
+    return await StructureSymmetry.buildAssembly(modelStructure, assemblyId).run();
+}

--- a/src/servers/membrane-orientation/web-schema.ts
+++ b/src/servers/membrane-orientation/web-schema.ts
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ */
+
+import { VERSION } from './version';
+import { MembraneServerConfig } from './config';
+
+export function getSchema() {
+    return {
+        openapi: '3.0.0',
+        info: {
+            version: VERSION,
+            title: 'Membrane Server',
+            description: 'The MembraneServer process an entry and predicts the orientation of the membrane layer.',
+        },
+        tags: [
+            {
+                name: 'General',
+            }
+        ],
+        paths: {
+            [`${MembraneServerConfig.apiPrefix}/predict/{id}/`]: {
+                get: {
+                    tags: ['General'],
+                    summary: 'Returns a JSON response specifying if data is available and the maximum region that can be queried.',
+                    operationId: 'predictMembrane',
+                    parameters: [
+                        { $ref: '#/components/parameters/id' },
+                        { $ref: '#/components/parameters/assemblyId' },
+                        { $ref: '#/components/parameters/numberOfSpherePoints' },
+                        { $ref: '#/components/parameters/stepSize' },
+                        { $ref: '#/components/parameters/minThickness' },
+                        { $ref: '#/components/parameters/maxThickness' },
+                        { $ref: '#/components/parameters/asaCutoff' },
+                        { $ref: '#/components/parameters/adjust' },
+                        { $ref: '#/components/parameters/tmdetDefinition' },
+                    ],
+                    responses: {
+                        200: {
+                            description: '',
+                            content: {
+                                'application/json': {
+                                    schema: { $ref: '#/components/schemas/prediction' }
+                                }
+                            }
+                        },
+                    },
+                }
+            },
+        },
+        components: {
+            schemas: {
+                prediction: {
+                    type: 'object',
+                    properties: {
+                        planePoint1: {
+                            type: 'array',
+                            items: {
+                                type: 'number'
+                            },
+                            minItems: 3,
+                            maxItems: 3,
+                            description: 'Array of three numbers representing the first plane point'
+                        },
+                        planePoint2: {
+                            type: 'array',
+                            items: {
+                                type: 'number'
+                            },
+                            minItems: 3,
+                            maxItems: 3,
+                            description: 'Array of three numbers representing the second plane point'
+                        },
+                        normalVector: {
+                            type: 'array',
+                            items: {
+                                type: 'number'
+                            },
+                            minItems: 3,
+                            maxItems: 3,
+                            description: 'Array of three numbers representing the normal vector'
+                        },
+                        centroid: {
+                            type: 'array',
+                            items: {
+                                type: 'number'
+                            },
+                            minItems: 3,
+                            maxItems: 3,
+                            description: 'Array of three numbers representing the centroid'
+                        },
+                        radius: {
+                            type: 'number',
+                            description: 'A number representing the radius'
+                        }
+                    }
+                },
+            },
+            parameters: {
+                id: {
+                    name: 'id',
+                    in: 'path',
+                    description: 'Entry identifier of the entry, e.g. 1brr.',
+                    required: true,
+                    schema: {
+                        default: '5cbg',
+                        type: 'string',
+                    },
+                    style: 'simple',
+                },
+                assemblyId: {
+                    name: 'assemblyId',
+                    in: 'query',
+                    description: 'Assembly identifier, e.g. 1',
+                    required: false,
+                    schema: {
+                        default: '1',
+                        type: 'string',
+                    },
+                    style: 'simple'
+                },
+                numberOfSpherePoints: {
+                    name: 'numberOfSpherePoints',
+                    in: 'query',
+                    description: 'Number of spheres/directions to test for membrane placement. Original value is 350.',
+                    required: false,
+                    schema: {
+                        type: 'integer',
+                        minimum: 35,
+                        maximum: 700,
+                        default: 175,
+                    },
+                    style: 'simple'
+                },
+                stepSize: {
+                    name: 'stepSize',
+                    in: 'query',
+                    description: 'Thickness of membrane slices that will be tested',
+                    required: false,
+                    schema: {
+                        type: 'number',
+                        minimum: 0.25,
+                        maximum: 4,
+                        default: 1,
+                    },
+                    style: 'simple'
+                },
+                minThickness: {
+                    name: 'minThickness',
+                    in: 'query',
+                    description: 'Minimum membrane thickness used during refinement',
+                    required: false,
+                    schema: {
+                        type: 'number',
+                        minimum: 10,
+                        maximum: 30,
+                        default: 20,
+                    },
+                    style: 'simple'
+                },
+                maxThickness: {
+                    name: 'maxThickness',
+                    in: 'query',
+                    description: 'Maximum membrane thickness used during refinement',
+                    required: false,
+                    schema: {
+                        type: 'integer',
+                        minimum: 30,
+                        maximum: 50,
+                        default: 40,
+                    },
+                    style: 'simple'
+                },
+                asaCutoff: {
+                    name: 'asaCutoff',
+                    in: 'query',
+                    description: 'Relative ASA cutoff above which residues will be considered',
+                    required: false,
+                    schema: {
+                        type: 'number',
+                        minimum: 10,
+                        maximum: 100,
+                        default: 40,
+                    },
+                    style: 'simple'
+                },
+                adjust: {
+                    name: 'adjust',
+                    in: 'query',
+                    description: 'Minimum length of membrane-spanning regions (original values: 14 for alpha-helices and 5 for beta sheets). Set to 0 to not optimize membrane thickness.',
+                    required: false,
+                    schema: {
+                        type: 'integer',
+                        minimum: 0,
+                        maximum: 30,
+                        default: 14,
+                    },
+                    style: 'simple'
+                },
+                tmdetDefinition: {
+                    name: 'tmdetDefinition',
+                    in: 'query',
+                    description: `Use TMDET's classification of membrane-favoring amino acids. TMDET's classification shows better performance on porins and other beta-barrel structures.`,
+                    required: false,
+                    schema: {
+                        type: 'boolean',
+                        default: false,
+                    },
+                    style: 'simple'
+                },
+            }
+        }
+    };
+}
+
+export const shortcutIconLink = `<link rel='shortcut icon' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAnUExURQAAAMIrHrspHr0oH7soILonHrwqH7onILsoHrsoH7soH7woILwpIKgVokoAAAAMdFJOUwAQHzNxWmBHS5XO6jdtAmoAAACZSURBVDjLxZNRCsQgDAVNXmwb9f7nXZEaLRgXloXOhwQdjMYYwpOLw55fBT46KhbOKhmRR2zLcFJQj8UR+HxFgArIF5BKJbEncC6NDEdI5SatBRSDJwGAoiFDONrEJXWYhGMIcRJGCrb1TOtDahfUuQXd10jkFYq0ViIrbUpNcVT6redeC1+b9tH2WLR93Sx2VCzkv/7NjfABxjQHksGB7lAAAAAASUVORK5CYII=' />`;

--- a/src/servers/membrane-orientation/web-schema.ts
+++ b/src/servers/membrane-orientation/web-schema.ts
@@ -13,7 +13,7 @@ export function getSchema() {
         info: {
             version: VERSION,
             title: 'Membrane Server',
-            description: 'The MembraneServer process an entry and predicts the orientation of the membrane layer.',
+            description: 'The MembraneServer process an entry and predicts the orientation of the membrane layer, which can be used to compose molecular scenes using MolViewSpec.',
         },
         tags: [
             {


### PR DESCRIPTION
# Description
Minimal server that allows computing the membrane orientation in the context of a MolViewSpec example.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`