### PR TITLE
Fix: missing partial charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix `PluginStateSnapshotManager.syncCurrent` to work as expected on re-loaded states.
 - Fix do not compute implicit hydrogens when unit is explicitly protonated (#1257)
 - ModelServer and VolumeServer: support for input files from Google Cloud Storage (gs://)
+- Fix color of missing partial charges for SB partial charges extension
 
 ## [v4.8.0] - 2024-10-27
 

--- a/src/extensions/sb-ncbr/partial-charges/color.ts
+++ b/src/extensions/sb-ncbr/partial-charges/color.ts
@@ -10,7 +10,7 @@ import { CustomProperty } from '../../../mol-model-props/common/custom-property'
 const Colors = {
     Bond: Color(0xffffff),
     Error: Color(0x00ff00),
-    MissingCharge: Color(0xffffff),
+    MissingCharge: Color(0x66ff00),
 
     Negative: Color(0xff0000),
     Zero: Color(0xffffff),

--- a/src/extensions/sb-ncbr/partial-charges/property.ts
+++ b/src/extensions/sb-ncbr/partial-charges/property.ts
@@ -107,7 +107,7 @@ function getTypeIdToAtomIdToCharge(model: Model): SBNcbrPartialChargeData['typeI
     for (let i = 0; i < rowCount; ++i) {
         const typeId = typeIds.int(i);
         const atomId = atomIds.int(i);
-        const isPresent = charges.valueKind(i) !== Column.ValueKind.Present;
+        const isPresent = charges.valueKind(i) === Column.ValueKind.Present;
         const charge = isPresent ? charges.float(i) : undefined;
         if (!atomIdToCharge.has(typeId)) atomIdToCharge.set(typeId, new Map());
         atomIdToCharge.get(typeId)?.set(atomId, charge);

--- a/src/extensions/sb-ncbr/partial-charges/property.ts
+++ b/src/extensions/sb-ncbr/partial-charges/property.ts
@@ -8,7 +8,7 @@ import { arrayMinMax } from '../../../mol-util/array';
 import { Column } from '../../../mol-data/db';
 
 type TypeId = number;
-type IdToCharge = Map<number, number | undefined>;
+type IdToCharge = Map<number, number>;
 export interface SBNcbrPartialChargeData {
     typeIdToMethod: Map<TypeId, string>;
     typeIdToAtomIdToCharge: Map<TypeId, IdToCharge>;
@@ -108,7 +108,8 @@ function getTypeIdToAtomIdToCharge(model: Model): SBNcbrPartialChargeData['typeI
         const typeId = typeIds.int(i);
         const atomId = atomIds.int(i);
         const isPresent = charges.valueKind(i) === Column.ValueKind.Present;
-        const charge = isPresent ? charges.float(i) : undefined;
+        if (!isPresent) continue;
+        const charge = charges.float(i)
         if (!atomIdToCharge.has(typeId)) atomIdToCharge.set(typeId, new Map());
         atomIdToCharge.get(typeId)?.set(atomId, charge);
     }
@@ -153,7 +154,7 @@ function getMaxAbsoluteCharges(
     const maxAbsoluteCharges: Map<number, number> = new Map();
 
     typeIdToCharge.forEach((idToCharge, typeId) => {
-        const charges = Array.from(idToCharge.values()).filter(value => value !== undefined);
+        const charges = Array.from(idToCharge.values());
         const [min, max] = arrayMinMax(charges);
         const bound = Math.max(Math.abs(min), max);
         maxAbsoluteCharges.set(typeId, bound);

--- a/src/extensions/sb-ncbr/partial-charges/property.ts
+++ b/src/extensions/sb-ncbr/partial-charges/property.ts
@@ -108,7 +108,7 @@ function getTypeIdToAtomIdToCharge(model: Model): SBNcbrPartialChargeData['typeI
         const typeId = typeIds.int(i);
         const atomId = atomIds.int(i);
         const isPresent = charges.valueKind(i) !== Column.ValueKind.Present;
-        const charge = isPresent ? charges.float(i) : undefined;        
+        const charge = isPresent ? charges.float(i) : undefined;
         if (!atomIdToCharge.has(typeId)) atomIdToCharge.set(typeId, new Map());
         atomIdToCharge.get(typeId)?.set(atomId, charge);
     }

--- a/src/extensions/sb-ncbr/partial-charges/property.ts
+++ b/src/extensions/sb-ncbr/partial-charges/property.ts
@@ -153,7 +153,7 @@ function getMaxAbsoluteCharges(
     const maxAbsoluteCharges: Map<number, number> = new Map();
 
     typeIdToCharge.forEach((idToCharge, typeId) => {
-        const charges = Array.from(idToCharge.values()).filter(isDefined);
+        const charges = Array.from(idToCharge.values()).filter(value => value !== undefined);
         const [min, max] = arrayMinMax(charges);
         const bound = Math.max(Math.abs(min), max);
         maxAbsoluteCharges.set(typeId, bound);
@@ -204,11 +204,3 @@ SBNcbrPartialChargeData | undefined
     isApplicable: (model: Model) => hasPartialChargesCategories(model),
     obtain: (_ctx: CustomProperty.Context, model: Model) => Promise.resolve(getData(model)),
 });
-
-function isNumber(value: string) {
-    return /-?(0|[1-9][0-9]*)([.][0-9]+)?([eE][+-]?[0-9]+)?/.test(value) && !isNaN(+value);
-}
-
-function isDefined<T>(value: T | undefined | null): value is T {
-    return value !== undefined && value !== null;
-}

--- a/src/extensions/sb-ncbr/partial-charges/property.ts
+++ b/src/extensions/sb-ncbr/partial-charges/property.ts
@@ -5,6 +5,7 @@ import { MmcifFormat } from '../../../mol-model-formats/structure/mmcif';
 import { CustomPropertyDescriptor } from '../../../mol-model/custom-property';
 import { CustomModelProperty } from '../../../mol-model-props/common/custom-model-property';
 import { arrayMinMax } from '../../../mol-util/array';
+import { Column } from '../../../mol-data/db';
 
 type TypeId = number;
 type IdToCharge = Map<number, number | undefined>;
@@ -106,7 +107,8 @@ function getTypeIdToAtomIdToCharge(model: Model): SBNcbrPartialChargeData['typeI
     for (let i = 0; i < rowCount; ++i) {
         const typeId = typeIds.int(i);
         const atomId = atomIds.int(i);
-        const charge = isNumber(charges.str(i)) ? charges.float(i) : undefined;
+        const isPresent = charges.valueKind(i) !== Column.ValueKind.Present;
+        const charge = isPresent ? charges.float(i) : undefined;        
         if (!atomIdToCharge.has(typeId)) atomIdToCharge.set(typeId, new Map());
         atomIdToCharge.get(typeId)?.set(atomId, charge);
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Changed color for missing partial charges in SB partial charges extension from white to green so that it's obvious that the charge isn't 0 but is instead missing.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [x] (Optional but encouraged) Improved documentation in `docs`