### PR TITLE
Do not infer implicit Hs when explicit Hs are set #1257

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix `StructConn.isExhaustive` for partial models (e.g., returned by the model server)
 - Refactor value swapping in molstar-math to fix SWC (Next.js) build (#1345)
 - Fix transform data not updated when structure child changes
+- Fix do not compute implicit hydrogens when unit is explicitly protonated (#1257)
 
 ## [v4.8.0] - 2024-10-27
 


### PR DESCRIPTION

<img width="234" alt="Screenshot 2024-11-18 at 17 25 58" src="https://github.com/user-attachments/assets/e3062ccb-3ee0-435d-af6d-53777b461216">

`6KNR` from the linked issue: the cation-Pi interaction that was previously perceived does not appear anymore by default (`assignH` set to `auto`)

<!-- Thank you for contributing to Mol* -->

# Description
This solves issue #1257  with the Valence Model where implicit hydrogens and consequently, charges, can be assigned even if the protonation is known at the level of a single unit.

## Discussion
This code does a traversal of the unit considered for computing the valence model and breaks as soon as an hydrogen has been found. I've considered a possible optimization were the upper bound could be of a few residues (not just one in case there is a capping) before we could assume that the unit has no explicit hydrogen. I don't know if that's a performance improvement worth implementing (it may introduce edge cases on some kind of polymers). 
I've decided against an arbitrary number of atoms as, some file formats like SDF/MOL favor setting hydrogens at the end of the atom block.
Another option could be to loop through the atoms and break as soon as we can find one where the expected valence does not match the explicit connectivity + charge or as soon as we find an hydrogen whichever comes first.

There are also edge cases of units that are not organic (like iron sulfur clusters `FES` in `5D8V`) where the explicit protonation of the model cannot be detected via this model. This is a larger problem than this fix though.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`