### PR TITLE
Loadstyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
-
+- Created a way to load a file of colors mapped to asym_id chain id values.
 - Fix PDBj structure data URL
 - Improve logic when to cull in renderer
 

--- a/src/mol-io/reader/ribocode/color.ts
+++ b/src/mol-io/reader/ribocode/color.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2025-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Andy Turner <agdturner@gmail.com>
+ */
+
+export interface SimpleData {
+    pdb_chain: string;
+    color: string;
+}
+
+// This function reads a JSON file and returns a promise that resolves to a Map object
+// The file is expected to be a JSON file with the following format:
+// {pdb_chain: color}
+// Where:
+// pdb_chain is the name of the PDB chain (e.g. 4ug0_LY)
+// color is a hex color code (e.g. #FF0000)
+export async function readJSONFile(file: File): Promise<SimpleData[]> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            try {
+                const text = event.target?.result as string;
+                const data = JSON.parse(text);
+                const transformedData = data.map((item: { pdb_chain: string; color: string }) => ({
+                    pdb_chain: item.pdb_chain,
+                    color: item.color
+                }));
+                resolve(transformedData);
+            } catch (error) {
+                reject(error);
+            }
+        };
+        reader.onerror = (error) => reject(error);
+        reader.readAsText(file);
+    });
+}
+
+export interface Data {
+    pdb_name: string;
+    RP_name: string;
+    color: string;
+    pdb_id: string;
+    pdb_chain: string;
+}
+
+// This function reads a file and returns a promise that resolves to an array of Data objects
+// The file is expected to be a text file with the following format:
+// pdb_name RP_name class color
+// Where:
+// pdb_name is the name of the PDB chain (e.g. 4ug0_LY)
+// RP_name is the name of the ribosomal protein (e.g. RPL26)
+// class is an integer representing the color class (e.g. 1) - this is ignored for now
+// color is a hex color code (e.g. #FF0000)
+export async function readFile(file: File): Promise<Data[]> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            const text = event.target?.result as string;
+            const lines = text.split('\n');
+            const data: Data[] = [];
+            if (lines.length > 0) {
+                const header = lines[0];
+                console.log('Filename:', file.name);
+                console.log('Header:', header);
+            }
+            for (let i = 1; i < lines.length; i++) {
+                const line = lines[i];
+                if (line.trim() === '') continue;
+                const [pdb_name, RP_name, , colorStr] = line.split(' ');
+                const [pdb_id, pdb_chain] = pdb_name.split('_');
+                data.push({
+                    pdb_name,
+                    RP_name,
+                    //class: parseInt(classStr, 10),
+                    color: colorStr, // Can later be parsed using mol-util.color.color.Color.fromHexStyle(colorStr),
+                    pdb_id,
+                    pdb_chain
+                });
+            }
+            resolve(data);
+        };
+        reader.onerror = (error) => reject(error);
+        reader.readAsText(file);
+    });
+}

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Andy Turner <agdturner@gmail.com>
  */
 
 import * as React from 'react';

--- a/src/mol-plugin-ui/structure/quick-styles.tsx
+++ b/src/mol-plugin-ui/structure/quick-styles.tsx
@@ -5,7 +5,6 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Adam Midlik <midlik@gmail.com>
  */
-
 import { PostprocessingParams } from '../../mol-canvas3d/passes/postprocessing';
 import { PresetStructureRepresentations } from '../../mol-plugin-state/builder/structure/representation-preset';
 import { PluginConfig } from '../../mol-plugin/config';
@@ -15,7 +14,6 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import { CollapsableControls, PurePluginUIComponent } from '../base';
 import { Button } from '../controls/common';
 import { MagicWandSvg } from '../controls/icons';
-
 
 export class StructureQuickStylesControls extends CollapsableControls {
     defaultState() {
@@ -41,7 +39,6 @@ interface QuickStylesState {
     busy: boolean,
     style: StyleName,
 }
-
 
 export class QuickStyles extends PurePluginUIComponent<{}, QuickStylesState> {
     state: QuickStylesState = { busy: false, style: 'default' };

--- a/src/mol-theme/color/chain-id.ts
+++ b/src/mol-theme/color/chain-id.ts
@@ -33,7 +33,7 @@ export function getChainIdColorThemeParams(ctx: ThemeDataContext) {
 
 type AsymIdType = 'auth' | 'label';
 
-function getAsymId(unit: Unit, type: AsymIdType): StructureElement.Property<string> {
+export function getAsymId(unit: Unit, type: AsymIdType): StructureElement.Property<string> {
     switch (unit.kind) {
         case Unit.Kind.Atomic:
             return type === 'auth'
@@ -45,7 +45,7 @@ function getAsymId(unit: Unit, type: AsymIdType): StructureElement.Property<stri
     }
 }
 
-function getAsymIdKey(location: StructureElement.Location, type: AsymIdType) {
+export function getAsymIdKey(location: StructureElement.Location, type: AsymIdType) {
     const asymId = getAsymId(location.unit, type)(location);
     return location.structure.root.models.length > 1
         ? getKey(location.unit.model, asymId)
@@ -126,3 +126,30 @@ export const ChainIdColorThemeProvider: ColorTheme.Provider<ChainIdColorThemePar
     defaultValues: PD.getDefaultValues(ChainIdColorThemeParams),
     isApplicable: (ctx: ThemeDataContext) => !!ctx.structure
 };
+
+export function saveColorTheme(themeParams: ChainIdColorThemeParams) {
+    const output = {
+        params: themeParams
+    };
+    const jsonString = JSON.stringify(output, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'color_theme.json';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+export function loadColorTheme(file: File): Promise<ChainIdColorThemeParams> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            const text = event.target?.result as string;
+            const json = JSON.parse(text);
+            resolve(json.params);
+        };
+        reader.onerror = (error) => reject(error);
+        reader.readAsText(file);
+    });
+}

--- a/src/mol-util/color/palette.ts
+++ b/src/mol-util/color/palette.ts
@@ -12,11 +12,11 @@ import { distinctColors, DistinctColorsParams } from './distinct';
 import { ColorListName, getColorListFromName } from './lists';
 import { ColorScale } from './scale';
 
-type PaletteType = 'generate' | 'colors'
+type PaletteType = 'generate' | 'colors';
 
 const DefaultGetPaletteProps = {
     type: 'generate' as PaletteType,
-    colorList: 'red-yellow-blue' as ColorListName
+    colorList: 'red-yellow-blue' as ColorListName,
 };
 type GetPaletteProps = typeof DefaultGetPaletteProps
 
@@ -30,7 +30,11 @@ export function getPaletteParams(props: Partial<GetPaletteProps> = {}) {
             generate: PD.Group({
                 ...DistinctColorsParams,
                 maxCount: PD.Numeric(75, { min: 1, max: 250, step: 1 }),
-            }, { isFlat: true })
+            }, { isFlat: true }),
+            load: PD.Group({
+                ...DistinctColorsParams,
+                maxCount: PD.Numeric(75, { min: 1, max: 250, step: 1 }),
+            })
         }, {
             options: [
                 ['colors', 'Color List'],


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
These changes allow users to load in colours. For example with 4ug0, you can load the attached file to colour in blue and orange the chains. To try this, download the structure 4ug0. Then in the Cartoon > Update 3D Representation > Chain Id ... > List 25 items > Colors 25 items > Scroll down the list to Browse... No file selected and action/click. Choose the file attached.

Currently the Json is written back out. This was because my colleagues use a different file format which can also optionally be loaded.

I suspect you might want a few changes in review, but thought this might be a useful contribution? I think I saw some discussion about others wanting functionality along these lines...   
[color_list.json](https://github.com/user-attachments/files/19136542/color_list.json)

## Actions

- [x ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`