### PR TITLE
Fix transparency rendering with occlusion in NodeJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix transparency rendering with occlusion in NodeJS
 
 ## [v4.14.1] - 2025-05-09
 - Do not raise error when creating duplicate state transformers and print console warning instead

--- a/src/mol-canvas3d/passes/draw.ts
+++ b/src/mol-canvas3d/passes/draw.ts
@@ -314,7 +314,7 @@ export class DrawPass {
                     if (!this.packedDepth) {
                         this.depthTextureOpaque.attachFramebuffer(this.transparentColorTarget.framebuffer, 'depth');
                     } else {
-                        this.colorTarget.depthRenderbuffer?.detachFramebuffer(this.transparentColorTarget.framebuffer);
+                        this.colorTarget.depthRenderbuffer?.attachFramebuffer(this.transparentColorTarget.framebuffer);
                     }
                 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This attempts to fix transparency rendering bug which occurs when occlusion is on, transparencyMode is blended, and depthTexture extension is not available (this is the case when running in NodeJS).

Before:
![1hda_2_B_Pfam_PF00042_image-800x800](https://github.com/user-attachments/assets/dfac53b2-262b-4416-bba4-35e051cd9a33)

After:
![1hda_2_B_Pfam_PF00042_image-800x800](https://github.com/user-attachments/assets/9315f711-b186-43fb-a4f9-655926758837)

Please, @arose and/or @giagitom  check if the fix makes sense. I have no idea what the code does but it looked suspicious to have `attach` in `if` and `detach` in `else`, and changing it seems to solve my issue 🤣 


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`