### PR TITLE
Improve struct_conn handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add `Unit.transientCache` and `Unit.getCopy`
 - Fix `ElementBondIterator` indices mapping logic for inter-unit bonds
 - Fix `pickPadding` and `pickScale` not updating `PickHelper`
+- Do not add bonds for pairs of residues that have a `struct_conn` entry
 
 ## [v4.12.0] - 2025-02-28
 

--- a/src/mol-model-formats/structure/mmcif.ts
+++ b/src/mol-model-formats/structure/mmcif.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -25,6 +25,7 @@ import { CCD_Database } from '../../mol-io/reader/cif/schema/ccd';
 import { EntityBuilder } from './common/entity';
 import { MoleculeType } from '../../mol-model/structure/model/types';
 import { ComponentBuilder } from './common/component';
+import { sortedCantorPairing } from '../../mol-data/util';
 
 function modelSymmetryFromMmcif(model: Model) {
     if (!MmcifFormat.is(model.sourceData)) return;
@@ -68,9 +69,16 @@ function structConnFromMmcif(model: Model) {
     const { struct_conn } = model.sourceData.data.db;
     if (struct_conn._rowCount === 0) return;
     const entries = StructConn.getEntriesFromStructConn(struct_conn, model);
+
+    const residueCantorPairs = new Set<number>();
+    for (const e of entries) {
+        residueCantorPairs.add(sortedCantorPairing(e.partnerA.residueIndex, e.partnerB.residueIndex));
+    }
+
     return {
         data: struct_conn,
         byAtomIndex: StructConn.getAtomIndexFromEntries(entries),
+        residueCantorPairs,
         entries,
     };
 }

--- a/src/mol-model-formats/structure/property/bonds/struct_conn.ts
+++ b/src/mol-model-formats/structure/property/bonds/struct_conn.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2025 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -21,6 +21,8 @@ import { FormatPropertyProvider } from '../../common/property';
 export interface StructConn {
     readonly data: Table<mmCIF_Schema['struct_conn']>
     readonly byAtomIndex: Map<ElementIndex, ReadonlyArray<StructConn.Entry>>
+    // Cantor pairs of residue indices that have a struct-conn record
+    readonly residueCantorPairs: Set<number>
     readonly entries: ReadonlyArray<StructConn.Entry>
 }
 

--- a/src/mol-model/structure/structure/unit/bonds/inter-compute.ts
+++ b/src/mol-model/structure/structure/unit/bonds/inter-compute.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2025 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -20,7 +20,7 @@ import { InterUnitGraph } from '../../../../../mol-math/graph/inter-unit-graph';
 import { StructConn } from '../../../../../mol-model-formats/structure/property/bonds/struct_conn';
 import { equalEps } from '../../../../../mol-math/linear-algebra/3d/common';
 import { Model } from '../../../model';
-import { cantorPairing, invertCantorPairing } from '../../../../../mol-data/util';
+import { cantorPairing, invertCantorPairing, sortedCantorPairing } from '../../../../../mol-data/util';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3distance = Vec3.distance;
@@ -179,6 +179,12 @@ function findPairBonds(unitA: Unit.Atomic, unitB: Unit.Atomic, props: BondComput
                 if (auth_seq_idA.value(residueIndexA[aI]) === auth_seq_idB.value(residueIndexB[bI])) {
                     continue;
                 }
+            }
+
+            if (structConn) {
+                const residuePair = sortedCantorPairing(residueIndexA[aI], residueIndexB[bI]);
+                // Do not add bonds for residue pairs that have a structConn entry
+                if (structConn.residueCantorPairs.has(residuePair)) continue;
             }
 
             const beI = getElementIdx(type_symbolB.value(bI)!);

--- a/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
+++ b/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2024 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2025 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -20,6 +20,7 @@ import { Vec3 } from '../../../../../mol-math/linear-algebra';
 import { ElementIndex } from '../../../model/indexing';
 import { equalEps } from '../../../../../mol-math/linear-algebra/3d/common';
 import { Model } from '../../../model/model';
+import { sortedCantorPairing } from '../../../../../mol-data/util';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3distance = Vec3.distance;
@@ -188,6 +189,10 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
                 hasStructConn = true;
                 structConnAdded.add(_bI);
             }
+
+            // Do not add bonds for residues that have a structConn entry
+            const residuePair = sortedCantorPairing(residueIndex[aI], residueIndex[aI]);
+            if (structConn?.residueCantorPairs.has(residuePair)) continue;
         }
         if (structConnExhaustive) continue;
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

PDB ID 6UH4 was adding an extra bond for focus visual despite a valid `struct_conn` record being present.
This PR improves this behavior by skipping computed bonds for residues pairs that have a `struct_conn` record.


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files