### PR TITLE
StructConn.isExhaustive fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix bonds not shown with `ignoreHydrogens` on (#1315)
     - Better handle mmCIF files with no entities defined by using `label_asym_id`
     - Show bonds in water chains when `ignoreHydorgensVariant` is `non-polar`
+- Fix `StructConn.isExhaustive` for partial models (e.g., returned by the model server)
 
 ## [v4.8.0] - 2024-10-27
 

--- a/src/mol-model-formats/structure/property/bonds/struct_conn.ts
+++ b/src/mol-model-formats/structure/property/bonds/struct_conn.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2023 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2024 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -59,7 +59,7 @@ export namespace StructConn {
      */
     export function isExhaustive(model: Model): boolean {
         const structConn = StructConn.Provider.get(model);
-        return !!structConn && (structConn.data.id.rowCount / model.atomicConformation.atomId.rowCount) > 0.95;
+        return !!structConn && (structConn.entries.length / model.atomicConformation.atomId.rowCount) > 0.95;
     }
 
     function hasAtom({ units }: Structure, element: ElementIndex) {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Fixes an issue with partial models returned by the model server. E.g. https://www.ebi.ac.uk/pdbe/model-server/v1/7v08/residueSurroundings?auth_seq_id=3419&pdbx_PDB_ins_code=&auth_asym_id=1&radius=10&encoding=cif previously rendered as

![image](https://github.com/user-attachments/assets/6d201141-00b3-4646-9a2d-6656a7e7df73)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
