### PR TITLE
fix: bond iterator starts from the same interbonds for every element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix color palette shown in the UI (for non-gradient palettes)
 - Fix colors description in the UI (when using custom thresholds)
 - Fix an edge case in the UI when the user deletes all colors from the color list
+- Fix `ElementBondIterator` indices mapping logic for inter-unit bonds
 
 ## [v4.12.0] - 2025-02-28
 

--- a/src/mol-model/structure/structure/unit/bonds.ts
+++ b/src/mol-model/structure/structure/unit/bonds.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2017-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { Unit, StructureElement } from '../../structure';
@@ -224,7 +225,7 @@ namespace Bond {
                 this.current.order = this.unit.bonds.edgeProps.order[this.intraBondIndex];
                 this.intraBondIndex += 1;
             } else if (this.interBondIndex < this.interBondCount) {
-                const b = this.structure.interUnitBonds.edges[this.interBondIndex];
+                const b = this.structure.interUnitBonds.edges[this.interBondIndices[this.interBondIndex]];
                 this.current.otherUnit = this.structure.unitMap.get(b.unitA !== this.unit.id ? b.unitA : b.unitB) as Unit.Atomic;
                 this.current.otherIndex = b.indexA !== this.index ? b.indexA : b.indexB;
                 this.current.type = b.props.flag;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
Using the ElementBondIterator in the case of the attachment point of a covalent ligand (FMN) in a dimer (8Q5F), we noticed a discrepancy between the chain A (no issue) and the chain B: undefined element index due to an out of bound `otherIndex` for the iterator.

This is due to the fact that, for inter unit bonds, the iteration always begins at index 0 in the array of edges. The mapping to the edge indices is missing in the iteration loop.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`