### PR TITLE
MVS: Basic volumetric data support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix PDBj structure data URL
 - Improve logic when to cull in renderer
 - Add `atom.ihm.has-seq-id` and `atom.ihm.overlaps-seq-id-range` symbol to the query language
-- Better IH/M support in MolViewSpec:
-  - Support `coarse` components
-  - Support `spacefill` representation
-  - Support for `custom.molstar_use_default_coloring` property on Color node.
-  - Use `atom.ihm.has-seq-id` and `atom.ihm.overlaps-seq-id-range` for matching `label_seq_id` locations to support querying coarse elements.
-  - Add ihm-restraints example
-- MolViewSpec extension: Add box, arrow, ellipse, ellipsoid primitives
+- MolViewSpec extension:
+  - Add box, arrow, ellipse, ellipsoid primitives
+  - Add basic support for volumetic data
+  - Better IH/M support:
+    - Support `coarse` components
+    - Support `spacefill` representation
+    - Support for `custom.molstar_use_default_coloring` property on Color node.
+    - Use `atom.ihm.has-seq-id` and `atom.ihm.overlaps-seq-id-range` for matching `label_seq_id` locations to support querying coarse elements.
+    - Add ihm-restraints example
 - Add Components example
 - Remove static uses of `ColorTheme` and `SizeTheme` fields. Should resolvent "undefined" errors in certain builds
 - Add `transform` property to clip objects

--- a/src/extensions/mvs/load-generic.ts
+++ b/src/extensions/mvs/load-generic.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
  * @author David Sehnal <david.sehnal@gmail.com>

--- a/src/extensions/mvs/load-generic.ts
+++ b/src/extensions/mvs/load-generic.ts
@@ -125,6 +125,9 @@ export interface UpdateTarget {
     readonly selector: StateObjectSelector,
     readonly targetManager: TargetManager,
     readonly mvsDependencyRefs: Set<string>,
+
+    readonly transformer?: StateTransformer,
+    readonly transformParams?: any,
 }
 export const UpdateTarget = {
     /** Create a new update, with `selector` pointing to the root. */
@@ -142,7 +145,7 @@ export const UpdateTarget = {
         }
         const ref = target.targetManager.getChildRef(target.selector, refSuffix);
         const msResult = target.update.to(target.selector).apply(transformer, params, { ...options, ref }).selector;
-        const result: UpdateTarget = { ...target, selector: msResult, mvsDependencyRefs: new Set() };
+        const result: UpdateTarget = { ...target, selector: msResult, mvsDependencyRefs: new Set(), transformer, transformParams: params };
         target.targetManager.allTargets.push(result);
         return result;
     },

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
  * @author David Sehnal <david.sehnal@gmail.com>

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -7,9 +7,11 @@
  */
 
 import { PluginStateSnapshotManager } from '../../mol-plugin-state/manager/snapshots';
-import { Download, ParseCif } from '../../mol-plugin-state/transforms/data';
+import { PluginStateObject } from '../../mol-plugin-state/objects';
+import { Download, ParseCcp4, ParseCif } from '../../mol-plugin-state/transforms/data';
 import { CustomModelProperties, CustomStructureProperties, ModelFromTrajectory, StructureComponent, StructureFromModel, TrajectoryFromMmCif, TrajectoryFromPDB, TransformStructureConformation } from '../../mol-plugin-state/transforms/model';
-import { ShapeRepresentation3D, StructureRepresentation3D } from '../../mol-plugin-state/transforms/representation';
+import { ShapeRepresentation3D, StructureRepresentation3D, VolumeRepresentation3D } from '../../mol-plugin-state/transforms/representation';
+import { VolumeFromCcp4 } from '../../mol-plugin-state/transforms/volume';
 import { PluginCommands } from '../../mol-plugin/commands';
 import { PluginContext } from '../../mol-plugin/context';
 import { StateObjectSelector } from '../../mol-state';
@@ -24,7 +26,7 @@ import { IsMVSModelProps, IsMVSModelProvider } from './components/is-mvs-model-p
 import { getPrimitiveStructureRefs, MVSBuildPrimitiveShape, MVSDownloadPrimitiveData, MVSInlinePrimitiveData } from './components/primitives';
 import { NonCovalentInteractionsExtension } from './load-extensions/non-covalent-interactions';
 import { LoadingActions, LoadingExtension, loadTree, loadTreeVirtual, UpdateTarget } from './load-generic';
-import { AnnotationFromSourceKind, AnnotationFromUriKind, collectAnnotationReferences, collectAnnotationTooltips, collectInlineLabels, collectInlineTooltips, colorThemeForNode, componentFromXProps, componentPropsFromSelector, isPhantomComponent, labelFromXProps, makeNearestReprMap, prettyNameFromSelector, representationProps, structureProps, transformProps } from './load-helpers';
+import { AnnotationFromSourceKind, AnnotationFromUriKind, collectAnnotationReferences, collectAnnotationTooltips, collectInlineLabels, collectInlineTooltips, colorThemeForNode, componentFromXProps, componentPropsFromSelector, isPhantomComponent, labelFromXProps, makeNearestReprMap, prettyNameFromSelector, representationProps, structureProps, transformProps, volumeColorThemeForNode, volumeRepresentationProps } from './load-helpers';
 import { MVSData, SnapshotMetadata } from './mvs-data';
 import { validateTree } from './tree/generic/tree-schema';
 import { convertMvsToMolstar, mvsSanityCheck } from './tree/molstar/conversion';
@@ -172,6 +174,8 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
             return UpdateTarget.apply(updateParent, ParseCif, {});
         } else if (format === 'pdb') {
             return updateParent;
+        } else if (format === 'map') {
+            return UpdateTarget.apply(updateParent, ParseCcp4, {});
         } else {
             console.error(`Unknown format in "parse" node: "${format}"`);
             return undefined;
@@ -270,6 +274,20 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
         return UpdateTarget.apply(updateParent, StructureRepresentation3D, {
             ...representationProps(node),
             colorTheme: colorThemeForNode(node, context),
+        });
+    },
+    volume(updateParent: UpdateTarget, node: MolstarNode<'volume'>): UpdateTarget | undefined {
+        if (updateParent.transformer?.definition.to.includes(PluginStateObject.Format.Ccp4)) {
+            return UpdateTarget.apply(updateParent, VolumeFromCcp4, { });
+        } else {
+            console.error(`Unsupported volume format`);
+            return undefined;
+        }
+    },
+    volume_representation(updateParent: UpdateTarget, node: MolstarNode<'volume_representation'>, context: MolstarLoadingContext): UpdateTarget {
+        return UpdateTarget.apply(updateParent, VolumeRepresentation3D, {
+            ...volumeRepresentationProps(node),
+            colorTheme: volumeColorThemeForNode(node, context),
         });
     },
     color: undefined, // No action needed, already loaded in `representation`

--- a/src/extensions/mvs/tree/molstar/conversion.ts
+++ b/src/extensions/mvs/tree/molstar/conversion.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { omitObjectKeys, pickObjectKeys } from '../../../../mol-util/object';

--- a/src/extensions/mvs/tree/molstar/conversion.ts
+++ b/src/extensions/mvs/tree/molstar/conversion.ts
@@ -17,6 +17,7 @@ export const ParseFormatMvsToMolstar = {
     mmcif: { format: 'cif', is_binary: false },
     bcif: { format: 'cif', is_binary: true },
     pdb: { format: 'pdb', is_binary: false },
+    map: { format: 'map', is_binary: true },
 } satisfies { [p in ParseFormatT]: { format: MolstarParseFormatT, is_binary: boolean } };
 
 
@@ -71,6 +72,7 @@ const StructureFormatExtensions: Record<ParseFormatT, (FileExtension | '*')[]> =
     mmcif: ['.cif', '.mmif'],
     bcif: ['.bcif'],
     pdb: ['.pdb', '.ent'],
+    map: ['.map', '.ccp4', '.mrc', '.mrcs'],
 };
 
 /** Run some sanity check on a MVSTree. Return a list of potential problems (`undefined` if there are none) */

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -152,6 +152,10 @@ export class Parse extends _Base<'parse'> {
             ref: params.ref,
         }));
     }
+    /** Add a 'volume' node representing raw volume data */
+    volume(params: MVSNodeParams<'volume'> & CustomAndRef = {}): any {
+        return this.addChild('volume', params);
+    }
 }
 
 
@@ -246,6 +250,33 @@ export class Representation extends _Base<'representation'> {
         this.addChild('opacity', params);
         return this;
     }
+}
+
+
+/** MVS builder pointing to a 'component' or 'component_from_uri' or 'component_from_source' node */
+export class Volume extends _Base<'volume'> implements FocusMixin {
+    /** Add a 'representation' node and return builder pointing to it. 'representation' node instructs to create a visual representation of a component. */
+    representation(params: Partial<MVSNodeParams<'volume_representation'>> & CustomAndRef = {}): VolumeRepresentation {
+        const fullParams: MVSNodeParams<'volume_representation'> = { ...params, type: params.type ?? 'isosurface' };
+        return new VolumeRepresentation(this._root, this.addChild('volume_representation', fullParams));
+    }
+    focus = bindMethod(this, FocusMixinImpl, 'focus');
+}
+
+
+/** MVS builder pointing to a 'volume_representation' node */
+export class VolumeRepresentation extends _Base<'volume_representation'> implements FocusMixin {
+    /** Add a 'color' node and return builder pointing back to the representation node. 'color' node instructs to apply color to a visual representation. */
+    color(params: MVSNodeParams<'color'> & CustomAndRef): VolumeRepresentation {
+        this.addChild('color', params);
+        return this;
+    }
+    /** Add an 'opacity' node and return builder pointing back to the representation node. 'opacity' node instructs to customize opacity/transparency of a visual representation. */
+    opacity(params: MVSNodeParams<'opacity'> & CustomAndRef): VolumeRepresentation {
+        this.addChild('opacity', params);
+        return this;
+    }
+    focus = bindMethod(this, FocusMixinImpl, 'focus');
 }
 
 

--- a/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
@@ -4,7 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-import { bool, float, OptionalField } from '../generic/field-schema';
+import { bool, float, nullable, OptionalField } from '../generic/field-schema';
 import { SimpleParamsSchema, UnionParamsSchema } from '../generic/params-schema';
 
 const Cartoon = {
@@ -43,5 +43,24 @@ export const MVSRepresentationParams = UnionParamsSchema(
         ball_and_stick: SimpleParamsSchema(BallAndStick),
         spacefill: SimpleParamsSchema(Spacefill),
         surface: SimpleParamsSchema(Surface),
+    },
+);
+
+const VolumeIsoSurface = {
+    /** Relative isovalue. */
+    relative_isovalue: OptionalField(nullable(float), null, 'Relative isovalue.'),
+    /** Absolute isovalue. Overrides `relative_isovalue`. */
+    absolute_isovalue: OptionalField(nullable(float), null, 'Absolute isovalue. Overrides `relative_isovalue`.'),
+    /** Show mesh wireframe. Defaults to false. */
+    show_wireframe: OptionalField(bool, true, 'Show mesh wireframe. Defaults to false.'),
+    /** Show mesh faces. Defaults to true. */
+    show_faces: OptionalField(bool, true, 'Show mesh faces. Defaults to true.'),
+};
+
+export const MVSVolumeRepresentationParams = UnionParamsSchema(
+    'type',
+    'Representation type',
+    {
+        'isosurface': SimpleParamsSchema(VolumeIsoSurface),
     },
 );

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -8,7 +8,7 @@
 import { float, int, list, literal, nullable, OptionalField, RequiredField, str, tuple, union } from '../generic/field-schema';
 import { SimpleParamsSchema } from '../generic/params-schema';
 import { NodeFor, ParamsOfKind, SubtreeOfKind, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
-import { MVSRepresentationParams } from './mvs-tree-representations';
+import { MVSRepresentationParams, MVSVolumeRepresentationParams } from './mvs-tree-representations';
 import { MVSPrimitiveParams } from './mvs-tree-primitives';
 import { ColorT, ComponentExpressionT, ComponentSelectorT, Matrix, ParseFormatT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
 
@@ -148,10 +148,22 @@ export const MVSTreeSchema = TreeSchema({
             parent: ['component', 'component_from_uri', 'component_from_source'],
             params: MVSRepresentationParams,
         },
+        /** This node instructs to create a volume from a parsed data resource. "Volume" refers to an internal representation of volumetric data without any visual representation. */
+        volume: {
+            description: 'This node instructs to create a volume from a parsed data resource. "Volume" refers to an internal representation of volumetric data without any visual representation.',
+            parent: ['parse'],
+            params: SimpleParamsSchema({}),
+        },
+        /** This node instructs to create a visual representation of a volume. */
+        volume_representation: {
+            description: 'This node instructs to create a visual representation of a volume.',
+            parent: ['volume'],
+            params: MVSVolumeRepresentationParams,
+        },
         /** This node instructs to apply color to a visual representation. */
         color: {
             description: 'This node instructs to apply color to a visual representation.',
-            parent: ['representation'],
+            parent: ['representation', 'volume_representation'],
             params: SimpleParamsSchema({
                 /** Color to apply to the representation. Can be either an X11 color name (e.g. `"red"`) or a hexadecimal code (e.g. `"#FF0011"`). */
                 color: OptionalField(ColorT, DefaultColor, 'Color to apply to the representation. Can be either an X11 color name (e.g. `"red"`) or a hexadecimal code (e.g. `"#FF0011"`).'),
@@ -182,7 +194,7 @@ export const MVSTreeSchema = TreeSchema({
         /** This node instructs to apply opacity/transparency to a visual representation. */
         opacity: {
             description: 'This node instructs to apply opacity/transparency to a visual representation.',
-            parent: ['representation'],
+            parent: ['representation', 'volume_representation'],
             params: SimpleParamsSchema({
                 /** Opacity of a representation. 0.0: fully transparent, 1.0: fully opaque. */
                 opacity: RequiredField(float, 'Opacity of a representation. 0.0: fully transparent, 1.0: fully opaque.'),
@@ -249,7 +261,7 @@ export const MVSTreeSchema = TreeSchema({
         /** This node instructs to set the camera focus to a component (zoom in). */
         focus: {
             description: 'This node instructs to set the camera focus to a component (zoom in).',
-            parent: ['root', 'component', 'component_from_uri', 'component_from_source', 'primitives', 'primitives_from_uri'],
+            parent: ['root', 'component', 'component_from_uri', 'component_from_source', 'primitives', 'primitives_from_uri', 'volume', 'volume_representation'],
             params: SimpleParamsSchema({
                 /** Vector describing the direction of the view (camera position -> focused target). */
                 direction: OptionalField(Vector3, [0, 0, -1], 'Vector describing the direction of the view (camera position -> focused target).'),

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -12,11 +12,11 @@ import { ColorNames } from '../../../../mol-util/color/names';
 
 
 /** `format` parameter values for `parse` node in MVS tree */
-export const ParseFormatT = literal('mmcif', 'bcif', 'pdb');
+export const ParseFormatT = literal('mmcif', 'bcif', 'pdb', 'map');
 export type ParseFormatT = ValueFor<typeof ParseFormatT>
 
 /** `format` parameter values for `parse` node in Molstar tree */
-export const MolstarParseFormatT = literal('cif', 'pdb');
+export const MolstarParseFormatT = literal('cif', 'pdb', 'map');
 export type MolstarParseFormatT = ValueFor<typeof MolstarParseFormatT>
 
 /** `kind` parameter values for `structure` node in MVS tree */


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] Add support for basic volumetric data loading and rendering implemented in https://github.com/molstar/mol-view-spec/pull/45


```py
builder = create_builder()

download = builder.download(url="https://www.ebi.ac.uk/pdbe/entry-files/1tqn.ccp4")
volume = download.parse(format="map").volume()
(
    volume.representation(type="isosurface", relative_isovalue=1, show_wireframe=True)
    .color(color="blue")
    .opacity(opacity=0.66)
)
```

![image](https://github.com/user-attachments/assets/fa918fc8-3c97-45e4-8c0c-dffda30afe75)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files