### PR TITLE
Xray shading fix for high XrayEdgeFalloff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Fix artifacts when using xray shading with high xrayEdgeFalloff values
 - Enable double rounded capping on tubular helices
 - Fix single residue tubular helices not showing up
 - Fix outlines on volume and surface reps that do not disappear (#1326)

--- a/src/mol-gl/shader/chunks/common-frag-params.glsl.ts
+++ b/src/mol-gl/shader/chunks/common-frag-params.glsl.ts
@@ -157,7 +157,7 @@ float fbm(in vec3 p) {
         #elif defined(dXrayShaded_inverted)
             alpha *= pow(abs(dot(normal, vec3(0.0, 0.0, 1.0))), uXrayEdgeFalloff);
         #endif
-        return min(max(alpha, 0.001), 0.999);
+        return clamp(alpha, 0.001, 0.999);
     }
 #endif
 `;

--- a/src/mol-gl/shader/chunks/common-frag-params.glsl.ts
+++ b/src/mol-gl/shader/chunks/common-frag-params.glsl.ts
@@ -157,7 +157,7 @@ float fbm(in vec3 p) {
         #elif defined(dXrayShaded_inverted)
             alpha *= pow(abs(dot(normal, vec3(0.0, 0.0, 1.0))), uXrayEdgeFalloff);
         #endif
-        return alpha;
+        return min(max(alpha, 0.001), 0.999);
     }
 #endif
 `;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Fix for xRay shading with high XrayEdgeFalloff values generating this kind of artifacts

![image](https://github.com/user-attachments/assets/91fa19b1-34dc-4863-84d8-796a2935ef6b)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`