### PR TITLE
WebGL ContextLost handling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Note that since we don't clearly distinguish between a public and private interf
   - `JSONCifLigandGraph` that enables editing of small molecules via modifying `atom_site` and `molstar_bond_site` categories
 - Add `ligand-editor` example that showcases possible use-cases of the `json-cif` extension
 - Breaking (minor): Changed `atom_site.id` indexing to 1-based in `mol-model-formats/structure/mol.ts::getMolModels`.
+- WebGL ContextLost handling
+    - Fix missing framebuffer & drawbuffer re-attachments
+    - Fix missing cube texture re-initialization
+    - Fix missing extensions reset
+    - Fix timer clearing edge case
+    - Add reset support for geometry generated on he GPU
 
 ## [v4.14.1] - 2025-05-09
 - Do not raise error when creating duplicate state transformers and print console warning instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Fix missing cube texture re-initialization
     - Fix missing extensions reset
     - Fix timer clearing edge case
-    - Add reset support for geometry generated on he GPU
+    - Add reset support for geometry generated on the GPU
 
 ## [v4.14.1] - 2025-05-09
 - Do not raise error when creating duplicate state transformers and print console warning instead

--- a/src/mol-canvas3d/passes/draw.ts
+++ b/src/mol-canvas3d/passes/draw.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Áron Samuel Kovács <aron.kovacs@mail.muni.cz>
@@ -123,6 +123,7 @@ export class DrawPass {
     reset() {
         this.wboit.reset();
         this.dpoit.reset();
+        this.postprocessing.reset();
     }
 
     setSize(width: number, height: number) {

--- a/src/mol-canvas3d/passes/illumination.ts
+++ b/src/mol-canvas3d/passes/illumination.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2024-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -264,10 +264,18 @@ export class IlluminationPass {
         this.drawPass.setSize(width, height);
     }
 
-    reset(clearAdjustedProps = false) {
+    reset() {
         if (!this._supported) return;
 
-        this.tracing.reset(clearAdjustedProps);
+        this.tracing.reset();
+        this._iteration = 0;
+        this.prevSampleIndex = -1;
+    }
+
+    restart(clearAdjustedProps = false) {
+        if (!this._supported) return;
+
+        this.tracing.restart(clearAdjustedProps);
         this._iteration = 0;
         this.prevSampleIndex = -1;
     }

--- a/src/mol-canvas3d/passes/image.ts
+++ b/src/mol-canvas3d/passes/image.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -105,7 +105,7 @@ export class ImagePass {
         const ctx = { renderer: this.renderer, camera: this._camera, scene: this.scene, helper: this.helper };
         if (this.illuminationPass.supported && this.props.illumination.enabled) {
             await runtime.update({ message: 'Tracing...', current: 1, max: this.illuminationPass.getMaxIterations(this.props) });
-            this.illuminationPass.reset(true);
+            this.illuminationPass.restart(true);
             while (this.illuminationPass.shouldRender(this.props)) {
                 if (isTimingMode) this.webgl.timer.mark('ImagePass.render', { captureStats: true });
                 this.illuminationPass.render(ctx, this.props, false);

--- a/src/mol-canvas3d/passes/pick.ts
+++ b/src/mol-canvas3d/passes/pick.ts
@@ -179,6 +179,32 @@ export class PickPass {
         }
     }
 
+    reset() {
+        const { drawBuffers } = this.webgl.extensions;
+
+        if (drawBuffers) {
+            this.framebuffer.bind();
+            drawBuffers!.drawBuffers([
+                drawBuffers!.COLOR_ATTACHMENT0,
+                drawBuffers!.COLOR_ATTACHMENT1,
+                drawBuffers!.COLOR_ATTACHMENT2,
+                drawBuffers!.COLOR_ATTACHMENT3,
+            ]);
+
+            this.objectPickTexture.attachFramebuffer(this.framebuffer, 'color0');
+            this.instancePickTexture.attachFramebuffer(this.framebuffer, 'color1');
+            this.groupPickTexture.attachFramebuffer(this.framebuffer, 'color2');
+            this.depthPickTexture.attachFramebuffer(this.framebuffer, 'color3');
+
+            this.depthRenderbuffer.attachFramebuffer(this.framebuffer);
+
+            this.objectPickTexture.attachFramebuffer(this.objectPickFramebuffer, 'color0');
+            this.instancePickTexture.attachFramebuffer(this.instancePickFramebuffer, 'color0');
+            this.groupPickTexture.attachFramebuffer(this.groupPickFramebuffer, 'color0');
+            this.depthPickTexture.attachFramebuffer(this.depthPickFramebuffer, 'color0');
+        }
+    }
+
     private renderVariant(renderer: Renderer, camera: ICamera, scene: Scene, helper: Helper, variant: 'pick' | 'depth', pickType: number) {
         renderer.clear(false);
         renderer.update(camera, scene);

--- a/src/mol-canvas3d/passes/postprocessing.ts
+++ b/src/mol-canvas3d/passes/postprocessing.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Áron Samuel Kovács <aron.kovacs@mail.muni.cz>
@@ -213,6 +213,10 @@ export class PostprocessingPass {
         this.shadow.setSize(width, height);
         this.outline.setSize(width, height);
         this.background.setSize(width, height);
+    }
+
+    reset() {
+        this.ssao.reset();
     }
 
     updateState(camera: ICamera, scene: Scene, transparentBackground: boolean, backgroundColor: Color, props: PostprocessingProps, light: Light, ambientColor: Vec3) {

--- a/src/mol-canvas3d/passes/ssao.ts
+++ b/src/mol-canvas3d/passes/ssao.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Áron Samuel Kovács <aron.kovacs@mail.muni.cz>
@@ -262,6 +262,11 @@ export class SsaoPass {
             this.depthHalfRenderableTransparent.update();
             this.renderable.update();
         }
+    }
+
+    reset() {
+        this.ssaoDepthTexture.attachFramebuffer(this.framebuffer, 'color0');
+        this.depthBlurProxyTexture.attachFramebuffer(this.blurFirstPassFramebuffer, 'color0');
     }
 
     update(camera: ICamera, scene: Scene, props: SsaoProps, illuminationMode = false) {

--- a/src/mol-canvas3d/passes/tracing.ts
+++ b/src/mol-canvas3d/passes/tracing.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2024-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -165,9 +165,26 @@ export class TracingPass {
         }
     }
 
+    reset() {
+        const { drawBuffers } = this.webgl.extensions;
+
+        this.framebuffer.bind();
+        drawBuffers!.drawBuffers([
+            drawBuffers!.COLOR_ATTACHMENT0,
+            drawBuffers!.COLOR_ATTACHMENT1,
+            drawBuffers!.COLOR_ATTACHMENT2,
+        ]);
+
+        this.shadedTextureOpaque.attachFramebuffer(this.framebuffer, 'color0');
+        this.normalTextureOpaque.attachFramebuffer(this.framebuffer, 'color1');
+        this.colorTextureOpaque.attachFramebuffer(this.framebuffer, 'color2');
+
+        this.restart(true);
+    }
+
     private clearAdjustedProps = true;
 
-    reset(clearAdjustedProps = false) {
+    restart(clearAdjustedProps = false) {
         const { gl, state } = this.webgl;
 
         this.accumulateTarget.bind();

--- a/src/mol-geo/geometry/direct-volume/direct-volume.ts
+++ b/src/mol-geo/geometry/direct-volume/direct-volume.ts
@@ -55,6 +55,11 @@ export interface DirectVolume {
     readonly boundingSphere: Sphere3D
 
     setBoundingSphere(boundingSphere: Sphere3D): void
+
+    readonly meta: {
+        /** Called to restore when a webgl context is lost */
+        reset?: () => void
+    }
 }
 
 export namespace DirectVolume {
@@ -108,7 +113,8 @@ export namespace DirectVolume {
             setBoundingSphere(sphere: Sphere3D) {
                 Sphere3D.copy(boundingSphere, sphere);
                 currentHash = hashCode(directVolume);
-            }
+            },
+            meta: {}
         };
         return directVolume;
     }
@@ -279,6 +285,8 @@ export namespace DirectVolume {
             dIgnoreLight: ValueCell.create(props.ignoreLight),
             dCelShaded: ValueCell.create(props.celShaded),
             dXrayShaded: ValueCell.create(props.xrayShaded === 'inverted' ? 'inverted' : props.xrayShaded === true ? 'on' : 'off'),
+
+            meta: ValueCell.create(directVolume.meta),
         };
     }
 

--- a/src/mol-geo/geometry/texture-mesh/texture-mesh.ts
+++ b/src/mol-geo/geometry/texture-mesh/texture-mesh.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Cai Huiyu <szmun.caihy@gmail.com>
@@ -48,6 +48,8 @@ export interface TextureMesh {
 
     readonly meta: {
         webgl?: WebGLContext
+        /** Called to restore when a webgl context is lost */
+        reset?: () => void
         [k: string]: unknown
     }
 }

--- a/src/mol-gl/compute/histogram-pyramid/reduction.ts
+++ b/src/mol-gl/compute/histogram-pyramid/reduction.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -75,8 +75,8 @@ function getLevelTextureFramebuffer(ctx: WebGLContext, level: number) {
     let framebuffer = tryGetFramebuffer(name, ctx);
     if (!framebuffer) {
         framebuffer = getFramebuffer(name, ctx);
-        texture.attachFramebuffer(framebuffer, 0);
     }
+    texture.attachFramebuffer(framebuffer, 0);
     return { texture, framebuffer };
 }
 

--- a/src/mol-gl/renderable/direct-volume.ts
+++ b/src/mol-gl/renderable/direct-volume.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -7,7 +7,7 @@
 import { Renderable, RenderableState, createRenderable } from '../renderable';
 import { WebGLContext } from '../webgl/context';
 import { createGraphicsRenderItem, Transparency } from '../webgl/render-item';
-import { AttributeSpec, Values, UniformSpec, GlobalUniformSchema, InternalSchema, TextureSpec, ElementsSpec, DefineSpec, InternalValues, GlobalTextureSchema, BaseSchema } from './schema';
+import { AttributeSpec, Values, UniformSpec, GlobalUniformSchema, InternalSchema, TextureSpec, ElementsSpec, DefineSpec, InternalValues, GlobalTextureSchema, BaseSchema, ValueSpec } from './schema';
 import { DirectVolumeShaderCode } from '../shader-code';
 import { ValueCell } from '../../mol-util';
 
@@ -42,6 +42,8 @@ export const DirectVolumeSchema = {
     dIgnoreLight: DefineSpec('boolean'),
     dCelShaded: DefineSpec('boolean'),
     dXrayShaded: DefineSpec('string', ['off', 'on', 'inverted']),
+
+    meta: ValueSpec('unknown')
 };
 export type DirectVolumeSchema = typeof DirectVolumeSchema
 export type DirectVolumeValues = Values<DirectVolumeSchema>

--- a/src/mol-gl/webgl/context.ts
+++ b/src/mol-gl/webgl/context.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -8,7 +8,7 @@ import { GLRenderingContext, isWebGL2 } from './compat';
 import { checkFramebufferStatus, Framebuffer } from './framebuffer';
 import { Scheduler } from '../../mol-task';
 import { isDebugMode } from '../../mol-util/debug';
-import { createExtensions, WebGLExtensions } from './extensions';
+import { createExtensions, resetExtensions, WebGLExtensions } from './extensions';
 import { WebGLState, createState } from './state';
 import { PixelData } from '../../mol-util/image';
 import { WebGLResources, createResources } from './resources';
@@ -379,7 +379,7 @@ export function createContext(gl: GLRenderingContext, props: Partial<{ pixelScal
             timer.clear();
         },
         handleContextRestored: (extraResets?: () => void) => {
-            Object.assign(extensions, createExtensions(gl));
+            resetExtensions(gl, extensions);
 
             state.reset();
             state.currentMaterialId = -1;

--- a/src/mol-gl/webgl/extensions.ts
+++ b/src/mol-gl/webgl/extensions.ts
@@ -1,11 +1,12 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import { GLRenderingContext, COMPAT_instanced_arrays, COMPAT_standard_derivatives, COMPAT_vertex_array_object, getInstancedArrays, getStandardDerivatives, COMPAT_element_index_uint, getElementIndexUint, COMPAT_texture_float, getTextureFloat, COMPAT_texture_float_linear, getTextureFloatLinear, COMPAT_blend_minmax, getBlendMinMax, getFragDepth, COMPAT_frag_depth, COMPAT_color_buffer_float, getColorBufferFloat, COMPAT_draw_buffers, getDrawBuffers, getShaderTextureLod, COMPAT_shader_texture_lod, getDepthTexture, COMPAT_depth_texture, COMPAT_sRGB, getSRGB, getTextureHalfFloat, getTextureHalfFloatLinear, COMPAT_texture_half_float, COMPAT_texture_half_float_linear, COMPAT_color_buffer_half_float, getColorBufferHalfFloat, getVertexArrayObject, getDisjointTimerQuery, COMPAT_disjoint_timer_query, getNoNonInstancedActiveAttribs, COMPAT_multi_draw, getMultiDraw, getDrawInstancedBaseVertexBaseInstance, getMultiDrawInstancedBaseVertexBaseInstance, COMPAT_draw_instanced_base_vertex_base_instance, COMPAT_multi_draw_instanced_base_vertex_base_instance, getDrawBuffersIndexed, COMPAT_draw_buffers_indexed, getParallelShaderCompile, COMPAT_parallel_shader_compile, getFboRenderMipmap, COMPAT_fboRenderMipmap, COMPAT_provoking_vertex, getProvokingVertex, COMPAT_clip_cull_distance, getClipCullDistance, COMPAT_conservative_depth, getConservativeDepth, COMPAT_stencil_texturing, getStencilTexturing, COMPAT_clip_control, getClipControl, getRenderSnorm, COMPAT_render_snorm, getRenderSharedExponent, COMPAT_render_shared_exponent, getTextureNorm16, COMPAT_texture_norm16, getDepthClamp, COMPAT_depth_clamp } from './compat';
 import { isDebugMode } from '../../mol-util/debug';
+import { objectForEach } from '../../mol-util/object';
 
 export type WebGLExtensions = {
     instancedArrays: COMPAT_instanced_arrays
@@ -221,4 +222,20 @@ export function createExtensions(gl: GLRenderingContext): WebGLExtensions {
 
         noNonInstancedActiveAttribs,
     };
+}
+
+export function resetExtensions(gl: GLRenderingContext, extensions: WebGLExtensions) {
+    const e = createExtensions(gl);
+
+    objectForEach(extensions, (v, k) => {
+        if (k === 'noNonInstancedActiveAttribs') {
+            extensions.noNonInstancedActiveAttribs = e.noNonInstancedActiveAttribs;
+        } else if (v !== null) {
+            if (e[k] === null) {
+                extensions[k] = null as any;
+            } else {
+                Object.assign(v, e[k]);
+            }
+        }
+    });
 }

--- a/src/mol-gl/webgl/resources.ts
+++ b/src/mol-gl/webgl/resources.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -177,6 +177,7 @@ export function createResources(gl: GLRenderingContext, state: WebGLState, stats
             sets.program.forEach(r => r.reset());
             sets.vertexArray.forEach(r => r.reset());
             sets.texture.forEach(r => r.reset());
+            sets.cubeTexture.forEach(r => r.reset());
         },
         destroy: () => {
             sets.attribute.forEach(r => r.destroy());
@@ -187,6 +188,7 @@ export function createResources(gl: GLRenderingContext, state: WebGLState, stats
             sets.program.forEach(r => r.destroy());
             sets.vertexArray.forEach(r => r.destroy());
             sets.texture.forEach(r => r.destroy());
+            sets.cubeTexture.forEach(r => r.destroy());
 
             shaderCache.clear();
             programCache.clear();

--- a/src/mol-gl/webgl/texture.ts
+++ b/src/mol-gl/webgl/texture.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
@@ -484,8 +484,37 @@ export function createCubeTexture(gl: GLRenderingContext, faces: CubeFaces, mipm
 
     let size = 0;
 
-    const texture = gl.createTexture();
+    let texture = gl.createTexture();
     gl.bindTexture(target, texture);
+
+    function load(cubeTarget: number, level: number, image: HTMLImageElement, isReset: boolean) {
+        if (size === 0) size = image.width;
+
+        gl.bindTexture(target, texture);
+        gl.texImage2D(cubeTarget, level, internalFormat, size, size, 0, format, type, null);
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
+        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+        gl.bindTexture(target, texture);
+        gl.texImage2D(cubeTarget, level, internalFormat, format, type, image);
+
+        loadedCount += 1;
+        if (loadedCount === 6) {
+            if (!destroyed) {
+                if (mipmaps) {
+                    gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+                    gl.generateMipmap(target);
+                } else {
+                    gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, filter);
+                }
+                gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, filter);
+            }
+            if (!isReset) onload?.(destroyed);
+        }
+    }
+
+    const facesData: { cubeTarget: number, level: number, image: HTMLImageElement }[] = [];
 
     let loadedCount = 0;
     objectForEach(faces, (source, side) => {
@@ -504,30 +533,11 @@ export function createCubeTexture(gl: GLRenderingContext, faces: CubeFaces, mipm
         } else {
             image.src = source;
         }
+
+        facesData.push({ cubeTarget, level, image });
+
         image.addEventListener('load', () => {
-            if (size === 0) size = image.width;
-
-            gl.texImage2D(cubeTarget, level, internalFormat, size, size, 0, format, type, null);
-            gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
-            gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
-            gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
-            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-            gl.bindTexture(target, texture);
-            gl.texImage2D(cubeTarget, level, internalFormat, format, type, image);
-
-            loadedCount += 1;
-            if (loadedCount === 6) {
-                if (!destroyed) {
-                    if (mipmaps) {
-                        gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-                        gl.generateMipmap(target);
-                    } else {
-                        gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, filter);
-                    }
-                    gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, filter);
-                }
-                onload?.(destroyed);
-            }
+            load(cubeTarget, level, image, false);
         });
         image.addEventListener('error', () => {
             onload?.(true);
@@ -565,7 +575,15 @@ export function createCubeTexture(gl: GLRenderingContext, faces: CubeFaces, mipm
         attachFramebuffer: () => {},
         detachFramebuffer: () => {},
 
-        reset: () => {},
+        reset: () => {
+            texture = getTexture(gl);
+            gl.bindTexture(target, texture);
+
+            loadedCount = 0;
+            for (const { cubeTarget, level, image } of facesData) {
+                load(cubeTarget, level, image, true);
+            }
+        },
         destroy: () => {
             if (destroyed) return;
             gl.deleteTexture(texture);

--- a/src/mol-gl/webgl/timer.ts
+++ b/src/mol-gl/webgl/timer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -113,11 +113,6 @@ export function createTimer(gl: GLRenderingContext, extensions: WebGLExtensions,
     let capturingStats = false;
 
     const clear = () => {
-        if (!dtq) return;
-
-        queries.forEach((_, query) => {
-            dtq.deleteQuery(query);
-        });
         pending.clear();
         stack.length = 0;
         gpuAvgs.clear();
@@ -126,6 +121,13 @@ export function createTimer(gl: GLRenderingContext, extensions: WebGLExtensions,
         measures = [];
         current = null;
         capturingStats = false;
+
+        if (dtq) {
+            queries.forEach((_, query) => {
+                dtq.deleteQuery(query);
+            });
+        }
+        queries.clear();
     };
 
     const add = () => {

--- a/src/mol-repr/structure/visual/gaussian-density-volume.ts
+++ b/src/mol-repr/structure/visual/gaussian-density-volume.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -17,24 +17,37 @@ import { eachElement, eachSerialElement, ElementIterator, getElementLoci, getSer
 import { Sphere3D } from '../../../mol-math/geometry';
 import { UnitsDirectVolumeParams, UnitsVisual, UnitsDirectVolumeVisual } from '../units-visual';
 
-async function createGaussianDensityVolume(ctx: VisualContext, structure: Structure, theme: Theme, props: GaussianDensityProps, directVolume?: DirectVolume): Promise<DirectVolume> {
-    const { runtime, webgl } = ctx;
-    if (!webgl || !webgl.extensions.blendMinMax) {
-        throw new Error('GaussianDensityVolume requires `webgl` and `blendMinMax` extension');
+function createGaussianDensityVolume(ctx: VisualContext, structure: Structure, theme: Theme, props: GaussianDensityProps, directVolume?: DirectVolume): DirectVolume {
+    const { webgl } = ctx;
+    if (!webgl) {
+        // gpu gaussian density also needs blendMinMax but there is no fallback here so
+        // we allow it here with the results that there is no group id assignment and
+        // hence no group-based coloring or picking
+        throw new Error('GaussianDensityVolume requires `webgl`');
     }
 
-    const oldTexture = directVolume ? directVolume.gridTexture.ref.value : undefined;
-    const densityTextureData = await computeStructureGaussianDensityTexture(structure, theme.size, props, webgl, oldTexture).runInContext(runtime);
-    const { transform, texture, bbox, gridDim } = densityTextureData;
+    const axisOrder = Vec3.create(0, 1, 2);
     const stats = { min: 0, max: 1, mean: 0.04, sigma: 0.01 };
 
-    const unitToCartn = Mat4.mul(Mat4(), transform, Mat4.fromScaling(Mat4(), gridDim));
-    const cellDim = Mat4.getScaling(Vec3(), transform);
-    const axisOrder = Vec3.create(0, 1, 2);
-    const vol = DirectVolume.create(bbox, gridDim, transform, unitToCartn, cellDim, texture, stats, true, axisOrder, 'byte', directVolume);
+    const create = (directVolume?: DirectVolume) => {
+        const oldTexture = directVolume ? directVolume.gridTexture.ref.value : undefined;
+        const densityTextureData = computeStructureGaussianDensityTexture(structure, theme.size, props, webgl, oldTexture);
+        const { transform, texture, bbox, gridDim } = densityTextureData;
 
-    const sphere = Sphere3D.expand(Sphere3D(), structure.boundary.sphere, densityTextureData.maxRadius);
-    vol.setBoundingSphere(sphere);
+        const unitToCartn = Mat4.mul(Mat4(), transform, Mat4.fromScaling(Mat4(), gridDim));
+        const cellDim = Mat4.getScaling(Vec3(), transform);
+
+        const vol = DirectVolume.create(bbox, gridDim, transform, unitToCartn, cellDim, texture, stats, true, axisOrder, 'byte', directVolume);
+
+        const sphere = Sphere3D.expand(Sphere3D(), structure.boundary.sphere, densityTextureData.maxRadius);
+        vol.setBoundingSphere(sphere);
+        return vol;
+    };
+
+    const vol = create(directVolume);
+    vol.meta.reset = () => {
+        create(vol);
+    };
 
     return vol;
 }
@@ -72,8 +85,8 @@ export function GaussianDensityVolumeVisual(materialId: number): ComplexVisual<G
 
 //
 
-async function createUnitsGaussianDensityVolume(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: GaussianDensityProps, directVolume?: DirectVolume): Promise<DirectVolume> {
-    const { runtime, webgl } = ctx;
+function createUnitsGaussianDensityVolume(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: GaussianDensityProps, directVolume?: DirectVolume): DirectVolume {
+    const { webgl } = ctx;
     if (!webgl) {
         // gpu gaussian density also needs blendMinMax but there is no fallback here so
         // we allow it here with the results that there is no group id assignment and
@@ -81,18 +94,27 @@ async function createUnitsGaussianDensityVolume(ctx: VisualContext, unit: Unit, 
         throw new Error('GaussianDensityVolume requires `webgl`');
     }
 
-    const oldTexture = directVolume ? directVolume.gridTexture.ref.value : undefined;
-    const densityTextureData = await computeUnitGaussianDensityTexture(structure, unit, theme.size, props, webgl, oldTexture).runInContext(runtime);
-    const { transform, texture, bbox, gridDim } = densityTextureData;
+    const axisOrder = Vec3.create(0, 1, 2);
     const stats = { min: 0, max: 1, mean: 0.04, sigma: 0.01 };
 
-    const unitToCartn = Mat4.mul(Mat4(), transform, Mat4.fromScaling(Mat4(), gridDim));
-    const cellDim = Mat4.getScaling(Vec3(), transform);
-    const axisOrder = Vec3.create(0, 1, 2);
-    const vol = DirectVolume.create(bbox, gridDim, transform, unitToCartn, cellDim, texture, stats, true, axisOrder, 'byte', directVolume);
+    const create = (directVolume?: DirectVolume) => {
+        const oldTexture = directVolume ? directVolume.gridTexture.ref.value : undefined;
+        const densityTextureData = computeUnitGaussianDensityTexture(structure, unit, theme.size, props, webgl, oldTexture);
+        const { transform, texture, bbox, gridDim } = densityTextureData;
 
-    const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, densityTextureData.maxRadius);
-    vol.setBoundingSphere(sphere);
+        const unitToCartn = Mat4.mul(Mat4(), transform, Mat4.fromScaling(Mat4(), gridDim));
+        const cellDim = Mat4.getScaling(Vec3(), transform);
+        const vol = DirectVolume.create(bbox, gridDim, transform, unitToCartn, cellDim, texture, stats, true, axisOrder, 'byte', directVolume);
+
+        const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, densityTextureData.maxRadius);
+        vol.setBoundingSphere(sphere);
+        return vol;
+    };
+
+    const vol = create(directVolume);
+    vol.meta.reset = () => {
+        create(vol);
+    };
 
     return vol;
 }

--- a/src/mol-repr/structure/visual/util/gaussian.ts
+++ b/src/mol-repr/structure/visual/util/gaussian.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -44,17 +44,13 @@ export function computeUnitGaussianDensity(structure: Structure, unit: Unit, siz
 export function computeUnitGaussianDensityTexture(structure: Structure, unit: Unit, sizeTheme: SizeTheme<any>, props: GaussianDensityProps, webgl: WebGLContext, texture?: Texture) {
     const { position, boundary, radius } = getUnitConformationAndRadius(structure, unit, sizeTheme, props);
     const p = ensureReasonableResolution(boundary.box, props, getTextureMaxCells(webgl, structure));
-    return Task.create('Gaussian Density', async ctx => {
-        return GaussianDensityTexture(webgl, position, boundary.box, radius, p, texture);
-    });
+    return GaussianDensityTexture(webgl, position, boundary.box, radius, p, texture);
 }
 
 export function computeUnitGaussianDensityTexture2d(structure: Structure, unit: Unit, sizeTheme: SizeTheme<any>, powerOfTwo: boolean, props: GaussianDensityProps, webgl: WebGLContext, texture?: Texture) {
     const { position, boundary, radius } = getUnitConformationAndRadius(structure, unit, sizeTheme, props);
     const p = ensureReasonableResolution(boundary.box, props, getTextureMaxCells(webgl, structure));
-    return Task.create('Gaussian Density', async ctx => {
-        return GaussianDensityTexture2d(webgl, position, boundary.box, radius, powerOfTwo, p, texture);
-    });
+    return GaussianDensityTexture2d(webgl, position, boundary.box, radius, powerOfTwo, p, texture);
 }
 
 //
@@ -70,16 +66,12 @@ export function computeStructureGaussianDensity(structure: Structure, sizeTheme:
 export function computeStructureGaussianDensityTexture(structure: Structure, sizeTheme: SizeTheme<any>, props: GaussianDensityProps, webgl: WebGLContext, texture?: Texture) {
     const { position, boundary, radius } = getStructureConformationAndRadius(structure, sizeTheme, props);
     const p = ensureReasonableResolution(boundary.box, props);
-    return Task.create('Gaussian Density', async ctx => {
-        return GaussianDensityTexture(webgl, position, boundary.box, radius, p, texture);
-    });
+    return GaussianDensityTexture(webgl, position, boundary.box, radius, p, texture);
 }
 
 export function computeStructureGaussianDensityTexture2d(structure: Structure, sizeTheme: SizeTheme<any>, powerOfTwo: boolean, props: GaussianDensityProps, webgl: WebGLContext, texture?: Texture) {
     const { box } = structure.lookup3d.boundary;
     const { position, boundary, radius } = getStructureConformationAndRadius(structure, sizeTheme, props);
     const p = ensureReasonableResolution(boundary.box, props);
-    return Task.create('Gaussian Density', async ctx => {
-        return GaussianDensityTexture2d(webgl, position, box, radius, powerOfTwo, p, texture);
-    });
+    return GaussianDensityTexture2d(webgl, position, box, radius, powerOfTwo, p, texture);
 }


### PR DESCRIPTION
- Fix missing framebuffer & drawbuffer re-attachments
- Fix missing cube texture re-initialization
- Fix missing extensions reset
- Fix timer clearing edge case
- Add reset support for geometry generated on the GPU

Test by running in debug mode, then hold shift+ctrl+alt and mouse left click. This will trigger a context loss. 