### PR TITLE
MVS: FoV adjusted position Camera Info & MVSX assets in multi-snapshot states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Note that since we don't clearly distinguish between a public and private interf
   - Primitive arrow - nicer default cap size (relative to tube_radius)
   - Primitive angle_measurement - added vector_radius param
   - Fix MVSX file assets being disposed in multi-snapshot states
-- Show FOV adjusted position in `CameraInfo` UI and use it in "Copy MVS State"
+- Add `mol-utils/camera.ts` with `fovAdjustedPosition` and `fovNormalizedCameraPosition`
+- Show FOV normalized position in `CameraInfo` UI and use it in "Copy MVS State"
 - Support static resources in `AssetManager`
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Geometric primitives - do not render if position refers to empty substructure
   - Primitive arrow - nicer default cap size (relative to tube_radius)
   - Primitive angle_measurement - added vector_radius param
+- Show FOV adjusted position in `CameraInfo` UI and use it in "Copy MVS State"
 
 ## [v4.17.0] - 2025-05-22
 - Remove `xhr2` dependency for NodeJS, use `fetch`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Note that since we don't clearly distinguish between a public and private interf
   - Geometric primitives - do not render if position refers to empty substructure
   - Primitive arrow - nicer default cap size (relative to tube_radius)
   - Primitive angle_measurement - added vector_radius param
+  - Fix MVSX file assets being disposed in multi-snapshot states
 - Show FOV adjusted position in `CameraInfo` UI and use it in "Copy MVS State"
+- Support static resources in `AssetManager`
+
 
 ## [v4.17.0] - 2025-05-22
 - Remove `xhr2` dependency for NodeJS, use `fetch`

--- a/src/extensions/mvs/camera.ts
+++ b/src/extensions/mvs/camera.ts
@@ -13,6 +13,7 @@ import { PluginCommands } from '../../mol-plugin/commands';
 import { PluginContext } from '../../mol-plugin/context';
 import { PluginState } from '../../mol-plugin/state';
 import { StateObjectSelector } from '../../mol-state';
+import { fovAdjustedPosition } from '../../mol-util/camera';
 import { ColorNames } from '../../mol-util/color/names';
 import { decodeColor } from './helpers/utils';
 import { MolstarLoadingContext } from './load';
@@ -96,24 +97,6 @@ function adjustSceneRadiusFactor(plugin: PluginContext, cameraTarget: Vec3 | und
 function resetSceneRadiusFactor(plugin: PluginContext) {
     const sceneRadiusFactor = Canvas3DParams.sceneRadiusFactor.defaultValue;
     plugin.canvas3d?.setProps({ sceneRadiusFactor });
-}
-
-/** Return the distance adjustment ratio for conversion from the "reference camera"
- * to a camera with an arbitrary field of view `fov`. */
-function distanceAdjustment(mode: Camera.Mode, fov: number) {
-    if (mode === 'orthographic') return 1 / (2 * Math.tan(fov / 2));
-    else return 1 / (2 * Math.sin(fov / 2));
-}
-
-/** Return the position for a camera with an arbitrary field of view `fov`
- * necessary to just fit into view the same sphere (with center at `target`)
- * as the "reference camera" placed at `refPosition` would fit, while keeping the camera orientation.
- * The "reference camera" is a camera which can just fit into view a sphere of radius R with center at distance 2R
- * (this corresponds to FOV = 2 * asin(1/2) in perspective mode or FOV = 2 * atan(1/2) in orthographic mode). */
-function fovAdjustedPosition(target: Vec3, refPosition: Vec3, mode: Camera.Mode, fov: number) {
-    const delta = Vec3.sub(Vec3(), refPosition, target);
-    const adjustment = distanceAdjustment(mode, fov);
-    return Vec3.scaleAndAdd(delta, target, delta, adjustment); // return target + delta * adjustment
 }
 
 /** Create object for PluginState.Snapshot.camera based on tree loading context and MVS snapshot metadata */

--- a/src/extensions/mvs/components/formats.ts
+++ b/src/extensions/mvs/components/formats.ts
@@ -114,7 +114,7 @@ export const MVSXFormatProvider: DataFormatProvider<{}, StateObjectRef<Mvs>, any
  * Return parsed MVS data and `sourceUrl` for resolution of relative URIs.  */
 export async function loadMVSX(plugin: PluginContext, runtimeCtx: RuntimeContext, data: Uint8Array, mainFilePath: string = 'index.mvsj'): Promise<{ mvsData: MVSData, sourceUrl: string }> {
     // Ensure at most one generation of MVSX file assets exists in the asset manager.
-    // Hopefully, this is a reasonable compromise to encure MVSX files work in multi-snapshot
+    // Hopefully, this is a reasonable compromise to ensure MVSX files work in multi-snapshot
     // states.
     clearMVSXFileAssets(plugin);
 

--- a/src/extensions/mvs/components/formats.ts
+++ b/src/extensions/mvs/components/formats.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { hashFnv32a } from '../../../mol-data/util';
@@ -112,6 +113,11 @@ export const MVSXFormatProvider: DataFormatProvider<{}, StateObjectRef<Mvs>, any
  * and parse the main file in the archive as MVSJ.
  * Return parsed MVS data and `sourceUrl` for resolution of relative URIs.  */
 export async function loadMVSX(plugin: PluginContext, runtimeCtx: RuntimeContext, data: Uint8Array, mainFilePath: string = 'index.mvsj'): Promise<{ mvsData: MVSData, sourceUrl: string }> {
+    // Ensure at most one generation of MVSX file assets exists in the asset manager.
+    // Hopefully, this is a reasonable compromise to encure MVSX files work in multi-snapshot
+    // states.
+    clearMVSXFileAssets(plugin);
+
     const archiveId = `ni,fnv1a;${hashFnv32a(data)}`;
     let files: { [path: string]: Uint8Array };
     try {
@@ -122,7 +128,8 @@ export async function loadMVSX(plugin: PluginContext, runtimeCtx: RuntimeContext
     }
     for (const path in files) {
         const url = arcpUri(archiveId, path);
-        ensureUrlAsset(plugin.managers.asset, url, files[path]);
+        // Need to use static assets so they persist accross snapsho
+        ensureUrlAsset(plugin.managers.asset, url, files[path], { isFile: true });
     }
     const mainFile = files[mainFilePath];
     if (!mainFile) throw new Error(`File ${mainFilePath} not found in the MVSX archive`);
@@ -154,11 +161,15 @@ export async function loadMVSData(plugin: PluginContext, data: MVSData | StringL
         }
         await plugin.runTask(Task.create('Load MVSX file', async ctx => {
             const parsed = await loadMVSX(plugin, ctx, data as Uint8Array);
-            await loadMVS(plugin, parsed.mvsData, { sanityChecks: true, sourceUrl: parsed.sourceUrl, ...options });
+            await loadMVS(plugin, parsed.mvsData, { sanityChecks: true, ...options, sourceUrl: parsed.sourceUrl });
         }));
     } else {
         throw new Error(`Unknown MolViewSpec format: ${format}`);
     }
+}
+
+function clearMVSXFileAssets(plugin: PluginContext) {
+    plugin.managers.asset.clearTag('mvsx-file');
 }
 
 /** If the PluginStateObject `pso` comes from a Download transform, try to get its `url` parameter. */
@@ -177,11 +188,13 @@ function arcpUri(archiveId: string, path: string): string {
 
 /** Add a URL asset to asset manager.
  * Skip if an asset with the same URL already exists. */
-function ensureUrlAsset(manager: AssetManager, url: string, data: Uint8Array) {
+function ensureUrlAsset(manager: AssetManager, url: string, data: Uint8Array, options?: { isFile?: boolean }) {
     const asset = Asset.getUrlAsset(manager, url);
     if (!manager.has(asset)) {
         const filename = url.split('/').pop() ?? 'file';
-        manager.set(asset, new File([data], filename));
+        // We need to mark files as static resources to prevent deleting them
+        // when changing state snapshots.
+        manager.set(asset, new File([data], filename), options?.isFile ? { isStatic: true, tag: 'mvsx-file' } : undefined);
     }
 }
 

--- a/src/mol-plugin-ui/viewport/screenshot.tsx
+++ b/src/mol-plugin-ui/viewport/screenshot.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { round } from '../../mol-util';
 import { Vec3 } from '../../mol-math/linear-algebra';
 import { Camera } from '../../mol-canvas3d/camera';
+import { fovNormalizedCameraPosition } from '../../mol-util/camera';
 
 interface ImageControlsState {
     showPreview: boolean,
@@ -113,14 +114,15 @@ function CameraInfoSection({ title, children }: { title: string, children: any }
     </div>;
 }
 
-function fovAdjustedCameraPosition(camera?: Camera.Snapshot) {
+function normalizedCameraPosition(camera?: Camera.Snapshot) {
     if (!camera) return;
 
-    // MolViewSpec uses FOV-adjusted camera position
-    //   => need to apply inverse here so it doesn't offset the view when loaded
-    const f = camera.mode === 'orthographic' ? 1 / (2 * Math.tan(camera.fov / 2)) : 1 / (2 * Math.sin(camera.fov / 2));
-    const delta = Vec3.sub(Vec3(), camera.position, camera.target);
-    return Vec3.scaleAndAdd(delta, camera.target, delta, 1 / (f || 1));
+    return fovNormalizedCameraPosition(
+        camera.target,
+        camera.position,
+        camera.mode,
+        camera.fov,
+    );
 }
 
 function CameraInfo({ plugin }: { plugin: PluginContext }) {
@@ -131,20 +133,23 @@ function CameraInfo({ plugin }: { plugin: PluginContext }) {
     }, [plugin]);
 
     const state = plugin.canvas3d?.camera.state;
-    const fovAdjusted = fovAdjustedCameraPosition(state);
+    const fovNormalized = normalizedCameraPosition(state);
+
+    const direction = Vec3.sub(Vec3(), state?.target ?? Vec3.origin, state?.position ?? Vec3.origin);
+    Vec3.normalize(direction, direction);
 
     return <div>
-        <CameraInfoSection title='Ref. Position'>
+        <CameraInfoSection title='Position'>
             {renderVector(state?.position)}
         </CameraInfoSection>
-        <CameraInfoSection title='FoV Adj. Pos.'>
-            {renderVector(fovAdjusted)}
+        <CameraInfoSection title='FoV Norm. Pos.'>
+            {renderVector(fovNormalized)}
         </CameraInfoSection>
         <CameraInfoSection title='Target'>
             {renderVector(state?.target)}
         </CameraInfoSection>
         <CameraInfoSection title='Direction'>
-            {renderVector(Vec3.sub(Vec3(), state?.target ?? Vec3.origin, state?.position ?? Vec3.origin))}
+            {renderVector(direction)}
         </CameraInfoSection>
         <CameraInfoSection title='Up'>
             {renderVector(state?.up)}
@@ -158,12 +163,12 @@ function CameraInfo({ plugin }: { plugin: PluginContext }) {
         <Button onClick={() => {
             if (!navigator.clipboard) return;
             const ret = `{
-    position: [${fovAdjusted?.map(v => round(v, 2)).join(', ')}],
+    position: [${fovNormalized?.map(v => round(v, 2)).join(', ')}],
     target: [${state?.target.map(v => round(v, 2)).join(', ')}],
     up: [${state?.up.map(v => round(v, 2)).join(', ')}],
 }`;
             navigator.clipboard.writeText(ret);
-        }} style={{ marginTop: 1 }} title='Copy JSON usable in MolViewSpec'>Copy MVS JSON</Button>
+        }} style={{ marginTop: 1 }} title='Copy JSON usable in MolViewSpec, uses FoV Normalized Position'>Copy MVS JSON</Button>
     </div>;
 }
 

--- a/src/mol-util/assets.ts
+++ b/src/mol-util/assets.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -67,7 +67,7 @@ class AssetManager {
     // TODO: add URL based ref-counted cache?
     // TODO: when serializing, check for duplicates?
 
-    private _assets = new Map<string, { asset: Asset, file: File, refCount: number }>();
+    private _assets = new Map<string, { asset: Asset, file: File, refCount: number, isStatic?: boolean, tag?: string }>();
 
     get assets() {
         return iterableToArray(this._assets.values());
@@ -83,8 +83,8 @@ class AssetManager {
         }
     }
 
-    set(asset: Asset, file: File) {
-        this._assets.set(asset.id, { asset, file, refCount: 0 });
+    set(asset: Asset, file: File, options?: { isStatic?: boolean, tag?: string }) {
+        this._assets.set(asset.id, { asset, file, refCount: 0, tag: options?.tag, isStatic: options?.isStatic });
     }
 
     get(asset: Asset) {
@@ -139,7 +139,17 @@ class AssetManager {
         const entry = this._assets.get(asset.id);
         if (!entry) return;
         entry.refCount--;
-        if (entry.refCount <= 0) this._assets.delete(asset.id);
+        if (entry.refCount <= 0 && !entry.isStatic) this._assets.delete(asset.id);
+    }
+
+    clearTag(tag: string) {
+        const keys = Array.from(this._assets.keys());
+        for (const key of keys) {
+            const entry = this._assets.get(key);
+            if (entry && entry.tag === tag) {
+                this._assets.delete(key);
+            }
+        }
     }
 
     clear() {

--- a/src/mol-util/camera.ts
+++ b/src/mol-util/camera.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Adam Midlik <midlik@gmail.com>
+ * @author David Sehnal <david.sehnal@gmail.com>
+ */
+
+import { Camera } from '../mol-canvas3d/camera';
+import { Vec3 } from '../mol-math/linear-algebra';
+
+/** Return the distance adjustment ratio for conversion from the "reference camera"
+ * to a camera with an arbitrary field of view `fov`. */
+function distanceAdjustment(mode: Camera.Mode, fov: number) {
+    if (mode === 'orthographic') return 1 / (2 * Math.tan(fov / 2));
+    else return 1 / (2 * Math.sin(fov / 2));
+}
+
+/** Return the position for a camera with an arbitrary field of view `fov`
+ * necessary to just fit into view the same sphere (with center at `target`)
+ * as the "reference camera" placed at `refPosition` would fit, while keeping the camera orientation.
+ * The "reference camera" is a camera which can just fit into view a sphere of radius R with center at distance 2R
+ * (this corresponds to FOV = 2 * asin(1/2) in perspective mode or FOV = 2 * atan(1/2) in orthographic mode). */
+export function fovAdjustedPosition(target: Vec3, refPosition: Vec3, mode: Camera.Mode, fov: number) {
+    const delta = Vec3.sub(Vec3(), refPosition, target);
+    const adjustment = distanceAdjustment(mode, fov);
+    return Vec3.scaleAndAdd(delta, target, delta, adjustment); // return target + delta * adjustment
+}
+
+/** Return the inverse of fovAdjustedPosition to be able to store invariant camera position,
+ * e.g., in MolViewSpec snapshots.
+ */
+export function fovNormalizedCameraPosition(target: Vec3, refPosition: Vec3, mode: Camera.Mode, fov: number) {
+    const delta = Vec3.sub(Vec3(), refPosition, target);
+    const adjustment = distanceAdjustment(mode, fov) || 1;
+    return Vec3.scaleAndAdd(delta, target, delta, 1 / adjustment); // return target + delta / adjustment
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] Adjusts camera position for MVS export to prevent camera shift when the state is reloaded
- [x] Fix MVSX file assets being disposed in multi-snapshot states

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
