### PR TITLE
MVS: Volume Server support + Support carbohydrate representation + Camera section in Screenshot / State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add `atom.ihm.has-seq-id` and `atom.ihm.overlaps-seq-id-range` symbol to the query language
 - MolViewSpec extension:
   - Add box, arrow, ellipse, ellipsoid primitives
-  - Add basic support for volumetic data
+  - Add basic support for volumetric data (map, Volume Server)
+  - Add support for `molstar_color_theme_name` custom extension
   - Better IH/M support:
     - Support `coarse` components
     - Support `spacefill` representation
@@ -29,6 +30,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Can be colored with the `external-volume` theme
     - Can show atoms as a cutout
     - Supports principal axes and bounding box as a reference frame
+- Add `Camera` section to "Screenshot / State" controls
 
 ## [v4.11.0] - 2025-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Better IH/M support:
     - Support `coarse` components
     - Support `spacefill` representation
+    - Support `carbohydrate` representation
     - Support for `custom.molstar_use_default_coloring` property on Color node.
     - Use `atom.ihm.has-seq-id` and `atom.ihm.overlaps-seq-id-range` for matching `label_seq_id` locations to support querying coarse elements.
     - Add ihm-restraints example

--- a/src/extensions/mvs/load-helpers.ts
+++ b/src/extensions/mvs/load-helpers.ts
@@ -319,6 +319,12 @@ export function alphaForNode(node: MolstarSubtree<'representation' | 'volume_rep
         return 1;
     }
 }
+
+function hasMolStarUseDefaultColoring(node: MolstarNode): boolean {
+    if (!node.custom) return false;
+    return 'molstar_use_default_coloring' in node.custom || 'molstar_color_theme_name' in node.custom;
+}
+
 /** Create value for `colorTheme` prop for `StructureRepresentation3D` transformer from a representation node based on color* nodes in its subtree. */
 export function colorThemeForNode(node: MolstarSubtree<'color' | 'color_from_uri' | 'color_from_source' | 'representation'> | undefined, context: MolstarLoadingContext): StateTransformer.Params<StructureRepresentation3D>['colorTheme'] | undefined {
     if (node?.kind === 'representation') {
@@ -328,8 +334,13 @@ export function colorThemeForNode(node: MolstarSubtree<'color' | 'color_from_uri
                 name: 'uniform',
                 params: { value: decodeColor(DefaultColor) },
             };
-        } else if (children.length === 1 && children[0].custom?.molstar_use_default_coloring) {
-            return undefined;
+        } else if (children.length === 1 && hasMolStarUseDefaultColoring(children[0])) {
+            if (children[0].custom?.molstar_use_default_coloring) return undefined;
+            const colorThemeName = children[0].custom?.molstar_color_theme_name;
+            return {
+                name: colorThemeName ?? undefined,
+                params: {},
+            };
         } else if (children.length === 1 && appliesColorToWholeRepr(children[0])) {
             return colorThemeForNode(children[0], context);
         } else {

--- a/src/extensions/mvs/load-helpers.ts
+++ b/src/extensions/mvs/load-helpers.ts
@@ -300,6 +300,10 @@ export function representationProps(node: MolstarSubtree<'representation'>): Par
                 type: { name: 'spacefill', params: { alpha, ignoreHydrogens: params.ignore_hydrogens } },
                 sizeTheme: { name: 'physical', params: { scale: params.size_factor } },
             };
+        case 'carbohydrate':
+            return {
+                type: { name: 'carbohydrate', params: { alpha, sizeFactor: params.size_factor ?? 1 } },
+            };
         case 'surface':
             return {
                 type: { name: 'molecular-surface', params: { alpha, ignoreHydrogens: params.ignore_hydrogens } },

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -11,7 +11,7 @@ import { PluginStateObject } from '../../mol-plugin-state/objects';
 import { Download, ParseCcp4, ParseCif } from '../../mol-plugin-state/transforms/data';
 import { CustomModelProperties, CustomStructureProperties, ModelFromTrajectory, StructureComponent, StructureFromModel, TrajectoryFromMmCif, TrajectoryFromPDB, TransformStructureConformation } from '../../mol-plugin-state/transforms/model';
 import { ShapeRepresentation3D, StructureRepresentation3D, VolumeRepresentation3D } from '../../mol-plugin-state/transforms/representation';
-import { VolumeFromCcp4 } from '../../mol-plugin-state/transforms/volume';
+import { VolumeFromCcp4, VolumeFromDensityServerCif } from '../../mol-plugin-state/transforms/volume';
 import { PluginCommands } from '../../mol-plugin/commands';
 import { PluginContext } from '../../mol-plugin/context';
 import { StateObjectSelector } from '../../mol-state';
@@ -279,6 +279,8 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
     volume(updateParent: UpdateTarget, node: MolstarNode<'volume'>): UpdateTarget | undefined {
         if (updateParent.transformer?.definition.to.includes(PluginStateObject.Format.Ccp4)) {
             return UpdateTarget.apply(updateParent, VolumeFromCcp4, { });
+        } else if (updateParent.transformer?.definition.to.includes(PluginStateObject.Format.Cif)) {
+            return UpdateTarget.apply(updateParent, VolumeFromDensityServerCif, { blockHeader: node.params.channel_id || undefined });
         } else {
             console.error(`Unsupported volume format`);
             return undefined;

--- a/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
@@ -28,6 +28,11 @@ const Spacefill = {
     ignore_hydrogens: OptionalField(bool, false, 'Controls whether hydrogen atoms are drawn.'),
 };
 
+const Carbohydrate = {
+    /** Scales the corresponding visuals */
+    size_factor: OptionalField(float, 1, 'Scales the corresponding visuals.'),
+};
+
 const Surface = {
     /** Scales the corresponding visuals */
     size_factor: OptionalField(float, 1, 'Scales the corresponding visuals.'),
@@ -42,6 +47,7 @@ export const MVSRepresentationParams = UnionParamsSchema(
         cartoon: SimpleParamsSchema(Cartoon),
         ball_and_stick: SimpleParamsSchema(BallAndStick),
         spacefill: SimpleParamsSchema(Spacefill),
+        carbohydrate: SimpleParamsSchema(Carbohydrate),
         surface: SimpleParamsSchema(Surface),
     },
 );

--- a/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
@@ -52,7 +52,7 @@ const VolumeIsoSurface = {
     /** Absolute isovalue. Overrides `relative_isovalue`. */
     absolute_isovalue: OptionalField(nullable(float), null, 'Absolute isovalue. Overrides `relative_isovalue`.'),
     /** Show mesh wireframe. Defaults to false. */
-    show_wireframe: OptionalField(bool, true, 'Show mesh wireframe. Defaults to false.'),
+    show_wireframe: OptionalField(bool, false, 'Show mesh wireframe. Defaults to false.'),
     /** Show mesh faces. Defaults to true. */
     show_faces: OptionalField(bool, true, 'Show mesh faces. Defaults to true.'),
 };

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -152,7 +152,9 @@ export const MVSTreeSchema = TreeSchema({
         volume: {
             description: 'This node instructs to create a volume from a parsed data resource. "Volume" refers to an internal representation of volumetric data without any visual representation.',
             parent: ['parse'],
-            params: SimpleParamsSchema({}),
+            params: SimpleParamsSchema({
+                channel_id: OptionalField(nullable(str), null, 'Channel identifier (only applies when the input data contain multiple channels).'),
+            }),
         },
         /** This node instructs to create a visual representation of a volume. */
         volume_representation: {

--- a/src/mol-plugin-ui/skin/base/components/controls.scss
+++ b/src/mol-plugin-ui/skin/base/components/controls.scss
@@ -48,6 +48,17 @@
         bottom: 0;
     }
 
+    > div.msp-control-row-text {
+        position: absolute;
+        left: $control-label-width + $control-spacing;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        padding: 0 $control-spacing;
+    }
+
     > div {
         background: $msp-form-control-background;
     }

--- a/src/mol-plugin-ui/skin/base/components/viewport.scss
+++ b/src/mol-plugin-ui/skin/base/components/viewport.scss
@@ -183,6 +183,7 @@
     overflow: hidden;
     overflow-y: auto;
 
+    width: max-content;
     max-width: 400px;
 
     a {

--- a/src/mol-plugin-ui/viewport/screenshot.tsx
+++ b/src/mol-plugin-ui/viewport/screenshot.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -15,6 +15,9 @@ import { ParameterControls } from '../controls/parameters';
 import { ScreenshotPreview } from '../controls/screenshot';
 import { useBehavior } from '../hooks/use-behavior';
 import { LocalStateSnapshotParams, StateExportImportControls } from '../state/snapshots';
+import { useEffect, useState } from 'react';
+import { round } from '../../mol-util';
+import { Vec3 } from '../../mol-math/linear-algebra';
 
 interface ImageControlsState {
     showPreview: boolean,
@@ -91,8 +94,53 @@ export class DownloadScreenshotControls extends PluginUIComponent<{ close: () =>
                     <LocalStateSnapshotParams />
                 </ExpandGroup>
             </ExpandGroup>
+            <ExpandGroup header='Camera'>
+                <CameraInfo plugin={this.plugin} />
+            </ExpandGroup>
         </div>;
     }
+}
+
+function renderVector(v: number[] | undefined) {
+    return `${v?.map(v => round(v, 2)).join(', ')}`;
+}
+
+function CameraInfoSection({ title, children }: { title: string, children: any }): JSX.Element {
+    return <div className='msp-control-row'>
+        <span className='msp-control-row-label'>{title}</span>
+        <div className='msp-control-row-text' style={{ fontSize: '0.85rem', overflow: 'hidden', whiteSpace: 'nowrap' }}>{children}</div>
+    </div>;
+}
+
+function CameraInfo({ plugin }: { plugin: PluginContext }) {
+    const [, setUpdate] = useState({});
+    useEffect(() => {
+        const sub = plugin.canvas3d?.didDraw.subscribe(() => setUpdate({}));
+        return () => sub?.unsubscribe();
+    }, [plugin]);
+
+    const state = plugin.canvas3d?.camera.state;
+
+    return <div>
+        <CameraInfoSection title='Position'>
+            {renderVector(state?.position)}
+        </CameraInfoSection>
+        <CameraInfoSection title='Target'>
+            {renderVector(state?.target)}
+        </CameraInfoSection>
+        <CameraInfoSection title='Direction'>
+            {renderVector(Vec3.sub(Vec3(), state?.target ?? Vec3.origin, state?.position ?? Vec3.origin))}
+        </CameraInfoSection>
+        <CameraInfoSection title='Up'>
+            {renderVector(state?.up)}
+        </CameraInfoSection>
+        <CameraInfoSection title='Distance'>
+            {round(Vec3.distance(state?.position ?? Vec3.origin, state?.target ?? Vec3.origin), 2)}
+        </CameraInfoSection>
+        <CameraInfoSection title='Radius'>
+            {round(state?.radius ?? 0, 2)}
+        </CameraInfoSection>
+    </div>;
 }
 
 function ScreenshotParams({ plugin, isDisabled }: { plugin: PluginContext, isDisabled: boolean }) {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] MVS: Volume Server
- [x] MVS: Support `molstar_color_theme_name` custom extension
- [x] MVS: Support `carbohydrate` representation
- [x] Add `Camera` section to "Screenshot / State" controls 

goes with https://github.com/molstar/mol-view-spec/pull/47

```py
builder = create_builder()

structure = builder.download(url=_url_for_mmcif("1tqn")).parse(format="mmcif").model_structure()
structure.component(selector="polymer").representation(type="cartoon").color(color="white")
ligand = structure.component(selector="ligand")
ligand.representation(type="ball_and_stick").color(custom={"molstar_color_theme_name": "element-symbol"})
ligand.focus(up=[0.98, -0.19, 0], direction=[-28.47, -17.66, -16.32], radius=14, radius_extent=5)

volume_data = builder.download(
    url="https://www.ebi.ac.uk/pdbe/densities/x-ray/1tqn/box/-22.367,-33.367,-21.634/-7.106,-10.042,-0.937?detail=3"
).parse(format="bcif")

volume_data.volume(channel_id="2FO-FC").representation(
    type="isosurface",
    relative_isovalue=1.5,
    show_wireframe=True,
    show_faces=False,
).color(color="blue").opacity(opacity=0.3)

fo_fc = volume_data.volume(channel_id="FO-FC")
fo_fc.representation(type="isosurface", relative_isovalue=3, show_wireframe=True).color(color="green").opacity(
    opacity=0.3
)
fo_fc.representation(type="isosurface", relative_isovalue=-3, show_wireframe=True).color(color="red").opacity(
    opacity=0.3
)

snapshot = builder.get_snapshot(
    title="1tqn",
    description="""
### 1tqn with ligand and electron density map
- 2FO-FC at 1.5σ, blue
- FO-FC (positive) at 3σ, green
- FO-FC (negative) at -3σ, red
""",
)

return PlainTextResponse(
    States(snapshots=[snapshot], metadata=GlobalMetadata(description="1tqn + Volume Server")).json(
        exclude_none=True, indent=2
    )
)
```

![image](https://github.com/user-attachments/assets/f3a3b661-5391-4104-bf6c-0be39d3252e7)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
