### PR TITLE
add external-structure theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
-- Volume UI improvements 
+- Volume UI improvements
   - Render all volume entries instead of selecting them one-by-one
   - Toggle visibility of all volumes
   - More accessible iso value control
@@ -13,6 +13,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - MolViewSpec extension:
   - Add validation for discriminated union params
   - Primitives: remove triangle_colors, line_colors, have implicit grouping instead; rename many parameters
+- Add `external-structure` theme that colors any geometry by structure properties
 
 ## [v4.10.0] - 2024-12-15
 

--- a/src/mol-math/geometry/lookup3d/common.ts
+++ b/src/mol-math/geometry/lookup3d/common.ts
@@ -43,6 +43,7 @@ export interface Lookup3D<T = number> {
     find(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T>,
     nearest(x: number, y: number, z: number, k: number, stopIf?: Function, result?: Result<T>): Result<T>,
     check(x: number, y: number, z: number, radius: number): boolean,
+    first(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T>,
     readonly boundary: { readonly box: Box3D, readonly sphere: Sphere3D }
     /** transient result */
     readonly result: Result<T>

--- a/src/mol-math/geometry/lookup3d/common.ts
+++ b/src/mol-math/geometry/lookup3d/common.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -43,7 +43,7 @@ export interface Lookup3D<T = number> {
     find(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T>,
     nearest(x: number, y: number, z: number, k: number, stopIf?: Function, result?: Result<T>): Result<T>,
     check(x: number, y: number, z: number, radius: number): boolean,
-    first(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T>,
+    approxNearest(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T>,
     readonly boundary: { readonly box: Box3D, readonly sphere: Sphere3D }
     /** transient result */
     readonly result: Result<T>

--- a/src/mol-math/geometry/lookup3d/grid.ts
+++ b/src/mol-math/geometry/lookup3d/grid.ts
@@ -62,6 +62,17 @@ class GridLookup3DImpl<T extends number = number> implements GridLookup3D<T> {
         return query(this.ctx, this.result);
     }
 
+    first(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T> {
+        this.ctx.x = x;
+        this.ctx.y = y;
+        this.ctx.z = z;
+        this.ctx.radius = radius;
+        this.ctx.isCheck = true;
+        const ret = result ?? this.result;
+        query(this.ctx, ret);
+        return ret;
+    }
+
     constructor(data: PositionData, boundary: Boundary, cellSizeOrCount?: Vec3 | number) {
         const structure = build(data, boundary, cellSizeOrCount);
         this.ctx = createContext(structure);

--- a/src/mol-math/geometry/lookup3d/grid.ts
+++ b/src/mol-math/geometry/lookup3d/grid.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -14,6 +14,7 @@ import { Vec3 } from '../../linear-algebra';
 import { OrderedSet } from '../../../mol-data/int';
 import { Boundary } from '../boundary';
 import { FibonacciHeap } from '../../../mol-util/fibonacci-heap';
+import { memoize1 } from '../../../mol-util/memoize';
 
 interface GridLookup3D<T = number> extends Lookup3D<T> {
     readonly buckets: { readonly offset: ArrayLike<number>, readonly count: ArrayLike<number>, readonly array: ArrayLike<number> }
@@ -62,14 +63,14 @@ class GridLookup3DImpl<T extends number = number> implements GridLookup3D<T> {
         return query(this.ctx, this.result);
     }
 
-    first(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T> {
+    approxNearest(x: number, y: number, z: number, radius: number, result?: Result<T>): Result<T> {
         this.ctx.x = x;
         this.ctx.y = y;
         this.ctx.z = z;
         this.ctx.radius = radius;
-        this.ctx.isCheck = true;
+        this.ctx.isCheck = false;
         const ret = result ?? this.result;
-        query(this.ctx, ret);
+        approxQueryNearest(this.ctx, ret);
         return ret;
     }
 
@@ -302,6 +303,84 @@ function query<T extends number = number>(ctx: QueryContext, result: Result<T>):
             }
         }
     }
+    return result.count > 0;
+}
+
+function _insideOut(r: number) {
+    const cells: Vec3[] = [];
+    const n = r * 2 + 1;
+
+    for (let x = 0; x < n; ++x) {
+        for (let y = 0; y < n; ++y) {
+            for (let z = 0; z < n; ++z) {
+                cells.push(Vec3.create(x - r, y - r, z - r));
+            }
+        }
+    }
+
+    cells.sort((a, b) => Vec3.squaredMagnitude(a) - Vec3.squaredMagnitude(b));
+    return cells.flat();
+}
+const insideOut = memoize1(_insideOut);
+
+/**
+ * The maximum error is on the order of cell size + max radius (if the grid has radii).
+ */
+function approxQueryNearest<T extends number = number>(ctx: QueryContext, result: Result<T>): boolean {
+    const { min, size: [sX, sY, sZ], bucketOffset, bucketCounts, bucketArray, grid, data: { x: px, y: py, z: pz, indices }, delta } = ctx.grid;
+    const { radius, x, y, z } = ctx;
+
+    const rSq = radius * radius;
+
+    Result.reset(result);
+
+    const loX = Math.max(0, Math.floor((x - radius - min[0]) / delta[0]));
+    const loY = Math.max(0, Math.floor((y - radius - min[1]) / delta[1]));
+    const loZ = Math.max(0, Math.floor((z - radius - min[2]) / delta[2]));
+
+    const hiX = Math.min(sX - 1, Math.floor((x + radius - min[0]) / delta[0]));
+    const hiY = Math.min(sY - 1, Math.floor((y + radius - min[1]) / delta[1]));
+    const hiZ = Math.min(sZ - 1, Math.floor((z + radius - min[2]) / delta[2]));
+
+    if (loX > hiX || loY > hiY || loZ > hiZ) return false;
+
+    const miX = Math.floor((x - min[0]) / delta[0]);
+    const miY = Math.floor((y - min[1]) / delta[1]);
+    const miZ = Math.floor((z - min[2]) / delta[2]);
+
+    const cells = insideOut(Math.max(hiX - loX, hiY - loY, hiZ - loZ) + 1);
+
+    for (let i = 0, _i = cells.length; i < _i; i += 3) {
+        const ix = miX + cells[i];
+        const iy = miY + cells[i + 1];
+        const iz = miZ + cells[i + 2];
+        if (ix < loX || ix > hiX || iy < loY || iy > hiY || iz < loZ || iz > hiZ) continue;
+
+        const bucketIdx = grid[(((ix * sY) + iy) * sZ) + iz];
+        if (bucketIdx === 0) continue;
+
+        const k = bucketIdx - 1;
+        const offset = bucketOffset[k];
+        const count = bucketCounts[k];
+        const end = offset + count;
+
+        let minDistSq = Number.MAX_VALUE;
+        for (let i = offset; i < end; i++) {
+            const idx = OrderedSet.getAt(indices, bucketArray[i]);
+
+            const dx = px[idx] - x;
+            const dy = py[idx] - y;
+            const dz = pz[idx] - z;
+            const distSq = dx * dx + dy * dy + dz * dz;
+
+            if (distSq <= rSq && distSq < minDistSq) {
+                Result.add(result, bucketArray[i], distSq);
+                minDistSq = distSq;
+            }
+        }
+        if (minDistSq !== Number.MAX_VALUE) return true;
+    }
+
     return result.count > 0;
 }
 

--- a/src/mol-theme/color.ts
+++ b/src/mol-theme/color.ts
@@ -45,6 +45,7 @@ import { ExternalVolumeColorThemeProvider } from './color/external-volume';
 import { ColorThemeCategory } from './color/categories';
 import { CartoonColorThemeProvider } from './color/cartoon';
 import { FormalChargeColorThemeProvider } from './color/formal-charge';
+import { ExternalStructureColorThemeProvider } from './color/external-structure';
 
 export type LocationColor = (location: Location, isSecondary: boolean) => Color
 
@@ -94,7 +95,7 @@ namespace ColorTheme {
 
     export interface Palette {
         filter?: TextureFilter,
-        colors: Color[]
+        colors: Color[],
     }
 
     export const PaletteScale = (1 << 24) - 1;
@@ -131,6 +132,8 @@ namespace ColorTheme {
         'element-symbol': ElementSymbolColorThemeProvider,
         'entity-id': EntityIdColorThemeProvider,
         'entity-source': EntitySourceColorThemeProvider,
+        'external-structure': ExternalStructureColorThemeProvider,
+        'external-volume': ExternalVolumeColorThemeProvider,
         'formal-charge': FormalChargeColorThemeProvider,
         'hydrophobicity': HydrophobicityColorThemeProvider,
         'illustrative': IllustrativeColorThemeProvider,
@@ -153,7 +156,6 @@ namespace ColorTheme {
         'uniform': UniformColorThemeProvider,
         'volume-segment': VolumeSegmentColorThemeProvider,
         'volume-value': VolumeValueColorThemeProvider,
-        'external-volume': ExternalVolumeColorThemeProvider,
     };
     type _BuiltIn = typeof BuiltIn
     export type BuiltIn = keyof _BuiltIn

--- a/src/mol-theme/color/external-structure.ts
+++ b/src/mol-theme/color/external-structure.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { Color } from '../../mol-util/color';
+import { Location } from '../../mol-model/location';
+import type { ColorTheme, LocationColor } from '../color';
+import { ParamDefinition as PD } from '../../mol-util/param-definition';
+import { ThemeDataContext } from '../theme';
+import { type PluginContext } from '../../mol-plugin/context';
+import { isPositionLocation } from '../../mol-geo/util/location-iterator';
+import { ColorThemeCategory } from './categories';
+import { StateSelection } from '../../mol-state/state/selection';
+import { PluginStateObject } from '../../mol-plugin-state/objects';
+import { QueryContext, Structure, StructureElement, StructureSelection } from '../../mol-model/structure';
+import { ChainIdColorTheme, ChainIdColorThemeParams } from './chain-id';
+import { EntityIdColorTheme, EntityIdColorThemeParams } from './entity-id';
+import { EntitySourceColorTheme, EntitySourceColorThemeParams } from './entity-source';
+import { MoleculeTypeColorTheme, MoleculeTypeColorThemeParams } from './molecule-type';
+import { ModelIndexColorTheme, ModelIndexColorThemeParams } from './model-index';
+import { StructureIndexColorTheme, StructureIndexColorThemeParams } from './structure-index';
+import { assertUnreachable } from '../../mol-util/type-helpers';
+import { ScaleLegend, TableLegend } from '../../mol-util/legend';
+import { StructureLookup3DResultContext } from '../../mol-model/structure/structure/util/lookup3d';
+import { StructureSelectionQueries } from '../../mol-plugin-state/helpers/structure-selection-query';
+import { Vec3 } from '../../mol-math/linear-algebra/3d/vec3';
+
+const Description = `Assigns a color based on structure property at a given vertex.`;
+
+export const ExternalStructureColorThemeParams = {
+    structure: PD.ValueRef<Structure>(
+        (ctx: PluginContext) => {
+            const structures = ctx.state.data.select(StateSelection.Generators.rootsOfType(PluginStateObject.Molecule.Structure)).filter(c => c.obj?.data);
+            return structures.map(v => [v.transform.ref, v.obj?.label ?? '<unknown>'] as [string, string]);
+        },
+        (ref, getData) => getData(ref),
+    ),
+    style: PD.MappedStatic('chain-id', {
+        'chain-id': PD.Group(ChainIdColorThemeParams),
+        'entity-id': PD.Group(EntityIdColorThemeParams),
+        'entity-source': PD.Group(EntitySourceColorThemeParams),
+        'molecule-type': PD.Group(MoleculeTypeColorThemeParams),
+        'model-index': PD.Group(ModelIndexColorThemeParams),
+        'structure-index': PD.Group(StructureIndexColorThemeParams),
+    }),
+    defaultColor: PD.Color(Color(0xcccccc)),
+    maxDistance: PD.Numeric(8, { min: 0.1, max: 24, step: 0.1 }),
+    takeFirstDistance: PD.Numeric(4, { min: 0.1, max: 12, step: 0.1 }),
+    normalOffset: PD.Numeric(0, { min: -10, max: 20, step: 0.1 }, { description: 'Offset vertex position along its normal by given amount.' }),
+    backboneOnly: PD.Boolean(false),
+};
+export type ExternalStructureColorThemeParams = typeof ExternalStructureColorThemeParams
+
+type ExternalStructureColorThemeProps = PD.Values<ExternalStructureColorThemeParams>
+
+function getStyleTheme(ctx: ThemeDataContext, props: ExternalStructureColorThemeProps['style']) {
+    switch (props.name) {
+        case 'chain-id': return ChainIdColorTheme(ctx, props.params);
+        case 'entity-id': return EntityIdColorTheme(ctx, props.params);
+        case 'entity-source': return EntitySourceColorTheme(ctx, props.params);
+        case 'molecule-type': return MoleculeTypeColorTheme(ctx, props.params);
+        case 'model-index': return ModelIndexColorTheme(ctx, props.params);
+        case 'structure-index': return StructureIndexColorTheme(ctx, props.params);
+        default: assertUnreachable(props);
+    }
+}
+
+export function ExternalStructureColorTheme(ctx: ThemeDataContext, props: PD.Values<ExternalStructureColorThemeParams>): ColorTheme<ExternalStructureColorThemeParams> {
+    let structure: Structure | undefined;
+    try {
+        structure = props.structure.getValue();
+    } catch {
+        // .getValue() is resolved during state reconciliation => would throw from UI
+    }
+
+    // NOTE: this will currently be slow for with GPU/texture meshes due to slow iteration
+    // TODO: create texture to be able to do the sampling on the GPU
+
+    let color: LocationColor;
+    let contextHash: number | undefined = undefined;
+    let legend: Readonly<ScaleLegend | TableLegend> | undefined = undefined;
+
+    const { maxDistance, takeFirstDistance, normalOffset, defaultColor, backboneOnly } = props;
+
+    if (structure) {
+        const styleTheme = getStyleTheme({ ...ctx, structure }, props.style);
+
+        const lookupFirstCtx = StructureLookup3DResultContext();
+        const lookupNearestCtx = StructureLookup3DResultContext();
+
+        let s = structure;
+        if (backboneOnly) {
+            s = StructureSelection.unionStructure(StructureSelectionQueries.backbone.query(new QueryContext(structure)));
+        }
+
+        const position = Vec3();
+        const l = StructureElement.Location.create(s);
+
+        color = (location: Location, isSecondary: boolean): Color => {
+            if (!isPositionLocation(location)) {
+                return defaultColor;
+            }
+
+            // Offset the vertex position along its normal
+            if (normalOffset !== 0) {
+                Vec3.scaleAndAdd(position, location.position, location.normal, normalOffset);
+            } else {
+                Vec3.copy(position, location.position);
+            }
+
+            const [x, y, z] = position;
+            if (!s.lookup3d.check(x, y, z, maxDistance)) return defaultColor;
+
+            const rf = s.lookup3d.first(x, y, z, takeFirstDistance, lookupFirstCtx);
+            if (rf.count > 0) {
+                l.unit = rf.units[0];
+                l.element = l.unit.elements[rf.indices[0]];
+                return styleTheme.color(l, isSecondary);
+            }
+
+            const rn = s.lookup3d.nearest(x, y, z, 1, lookupNearestCtx);
+            if (rn.count === 0) return defaultColor;
+
+            l.unit = rn.units[0];
+            l.element = l.unit.elements[rn.indices[0]];
+            return styleTheme.color(l, isSecondary);
+        };
+
+        contextHash = styleTheme.contextHash;
+        legend = styleTheme.legend;
+    } else {
+        color = () => defaultColor;
+    }
+
+    return {
+        factory: ExternalStructureColorTheme,
+        granularity: 'vertex',
+        preferSmoothing: true,
+        color,
+        props,
+        contextHash,
+        description: Description,
+        legend,
+    };
+}
+
+export const ExternalStructureColorThemeProvider: ColorTheme.Provider<ExternalStructureColorThemeParams, 'external-structure'> = {
+    name: 'external-structure',
+    label: 'External Structure',
+    category: ColorThemeCategory.Misc,
+    factory: ExternalStructureColorTheme,
+    getParams: () => ExternalStructureColorThemeParams,
+    defaultValues: PD.getDefaultValues(ExternalStructureColorThemeParams),
+    isApplicable: (ctx: ThemeDataContext) => true,
+};


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Add external-structure theme that colors any geometry by structure properties.

EMD-45213 and PDB entry 9C5B take 200ms with default parameters on my machine:

![9C5B](https://github.com/user-attachments/assets/197abb01-6e9b-413e-bfe8-1e94122219ac)

![9C5B (1)](https://github.com/user-attachments/assets/876ede65-3edd-409a-9fa2-582f5e6380c1)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`

