### PR TITLE
Fix command typo in docs: changed 'npm build' to 'npm run build' 

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -25,7 +25,7 @@ import { PluginContext } from 'molstar/lib/mol-plugin/context';
 git clone https://github.com/molstar/molstar.git
 cd molstar
 npm install
-npm build
+npm run build
 ```
 
 --------------------


### PR DESCRIPTION
Fix command typo: changed 'npm build' to 'npm run build'

<!-- Thank you for contributing to Mol* -->

# Description


## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [x] (Optional but encouraged) Improved documentation in `docs`