### PR TITLE
Refactor value swapping in molstar-math to fix SWC (Next.js) build (#1345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Better handle mmCIF files with no entities defined by using `label_asym_id`
     - Show bonds in water chains when `ignoreHydorgensVariant` is `non-polar`
 - Fix `StructConn.isExhaustive` for partial models (e.g., returned by the model server)
+- Refactor value swapping in molstar-math to fix SWC (Next.js) build (#1345)
 
 ## [v4.8.0] - 2024-10-27
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "Herman Bergwerf <post@hbergwerf.nl>",
     "Eric E <etongfu@outlook.com>",
     "Xavier Martinez <xavier.martinez.xm@gmail.com>",
-    "Alex Chan <smalldirkalex@gmail.com>"
+    "Alex Chan <smalldirkalex@gmail.com>",
+    "Simeon Borko <simeon.borko@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-math/misc.ts
+++ b/src/mol-math/misc.ts
@@ -43,7 +43,8 @@ export function arcLength(angle: number, radius: number) {
 export function spiral2d(radius: number) {
     let x = 0;
     let y = 0;
-    const delta = [0, -1];
+    let deltaX = 0;
+    let deltaY = -1;
     const size = radius * 2 + 1;
     const halfSize = size / 2;
     const out: [number, number][] = [];
@@ -54,11 +55,15 @@ export function spiral2d(radius: number) {
         }
 
         if (x === y || (x < 0 && x === -y) || (x > 0 && x === 1 - y)) {
-            [delta[0], delta[1]] = [-delta[1], delta[0]]; // change direction
+            // change direction
+            const prevDeltaX = deltaX;
+            const prevDeltaY = deltaY;
+            deltaX = -prevDeltaY;
+            deltaY = prevDeltaX;
         }
 
-        x += delta[0];
-        y += delta[1];
+        x += deltaX;
+        y += deltaY;
     }
     return out;
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

The current version of SWC (1.9.2) cannot handle swap using array destructuring, if the left-hand-side values are not variables but array elements. To make code in molstar as simple as possible, I got rid of any array and use variables for both storing deltas and swapping.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`