### PR TITLE
Fix arrow primitives orientation and `Vec3.makeRotation` behavior when along [0, -1, 0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Sequence panel: Mark focused loci (bold+underline)
 - Change modifier key behavior in Normal Mode (default = select only, Ctrl/Cmd = add to selection, Shift = extend last selected range)
 - Handle Firefox's limit on vertex ids per draw (#1116)
+- Fix behavior of `Vec3.makeRotation(out, a, b)` when `a ≈ -b`
 
 ## [v4.10.0] - 2024-12-15
 

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -7,7 +7,7 @@
 
 import { Lines } from '../../../mol-geo/geometry/lines/lines';
 import { LinesBuilder } from '../../../mol-geo/geometry/lines/lines-builder';
-import { addCylinder, addFixedCountDashedCylinder, addSimpleCylinder, BasicCylinderProps } from '../../../mol-geo/geometry/mesh/builder/cylinder';
+import { addFixedCountDashedCylinder, addSimpleCylinder, BasicCylinderProps } from '../../../mol-geo/geometry/mesh/builder/cylinder';
 import { addEllipsoid } from '../../../mol-geo/geometry/mesh/builder/ellipsoid';
 import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
@@ -698,7 +698,7 @@ function addArrowMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBu
     const startRadius = params.start_cap_radius ?? tubeRadius;
     if (params.show_start_cap) {
         Vec3.scaleAndAdd(ArrowState.startCap, ArrowState.start, ArrowState.dir, startRadius);
-        addCylinder(mesh, ArrowState.start, ArrowState.startCap, 1, {
+        addSimpleCylinder(mesh, ArrowState.startCap, ArrowState.start, {
             radiusBottom: startRadius,
             radiusTop: 0,
             topCap: false,
@@ -712,7 +712,7 @@ function addArrowMesh(context: PrimitiveBuilderContext, { groups, mesh }: MeshBu
     const endRadius = params.end_cap_radius ?? tubeRadius;
     if (params.show_end_cap) {
         Vec3.scaleAndAdd(ArrowState.endCap, ArrowState.end, ArrowState.dir, -endRadius);
-        addCylinder(mesh, ArrowState.end, ArrowState.endCap, 1, {
+        addSimpleCylinder(mesh, ArrowState.endCap, ArrowState.end, {
             radiusBottom: endRadius,
             radiusTop: 0,
             topCap: false,

--- a/src/mol-math/linear-algebra/3d/vec3.ts
+++ b/src/mol-math/linear-algebra/3d/vec3.ts
@@ -584,8 +584,8 @@ namespace Vec3 {
         const by = angle(a, b);
         if (Math.abs(by) < 0.0001) return Mat4.setIdentity(mat);
         if (Math.abs(by - Math.PI) < EPSILON) {
-            // here, axis can be [0,0,0] but the rotation is a simple flip
-            return Mat4.fromScaling(mat, negUnit);
+            // choose arbitrary orthogonal axis
+            return Mat4.fromRotation(mat, Math.PI, Math.abs(a[0]) < 0.9 ? Vec3.unitX : Vec3.unitZ);
         }
         const axis = cross(rotTemp, a, b);
         return Mat4.fromRotation(mat, by, axis);


### PR DESCRIPTION
# Description

 . | [Case 1](http://localhost:1338/build/viewer/?mvs-data={%22kind%22:%22single%22,%22root%22:{%22kind%22:%22root%22,%22children%22:[{%22kind%22:%22primitives%22,%22children%22:[{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[0,-1,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}},{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[0,1,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}},{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[-1,0,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}},{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[1,0,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}}]}]},%22metadata%22:{%22timestamp%22:%222025-02-19T05:06:37.158240+00:00%22,%22version%22:%221.1%22}}) | [Case 2](http://localhost:1338/build/viewer/?mvs-data={%22kind%22:%22single%22,%22root%22:{%22kind%22:%22root%22,%22children%22:[{%22kind%22:%22primitives%22,%22children%22:[{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[0.5,0.5,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}},{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[-0.5,0.5,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}},{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[0.5,-0.5,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}},{%22kind%22:%22primitive%22,%22params%22:{%22kind%22:%22arrow%22,%22start%22:[0,0,0],%22end%22:[-0.5,-0.5,0],%22tube_radius%22:0.05,%22show_end_cap%22:true}}]}]},%22metadata%22:{%22timestamp%22:%222025-02-19T05:06:37.158240+00:00%22,%22version%22:%221.1%22}})
--- | --- | ---
before | ![pre1](https://github.com/user-attachments/assets/34051e27-897a-42c2-a2a9-5ddd2abc7735) |  ![pre2](https://github.com/user-attachments/assets/d04a1a30-c03c-4c3d-a854-28046f31c904)
fixed | ![post1](https://github.com/user-attachments/assets/5c2b5566-08e9-4950-ba34-60973604c3ef) | ![post2](https://github.com/user-attachments/assets/f043ddb1-7cbf-44dc-b11a-de60c28a2cc9)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`