### PR TITLE
fix get bounding spheres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- fix get bounding spheres
 - Fix artifacts when using xray shading with high xrayEdgeFalloff values
 - Enable double rounded capping on tubular helices
 - Fix single residue tubular helices not showing up

--- a/src/mol-canvas3d/canvas3d.ts
+++ b/src/mol-canvas3d/canvas3d.ts
@@ -1013,8 +1013,8 @@ namespace Canvas3D {
                 cameraResetRequested = true;
             },
             camera,
-            boundingSphere: scene.boundingSphere,
-            boundingSphereVisible: scene.boundingSphereVisible,
+            get boundingSphere() { return scene.boundingSphere; },
+            get boundingSphereVisible() { return scene.boundingSphereVisible; },
             get notifyDidDraw() { return notifyDidDraw; },
             set notifyDidDraw(v: boolean) { notifyDidDraw = v; },
             didDraw,


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This fixes an issue on my side when I need an updated canvas3d.boundingSphereVisible  

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`