### PR TITLE
Add format selection option to image export UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ Note that since we don't clearly distinguish between a public and private interf
 
 
 ## [Unreleased]
-- Fix `Viewer.loadTrajectory` when loading a topology file.
-- Fix `StructConn.residueCantorPairs` to not include identity pairs.
+- Fix `Viewer.loadTrajectory` when loading a topology file
+- Fix `StructConn.residueCantorPairs` to not include identity pairs
+- Add format selection option to image export UI (PNG, WebP, JPEG)
 
 ## [v4.13.0] - 2025-04-14
-- Support `--host` option for build-dev.mjs script.
+- Support `--host` option for build-dev.mjs script
 - Add `Viewer.loadFiles` to open supported files
 - Support installing the viewer as a Progressive Web App (PWA)
 - `ihm-restraints` example: show entity labels

--- a/src/mol-plugin/util/viewport-screenshot.ts
+++ b/src/mol-plugin/util/viewport-screenshot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -57,6 +57,15 @@ class ViewportScreenshotHelper extends PluginComponent {
                     ['custom', 'Custom']
                 ]
             }),
+            format: PD.MappedStatic('png', {
+                png: PD.Group({}),
+                webp: PD.Group({
+                    quality: PD.Numeric(0.9, { min: 0, max: 1, step: 0.01 })
+                }),
+                jpeg: PD.Group({
+                    quality: PD.Numeric(0.9, { min: 0, max: 1, step: 0.01 })
+                }),
+            }, { options: [['png', 'PNG'], ['webp', 'WebP'], ['jpeg', 'JPEG']] }),
             transparent: PD.Boolean(false),
             axes: CameraHelperParams.axes,
             illumination: PD.Group({
@@ -74,6 +83,7 @@ class ViewportScreenshotHelper extends PluginComponent {
     readonly behaviors = {
         values: this.ev.behavior<ViewportScreenshotHelperParams>({
             transparent: this.params.transparent.defaultValue,
+            format: { name: 'png', params: {} },
             axes: { name: 'off', params: {} },
             resolution: this.params.resolution.defaultValue,
             illumination: this.params.illumination.defaultValue,
@@ -180,7 +190,8 @@ class ViewportScreenshotHelper extends PluginComponent {
         return this._imagePass = this.createPass(false);
     }
 
-    getFilename(extension = '.png') {
+    getFilename(extension?: string) {
+        if (typeof extension !== 'string') extension = this.extension;
         const models = this.plugin.state.data.select(StateSelection.Generators.rootsOfType(PluginStateObject.Molecule.Model)).map(s => s.obj!.data);
         const uniqueIds = new Set<string>();
         models.forEach(m => uniqueIds.add(m.entryId.toUpperCase()));
@@ -365,18 +376,42 @@ class ViewportScreenshotHelper extends PluginComponent {
         return Task.create('Copy Image', async ctx => {
             await this.draw(ctx);
             await ctx.update('Converting image...');
-            const blob = await canvasToBlob(this.canvas, 'png');
-            const item = new ClipboardItem({ 'image/png': blob });
+            const mime = this.mimeType;
+            const blob = await canvasToBlob(this.canvas, mime, this.quality);
+            const item = new ClipboardItem({ [mime]: blob });
             await cb.write([item]);
             this.plugin.log.message('Image copied to clipboard.');
         });
+    }
+
+    private get mimeType() {
+        return `image/${this.values.format?.name ?? 'png'}`;
+    }
+
+    private get extension() {
+        switch (this.values.format?.name) {
+            case 'jpeg':
+                return '.jpg';
+            default:
+                return `.${this.values.format?.name ?? 'png'}`;
+        }
+    }
+
+    private get quality() {
+        switch (this.values.format?.name) {
+            case 'webp':
+            case 'jpeg':
+                return this.values.format?.params?.quality ?? 0.9;
+            default:
+                return undefined;
+        }
     }
 
     getImageDataUri() {
         return this.plugin.runTask(Task.create('Generate Image', async ctx => {
             await this.draw(ctx);
             await ctx.update('Converting image...');
-            return this.canvas.toDataURL('png');
+            return this.canvas.toDataURL(this.mimeType);
         }));
     }
 
@@ -390,8 +425,8 @@ class ViewportScreenshotHelper extends PluginComponent {
         return Task.create('Download Image', async ctx => {
             await this.draw(ctx);
             await ctx.update('Downloading image...');
-            const blob = await canvasToBlob(this.canvas, 'png');
-            download(blob, filename ?? this.getFilename());
+            const blob = await canvasToBlob(this.canvas, this.mimeType, this.quality);
+            download(blob, filename ?? this.getFilename(this.extension));
         });
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] Add format selection option to image export UI (PNG, WebP, JPEG)

![image](https://github.com/user-attachments/assets/96381675-ae20-4394-94c7-450cd94cce99)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files