### PR TITLE
Support `pickingAlphaThreshold` when `xrayShaded` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add `mol-utils/camera.ts` with `fovAdjustedPosition` and `fovNormalizedCameraPosition`
 - Show FOV normalized position in `CameraInfo` UI and use it in "Copy MVS State"
 - Support static resources in `AssetManager`
-
+- Support `pickingAlphaThreshold` when `xrayShaded` is enabled
 
 ## [v4.17.0] - 2025-05-22
 - Remove `xhr2` dependency for NodeJS, use `fetch`

--- a/src/mol-gl/shader-code.ts
+++ b/src/mol-gl/shader-code.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>

--- a/src/mol-gl/shader-code.ts
+++ b/src/mol-gl/shader-code.ts
@@ -176,7 +176,7 @@ function ignoreDefine(name: string, variant: string, defines: ShaderDefines): bo
             'dColorMarker', 'dCelShaded',
             'dLightCount',
         ];
-        if (variant !== 'depth') {
+        if (variant !== 'depth' && !variant.startsWith('pick')) {
             ignore.push('dXrayShaded');
         }
         if (variant !== 'emissive') {

--- a/src/mol-gl/shader/chunks/check-picking-alpha.glsl.ts
+++ b/src/mol-gl/shader/chunks/check-picking-alpha.glsl.ts
@@ -1,9 +1,14 @@
 export const check_picking_alpha = `
 float viewZ = depthToViewZ(uIsOrtho, fragmentDepth, uNear, uFar);
 float fogFactor = smoothstep(uFogNear, uFogFar, abs(viewZ));
-float alpha = (1.0 - fogFactor) * uAlpha;
+float fogAlpha = (1.0 - fogFactor) * uAlpha;
+float alpha = uAlpha;
+#ifdef dXrayShaded
+    // add bias to make picking xray shaded elements easier
+    alpha = calcXrayShadedAlpha(alpha, normal) + (0.3 * uPickingAlphaThreshold);
+#endif
 // if not opaque enough ignore so the element below can be picked
-if (uAlpha < uPickingAlphaThreshold || alpha < 0.1) {
+if (alpha < uPickingAlphaThreshold || fogAlpha < 0.1) {
     #ifdef dTransparentBackfaces_opaque
         if (!interior) discard;
     #else

--- a/src/mol-gl/shader/chunks/common.glsl.ts
+++ b/src/mol-gl/shader/chunks/common.glsl.ts
@@ -25,7 +25,7 @@ export const common = `
     #define dXrayShaded
 #endif
 
-#if defined(dRenderVariant_color) || defined(dRenderVariant_tracing) || (defined(dRenderVariant_depth) && defined(dXrayShaded))
+#if defined(dRenderVariant_color) || defined(dRenderVariant_tracing) || ((defined(dRenderVariant_depth) || defined(dRenderVariant_pick)) && defined(dXrayShaded))
     #define dNeedsNormal
 #endif
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Support `pickingAlphaThreshold` when `xrayShaded` is enabled. This allows to pick things below the more transparent parts of xray shaded elements.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files