### PR TITLE
Update support for QA metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix `ElementBondIterator` indices mapping logic for inter-unit bonds
 - Fix `pickPadding` and `pickScale` not updating `PickHelper`
 - Do not add bonds for pairs of residues that have a `struct_conn` entry
+- Improved `ma_qa_metric` support
+  - Parse all local metrics
+  - Ability to select alternate metrics in the pLDDT/qmean themes
+  - Do not assume PAE plot is symmetric
 
 ## [v4.12.0] - 2025-02-28
 

--- a/src/examples/alphafolddb-pae/index.tsx
+++ b/src/examples/alphafolddb-pae/index.tsx
@@ -46,7 +46,7 @@ export class AlphaFoldPAEExample {
             const model = this.viewer.plugin.managers.structure.hierarchy.current.models[0]?.cell.obj?.data!;
             const metric = pairwiseMetricFromAlphaFoldDbJson(model, json)!;
 
-            createRoot(document.getElementById(this.plotContainerId)!).render(
+            plotRoot.render(
                 <div className='msp-plugin' style={{ background: 'white' }}>
                     <MAPairwiseScorePlot plugin={this.viewer.plugin} pairwiseMetric={metric} model={model} />
                 </div>

--- a/src/extensions/model-archive/quality-assessment/behavior.ts
+++ b/src/extensions/model-archive/quality-assessment/behavior.ts
@@ -166,7 +166,7 @@ function metricLabels(loci: Loci): string[] | undefined {
     for (const { metric, scoreSum, seenResidues } of seenMetrics) {
         let countInfo = '';
         if (seenResidues.size > 1) {
-            countInfo = ` <small>(${seenResidues.size} Residues avg.</small>`;
+            countInfo = ` <small>(${seenResidues.size} Residues avg.)</small>`;
         }
         const scoreAvg = scoreSum / seenResidues.size;
         const label = buildLabel(metric, scoreAvg, countInfo);

--- a/src/extensions/model-archive/quality-assessment/behavior.ts
+++ b/src/extensions/model-archive/quality-assessment/behavior.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-24 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-25 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -38,10 +38,7 @@ export const MAQualityAssessment = PluginBehavior.create<{ autoAttach: boolean, 
         private labelProvider = {
             label: (loci: Loci): string | undefined => {
                 if (!this.params.showTooltip) return;
-                return [
-                    plddtLabel(loci),
-                    qmeanLabel(loci),
-                ].filter(l => !!l).join('</br>');
+                return metricLabels(loci)?.join('</br>');
             }
         };
 
@@ -106,59 +103,77 @@ function plddtCategory(score: number) {
     return 'Very low';
 }
 
-function plddtLabel(loci: Loci): string | undefined {
-    return metricLabel(loci, 'pLDDT', (scoreAvg: number, countInfo: string) => `pLDDT Score ${countInfo}: ${scoreAvg.toFixed(2)} <small>(${plddtCategory(scoreAvg)})</small>`);
+function buildLabel(metric: QualityAssessment.Local, scoreAvg: number, countInfo: string) {
+    let label = metric.name;
+    if (metric.type !== metric.name) label += ` (${metric.type})`;
+    if (countInfo) label += countInfo;
+    label += `: ${scoreAvg.toFixed(2)}`;
+    if (metric.kind === 'pLDDT') label += ` <small>(${plddtCategory(scoreAvg)})</small>`;
+    return label;
 }
 
-function qmeanLabel(loci: Loci): string | undefined {
-    return metricLabel(loci, 'qmean', (scoreAvg: number, countInfo: string) => `QMEAN Score ${countInfo}: ${scoreAvg.toFixed(2)}`);
+interface MetricAggregate {
+    metric: QualityAssessment.Local,
+    scoreSum: number,
+    seenResidues: Set<number>,
 }
 
-function metricLabel(loci: Loci, name: 'qmean' | 'pLDDT', label: (scoreAvg: number, countInfo: string) => string): string | undefined {
-    if (loci.kind === 'element-loci') {
-        if (loci.elements.length === 0) return;
+function metricLabels(loci: Loci): string[] | undefined {
+    if (loci.kind !== 'element-loci') return;
+    if (loci.elements.length === 0) return;
 
-        const seen = new Set<number>();
-        const scoreSeen = new Set<number>();
-        let scoreSum = 0;
+    const seenMetrics: MetricAggregate[] = [];
+    const aggregates = new Map<string, MetricAggregate>();
 
-        for (const { indices, unit } of loci.elements) {
-            const metric = QualityAssessmentProvider.get(unit.model).value?.[name];
-            if (!metric) continue;
+    for (const { indices, unit } of loci.elements) {
+        const metrics = QualityAssessmentProvider.get(unit.model).value?.local;
+        if (!metrics) continue;
 
-            const residueIndex = unit.model.atomicHierarchy.residueAtomSegments.index;
-            const { elements } = unit;
+        const residueIndex = unit.model.atomicHierarchy.residueAtomSegments.index;
+        const { elements } = unit;
+
+        for (const metric of metrics) {
+            const key = `${metric.name}-${metric.type}`;
+            let aggregate = aggregates.get(key);
+            if (!aggregate) {
+                aggregate = { metric, scoreSum: 0, seenResidues: new Set() };
+                aggregates.set(key, aggregate);
+                seenMetrics.push(aggregate);
+            }
+
+            const values = metric.values;
+            const { seenResidues } = aggregate;
 
             OrderedSet.forEach(indices, idx => {
                 const eI = elements[idx];
                 const rI = residueIndex[eI];
 
                 const residueKey = cantorPairing(rI, unit.id);
-                if (!seen.has(residueKey)) {
-                    const score = metric.get(residueIndex[eI]) ?? -1;
-                    if (score !== -1) {
-                        scoreSum += score;
-                        scoreSeen.add(residueKey);
-                    }
-                    seen.add(residueKey);
-                }
+                if (seenResidues.has(residueKey)) return;
+
+                const score = values.get(residueIndex[eI]);
+                if (typeof score === 'undefined') return;
+
+                aggregate!.scoreSum += score;
+                aggregate!.seenResidues.add(residueKey);
             });
         }
-
-        if (seen.size === 0) return;
-
-        const summary: string[] = [];
-
-        if (scoreSeen.size) {
-            const countInfo = `<small>(${scoreSeen.size} ${scoreSeen.size > 1 ? 'Residues avg.' : 'Residue'})</small>`;
-            const scoreAvg = scoreSum / scoreSeen.size;
-            summary.push(label(scoreAvg, countInfo));
-        }
-
-        if (summary.length) {
-            return summary.join('</br>');
-        }
     }
+
+    if (seenMetrics.length === 0) return;
+
+    const labels: string[] = [];
+    for (const { metric, scoreSum, seenResidues } of seenMetrics) {
+        let countInfo = '';
+        if (seenResidues.size > 1) {
+            countInfo = ` <small>(${seenResidues.size} Residues avg.</small>`;
+        }
+        const scoreAvg = scoreSum / seenResidues.size;
+        const label = buildLabel(metric, scoreAvg, countInfo);
+        labels.push(label);
+    }
+
+    return labels;
 }
 
 //

--- a/src/extensions/model-archive/quality-assessment/color/plddt.ts
+++ b/src/extensions/model-archive/quality-assessment/color/plddt.ts
@@ -1,9 +1,10 @@
 /**
- * Copyright (c) 2021-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Mandar Deshpande <mandar@ebi.ac.uk>
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { QualityAssessment, QualityAssessmentProvider } from '../prop';
@@ -29,7 +30,9 @@ const ConfidenceColors = {
 const ConfidenceColorLegend = TableLegend(Object.entries(ConfidenceColors));
 
 export function getPLDDTConfidenceColorThemeParams(ctx: ThemeDataContext) {
-    return {};
+    return {
+        metricId: QualityAssessment.getLocalOptions(ctx.structure?.models[0], 'pLDDT'),
+    };
 }
 export type PLDDTConfidenceColorThemeParams = ReturnType<typeof getPLDDTConfidenceColorThemeParams>
 
@@ -44,7 +47,8 @@ export function PLDDTConfidenceColorTheme(ctx: ThemeDataContext, props: PD.Value
             if (!Unit.isAtomic(unit)) return DefaultColor;
 
             const qualityAssessment = QualityAssessmentProvider.get(unit.model).value;
-            let score = qualityAssessment?.pLDDT?.get(unit.model.atomicHierarchy.residueAtomSegments.index[element]);
+            const metric = qualityAssessment?.localMap.get(props.metricId!)?.values ?? qualityAssessment?.pLDDT;
+            let score = metric?.get(unit.model.atomicHierarchy.residueAtomSegments.index[element]);
             if (typeof score !== 'number') {
                 score = unit.model.atomicConformation.B_iso_or_equiv.value(element);
             }

--- a/src/extensions/model-archive/quality-assessment/color/qmean.ts
+++ b/src/extensions/model-archive/quality-assessment/color/qmean.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-25 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { QualityAssessment, QualityAssessmentProvider } from '../prop';
@@ -17,7 +18,9 @@ import { ColorThemeCategory } from '../../../../mol-theme/color/categories';
 const DefaultColor = Color(0xaaaaaa);
 
 export function getQmeanScoreColorThemeParams(ctx: ThemeDataContext) {
-    return {};
+    return {
+        metricId: QualityAssessment.getLocalOptions(ctx.structure?.models[0], 'qmean'),
+    };
 }
 export type QmeanScoreColorThemeParams = ReturnType<typeof getQmeanScoreColorThemeParams>
 
@@ -38,7 +41,8 @@ export function QmeanScoreColorTheme(ctx: ThemeDataContext, props: PD.Values<Qme
             const { unit, element } = location;
             if (!Unit.isAtomic(unit)) return DefaultColor;
             const qualityAssessment = QualityAssessmentProvider.get(unit.model).value;
-            const score = qualityAssessment?.qmean?.get(unit.model.atomicHierarchy.residueAtomSegments.index[element]) ?? -1;
+            const metric = qualityAssessment?.localMap.get(props.metricId!)?.values ?? qualityAssessment?.qmean;
+            const score = metric?.get(unit.model.atomicHierarchy.residueAtomSegments.index[element]) ?? -1;
             if (score < 0) {
                 return DefaultColor;
             } else {

--- a/src/extensions/model-archive/quality-assessment/pairwise/plot.ts
+++ b/src/extensions/model-archive/quality-assessment/pairwise/plot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2024-25 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */
@@ -29,6 +29,18 @@ function drawMetricPNG(model: Model, metric: QualityAssessment.Pairwise, colorRa
     ctx.fillStyle = Color.toStyle(noDataColor);
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
+    const colorCache = new Map<number, string>();
+    const getColor = (t: number) => {
+        const rounded = Math.round(t * 0xffff);
+        if (colorCache.has(rounded)) {
+            return colorCache.get(rounded)!;
+        }
+        const color = Color.interpolate(minColor, maxColor, rounded / 0xffff);
+        const style = Color.toStyle(color);
+        colorCache.set(rounded, style);
+        return style;
+    };
+
     for (let rA = minResidueIndex; rA <= maxResidueIndex; rA++) {
         const row = values[rA];
         if (!row) continue;
@@ -40,11 +52,12 @@ function drawMetricPNG(model: Model, metric: QualityAssessment.Pairwise, colorRa
             const x = rA - minResidueIndex;
             const y = rB - minResidueIndex;
             const t = (value - minMetric) / valueRange;
-
-            const color = Color.interpolate(minColor, maxColor, t);
-            ctx.fillStyle = Color.toStyle(color);
+            ctx.fillStyle = getColor(t);
             ctx.fillRect(x, y, 1, 1);
-            ctx.fillRect(y, x, 1, 1);
+
+            if (typeof values[rB]?.[rA] !== 'number') {
+                ctx.fillRect(y, x, 1, 1);
+            }
         }
     }
 

--- a/src/extensions/model-archive/quality-assessment/prop.ts
+++ b/src/extensions/model-archive/quality-assessment/prop.ts
@@ -37,7 +37,7 @@ interface QualityAssessment {
      * NOTE: Keeping this around in case someone is using it
      * TODO: Remove in Mol* 5.0
      */
-     localMetrics: Map<string, Map<ResidueIndex, number>>
+    localMetrics: Map<string, Map<ResidueIndex, number>>
 }
 
 namespace QualityAssessment {

--- a/src/extensions/model-archive/quality-assessment/prop.ts
+++ b/src/extensions/model-archive/quality-assessment/prop.ts
@@ -31,9 +31,12 @@ interface QualityAssessment {
     pLDDT?: Map<ResidueIndex, number>
     qmean?: Map<ResidueIndex, number>
 
-    // NOTE: Keeping this around in case someone is using it
-    // TODO: Remove in Mol* 5.0
-    localMetrics: Map<string, Map<ResidueIndex, number>>
+    /**
+     * @deprecated
+     * NOTE: Keeping this around in case someone is using it
+     * TODO: Remove in Mol* 5.0
+     */
+     localMetrics: Map<string, Map<ResidueIndex, number>>
 }
 
 namespace QualityAssessment {

--- a/src/extensions/model-archive/quality-assessment/prop.ts
+++ b/src/extensions/model-archive/quality-assessment/prop.ts
@@ -18,17 +18,35 @@ import { AtomicIndex } from '../../../mol-model/structure/model/properties/atomi
 import { CustomPropSymbol } from '../../../mol-script/language/symbol';
 import { Type } from '../../../mol-script/language/type';
 import { QuerySymbolRuntime } from '../../../mol-script/runtime/query/compiler';
-import { ParamDefinition as PD } from '../../../mol-util/param-definition';
+import { ParamDefinition, ParamDefinition as PD } from '../../../mol-util/param-definition';
 
 export { QualityAssessment };
 
 interface QualityAssessment {
-    localMetrics: Map<string, Map<ResidueIndex, number>>
+    local: QualityAssessment.Local[]
+    /** id -> metric info */
+    localMap: Map<number, QualityAssessment.Local>
+
+    // default pLDDT and qmean metrics
     pLDDT?: Map<ResidueIndex, number>
     qmean?: Map<ResidueIndex, number>
+
+    // NOTE: Keeping this around in case someone is using it
+    // TODO: Remove in Mol* 5.0
+    localMetrics: Map<string, Map<ResidueIndex, number>>
 }
 
 namespace QualityAssessment {
+    export interface Local {
+        id: number
+        kind?: 'pLDDT' | 'qmean';
+        type: mmCIF_Schema['ma_qa_metric']['type']['T']
+        name: string
+        domain?: [number, number]
+        valueRange: [number, number]
+        values: Map<ResidueIndex, number>
+    }
+
     export interface Pairwise {
         id: number
         name: string
@@ -40,6 +58,8 @@ namespace QualityAssessment {
 
     const Empty = {
         value: {
+            local: [],
+            localMap: new Map<number, Local>(),
             localMetrics: new Map(),
         } satisfies QualityAssessment
     };
@@ -52,14 +72,24 @@ namespace QualityAssessment {
             db.ma_qa_metric_local.ordinal_id.isDefined
         );
         if (localMetricName && hasLocalMetric) {
+            const nameQuery = localMetricName.toLowerCase();
             for (let i = 0, il = db.ma_qa_metric._rowCount; i < il; i++) {
                 if (db.ma_qa_metric.mode.value(i) !== 'local') continue;
-                if (localMetricName === db.ma_qa_metric.name.value(i)) return true;
+                const name = db.ma_qa_metric.name.value(i).toLowerCase();
+                if (name.includes(nameQuery)) return true;
             }
             return false;
         } else {
             return hasLocalMetric;
         }
+    }
+
+    export function getLocalOptions(model: Model | undefined, kind: 'pLDDT' | 'qmean') {
+        if (!model) return ParamDefinition.Select(undefined, [], { label: 'Metric', isHidden: true });
+        const local = QualityAssessmentProvider.get(model).value?.local;
+        if (!local) return ParamDefinition.Select(undefined, [], { label: 'Metric', isHidden: true });
+        const options = local.filter(m => m.kind === kind).map(m => [m.id, `${m.name} (${m.type})`] as [number, string]);
+        return ParamDefinition.Select(options[0]?.[0], options, { label: 'Metric ' });
     }
 
     export async function obtain(ctx: CustomProperty.Context, model: Model, props: QualityAssessmentProps): Promise<CustomProperty.Data<QualityAssessment>> {
@@ -68,21 +98,51 @@ namespace QualityAssessment {
         const { model_id, label_asym_id, label_seq_id, metric_id, metric_value } = ma_qa_metric_local;
         const { index } = model.atomicHierarchy;
 
+        const locals: Local[] = [];
+        const localMetrics = new Map<number, Local>();
+
         // for simplicity we assume names in ma_qa_metric for mode 'local' are unique
-        const localMetrics = new Map<string, Map<ResidueIndex, number>>();
+        const localMetricValues = new Map<string, Map<ResidueIndex, number>>();
         const localNames = new Map<number, string>();
 
         for (let i = 0, il = ma_qa_metric._rowCount; i < il; i++) {
             if (ma_qa_metric.mode.value(i) !== 'local') continue;
 
+            const id = ma_qa_metric.id.value(i);
             const name = ma_qa_metric.name.value(i);
-            if (localMetrics.has(name)) {
+            const type = ma_qa_metric.type.value(i);
+            const values: Map<ResidueIndex, number> = new Map();
+            const ispPLDDType = type.toLowerCase().includes('plddt');
+            const has01Range = type.replace(/\s/g, '').includes('[0,1]');
+
+            let domain: [number, number] | undefined;
+            if (has01Range) {
+                domain = [0, 1];
+            } else if (ispPLDDType) {
+                domain = [0, 100];
+            }
+
+            let kind: 'pLDDT' | 'qmean' | undefined;
+
+            const nameLower = name.toLowerCase();
+            if (nameLower.includes('plddt')) kind = 'pLDDT';
+            else if (nameLower.includes('qmean')) kind = 'qmean';
+
+            if (!kind && ispPLDDType) kind = 'pLDDT';
+            if (!kind && has01Range) kind = 'qmean';
+
+            const metric: Local = { id, kind, type, name, domain, valueRange: [Number.MAX_VALUE, -Number.MAX_VALUE], values };
+
+            localMetrics.set(id, metric);
+            locals.push(metric);
+
+            if (localMetricValues.has(name)) {
                 console.warn(`local ma_qa_metric with name '${name}' already added`);
                 continue;
             }
 
-            localMetrics.set(name, new Map());
-            localNames.set(ma_qa_metric.id.value(i), name);
+            localMetricValues.set(name, values);
+            localNames.set(id, name);
         }
 
         const residueKey: AtomicIndex.ResidueLabelKey = {
@@ -104,16 +164,25 @@ namespace QualityAssessment {
 
             const rI = index.findResidueLabel(residueKey);
             if (rI >= 0) {
-                const name = localNames.get(metric_id.value(i))!;
-                localMetrics.get(name)!.set(rI, metric_value.value(i));
+                const entry = localMetrics.get(metric_id.value(i));
+                if (!entry) continue;
+
+                const value = metric_value.value(i);
+                const range = entry.valueRange;
+                if (value < range[0]) range[0] = value;
+                if (value > range[1]) range[1] = value;
+                entry.values.set(rI, value);
             }
         }
 
         return {
             value: {
-                localMetrics,
-                pLDDT: localMetrics.get('pLDDT'),
-                qmean: localMetrics.get('qmean'),
+                local: Array.from(localMetrics.values()),
+                localMap: localMetrics,
+                pLDDT: locals.find(m => m.kind === 'pLDDT')?.values,
+                qmean: locals.find(m => m.kind === 'qmean')?.values,
+
+                localMetrics: localMetricValues,
             }
         };
     }

--- a/src/extensions/model-archive/quality-assessment/prop.ts
+++ b/src/extensions/model-archive/quality-assessment/prop.ts
@@ -27,8 +27,9 @@ interface QualityAssessment {
     /** id -> metric info */
     localMap: Map<number, QualityAssessment.Local>
 
-    // default pLDDT and qmean metrics
+    /** default pLDDT metric */
     pLDDT?: Map<ResidueIndex, number>
+    /** default qmean metric */
     qmean?: Map<ResidueIndex, number>
 
     /**


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] Parse all local metrics
- [x] Ability to select alternate metrics in the pLDDT/qmean themes
- [x] Do not assume PAE plot is symmetric

Superseeds https://github.com/molstar/molstar/pull/602

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files