### PR TITLE
MVS: Angle primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Improve logic when to cull in renderer
 - Add `atom.ihm.has-seq-id` and `atom.ihm.overlaps-seq-id-range` symbol to the query language
 - MolViewSpec extension:
-  - Add box, arrow, ellipse, ellipsoid primitives
+  - Add box, arrow, ellipse, ellipsoid, angle primitives
   - Add basic support for volumetric data (map, Volume Server)
   - Add support for `molstar_color_theme_name` custom extension
   - Better IH/M support:

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -18,6 +18,7 @@ import { Circle } from '../../../mol-geo/primitive/circle';
 import { Primitive } from '../../../mol-geo/primitive/primitive';
 import { Box3D, Sphere3D } from '../../../mol-math/geometry';
 import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
+import { radToDeg } from '../../../mol-math/misc';
 import { Shape } from '../../../mol-model/shape';
 import { Structure, StructureElement, StructureSelection } from '../../../mol-model/structure';
 import { StructureQueryHelper } from '../../../mol-plugin-state/helpers/structure-query';
@@ -303,6 +304,17 @@ const Builders: Record<PrimitiveParams['kind'], PrimitiveBuilder> = {
             label: addDistanceLabel,
         },
         resolveRefs: resolveLineRefs,
+    },
+    angle_measurement: {
+        builders: {
+            mesh: addAngleMesh,
+            label: addAngleLabel,
+        },
+        resolveRefs: (params: PrimitiveParams<'angle_measurement'>, refs: Set<string>) => {
+            addRef(params.a, refs);
+            addRef(params.b, refs);
+            addRef(params.c, refs);
+        },
     },
     ellipse: {
         builders: {
@@ -767,6 +779,116 @@ function addDistanceLabel(context: PrimitiveBuilderContext, state: LabelBuilderS
     labels.add(label, labelPos[0], labelPos[1], labelPos[2], 1.05 * (params.radius), 1, group);
 }
 
+
+const AngleState = {
+    a: Vec3(),
+    b: Vec3(),
+    c: Vec3(),
+    ba: Vec3(),
+    bc: Vec3(),
+    labelPos: Vec3(),
+    radius: 0,
+};
+
+function syncAngleState(context: PrimitiveBuilderContext, params: PrimitiveParams<'angle_measurement'>) {
+    resolveBasePosition(context, params.a, AngleState.a);
+    resolveBasePosition(context, params.b, AngleState.b);
+    resolveBasePosition(context, params.c, AngleState.c);
+    Vec3.sub(AngleState.ba, AngleState.a, AngleState.b);
+    Vec3.sub(AngleState.bc, AngleState.c, AngleState.b);
+    const value = radToDeg(Vec3.angle(AngleState.ba, AngleState.bc));
+
+    const angle = `${round(value, 2)}\u00B0`;
+    const label = typeof params.label_template === 'string' ? params.label_template.replace('{{angle}}', angle) : angle;
+
+    if (typeof params.section_radius === 'number') {
+        AngleState.radius = params.section_radius;
+    } else {
+        AngleState.radius = Math.min(Vec3.magnitude(AngleState.ba), Vec3.magnitude(AngleState.bc));
+        if (typeof params.section_radius_scale === 'number') {
+            AngleState.radius *= params.section_radius_scale;
+        }
+    }
+
+    return label;
+}
+
+function addAngleMesh(context: PrimitiveBuilderContext, state: MeshBuilderState, node: MVSNode<'primitive'>, params: PrimitiveParams<'angle_measurement'>) {
+    const label = syncAngleState(context, params);
+    const { groups, mesh } = state;
+
+    if (params.show_vector) {
+        const radius = 0.01;
+        const cylinderProps: BasicCylinderProps = {
+            radiusBottom: radius,
+            radiusTop: radius,
+            topCap: true,
+            bottomCap: true,
+        };
+
+        mesh.currentGroup = groups.allocateSingle(node);
+        groups.updateColor(mesh.currentGroup, params.vector_color);
+        groups.updateTooltip(mesh.currentGroup, label);
+
+        let count = Math.ceil(Vec3.magnitude(AngleState.ba) / (2 * radius));
+        addFixedCountDashedCylinder(mesh, AngleState.a, AngleState.b, 1.0, count, true, cylinderProps);
+        count = Math.ceil(Vec3.magnitude(AngleState.bc) / (2 * radius));
+        addFixedCountDashedCylinder(mesh, AngleState.b, AngleState.c, 1.0, count, true, cylinderProps);
+    }
+
+    if (params.show_section) {
+        const angle = Vec3.angle(AngleState.ba, AngleState.bc);
+        Vec3.normalize(AngleState.ba, AngleState.ba);
+        Vec3.normalize(AngleState.bc, AngleState.bc);
+        Vec3.scale(AngleState.ba, AngleState.ba, AngleState.radius);
+        Vec3.scale(AngleState.bc, AngleState.bc, AngleState.radius);
+
+        addEllipseMesh(context, state, node, {
+            kind: 'ellipse',
+            as_circle: true,
+            center: AngleState.b as any,
+            major_axis_endpoint: null,
+            major_axis: AngleState.ba as any,
+            minor_axis_endpoint: null,
+            minor_axis: AngleState.bc as any,
+            radius_major: AngleState.radius,
+            radius_minor: AngleState.radius,
+            theta_start: 0,
+            theta_end: angle,
+            color: params.section_color,
+            tooltip: label,
+        });
+    }
+}
+
+function addAngleLabel(context: PrimitiveBuilderContext, state: LabelBuilderState, node: MVSNode<'primitive'>, params: PrimitiveParams<'angle_measurement'>) {
+    const { labels, groups } = state;
+    const label = syncAngleState(context, params);
+
+    Vec3.normalize(AngleState.ba, AngleState.ba);
+    Vec3.normalize(AngleState.bc, AngleState.bc);
+    Vec3.scale(AngleState.ba, AngleState.ba, AngleState.radius);
+    Vec3.scale(AngleState.bc, AngleState.bc, AngleState.radius);
+
+    let size: number | undefined;
+    if (typeof params.label_size === 'number') {
+        size = params.label_size;
+    } else {
+        size = Math.max(AngleState.radius * (params.label_auto_size_scale), params.label_auto_size_min);
+    }
+
+    Vec3.add(AngleState.labelPos, AngleState.ba, AngleState.bc);
+    Vec3.normalize(AngleState.labelPos, AngleState.labelPos);
+    Vec3.scale(AngleState.labelPos, AngleState.labelPos, AngleState.radius);
+    Vec3.add(AngleState.labelPos, AngleState.labelPos, AngleState.b);
+
+    const group = groups.allocateSingle(node);
+    groups.updateColor(group, params.label_color);
+    groups.updateSize(group, size);
+
+    labels.add(label, AngleState.labelPos[0], AngleState.labelPos[1], AngleState.labelPos[2], 1, 1, group);
+}
+
 function resolveLabelRefs(params: PrimitiveParams<'label'>, refs: Set<string>) {
     addRef(params.position, refs);
 }
@@ -808,16 +930,17 @@ const EllipseState = {
     minorAxis: Vec3.zero(),
     scale: Vec3.zero(),
     normal: Vec3.zero(),
-    rotationAxis: Vec3.zero(),
     scaleXform: Mat4.identity(),
     rotationXform: Mat4.identity(),
     translationXform: Mat4.identity(),
-    xform: Mat4.zero(),
+    xform: Mat4.identity(),
 };
 
 
 function addEllipseMesh(context: PrimitiveBuilderContext, state: MeshBuilderState, node: MVSNode<'primitive'>, params: PrimitiveParams<'ellipse'>) {
     // Unit circle in the XZ plane (Y up)
+    // X = minor axis, Y = normal, Z = major axis
+
     const circle = getCircle({ thetaStart: params.theta_start, thetaEnd: params.theta_end });
     if (!circle) return;
 
@@ -849,16 +972,17 @@ function addEllipseMesh(context: PrimitiveBuilderContext, state: MeshBuilderStat
     } else {
         const major = params.radius_major ?? Vec3.magnitude(EllipseState.majorAxis);
         const minor = params.radius_minor ?? Vec3.magnitude(EllipseState.minorAxis);
-        Vec3.set(EllipseState.scale, major, 1, minor);
+        Vec3.set(EllipseState.scale, minor, 1, major);
     }
     Mat4.fromScaling(EllipseState.scaleXform, EllipseState.scale);
 
     // Rotation
+    Vec3.normalize(EllipseState.minorAxis, EllipseState.minorAxis);
+    Vec3.normalize(EllipseState.majorAxis, EllipseState.majorAxis);
     Vec3.cross(EllipseState.normal, EllipseState.majorAxis, EllipseState.minorAxis);
-    Vec3.normalize(EllipseState.normal, EllipseState.normal);
-    Vec3.cross(EllipseState.rotationAxis, Vec3.unitY, EllipseState.normal);
-    Vec3.normalize(EllipseState.rotationAxis, EllipseState.rotationAxis);
-    Mat4.fromRotation(EllipseState.rotationXform, -Vec3.angle(Vec3.unitY, EllipseState.normal), EllipseState.rotationAxis);
+
+    Mat4.targetTo(EllipseState.rotationXform, Vec3.origin, EllipseState.majorAxis, EllipseState.normal);
+    Mat4.mul(EllipseState.rotationXform, EllipseState.rotationXform, Mat4.rotY180);
 
     // Final xform
     Mat4.mul3(EllipseState.xform, EllipseState.translationXform, EllipseState.rotationXform, EllipseState.scaleXform);

--- a/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-primitives.ts
@@ -122,6 +122,37 @@ const DistanceMeasurementParams = {
     label_color: OptionalField(nullable(ColorT), null, 'Color of the label. If not specified, uses the parent primitives group `label_color`.'),
 };
 
+const AngleMeasurementParams = {
+    /** Point A. */
+    a: RequiredField(PrimitivePositionT, 'Point A.'),
+    /** Point B. */
+    b: RequiredField(PrimitivePositionT, 'Point B.'),
+    /** Point C. */
+    c: RequiredField(PrimitivePositionT, 'Point C.'),
+    /** Template used to construct the label. Use {{angle}} as placeholder for the angle in radians. */
+    label_template: OptionalField(str, '{{angle}}', 'Template used to construct the label. Use {{angle}} as placeholder for the angle in radians.'),
+    /** Size of the label (text height in Angstroms). If not specified, size will be relative to the distance (see label_auto_size_scale, label_auto_size_min). */
+    label_size: OptionalField(nullable(float), null, 'Size of the label (text height in Angstroms). If not specified, size will be relative to the distance (see label_auto_size_scale, label_auto_size_min).'),
+    /** Scaling factor for relative size. */
+    label_auto_size_scale: OptionalField(float, 0.33, 'Scaling factor for relative size.'),
+    /** Minimum size for relative size. */
+    label_auto_size_min: OptionalField(float, 0, 'Minimum size for relative size.'),
+    /** Color of the label. If not specified, uses the parent primitives group `label_color`. */
+    label_color: OptionalField(nullable(ColorT), null, 'Color of the label. If not specified, uses the parent primitives group `label_color`.'),
+    /** Draw vectors between (a, b) and (b, c). */
+    show_vector: OptionalField(bool, true, 'Draw vectors between (a, b) and (b, c).'),
+    /** Color of the vectors. */
+    vector_color: OptionalField(nullable(ColorT), null, 'Color of the vectors.'),
+    /** Draw a filled circle section representing the angle. */
+    show_section: OptionalField(bool, true, 'Draw a filled circle section representing the angle.'),
+    /** Color of the angle section. If not specified, the primitives group color is used. */
+    section_color: OptionalField(nullable(ColorT), null, 'Color of the angle section. If not specified, the primitives group color is used.'),
+    /** Radius of the angle section. In angstroms. */
+    section_radius: OptionalField(nullable(float), null, 'Radius of the angle section. In angstroms.'),
+    /** Factor to scale the radius of the angle section. Ignored if section_radius is set. */
+    section_radius_scale: OptionalField(float, 0.33, 'Factor to scale the radius of the angle section. Ignored if section_radius is set.'),
+};
+
 const PrimitiveLabelParams = {
     /** Position of this label. */
     position: RequiredField(PrimitivePositionT, 'Position of this label.'),
@@ -211,6 +242,7 @@ export const MVSPrimitiveParams = UnionParamsSchema(
         'tube': SimpleParamsSchema(TubeParams),
         'arrow': SimpleParamsSchema(ArrowParams),
         'distance_measurement': SimpleParamsSchema(DistanceMeasurementParams),
+        'angle_measurement': SimpleParamsSchema(AngleMeasurementParams),
         'label': SimpleParamsSchema(PrimitiveLabelParams),
         'ellipse': SimpleParamsSchema(EllipseParams),
         'ellipsoid': SimpleParamsSchema(EllipsoidParams),


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Goes with https://github.com/molstar/mol-view-spec/pull/48
- [x] MVS: Add angle measurement primitive

```py
builder = create_builder()
primitives = builder.primitives()
primitives.angle(
    a=(2, 1, 1),
    b=(1, 1, 1),
    c=(2, 2, 1),
    section_color="blue",
    section_radius_scale=0.5,
    vector_color="red",
    label_color="green",
)

return PlainTextResponse(builder.get_state())
```
![image](https://github.com/user-attachments/assets/2a8ceaff-a82e-43a4-8bd9-39504ebefce0)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
