### PR TITLE
MVS: Additional Primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Fix PDBj structure data URL
 - Improve logic when to cull in renderer
-- MolViewSpec extension: Add box, arrow, ellipsis, ellipsoid primitives
+- MolViewSpec extension: Add box, arrow, ellipse, ellipsoid primitives
 
 ## [v4.11.0] - 2025-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 - Fix PDBj structure data URL
 - Improve logic when to cull in renderer
+- MolViewSpec extension: Add box, arrow, ellipsis, ellipsoid primitives
 
 ## [v4.11.0] - 2025-01-26
 

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -743,7 +743,14 @@ function addEllipsisMesh(context: PrimitiveBuilderContext, state: MeshBuilderSta
     Mat4.fromTranslation(EllipsisState.translationXform, EllipsisState.centerPos);
 
     // Scale
-    Vec3.set(EllipsisState.scale, Vec3.magnitude(EllipsisState.majorAxis), 1, Vec3.magnitude(EllipsisState.minorAxis));
+    if (params.as_circle) {
+        const r = params.radius_major ?? Vec3.magnitude(EllipsisState.majorAxis);
+        Vec3.set(EllipsisState.scale, r, 1, r);
+    } else {
+        const major = params.radius_major ?? Vec3.magnitude(EllipsisState.majorAxis);
+        const minor = params.radius_minor ?? Vec3.magnitude(EllipsisState.minorAxis);
+        Vec3.set(EllipsisState.scale, major, 1, minor);
+    }
     Mat4.fromScaling(EllipsisState.scaleXform, EllipsisState.scale);
 
     // Rotation

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -660,10 +660,10 @@ function addArrowMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBu
     const length = Vec3.distance(ArrowState.start, ArrowState.end);
     if (length < 1e-3) return;
 
-    const radius = params.radius;
+    const tubeRadius = params.tube_radius;
     const tubeProps: BasicCylinderProps = {
-        radiusBottom: radius,
-        radiusTop: radius,
+        radiusBottom: tubeRadius,
+        radiusTop: tubeRadius,
         topCap: !params.arrow_end,
         bottomCap: !params.arrow_start,
     };
@@ -672,7 +672,7 @@ function addArrowMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBu
     groups.updateColor(mesh.currentGroup, params.color);
     groups.updateTooltip(mesh.currentGroup, params.tooltip);
 
-    const startRadius = params.arrow_start_radius ?? radius;
+    const startRadius = params.arrow_start_radius ?? tubeRadius;
     if (params.arrow_start) {
         Vec3.scaleAndAdd(ArrowState.startCap, ArrowState.start, ArrowState.dir, startRadius);
         addCylinder(mesh, ArrowState.start, ArrowState.startCap, 1, {
@@ -686,7 +686,7 @@ function addArrowMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBu
         Vec3.copy(ArrowState.startCap, ArrowState.start);
     }
 
-    const endRadius = params.arrow_end_radius ?? radius;
+    const endRadius = params.arrow_end_radius ?? tubeRadius;
     if (params.arrow_end) {
         Vec3.scaleAndAdd(ArrowState.endCap, ArrowState.end, ArrowState.dir, -endRadius);
         addCylinder(mesh, ArrowState.end, ArrowState.endCap, 1, {
@@ -700,12 +700,14 @@ function addArrowMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBu
         Vec3.copy(ArrowState.endCap, ArrowState.end);
     }
 
-    if (params.dash_length) {
-        const dist = Vec3.distance(ArrowState.startCap, ArrowState.endCap);
-        const count = Math.ceil(dist / (2 * params.dash_length));
-        addFixedCountDashedCylinder(mesh, ArrowState.startCap, ArrowState.endCap, 1.0, count, true, tubeProps);
-    } else {
-        addSimpleCylinder(mesh, ArrowState.startCap, ArrowState.endCap, tubeProps);
+    if (params.show_tube) {
+        if (params.tube_dash_length) {
+            const dist = Vec3.distance(ArrowState.startCap, ArrowState.endCap);
+            const count = Math.ceil(dist / (2 * params.tube_dash_length));
+            addFixedCountDashedCylinder(mesh, ArrowState.startCap, ArrowState.endCap, 1.0, count, true, tubeProps);
+        } else {
+            addSimpleCylinder(mesh, ArrowState.startCap, ArrowState.endCap, tubeProps);
+        }
     }
 }
 

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -300,8 +300,8 @@ const Builders: Record<PrimitiveParams['kind'], PrimitiveBuilder> = {
         },
         resolveRefs: (params: PrimitiveParams<'ellipsis'>, refs: Set<string>) => {
             addRef(params.center, refs);
-            addRef(params.major_axis, refs);
-            addRef(params.minor_axis, refs);
+            if (params.major_axis_endpoint) addRef(params.major_axis_endpoint, refs);
+            if (params.minor_axis_endpoint) addRef(params.minor_axis_endpoint, refs);
         },
     },
     box: {
@@ -722,11 +722,20 @@ function addEllipsisMesh(context: PrimitiveBuilderContext, state: MeshBuilderSta
     if (!circle) return;
 
     resolvePosition(context, params.center, EllipsisState.centerPos, undefined, undefined);
-    resolvePosition(context, params.major_axis, EllipsisState.majorPos, undefined, undefined);
-    resolvePosition(context, params.minor_axis, EllipsisState.minorPos, undefined, undefined);
 
-    Vec3.sub(EllipsisState.majorAxis, EllipsisState.majorPos, EllipsisState.centerPos);
-    Vec3.sub(EllipsisState.minorAxis, EllipsisState.minorPos, EllipsisState.centerPos);
+    if (params.major_axis_endpoint) {
+        resolvePosition(context, params.major_axis_endpoint, EllipsisState.majorPos, undefined, undefined);
+        Vec3.sub(EllipsisState.majorAxis, EllipsisState.majorPos, EllipsisState.centerPos);
+    } else {
+        Vec3.copy(EllipsisState.majorAxis, params.major_axis as Vec3);
+    }
+
+    if (params.minor_axis_endpoint) {
+        resolvePosition(context, params.minor_axis_endpoint, EllipsisState.minorPos, undefined, undefined);
+        Vec3.sub(EllipsisState.minorAxis, EllipsisState.minorPos, EllipsisState.centerPos);
+    } else {
+        Vec3.copy(EllipsisState.minorAxis, params.minor_axis as Vec3);
+    }
 
     const { mesh, groups } = state;
 

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -283,9 +283,9 @@ class Primitives extends _Base<'primitives'> implements FocusMixin {
         this.addChild('primitive', { kind: 'label', ...params });
         return this;
     }
-    /** Defines an ellipsis. */
-    ellipsis(params: MVSPrimitiveSubparams<'ellipsis'> & CustomAndRef): Primitives {
-        this.addChild('primitive', { kind: 'ellipsis', ...params });
+    /** Defines an ellipse. */
+    ellipse(params: MVSPrimitiveSubparams<'ellipse'> & CustomAndRef): Primitives {
+        this.addChild('primitive', { kind: 'ellipse', ...params });
         return this;
     }
     /** Defines an ellipsoid */

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -283,6 +283,11 @@ class Primitives extends _Base<'primitives'> implements FocusMixin {
         this.addChild('primitive', { kind: 'ellipsis', ...params });
         return this;
     }
+    /** Defines a box. */
+    box(params: MVSPrimitiveSubparams<'box'> & CustomAndRef): Primitives {
+        this.addChild('primitive', { kind: 'box', ...params });
+        return this;
+    }
     focus = bindMethod(this, FocusMixinImpl, 'focus');
 }
 

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { deepClone, pickObjectKeys } from '../../../../mol-util/object';
@@ -275,6 +276,11 @@ class Primitives extends _Base<'primitives'> implements FocusMixin {
     /** Defines a label. */
     label(params: MVSPrimitiveSubparams<'label'> & CustomAndRef): Primitives {
         this.addChild('primitive', { kind: 'label', ...params });
+        return this;
+    }
+    /** Defines an ellipsis. */
+    ellipsis(params: MVSPrimitiveSubparams<'ellipsis'> & CustomAndRef): Primitives {
+        this.addChild('primitive', { kind: 'ellipsis', ...params });
         return this;
     }
     focus = bindMethod(this, FocusMixinImpl, 'focus');

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -288,6 +288,11 @@ class Primitives extends _Base<'primitives'> implements FocusMixin {
         this.addChild('primitive', { kind: 'ellipsis', ...params });
         return this;
     }
+    /** Defines an ellipsoid */
+    ellipsoid(params: MVSPrimitiveSubparams<'ellipsoid'> & CustomAndRef): Primitives {
+        this.addChild('primitive', { kind: 'ellipsoid', ...params });
+        return this;
+    }
     /** Defines a box. */
     box(params: MVSPrimitiveSubparams<'box'> & CustomAndRef): Primitives {
         this.addChild('primitive', { kind: 'box', ...params });

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -268,6 +268,11 @@ class Primitives extends _Base<'primitives'> implements FocusMixin {
         this.addChild('primitive', { kind: 'tube', ...params });
         return this;
     }
+    /** Defines an arrow. */
+    arrow(params: MVSPrimitiveSubparams<'arrow'> & CustomAndRef): Primitives {
+        this.addChild('primitive', { kind: 'arrow', ...params });
+        return this;
+    }
     /** Defines a tube, connecting a start and an end point, with label containing distance between start and end. */
     distance(params: MVSPrimitiveSubparams<'distance_measurement'> & CustomAndRef): Primitives {
         this.addChild('primitive', { kind: 'distance_measurement', ...params });

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -105,6 +105,8 @@ const PrimitiveLabelParams = {
 const EllipsisParams = {
     /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
     color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
+    /** If true, ignores radius_minor/magnitude of the minor axis */
+    as_circle: OptionalField(bool, false, 'If true, ignores radius_minor/magnitude of the minor axis.'),
     /** Ellipsis center. */
     center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
     /** Major axis of this ellipsis. */
@@ -115,6 +117,10 @@ const EllipsisParams = {
     major_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center.'),
     /** Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center. */
     minor_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center.'),
+    /** Radius of the major axis. If unset, the length of the major axis is used. */
+    radius_major: OptionalField(nullable(float), null, 'Radius of the major axis. If unset, the length of the major axis is used.'),
+    /** Radius of the minor axis. If unset, the length of the minor axis is used. */
+    radius_minor: OptionalField(nullable(float), null, 'Radius of the minor axis. If unset, the length of the minor axis is used.'),
     /** Start of the arc. In radians */
     theta_start: OptionalField(float, 0, 'Start of the arc. In radians'),
     /** End of the arc. In radians */

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -84,18 +84,18 @@ const ArrowParams = {
     direction: OptionalField(nullable(Vector3), null, 'If specified, the endpoint is computed as start + direction.'),
     /** Length of the arrow. If unset, the distance between start and end is used. */
     length: OptionalField(nullable(float), null, 'Length of the arrow. If unset, the distance between start and end is used.'),
-    /** Draw an arrow at the start of the arrow. */
-    arrow_start: OptionalField(bool, false, 'Draw an arrow at the start of the arrow.'),
-    /** Height of the arrow at the start. */
-    arrow_start_height: OptionalField(float, 0.1, 'Height of the arrow at the start.'),
-    /** Radius of the arrow at the start. */
-    arrow_start_radius: OptionalField(float, 0.1, ''),
+    /** Draw a cap at the start of the arrow. */
+    show_start_cap: OptionalField(bool, false, 'Draw a cap at the start of the arrow.'),
+    /** Length of the start cap. */
+    start_cap_length: OptionalField(float, 0.1, 'Length of the start cap.'),
+    /** Radius of the start cap. */
+    start_cap_radius: OptionalField(float, 0.1, 'Radius of the start cap.'),
     /** Draw an arrow at the end of the arrow. */
-    arrow_end: OptionalField(bool, false, 'Draw an arrow at the end of the arrow.'),
+    show_end_cap: OptionalField(bool, false, 'Draw a cap at the end of the arrow.'),
     /** Height of the arrow at the end. */
-    arrow_end_height: OptionalField(float, 0.1, 'Height of the arrow at the end.'),
+    end_cap_length: OptionalField(float, 0.1, 'Length of the end cap.'),
     /** Radius of the arrow at the end. */
-    arrow_end_radius: OptionalField(float, 0.1, 'Radius of the arrow at the end.'),
+    end_cap_radius: OptionalField(float, 0.1, 'Radius of the end cap.'),
     /** Draw a tube connecting the start and end points. */
     show_tube: OptionalField(bool, true, 'Draw a tube connecting the start and end points.'),
     /** Tube radius (in Angstroms). */
@@ -135,17 +135,17 @@ const PrimitiveLabelParams = {
     label_offset: OptionalField(float, 0, 'Camera-facing offset to prevent overlap with geometry.'),
 };
 
-const EllipsisParams = {
+const EllipseParams = {
     /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
-    color: OptionalField(nullable(ColorT), null, 'Color of the ellipsis. If not specified, uses the parent primitives group `color`.'),
+    color: OptionalField(nullable(ColorT), null, 'Color of the ellipse. If not specified, uses the parent primitives group `color`.'),
     /** If true, ignores radius_minor/magnitude of the minor axis */
     as_circle: OptionalField(bool, false, 'If true, ignores radius_minor/magnitude of the minor axis.'),
-    /** Ellipsis center. */
-    center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
-    /** Major axis of this ellipsis. */
-    major_axis: OptionalField(nullable(Vector3), null, 'Major axis of this ellipsis.'),
-    /** Minor axis of this ellipsis. */
-    minor_axis: OptionalField(nullable(Vector3), null, 'Minor axis of this ellipsis.'),
+    /** ellipse center. */
+    center: RequiredField(PrimitivePositionT, 'The center of the ellipse.'),
+    /** Major axis of this ellipse. */
+    major_axis: OptionalField(nullable(Vector3), null, 'Major axis of this ellipse.'),
+    /** Minor axis of this ellipse. */
+    minor_axis: OptionalField(nullable(Vector3), null, 'Minor axis of this ellipse.'),
     /** Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center. */
     major_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center.'),
     /** Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center. */
@@ -165,11 +165,11 @@ const EllipsisParams = {
 const EllipsoidParams = {
     /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
     color: OptionalField(nullable(ColorT), null, 'Color of the ellipsoid. If not specified, uses the parent primitives group `color`.'),
-    /** Ellipsis center. */
-    center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
-    /** Major axis of this ellipsis. */
+    /** Ellipsoid center. */
+    center: RequiredField(PrimitivePositionT, 'The center of the ellipsoid.'),
+    /** Major axis of this ellipsoid. */
     major_axis: OptionalField(nullable(Vector3), null, 'Major axis of this ellipsoid.'),
-    /** Minor axis of this ellipsis. */
+    /** Minor axis of this ellipsoid. */
     minor_axis: OptionalField(nullable(Vector3), null, 'Minor axis of this ellipsoid.'),
     /** Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center. */
     major_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center.'),
@@ -212,7 +212,7 @@ export const MVSPrimitiveParams = UnionParamsSchema(
         'arrow': SimpleParamsSchema(ArrowParams),
         'distance_measurement': SimpleParamsSchema(DistanceMeasurementParams),
         'label': SimpleParamsSchema(PrimitiveLabelParams),
-        'ellipsis': SimpleParamsSchema(EllipsisParams),
+        'ellipse': SimpleParamsSchema(EllipseParams),
         'ellipsoid': SimpleParamsSchema(EllipsoidParams),
         'box': SimpleParamsSchema(BoxParams),
     },

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -75,6 +75,37 @@ const TubeParams = {
     tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`.'),
 };
 
+const ArrowParams = {
+    /** Start point of the tube. */
+    start: RequiredField(PrimitivePositionT, 'Start point of the arrow.'),
+    /** End point of the tube. */
+    end: OptionalField(nullable(PrimitivePositionT), null, 'End point of the arrow.'),
+    /** If specified, the endpoint is computed as start + direction. */
+    direction: OptionalField(nullable(Vector3), null, 'If specified, the endpoint is computed as start + direction.'),
+    /** Length of the arrow. If unset, the distance between start and end is used. */
+    length: OptionalField(nullable(float), null, 'Length of the arrow. If unset, the distance between start and end is used.'),
+    /** Draw an arrow at the start of the arrow. */
+    arrow_start: OptionalField(bool, false, 'Draw an arrow at the start of the arrow.'),
+    /** Height of the arrow at the start. */
+    arrow_start_height: OptionalField(float, 0.1, 'Height of the arrow at the start.'),
+    /** Radius of the arrow at the start. */
+    arrow_start_radius: OptionalField(float, 0.1, ''),
+    /** Draw an arrow at the end of the arrow. */
+    arrow_end: OptionalField(bool, false, 'Draw an arrow at the end of the arrow.'),
+    /** Height of the arrow at the end. */
+    arrow_end_height: OptionalField(float, 0.1, 'Height of the arrow at the end.'),
+    /** Radius of the arrow at the end. */
+    arrow_end_radius: OptionalField(float, 0.1, 'Radius of the arrow at the end.'),
+    /** Tube radius (in Angstroms). */
+    radius: OptionalField(float, 0.05, 'Tube radius (in Angstroms).'),
+    /** Length of each dash and gap between dashes. If not specified (null), draw full line. */
+    dash_length: OptionalField(nullable(float), null, 'Length of each dash and gap between dashes. If not specified (null), draw full line.'),
+    /** Color of the tube. If not specified, uses the parent primitives group `color`. */
+    color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
+    /** Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`. */
+    tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the arrow. If not specified, uses the parent primitives group `tooltip`.'),
+};
+
 const DistanceMeasurementParams = {
     ..._TubeBase,
     /** Template used to construct the label. Use {{distance}} as placeholder for the distance. */
@@ -155,6 +186,7 @@ export const MVSPrimitiveParams = UnionParamsSchema(
         'mesh': SimpleParamsSchema(MeshParams),
         'lines': SimpleParamsSchema(LinesParams),
         'tube': SimpleParamsSchema(TubeParams),
+        'arrow': SimpleParamsSchema(ArrowParams),
         'distance_measurement': SimpleParamsSchema(DistanceMeasurementParams),
         'label': SimpleParamsSchema(PrimitiveLabelParams),
         'ellipsis': SimpleParamsSchema(EllipsisParams),

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -102,6 +102,23 @@ const PrimitiveLabelParams = {
     label_offset: OptionalField(float, 0, 'Camera-facing offset to prevent overlap with geometry.'),
 };
 
+const EllisisParams = {
+    /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
+    color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
+    /** Ellipsis center. */
+    center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
+    /** Major axis of this circle. Computed as major_axis - center */
+    major_axis: RequiredField(PrimitivePositionT, 'Major axis of this circle. Computed as major_axis - center'),
+    /** Minor axis of this circle. Computed as minor_axis - center */
+    minor_axis: RequiredField(PrimitivePositionT, 'Minor axis of this circle. Computed as minor_axis - center'),
+    /** Start of the arc. In radians */
+    theta_start: OptionalField(float, 0, 'Start of the arc. In radians'),
+    /** End of the arc. In radians */
+    theta_end: OptionalField(float, 2 * Math.PI, 'End of the arc. In radians'),
+    /** Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`. */
+    tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`.'),
+};
+
 export const MVSPrimitiveParams = UnionParamsSchema(
     'kind',
     'Kind of geometrical primitive',
@@ -111,5 +128,6 @@ export const MVSPrimitiveParams = UnionParamsSchema(
         'tube': SimpleParamsSchema(TubeParams),
         'distance_measurement': SimpleParamsSchema(DistanceMeasurementParams),
         'label': SimpleParamsSchema(PrimitiveLabelParams),
+        'ellipsis': SimpleParamsSchema(EllisisParams),
     },
 );

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -5,7 +5,7 @@
  * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { bool, float, int, mapping, nullable, OptionalField, RequiredField, str } from '../generic/field-schema';
+import { bool, float, int, mapping, nullable, OptionalField, RequiredField, str, union } from '../generic/field-schema';
 import { SimpleParamsSchema, UnionParamsSchema } from '../generic/params-schema';
 import { ColorT, FloatList, IntList, PrimitivePositionT, Vector3 } from './param-types';
 
@@ -137,15 +137,15 @@ const PrimitiveLabelParams = {
 
 const EllipsisParams = {
     /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
-    color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
+    color: OptionalField(nullable(ColorT), null, 'Color of the ellipsis. If not specified, uses the parent primitives group `color`.'),
     /** If true, ignores radius_minor/magnitude of the minor axis */
     as_circle: OptionalField(bool, false, 'If true, ignores radius_minor/magnitude of the minor axis.'),
     /** Ellipsis center. */
     center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
     /** Major axis of this ellipsis. */
-    major_axis: OptionalField(nullable(PrimitivePositionT), null, 'Major axis of this ellipsis.'),
+    major_axis: OptionalField(nullable(Vector3), null, 'Major axis of this ellipsis.'),
     /** Minor axis of this ellipsis. */
-    minor_axis: OptionalField(nullable(PrimitivePositionT), null, 'Minor axis of this ellipsis.'),
+    minor_axis: OptionalField(nullable(Vector3), null, 'Minor axis of this ellipsis.'),
     /** Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center. */
     major_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center.'),
     /** Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center. */
@@ -158,6 +158,27 @@ const EllipsisParams = {
     theta_start: OptionalField(float, 0, 'Start of the arc. In radians'),
     /** End of the arc. In radians */
     theta_end: OptionalField(float, 2 * Math.PI, 'End of the arc. In radians'),
+    /** Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`. */
+    tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`.'),
+};
+
+const EllipsoidParams = {
+    /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
+    color: OptionalField(nullable(ColorT), null, 'Color of the ellipsoid. If not specified, uses the parent primitives group `color`.'),
+    /** Ellipsis center. */
+    center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
+    /** Major axis of this ellipsis. */
+    major_axis: OptionalField(nullable(Vector3), null, 'Major axis of this ellipsoid.'),
+    /** Minor axis of this ellipsis. */
+    minor_axis: OptionalField(nullable(Vector3), null, 'Minor axis of this ellipsoid.'),
+    /** Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center. */
+    major_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center.'),
+    /** Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center. */
+    minor_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center.'),
+    /** Radii of the ellipsoid along each axis. */
+    radius: OptionalField(nullable(union([Vector3, float])), null, 'Radii of the ellipsoid along each axis.'),
+    /** Added to the radii of the ellipsoid along each axis. */
+    radius_extent: OptionalField(nullable(union([Vector3, float])), null, 'Added to the radii of the ellipsoid along each axis.'),
     /** Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`. */
     tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`.'),
 };
@@ -192,6 +213,7 @@ export const MVSPrimitiveParams = UnionParamsSchema(
         'distance_measurement': SimpleParamsSchema(DistanceMeasurementParams),
         'label': SimpleParamsSchema(PrimitiveLabelParams),
         'ellipsis': SimpleParamsSchema(EllipsisParams),
+        'ellipsoid': SimpleParamsSchema(EllipsoidParams),
         'box': SimpleParamsSchema(BoxParams),
     },
 );

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -107,10 +107,14 @@ const EllipsisParams = {
     color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
     /** Ellipsis center. */
     center: RequiredField(PrimitivePositionT, 'The center of the ellipsis.'),
-    /** Major axis of this circle. Computed as major_axis - center */
-    major_axis: RequiredField(PrimitivePositionT, 'Major axis of this circle. Computed as major_axis - center'),
-    /** Minor axis of this circle. Computed as minor_axis - center */
-    minor_axis: RequiredField(PrimitivePositionT, 'Minor axis of this circle. Computed as minor_axis - center'),
+    /** Major axis of this ellipsis. */
+    major_axis: OptionalField(nullable(PrimitivePositionT), null, 'Major axis of this ellipsis.'),
+    /** Minor axis of this ellipsis. */
+    minor_axis: OptionalField(nullable(PrimitivePositionT), null, 'Minor axis of this ellipsis.'),
+    /** Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center. */
+    major_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Major axis endpoint. If specified, overrides major axis to be major_axis_endpoint - center.'),
+    /** Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center. */
+    minor_axis_endpoint: OptionalField(nullable(PrimitivePositionT), null, 'Minor axis endpoint. If specified, overrides minor axis to be minor_axis_endpoint - center.'),
     /** Start of the arc. In radians */
     theta_start: OptionalField(float, 0, 'Start of the arc. In radians'),
     /** End of the arc. In radians */

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -96,10 +96,12 @@ const ArrowParams = {
     arrow_end_height: OptionalField(float, 0.1, 'Height of the arrow at the end.'),
     /** Radius of the arrow at the end. */
     arrow_end_radius: OptionalField(float, 0.1, 'Radius of the arrow at the end.'),
+    /** Draw a tube connecting the start and end points. */
+    show_tube: OptionalField(bool, true, 'Draw a tube connecting the start and end points.'),
     /** Tube radius (in Angstroms). */
-    radius: OptionalField(float, 0.05, 'Tube radius (in Angstroms).'),
+    tube_radius: OptionalField(float, 0.05, 'Tube radius (in Angstroms).'),
     /** Length of each dash and gap between dashes. If not specified (null), draw full line. */
-    dash_length: OptionalField(nullable(float), null, 'Length of each dash and gap between dashes. If not specified (null), draw full line.'),
+    tube_dash_length: OptionalField(nullable(float), null, 'Length of each dash and gap between dashes. If not specified (null), draw full line.'),
     /** Color of the tube. If not specified, uses the parent primitives group `color`. */
     color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
     /** Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`. */

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -7,7 +7,7 @@
 
 import { bool, float, int, mapping, nullable, OptionalField, RequiredField, str } from '../generic/field-schema';
 import { SimpleParamsSchema, UnionParamsSchema } from '../generic/params-schema';
-import { ColorT, FloatList, IntList, PrimitivePositionT } from './param-types';
+import { ColorT, FloatList, IntList, PrimitivePositionT, Vector3 } from './param-types';
 
 
 const _TubeBase = {
@@ -102,7 +102,7 @@ const PrimitiveLabelParams = {
     label_offset: OptionalField(float, 0, 'Camera-facing offset to prevent overlap with geometry.'),
 };
 
-const EllisisParams = {
+const EllipsisParams = {
     /** Color of the primitive. If not specified, uses the parent primitives group `color`. */
     color: OptionalField(nullable(ColorT), null, 'Color of the tube. If not specified, uses the parent primitives group `color`.'),
     /** Ellipsis center. */
@@ -119,6 +119,25 @@ const EllisisParams = {
     tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`.'),
 };
 
+const BoxParams = {
+    /** The center of the box. */
+    center: RequiredField(PrimitivePositionT, 'The center of the box.'),
+    /** The width, the height, and the depth of the box. Added to the bounding box determined by the center. */
+    extent: OptionalField(nullable(Vector3), null, 'The width, the height, and the depth of the box. Added to the bounding box determined by the center.'),
+    /** Determine whether to render the faces of the box. */
+    show_faces: OptionalField(bool, true, 'Determine whether to render the faces of the box.'),
+    /** Color of the box faces. */
+    face_color: OptionalField(nullable(ColorT), null, 'Color of the box faces.'),
+    /** Determine whether to render the edges of the box. */
+    show_edges: OptionalField(bool, false, 'Determine whether to render the edges of the box.'),
+    /** Radius of the box edges. In angstroms. */
+    edge_radius: OptionalField(float, 0.1, 'Radius of the box edges. In angstroms.'),
+    /** Color of the box edges. */
+    edge_color: OptionalField(nullable(ColorT), null, 'Color of the edges.'),
+    /** Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`. */
+    tooltip: OptionalField(nullable(str), null, 'Tooltip to show when hovering over the tube. If not specified, uses the parent primitives group `tooltip`.'),
+};
+
 export const MVSPrimitiveParams = UnionParamsSchema(
     'kind',
     'Kind of geometrical primitive',
@@ -128,6 +147,7 @@ export const MVSPrimitiveParams = UnionParamsSchema(
         'tube': SimpleParamsSchema(TubeParams),
         'distance_measurement': SimpleParamsSchema(DistanceMeasurementParams),
         'label': SimpleParamsSchema(PrimitiveLabelParams),
-        'ellipsis': SimpleParamsSchema(EllisisParams),
+        'ellipsis': SimpleParamsSchema(EllipsisParams),
+        'box': SimpleParamsSchema(BoxParams),
     },
 );


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] Ellipse
- [x] Ellipsoid
- [x] Box
- [x] Arrow

## Examples

```py
builder = create_builder()
(
    builder.primitives(opacity=0.66)
    .ellipse(
        color="red",
        center=(1, 1, 1),
        major_axis=(1.5, 0, 0),
        minor_axis=(0, 2, 0),
        theta_start=0,
        theta_end=math.pi / 2,
        tooltip="XY",
    )
    .ellipse(
        color="green",
        center=(1, 1, 1),
        major_axis_endpoint=(1.5 + 1, 0 + 1, 0 + 1),
        minor_axis_endpoint=(0 + 1, 0 + 1, 1 + 1),
        theta_start=0,
        theta_end=math.pi / 2,
        tooltip="XZ",
    )
    .ellipse(
        color="blue",
        center=(1, 1, 1),
        major_axis=(0, 10, 0),
        minor_axis=(0, 0, 1),
        radius_major=2,
        radius_minor=1,
        theta_start=0,
        theta_end=math.pi / 2,
        tooltip="YZ",
    )
    .arrow(
        start=(1, 1, 1),
        end=(1 + 1.5, 1 + 0, 1 + 0),
        tube_radius=0.05,
        length=1.5 + 0.2,
        show_end_cap=True,
        color="#ffff00",
        tooltip="X",
    )
    .arrow(
        start=(1, 1, 1), direction=(0, 2 + 0.2, 0), tube_radius=0.05, show_end_cap=True, color="#ff00ff", tooltip="Y"
    )
    .arrow(
        end=(1, 1, 1),
        start=(1 + 0, 1 + 0, 1 + 1 + 0.2),
        show_start_cap=True,
        tube_radius=0.05,
        color="#00ffff",
        tooltip="Z",
    )
)

(
    builder.primitives(opacity=0.33).ellipsoid(
        center=(1, 1, 1),
        major_axis=(1, 0, 0),
        minor_axis=(0, 1, 0),
        radius=(1.5, 2, 1),
        color="#cccccc",
    )
)
```

![image](https://github.com/user-attachments/assets/62769964-4e8b-4ff2-8709-3c69428c8f81)

```py
builder = create_builder()

download = builder.download(url="https://www.ebi.ac.uk/pdbe/entry-files/download/1tqn_updated.cif")
structure = download.parse(format="mmcif").model_structure()

structure.component(selector="ligand").representation(type="ball_and_stick")
structure.component(selector="polymer").representation(type="cartoon")

structure.primitives(opacity=0.55).box(
    center=ComponentExpression(auth_seq_id=508),
    extent=(1, 1, 1),
    show_faces=True,
    face_color="blue",
    show_edges=True,
    edge_color="red",
    edge_radius=0.1,
    tooltip="Residue 508, boxed",
).focus()

structure.primitives(opacity=0.25).sphere(
    center=ComponentExpression(auth_seq_id=508),
    color="green",
)
```

![image](https://github.com/user-attachments/assets/8a358659-9a41-43b4-a4ea-ae2f6aeec7af)



## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`