### PR TITLE
Implement ColorScale.createDiscrete, fix UI color palette bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ Note that since we don't clearly distinguish between a public and private interf
 - Ignore `renderables` with empty draw count
 - Add experimental support for `esbuild` for development.
   - Use `npm run dev` for faster development builds
-
+- Implementation of `ColorScale.createDiscrete` (#1458)
+- Add `ColorScale.createDiscrete` to the `uncertainty` color theme
+- Fix color palette shown in the UI (for non-gradient palettes)
+- Fix colors description in the UI (when using custom thresholds)
+- Fix an edge case in the UI when the user deletes all colors from the color list
 
 ## [v4.12.0] - 2025-02-28
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "Xavier Martinez <xavier.martinez.xm@gmail.com>",
     "Alex Chan <smalldirkalex@gmail.com>",
     "Simeon Borko <simeon.borko@gmail.com>",
-    "Ventura Rivera <venturaxrivera@gmail.com>"
+    "Ventura Rivera <venturaxrivera@gmail.com>",
+    "Lukáš Polák <admin@lukaspolak.cz>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -704,6 +704,9 @@ const colorGradientBanded = memoize1((colors: ColorListEntry[]) => {
         if (!off[0]) {
             return 'linear-gradient(to right, #000 0%, #000 100%)';
         }
+        if (off[0][1] > off[off.length - 1][1]) {
+            off.reverse();
+        }
         styles.push(`${Color.toStyle(off[0][0])} ${(100 * off[0][1]).toFixed(2)}%`);
         for (let i = 0, il = off.length - 1; i < il; ++i) {
             const [c0, o0] = off[i];

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -690,11 +690,19 @@ function colorEntryToStyle(e: ColorListEntry, includeOffset = false) {
 }
 
 const colorGradientInterpolated = memoize1((colors: ColorListEntry[]) => {
-    const off = [...colors] as [Color, number][];
-    if (off[0][1] > off[off.length - 1][1]) {
-        off.reverse();
+    if (colors.length === 0) return 'linear-gradient(to right, #000 0%, #000 100%)';
+
+    const hasOffsets = colors.every(c => Array.isArray(c));
+    let styles;
+
+    if (hasOffsets) {
+        const off = [...colors] as [Color, number][];
+        off.sort((a, b) => a[1] - b[1]);
+        styles = off.map(c => colorEntryToStyle(c, true));
+    } else {
+        styles = colors.map(c => colorEntryToStyle(c));
     }
-    const styles = off.map(c => colorEntryToStyle(c, true));
+
     return `linear-gradient(to right, ${styles.join(', ')})`;
 });
 
@@ -709,9 +717,7 @@ const colorGradientBanded = memoize1((colors: ColorListEntry[]) => {
         if (!off[0]) {
             return 'linear-gradient(to right, #000 0%, #000 100%)';
         }
-        if (off[0][1] > off[off.length - 1][1]) {
-            off.reverse();
-        }
+        off.sort((a, b) => a[1] - b[1]);
         styles.push(`${Color.toStyle(off[0][0])} ${(100 * off[0][1]).toFixed(2)}%`);
         for (let i = 0, il = off.length - 1; i < il; ++i) {
             const [c0, o0] = off[i];

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -700,7 +700,7 @@ const colorGradientBanded = memoize1((colors: ColorListEntry[]) => {
 
     const hasOffsets = colors.every(c => Array.isArray(c));
     if (hasOffsets) {
-        const off = colors as [Color, number][];
+        const off = [...colors] as [Color, number][];
         // 0 colors present
         if (!off[0]) {
             return 'linear-gradient(to right, #000 0%, #000 100%)';

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -690,7 +690,11 @@ function colorEntryToStyle(e: ColorListEntry, includeOffset = false) {
 }
 
 const colorGradientInterpolated = memoize1((colors: ColorListEntry[]) => {
-    const styles = colors.map(c => colorEntryToStyle(c, true));
+    const off = [...colors] as [Color, number][];
+    if (off[0][1] > off[off.length - 1][1]) {
+        off.reverse();
+    }
+    const styles = off.map(c => colorEntryToStyle(c, true));
     return `linear-gradient(to right, ${styles.join(', ')})`;
 });
 

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -700,6 +700,10 @@ const colorGradientBanded = memoize1((colors: ColorListEntry[]) => {
     const hasOffsets = colors.every(c => Array.isArray(c));
     if (hasOffsets) {
         const off = colors as [Color, number][];
+        // 0 colors present
+        if (!off[0]) {
+            return 'linear-gradient(to right, #000 0%, #000 100%)';
+        }
         styles.push(`${Color.toStyle(off[0][0])} ${(100 * off[0][1]).toFixed(2)}%`);
         for (let i = 0, il = off.length - 1; i < il; ++i) {
             const [c0, o0] = off[i];
@@ -712,7 +716,7 @@ const colorGradientBanded = memoize1((colors: ColorListEntry[]) => {
         }
         styles.push(`${Color.toStyle(off[off.length - 1][0])} ${(100 * off[off.length - 1][1]).toFixed(2)}%`);
     } else {
-        const styles: string[] = [`${colorEntryToStyle(colors[0])} ${100 * (1 / n)}%`];
+        styles.push(`${colorEntryToStyle(colors[0])} ${100 * (1 / n)}%`);
         for (let i = 1, il = n - 1; i < il; ++i) {
             styles.push(
                 `${colorEntryToStyle(colors[i])} ${100 * (i / n)}%`,
@@ -817,7 +821,11 @@ export class ColorListControl extends React.PureComponent<ParamProps<PD.ColorLis
         const preset = ColorPresets[this.props.param.presetKind];
         if (this.state.show === 'presets') return <ActionMenu items={preset} onSelect={this.selectPreset} />;
 
-        const values = this.props.value.colors.map(color => ({ color }));
+        // It might happen that the colors are either in the form of [Color, number] or just Color, show them as just Color
+        const values = this.props.value.colors.map(color => ({
+            color: Array.isArray(color) ? color[0] : color
+        }));
+
         return <div className='msp-control-offset'>
             <ObjectListControl name='colors' param={ColorsParam} value={values} onChange={this.colorsChanged} isDisabled={this.props.isDisabled} onEnter={this.props.onEnter} />
             <BoolControl name='isInterpolated' param={IsInterpolatedParam} value={this.props.value.kind === 'interpolate'} onChange={this.isInterpolatedChanged} isDisabled={this.props.isDisabled} onEnter={this.props.onEnter} />

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Lukáš Polák <admin@lukaspolak.cz>
  */
 
 import * as React from 'react';

--- a/src/mol-theme/color/uncertainty.ts
+++ b/src/mol-theme/color/uncertainty.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Lukáš Polák <admin@lukaspolak.cz>
  */
 
 import { Color, ColorScale } from '../../mol-util/color';
@@ -35,11 +36,21 @@ export function getUncertainty(unit: Unit, element: ElementIndex): number {
 }
 
 export function UncertaintyColorTheme(ctx: ThemeDataContext, props: PD.Values<UncertaintyColorThemeParams>): ColorTheme<UncertaintyColorThemeParams> {
-    const scale = ColorScale.create({
-        reverse: true,
-        domain: props.domain,
-        listOrName: props.list.colors,
-    });
+    let scale: ColorScale;
+
+    if (props.list.kind === "set") {
+        scale = ColorScale.createDiscrete({
+            reverse: true,
+            domain: props.domain,
+            listOrName: props.list.colors
+        });
+    } else {
+        scale = ColorScale.create({
+            reverse: true,
+            domain: props.domain,
+            listOrName: props.list.colors
+        });
+    }
 
     // TODO calc domain based on data, set min/max as 10/90 percentile to be robust against outliers
 

--- a/src/mol-util/color/scale.ts
+++ b/src/mol-util/color/scale.ts
@@ -35,13 +35,22 @@ export const DefaultColorScaleProps = {
 };
 export type ColorScaleProps = Partial<typeof DefaultColorScaleProps>
 
+type ColorScaleType = 'continuous' | 'discrete'
+
 export namespace ColorScale {
     export function create(props: ColorScaleProps): ColorScale {
+        return createColorScaleByType(props, 'continuous');
+    }
+
+    export function createDiscrete(props: ColorScaleProps): ColorScale {
+        return createColorScaleByType(props, 'discrete');
+    }
+
+    function createColorScaleByType(props: ColorScaleProps, type: ColorScaleType): ColorScale {
         const { domain, reverse, listOrName } = { ...DefaultColorScaleProps, ...props };
         const list = typeof listOrName === 'string' ? getColorListFromName(listOrName).list : listOrName;
 
         const colors = reverse ? list.slice().reverse() : list;
-        const count1 = colors.length - 1;
 
         let diff = 0, min = 0, max = 0;
         function setDomain(_min: number, _max: number) {
@@ -65,29 +74,15 @@ export namespace ColorScale {
             const off = SortedArray.ofSortedArray(sorted.map(c => c[1]));
             const max = src.length - 1;
 
-            color = (v: number) => {
-                const t = clamp((v - min) / diff, 0, 1);
-                const i = SortedArray.findPredecessorIndex(off, t);
-
-                if (i === 0) {
-                    return src[min];
-                } else if (i > max) {
-                    return src[max];
-                }
-
-                const o1 = off[i - 1], o2 = off[i];
-                const t1 = clamp((t - o1) / (o2 - o1), 0, 1); // TODO: cache the deltas?
-
-                return Color.interpolate(src[i - 1], src[i], t1);
-            };
+            switch (type) {
+                case 'continuous': color = (value: number) => valueToColorWithOffsets(value, src, off, min, max, diff); break;
+                case 'discrete': color = (value: number) => valueToDiscreteColorWithOffsets(value, src, off, min, max, diff); break;
+            }
         } else {
-            color = (value: number) => {
-                const t = Math.min(colors.length - 1, Math.max(0, ((value - min) / diff) * count1));
-                const tf = Math.floor(t);
-                const c1 = colors[tf] as Color;
-                const c2 = colors[Math.ceil(t)] as Color;
-                return Color.interpolate(c1, c2, t - tf);
-            };
+            switch (type) {
+                case 'continuous': color = (value: number) => valueToColor(value, colors, min, max, diff); break;
+                case 'discrete': color = (value: number) => valueToDiscreteColor(value, colors, min, max, diff); break;
+            }
         }
         return {
             color,
@@ -102,81 +97,62 @@ export namespace ColorScale {
         };
     }
 
-    export function createDiscrete(props: ColorScaleProps): ColorScale {
-        const { domain, reverse, listOrName } = { ...DefaultColorScaleProps, ...props };
-        const list = typeof listOrName === 'string' ? getColorListFromName(listOrName).list : listOrName;
+    function valueToColorWithOffsets(value: number, src: Color[], off: SortedArray<number>, min: number, max: number, diff: number) {
+        const t = clamp((value - min) / diff, 0, 1);
+        const i = SortedArray.findPredecessorIndex(off, t);
 
-        const colors = reverse ? list.slice().reverse() : list;
-
-        let diff = 0, min = 0, max = 0;
-        function setDomain(_min: number, _max: number) {
-            min = _min;
-            max = _max;
-            diff = (max - min) || 1;
-        }
-        setDomain(domain[0], domain[1]);
-
-        const minLabel = defaults(props.minLabel, min.toString());
-        const maxLabel = defaults(props.maxLabel, max.toString());
-
-        let color: (v: number) => Color;
-
-        const hasOffsets = colors.every(c => Array.isArray(c));
-        if (hasOffsets) {
-            const sorted = [...colors] as [Color, number][];
-            sorted.sort((a, b) => a[1] - b[1]);
-
-            const src = sorted.map(c => c[0]);
-            const off = SortedArray.ofSortedArray(sorted.map(c => c[1]));
-            const max = src.length - 1;
-
-            color = (value: number) => {
-                if (colors.length === 0) {
-                    return Color.fromRgb(0, 0, 0);
-                }
-
-                const t = clamp((value - min) / diff, 0, 1);
-                const i = SortedArray.findPredecessorIndex(off, t);
-
-                if (i === 0) {
-                    return src[min] as Color;
-                } else if (i > max) {
-                    return src[max] as Color;
-                }
-
-                return src[i] as Color;
-            };
-        } else {
-            color = (value: number) => {
-                if (colors.length === 0) {
-                    return Color.fromRgb(0, 0, 0);
-                }
-
-                const intervalSize = diff / colors.length;
-
-                if (value <= min) {
-                    return colors[0] as Color;
-                } else if (value >= max) {
-                    return colors[colors.length - 1] as Color;
-                }
-
-                const i = Math.min(colors.length - 1, Math.floor((value - min) / intervalSize));
-                const ifl = Math.floor(i);
-
-                return colors[ifl] as Color;
-            };
+        if (i === 0) {
+            return src[min];
+        } else if (i > max) {
+            return src[max];
         }
 
-        return {
-            color,
-            colorToArray: (value: number, array: NumberArray, offset: number) => {
-                Color.toArray(color(value), array, offset);
-            },
-            normalizedColorToArray: (value: number, array: NumberArray, offset: number) => {
-                Color.toArrayNormalized(color(value), array, offset);
-            },
-            setDomain,
-            get legend() { return ScaleLegend(minLabel, maxLabel, colors); }
-        };
+        const o1 = off[i - 1], o2 = off[i];
+        const t1 = clamp((t - o1) / (o2 - o1), 0, 1); // TODO: cache the deltas?
+
+        return Color.interpolate(src[i - 1], src[i], t1);
+    }
+
+    function valueToColor(value: number, colors: ColorListEntry[], min: number, max: number, diff: number) {
+        const t = Math.min(colors.length - 1, Math.max(0, ((value - min) / diff) * colors.length - 1));
+        const tf = Math.floor(t);
+        const c1 = colors[tf] as Color;
+        const c2 = colors[Math.ceil(t)] as Color;
+        return Color.interpolate(c1, c2, t - tf);
+    }
+
+    function valueToDiscreteColorWithOffsets(value: number, src: Color[], off: SortedArray<number>, min: number, max: number, diff: number) {
+        if (src.length === 0) {
+            return Color.fromRgb(0, 0, 0);
+        }
+
+        const t = clamp((value - min) / diff, 0, 1);
+        const i = SortedArray.findPredecessorIndex(off, t);
+
+        if (i === 0) {
+            return src[min] as Color;
+        } else if (i > max) {
+            return src[max] as Color;
+        }
+
+        return src[i] as Color;
+    }
+
+    function valueToDiscreteColor(value: number, colors: ColorListEntry[], min: number, max: number, diff: number) {
+        if (colors.length === 0) {
+            return Color.fromRgb(0, 0, 0);
+        }
+
+        const intervalSize = diff / colors.length;
+
+        if (value <= min) {
+            return colors[0] as Color;
+        } else if (value >= max) {
+            return colors[colors.length - 1] as Color;
+        }
+
+        const i = Math.min(colors.length - 1, Math.floor((value - min) / intervalSize));
+
+        return colors[i] as Color;
     }
 }

--- a/src/mol-util/color/scale.ts
+++ b/src/mol-util/color/scale.ts
@@ -176,7 +176,7 @@ export namespace ColorScale {
                 Color.toArrayNormalized(color(value), array, offset);
             },
             setDomain,
-            get legend() { return ScaleLegend(minLabel, maxLabel, [Color(0xff0000), Color(0x00ff00)]); }
+            get legend() { return ScaleLegend(minLabel, maxLabel, colors); }
         };
     }
 }

--- a/src/mol-util/color/scale.ts
+++ b/src/mol-util/color/scale.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Lukáš Polák <admin@lukaspolak.cz>
  */
 
 import { Color, ColorListEntry } from './color';
@@ -98,6 +99,84 @@ export namespace ColorScale {
             },
             setDomain,
             get legend() { return ScaleLegend(minLabel, maxLabel, colors); }
+        };
+    }
+
+    export function createDiscrete(props: ColorScaleProps): ColorScale {
+        const { domain, reverse, listOrName } = { ...DefaultColorScaleProps, ...props };
+        const list = typeof listOrName === 'string' ? getColorListFromName(listOrName).list : listOrName;
+
+        const colors = reverse ? list.slice().reverse() : list;
+
+        let diff = 0, min = 0, max = 0;
+        function setDomain(_min: number, _max: number) {
+            min = _min;
+            max = _max;
+            diff = (max - min) || 1;
+        }
+        setDomain(domain[0], domain[1]);
+
+        const minLabel = defaults(props.minLabel, min.toString());
+        const maxLabel = defaults(props.maxLabel, max.toString());
+
+        let color: (v: number) => Color;
+
+        const hasOffsets = colors.every(c => Array.isArray(c));
+        if (hasOffsets) {
+            const sorted = [...colors] as [Color, number][];
+            sorted.sort((a, b) => a[1] - b[1]);
+
+            const src = sorted.map(c => c[0]);
+            const off = SortedArray.ofSortedArray(sorted.map(c => c[1]));
+            const max = src.length - 1;
+
+            color = (value: number) => {
+                if (colors.length === 0) {
+                    return Color.fromRgb(0, 0, 0);
+                }
+
+                const t = clamp((value - min) / diff, 0, 1);
+                const i = SortedArray.findPredecessorIndex(off, t);
+
+                if (i === 0) {
+                    return src[min] as Color;
+                } else if (i > max) {
+                    return src[max] as Color;
+                }
+
+                return src[i] as Color;
+            };
+        } else {
+            color = (value: number) => {
+                if (colors.length === 0) {
+                    return Color.fromRgb(0, 0, 0);
+                }
+
+                const intervalSize = diff / colors.length;
+
+                if (value <= min) {
+                    return colors[0] as Color;
+                } else if (value >= max) {
+                    return colors[colors.length - 1] as Color;
+                }
+
+                const i = Math.min(colors.length - 1, Math.floor((value - min) / intervalSize));
+                const ifl = Math.floor(i);
+
+                return colors[ifl] as Color;
+            };
+        }
+
+        return {
+            color,
+            colorToArray: (value: number, array: NumberArray, offset: number) => {
+                Color.toArray(color(value), array, offset);
+            },
+            normalizedColorToArray: (value: number, array: NumberArray, offset: number) => {
+                Color.toArrayNormalized(color(value), array, offset);
+            },
+            setDomain,
+            get legend() { return ScaleLegend(minLabel, maxLabel, [Color(0xff0000), Color(0x00ff00)]); }
         };
     }
 }


### PR DESCRIPTION
# Description

- Implementation of `ColorScale.createDiscrete`, as discussed in #1458 
- `ColorScale.createDiscrete` used in the `uncertainty` color theme
- Fix color palette shown in the UI (for non-gradient palettes)
- Fix colors description in the UI (when using custom thresholds)
- Fix an edge case in the UI when the user deletes all colors from the color list when interpolation is disabled

Feel free to leave any further comments, I will be glad to improve the code if needed.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`