### PR TITLE
Update Add engines field to specify required Node.js version (>=18.0.0).json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/molstar/molstar/issues"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",


### PR DESCRIPTION
This pull request adds an engines field to package.json specifying that Node.js version 18.0.0 or higher is recommended for development.

Since the project depends on Node.js scripts and Node 18+ types (@types/node), specifying an engine range improves clarity for contributors and helps prevent potential version mismatch issues during local development.

This change is non-breaking and only issues a warning if a contributor's local Node.js version is too old.

- Inserted "engines" field after the "bugs" section, following package.json convention.
- Set minimum Node version to >=18.0.0 to match existing dependencies and project usage.

Please let me know if you'd prefer a different Node version constraint or placement. Thank you for considering this small improvement!