### PR TITLE
Fix PDBj structure data URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 
+- Fix PDBj structure data URL
+
 ## [v4.11.0] - 2025-01-26
 
 - Fix for tubular helices issue (Fixes #1422)

--- a/src/mol-plugin-state/actions/structure.ts
+++ b/src/mol-plugin-state/actions/structure.ts
@@ -235,7 +235,7 @@ async function getPdbeDownloadParams(src: ReturnType<DownloadStructure['createDe
 
 async function getPdbjDownloadParams(src: ReturnType<DownloadStructure['createDefaultParams']>['source']) {
     if (src.name !== 'pdb' || src.params.provider.server.name !== 'pdbj') throw new Error('expected pdbj');
-    return getDownloadParams(src.params.provider.id, id => `https://data.pdbjbk1.pdbj.org/pub/pdb/data/structures/divided/mmCIF/${id.toLowerCase().substring(1, 3)}/${id.toLowerCase()}.cif`, id => `PDBj: ${id} (cif)`, false);
+    return getDownloadParams(src.params.provider.id, id => `https://data.pdbjlc1.pdbj.org/pub/pdb/data/structures/divided/mmCIF/${id.toLowerCase().substring(1, 3)}/${id.toLowerCase()}.cif`, id => `PDBj: ${id} (cif)`, false);
 }
 
 async function getRcsbDownloadParams(src: ReturnType<DownloadStructure['createDefaultParams']>['source']) {


### PR DESCRIPTION
# Description
The URL changed. https://data.pdbj.org/pub/pdb/data/structures/divided/mmCIF/tq/1tqn.cif also seems to work but the [download page](https://pdbj.org/mine/resources/1tqn) recommends https://data.pdbjlc1.pdbj.org/pub/pdb/data/structures/divided/mmCIF/tq/1tqn.cif, so going with that.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`