### PR TITLE
MVS single state loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 - Load potentially big text files as `StringLike` to bypass string size limit
+- MolViewSpec extension:
+  - Load single-state MVS as if it were multi-state with one state
+  - Merged `loadMVS` options `keepCamera` and `keepSnapshotCamera` -> `keepCamera`
+  - Removed `loadMVS` option `replaceExisting` (is now default)
+  - Added `loadMVS` option `appendSnapshots`
 
 ## [v4.15.0] - 2025-05-19
 - IHM improvements:

--- a/src/apps/viewer/app.ts
+++ b/src/apps/viewer/app.ts
@@ -517,7 +517,7 @@ export class Viewer {
         return { model, coords, preset };
     }
 
-    async loadMvsFromUrl(url: string, format: 'mvsj' | 'mvsx', options?: { replaceExisting?: boolean, keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
+    async loadMvsFromUrl(url: string, format: 'mvsj' | 'mvsx', options?: { appendSnapshots?: boolean, keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
         if (format === 'mvsj') {
             const data = await this.plugin.runTask(this.plugin.fetch({ url, type: 'string' }));
             const mvsData = MVSData.fromMVSJ(StringLike.toString(data));
@@ -536,7 +536,7 @@ export class Viewer {
     /** Load MolViewSpec from `data`.
      * If `format` is 'mvsj', `data` must be a string or a Uint8Array containing a UTF8-encoded string.
      * If `format` is 'mvsx', `data` must be a Uint8Array or a string containing base64-encoded binary data prefixed with 'base64,'. */
-    async loadMvsData(data: string | Uint8Array, format: 'mvsj' | 'mvsx', options?: { replaceExisting?: boolean, keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
+    async loadMvsData(data: string | Uint8Array, format: 'mvsj' | 'mvsx', options?: { appendSnapshots?: boolean, keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
         if (typeof data === 'string' && data.startsWith('base64')) {
             data = Uint8Array.from(atob(data.substring(7)), c => c.charCodeAt(0)); // Decode base64 string to Uint8Array
         }

--- a/src/cli/mvs/mvs-render.ts
+++ b/src/cli/mvs/mvs-render.ts
@@ -100,7 +100,7 @@ async function main(args: Args): Promise<void> {
         } else {
             throw new Error(`Input file name must end with .mvsj or .mvsx: ${input}`);
         }
-        await loadMVS(plugin, mvsData, { sanityChecks: true, replaceExisting: true, sourceUrl: sourceUrl, extensions: args.no_extensions ? [] : undefined });
+        await loadMVS(plugin, mvsData, { sanityChecks: true, sourceUrl: sourceUrl, extensions: args.no_extensions ? [] : undefined });
 
         fs.mkdirSync(path.dirname(output), { recursive: true });
         if (args.molj) {

--- a/src/examples/ihm-restraints/index.tsx
+++ b/src/examples/ihm-restraints/index.tsx
@@ -357,7 +357,7 @@ ${nSatisfied} restraints are satisfied.
         }
     };
 
-    await loadMVS(plugin, data, { sanityChecks: true, replaceExisting: true, keepCamera: true });
+    await loadMVS(plugin, data, { sanityChecks: true, keepCamera: true });
 
     return data;
 }

--- a/src/examples/ihm-restraints/index.tsx
+++ b/src/examples/ihm-restraints/index.tsx
@@ -357,7 +357,7 @@ ${nSatisfied} restraints are satisfied.
         }
     };
 
-    await loadMVS(plugin, data, { sanityChecks: true, replaceExisting: true, keepSnapshotCamera: true });
+    await loadMVS(plugin, data, { sanityChecks: true, replaceExisting: true, keepCamera: true });
 
     return data;
 }

--- a/src/examples/mvs-stories/elements/viewer.tsx
+++ b/src/examples/mvs-stories/elements/viewer.tsx
@@ -58,9 +58,9 @@ export class MolComponentViewerModel extends PluginComponent {
                 if (cmd.url) {
                     const data = await this.plugin!.runTask(this.plugin!.fetch({ url: cmd.url, type: 'string' }));
                     const mvsData = MVSData.fromMVSJ(StringLike.toString(data));
-                    await loadMVS(this.plugin!, mvsData, { sanityChecks: true, sourceUrl: cmd.url, replaceExisting: true });
+                    await loadMVS(this.plugin!, mvsData, { sanityChecks: true, sourceUrl: cmd.url });
                 } else if (cmd.data) {
-                    await loadMVS(this.plugin!, cmd.data, { sanityChecks: true, replaceExisting: true });
+                    await loadMVS(this.plugin!, cmd.data, { sanityChecks: true });
                 }
             }
         });

--- a/src/extensions/mvs/behavior.ts
+++ b/src/extensions/mvs/behavior.ts
@@ -173,7 +173,7 @@ const MVSDragAndDropHandler: DragAndDropHandler = {
                 const task = Task.create('Load MVSJ file', async ctx => {
                     const data = await file.text();
                     const mvsData = MVSData.fromMVSJ(data);
-                    await loadMVS(plugin, mvsData, { sanityChecks: true, replaceExisting: !applied, sourceUrl: undefined });
+                    await loadMVS(plugin, mvsData, { sanityChecks: true, appendSnapshots: applied, sourceUrl: undefined });
                 });
                 await plugin.runTask(task);
                 applied = true;
@@ -183,7 +183,7 @@ const MVSDragAndDropHandler: DragAndDropHandler = {
                     const buffer = await file.arrayBuffer();
                     const array = new Uint8Array(buffer);
                     const parsed = await loadMVSX(plugin, ctx, array);
-                    await loadMVS(plugin, parsed.mvsData, { sanityChecks: true, replaceExisting: !applied, sourceUrl: parsed.sourceUrl });
+                    await loadMVS(plugin, parsed.mvsData, { sanityChecks: true, appendSnapshots: applied, sourceUrl: parsed.sourceUrl });
                 });
                 await plugin.runTask(task);
                 applied = true;

--- a/src/extensions/mvs/components/formats.ts
+++ b/src/extensions/mvs/components/formats.ts
@@ -58,7 +58,7 @@ export const ParseMVSX = MVSTransform({
 
 /** Params for the `LoadMvsData` action */
 export const LoadMvsDataParams = {
-    replaceExisting: PD.Boolean(false, { description: 'If true, the loaded MVS view will replace the current state; if false, the MVS view will be added to the current state.' }),
+    appendSnapshots: PD.Boolean(false, { description: 'If true, add snapshots from MVS into current snapshot list; if false, replace the snapshot list.' }),
     keepCamera: PD.Boolean(false, { description: 'If true, any camera positioning from the MVS state will be ignored and the current camera position will be kept.' }),
     applyExtensions: PD.Boolean(true, { description: 'If true, apply builtin MVS-loading extensions (not a part of standard MVS specification).' }),
 };
@@ -70,7 +70,7 @@ export const LoadMvsData = StateAction.build({
     params: LoadMvsDataParams,
 })(({ a, params }, plugin: PluginContext) => Task.create('Load MVS Data', async () => {
     const { mvsData, sourceUrl } = a.data;
-    await loadMVS(plugin, mvsData, { replaceExisting: params.replaceExisting, keepCamera: params.keepCamera, sourceUrl: sourceUrl, extensions: params.applyExtensions ? undefined : [] });
+    await loadMVS(plugin, mvsData, { appendSnapshots: params.appendSnapshots, keepCamera: params.keepCamera, sourceUrl: sourceUrl, extensions: params.applyExtensions ? undefined : [] });
 }));
 
 

--- a/src/extensions/mvs/load-generic.ts
+++ b/src/extensions/mvs/load-generic.ts
@@ -37,21 +37,6 @@ export interface LoadingExtension<TTree extends Tree, TContext, TExtensionContex
 }
 
 
-/** Load a tree into Mol*, by applying loading actions in DFS order and then commiting at once.
- * If `options.replaceExisting`, remove all objects in the current Mol* state; otherwise add to the current state. */
-export async function loadTree<TTree extends Tree, TContext>(
-    plugin: PluginContext,
-    tree: TTree,
-    loadingActions: LoadingActions<TTree, TContext>,
-    context: TContext,
-    options?: { replaceExisting?: boolean, extensions?: LoadingExtension<TTree, TContext, any>[] }
-) {
-    const updateRoot: UpdateTarget = UpdateTarget.create(plugin, options?.replaceExisting ?? false);
-    loadTreeInUpdate(updateRoot, tree, loadingActions, context, options);
-    await UpdateTarget.commit(updateRoot);
-}
-
-
 export function loadTreeVirtual<TTree extends Tree, TContext>(
     plugin: PluginContext,
     tree: TTree,

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -38,7 +38,6 @@ import { MVSTreeSchema } from './tree/mvs/mvs-tree';
 export interface MVSLoadOptions {
     replaceExisting?: boolean,
     keepCamera?: boolean,
-    keepSnapshotCamera?: boolean,
     extensions?: MolstarLoadingExtension<any>[],
     sanityChecks?: boolean,
     sourceUrl?: string,
@@ -47,8 +46,7 @@ export interface MVSLoadOptions {
 
 /** Load a MolViewSpec (MVS) tree into the Mol* plugin.
  * If `options.replaceExisting`, remove all objects in the current Mol* state; otherwise add to the current state.
- * If `options.keepCamera`, ignore any camera positioning from the MVS state and keep the current camera position instead.
- * If `options.keepSnapshotCamera`, ignore any camera positioning when generating snapshots.
+ * If `options.keepCamera`, ignore any camera positioning from the MVS state and keep the current camera position instead, ignore any camera positioning when generating snapshots.
  * If `options.sanityChecks`, run some sanity checks and print potential issues to the console.
  * If `options.extensions` is provided, apply specified set of MVS-loading extensions (not a part of standard MVS specification); default: apply all builtin extensions; use `extensions: []` to avoid applying builtin extensions.
  * `options.sourceUrl` serves as the base for resolving relative URLs/URIs and may itself be relative to the window URL. */
@@ -96,13 +94,13 @@ export async function loadMVS(plugin: PluginContext, data: MVSData, options: MVS
 }
 
 
-function molstarTreeToEntry(plugin: PluginContext, tree: MolstarTree, metadata: SnapshotMetadata & { previousTransitionDurationMs?: number }, options?: { replaceExisting?: boolean, keepCamera?: boolean, keepSnapshotCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
+function molstarTreeToEntry(plugin: PluginContext, tree: MolstarTree, metadata: SnapshotMetadata & { previousTransitionDurationMs?: number }, options?: { replaceExisting?: boolean, keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
     const context = MolstarLoadingContext.create();
     const snapshot = loadTreeVirtual(plugin, tree, MolstarLoadingActions, context, { ...options, extensions: options?.extensions ?? BuiltinLoadingExtensions });
     snapshot.canvas3d = {
         props: plugin.canvas3d ? modifyCanvasProps(plugin.canvas3d.props, context.canvas) : undefined,
     };
-    if (!options?.keepSnapshotCamera) {
+    if (!options?.keepCamera) {
         snapshot.camera = createPluginStateSnapshotCamera(plugin, context, metadata);
     }
     snapshot.durationInMs = metadata.linger_duration_ms + (metadata.previousTransitionDurationMs ?? 0);

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -36,20 +36,20 @@ import { MVSTreeSchema } from './tree/mvs/mvs-tree';
 
 
 export interface MVSLoadOptions {
-    replaceExisting?: boolean,
+    /** Add snapshots from MVS into current snapshot list, instead of replacing the list. */
+    appendSnapshots?: boolean,
+    /** Ignore any camera positioning from the MVS state and keep the current camera position instead, ignore any camera positioning when generating snapshots. */
     keepCamera?: boolean,
+    /** Specifies a set of MVS-loading extensions (not a part of standard MVS specification). If undefined, apply all builtin extensions. If `[]`, do not apply builtin extensions. */
     extensions?: MolstarLoadingExtension<any>[],
+    /** Run some sanity checks and print potential issues to the console. */
     sanityChecks?: boolean,
+    /** Base for resolving relative URLs/URIs. May itself be a relative URL (relative to the window URL). */
     sourceUrl?: string,
     doNotReportErrors?: boolean
 }
 
-/** Load a MolViewSpec (MVS) tree into the Mol* plugin.
- * If `options.replaceExisting`, remove all objects in the current Mol* state; otherwise add to the current state.
- * If `options.keepCamera`, ignore any camera positioning from the MVS state and keep the current camera position instead, ignore any camera positioning when generating snapshots.
- * If `options.sanityChecks`, run some sanity checks and print potential issues to the console.
- * If `options.extensions` is provided, apply specified set of MVS-loading extensions (not a part of standard MVS specification); default: apply all builtin extensions; use `extensions: []` to avoid applying builtin extensions.
- * `options.sourceUrl` serves as the base for resolving relative URLs/URIs and may itself be relative to the window URL. */
+/** Load a MolViewSpec (MVS) state(s) into the Mol* plugin as plugin state snapshots. */
 export async function loadMVS(plugin: PluginContext, data: MVSData, options: MVSLoadOptions = {}) {
     plugin.errorContext.clear('mvs');
     try {
@@ -68,7 +68,9 @@ export async function loadMVS(plugin: PluginContext, data: MVSData, options: MVS
             const entry = molstarTreeToEntry(plugin, molstarTree, { ...snapshot.metadata, previousTransitionDurationMs: previousSnapshot.metadata.transition_duration_ms }, options);
             entries.push(entry);
         }
-        plugin.managers.snapshot.clear();
+        if (!options.appendSnapshots) {
+            plugin.managers.snapshot.clear();
+        }
         for (const entry of entries) {
             plugin.managers.snapshot.add(entry);
         }
@@ -94,9 +96,9 @@ export async function loadMVS(plugin: PluginContext, data: MVSData, options: MVS
 }
 
 
-function molstarTreeToEntry(plugin: PluginContext, tree: MolstarTree, metadata: SnapshotMetadata & { previousTransitionDurationMs?: number }, options?: { replaceExisting?: boolean, keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
+function molstarTreeToEntry(plugin: PluginContext, tree: MolstarTree, metadata: SnapshotMetadata & { previousTransitionDurationMs?: number }, options?: { keepCamera?: boolean, extensions?: MolstarLoadingExtension<any>[] }) {
     const context = MolstarLoadingContext.create();
-    const snapshot = loadTreeVirtual(plugin, tree, MolstarLoadingActions, context, { ...options, extensions: options?.extensions ?? BuiltinLoadingExtensions });
+    const snapshot = loadTreeVirtual(plugin, tree, MolstarLoadingActions, context, { replaceExisting: true, extensions: options?.extensions ?? BuiltinLoadingExtensions });
     snapshot.canvas3d = {
         props: plugin.canvas3d ? modifyCanvasProps(plugin.canvas3d.props, context.canvas) : undefined,
     };

--- a/src/extensions/mvs/mvs-data.ts
+++ b/src/extensions/mvs/mvs-data.ts
@@ -157,6 +157,25 @@ export const MVSData = {
             metadata: GlobalMetadata.create(metadata),
         };
     },
+
+    /** Convert single-state MVSData into multi-state MVSData with one state. */
+    stateToStates(state: MVSData_State): MVSData_States {
+        return {
+            kind: 'multiple',
+            metadata: state.metadata,
+            snapshots: [{
+                metadata: {
+                    title: state.metadata.title,
+                    description: state.metadata.description,
+                    description_format: state.metadata.description_format,
+                    key: undefined,
+                    linger_duration_ms: 1000,
+                    transition_duration_ms: 250,
+                },
+                root: state.root,
+            }],
+        };
+    },
 };
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This changes the way single-state MVS files are loaded. A single-state MVS is now treated the same as a multi-state MVS with one snapshot.

Related changes:
- Merged `loadMVS` options `keepCamera` and `keepSnapshotCamera`, as `keepCamera` lost meaning 
- Added `loadMVS` option `appendSnapshots` ("do not remove current list of snapshots")
- Removed `loadMVS` option `replaceExisting` (is now default, state trees are never combined)
- Drag-and-dropping multiple MVSs loads concatenation of their snapshots (instead of combining state trees into one)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`