### PR TITLE
added toggle for hiding screenshot controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Parse all local metrics
   - Ability to select alternate metrics in the pLDDT/qmean themes
   - Do not assume PAE plot is symmetric
+- Added `PluginConfig.Viewport.ShowScreenshotControls` to control visibility of screenshot controls
 
 ## [v4.12.0] - 2025-02-28
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     "Simeon Borko <simeon.borko@gmail.com>",
     "Ventura Rivera <venturaxrivera@gmail.com>",
     "Andy Turner <agdturner@gmail.com>",
-    "Lukáš Polák <admin@lukaspolak.cz>"
+    "Lukáš Polák <admin@lukaspolak.cz>",
+    "Chetan Mishra <chetan.s115@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-plugin-ui/viewport.tsx
+++ b/src/mol-plugin-ui/viewport.tsx
@@ -4,6 +4,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Adam Midlik <midlik@gmail.com>
+ * @author Chetan Mishra <chetan.s115@gmail.com>
  */
 
 import * as React from 'react';

--- a/src/mol-plugin-ui/viewport.tsx
+++ b/src/mol-plugin-ui/viewport.tsx
@@ -121,7 +121,7 @@ export class ViewportControls extends PluginUIComponent<ViewportControlsProps, V
                 </div>
                 <div>
                     <div className='msp-semi-transparent-background' />
-                    {this.icon(CameraOutlinedSvg, this.toggleScreenshotExpanded, 'Screenshot / State Snapshot', this.state.isScreenshotExpanded)}
+                    {this.plugin.config.get(PluginConfig.Viewport.ShowScreenshotControls) && this.icon(CameraOutlinedSvg, this.toggleScreenshotExpanded, 'Screenshot / State Snapshot', this.state.isScreenshotExpanded)}
                 </div>
                 <div>
                     <div className='msp-semi-transparent-background' />

--- a/src/mol-plugin/config.ts
+++ b/src/mol-plugin/config.ts
@@ -58,6 +58,7 @@ export const PluginConfig = {
         ShowSelectionMode: item('viewer.show-selection-model-button', true),
         ShowAnimation: item('viewer.show-animation-button', true),
         ShowTrajectoryControls: item('viewer.show-trajectory-controls', true),
+        ShowScreenshotControls: item('viewer.show-screenshot-controls', true),
     },
     Download: {
         DefaultPdbProvider: item<PdbDownloadProvider>('download.default-pdb-provider', 'pdbe'),


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Added an extra config to control whether the screenshot tool pops up in the viewer or not. Seems reasonable to have given most of the other buttons have a toggle. 

Maybe it makes sense to also add one to Refresh / reset button? I don't need to hide it, but happy to add one for others if you all think it does. 

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`