### PR TITLE
Avoid grid expansion when requiring unit cell on volume server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
-- Avoid grid expansion when requiring unit cell on volume server
 - Fix `Viewer.loadTrajectory` when loading a topology file.
 
 ## [v4.13.0] - 2025-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
+- Avoid grid expansion when requiring unit cell on volume server
 - Fix `Viewer.loadTrajectory` when loading a topology file.
 
 ## [v4.13.0] - 2025-04-14

--- a/src/servers/volume/CHANGELOG.md
+++ b/src/servers/volume/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.7
+* Avoid grid expansion when requiring unit cell.
+
 # 0.9.6
 * Add `health-check` endpoint + `healthCheckPath` config prop to report service health.
 

--- a/src/servers/volume/server/version.ts
+++ b/src/servers/volume/server/version.ts
@@ -1,2 +1,2 @@
-export const VOLUME_SERVER_VERSION = '0.9.6';
+export const VOLUME_SERVER_VERSION = '0.9.7';
 export const VOLUME_SERVER_HEADER = `VolumeServer ${VOLUME_SERVER_VERSION}, (c) 2018-2024, Mol* contributors`;

--- a/src/servers/volume/server/version.ts
+++ b/src/servers/volume/server/version.ts
@@ -1,2 +1,2 @@
 export const VOLUME_SERVER_VERSION = '0.9.7';
-export const VOLUME_SERVER_HEADER = `VolumeServer ${VOLUME_SERVER_VERSION}, (c) 2018-2024, Mol* contributors`;
+export const VOLUME_SERVER_HEADER = `VolumeServer ${VOLUME_SERVER_VERSION}, (c) 2018-2025, Mol* contributors`;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Avoids expanding the box when the whole unit cell is required. 

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`