### PR TITLE
isolatedModules and fix turbopack build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add `mol-utils/camera.ts` with `fovAdjustedPosition` and `fovNormalizedCameraPosition`
 - Show FOV normalized position in `CameraInfo` UI and use it in "Copy MVS State"
 - Support static resources in `AssetManager`
+- General:
+  - Use `isolatedModules` tsconfig flag
+  - Fix TurboPack build when using ES6 modules
 
 
 ## [v4.17.0] - 2025-05-22

--- a/src/mol-canvas3d/camera.ts
+++ b/src/mol-canvas3d/camera.ts
@@ -12,7 +12,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Scene } from '../mol-gl/scene';
 import { assertUnreachable } from '../mol-util/type-helpers';
 
-export { ICamera, Camera };
+export type { ICamera };
 
 interface ICamera {
     readonly viewport: Viewport,
@@ -30,7 +30,7 @@ interface ICamera {
 
 const tmpClip = Vec4();
 
-class Camera implements ICamera {
+export class Camera implements ICamera {
     readonly view: Mat4 = Mat4.identity();
     readonly projection: Mat4 = Mat4.identity();
     readonly projectionView: Mat4 = Mat4.identity();
@@ -197,7 +197,7 @@ class Camera implements ICamera {
     }
 }
 
-namespace Camera {
+export namespace Camera {
     export type Mode = 'perspective' | 'orthographic'
 
     export type SnapshotProvider = Partial<Snapshot> | ((scene: Scene, camera: Camera) => Partial<Snapshot>)

--- a/src/mol-data/db.ts
+++ b/src/mol-data/db.ts
@@ -10,6 +10,6 @@ import { Table } from './db/table';
 import { Column } from './db/column';
 import * as ColumnHelpers from './db/column-helpers';
 
-type DatabaseCollection<T extends Database.Schema> = { [name: string]: Database<T> }
+export type DatabaseCollection<T extends Database.Schema> = { [name: string]: Database<T> }
 
-export { DatabaseCollection, Database, Table, Column, ColumnHelpers };
+export { Database, Table, Column, ColumnHelpers };

--- a/src/mol-gl/_spec/gl.shim.ts
+++ b/src/mol-gl/_spec/gl.shim.ts
@@ -786,5 +786,5 @@ export function createGl(width: number, height: number, contextAttributes: WebGL
         stencilOp: function () { },
         stencilOpSeparate: function () { },
         unpackColorSpace: 'srgb',
-    } as unknown as WebGLRenderingContext;
+    };
 }

--- a/src/mol-gl/_spec/gl.shim.ts
+++ b/src/mol-gl/_spec/gl.shim.ts
@@ -787,5 +787,5 @@ export function createGl(width: number, height: number, contextAttributes: WebGL
         stencilOpSeparate: function () { },
         // Caused TSC build error with isolated modules
         // unpackColorSpace: 'srgb',
-    };
+    } as unknown as WebGLRenderingContext;
 }

--- a/src/mol-gl/_spec/gl.shim.ts
+++ b/src/mol-gl/_spec/gl.shim.ts
@@ -785,7 +785,6 @@ export function createGl(width: number, height: number, contextAttributes: WebGL
         stencilMaskSeparate: function () { },
         stencilOp: function () { },
         stencilOpSeparate: function () { },
-        // Caused TSC build error with isolated modules
-        // unpackColorSpace: 'srgb',
+        unpackColorSpace: 'srgb',
     } as unknown as WebGLRenderingContext;
 }

--- a/src/mol-gl/_spec/gl.shim.ts
+++ b/src/mol-gl/_spec/gl.shim.ts
@@ -785,6 +785,7 @@ export function createGl(width: number, height: number, contextAttributes: WebGL
         stencilMaskSeparate: function () { },
         stencilOp: function () { },
         stencilOpSeparate: function () { },
-        unpackColorSpace: 'srgb',
+        // Caused TSC build error with isolated modules
+        // unpackColorSpace: 'srgb',
     };
 }

--- a/src/mol-io/writer/encoder.ts
+++ b/src/mol-io/writer/encoder.ts
@@ -6,10 +6,8 @@
 
 import { Writer } from './writer';
 
-interface Encoder {
+export interface Encoder {
     encode(): void,
     writeTo(writer: Writer): void,
     getSize(): number
 }
-
-export { Encoder };

--- a/src/mol-io/writer/writer.ts
+++ b/src/mol-io/writer/writer.ts
@@ -4,13 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-interface Writer {
+export interface Writer {
     writeString(data: string): boolean,
     writeBinary(data: Uint8Array): boolean
 }
-
-namespace Writer {
-
-}
-
-export { Writer };

--- a/src/mol-math/geometry/boundary-helper.ts
+++ b/src/mol-math/geometry/boundary-helper.ts
@@ -6,7 +6,7 @@
 
 import { Vec3 } from '../linear-algebra/3d/vec3';
 import { CentroidHelper } from './centroid-helper';
-import { Sphere3D } from '../geometry';
+import { Sphere3D } from '../geometry/primitives/sphere3d';
 import { Box3D } from './primitives/box3d';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)

--- a/src/mol-math/geometry/boundary.ts
+++ b/src/mol-math/geometry/boundary.ts
@@ -9,7 +9,8 @@ import { PositionData } from './common';
 import { Vec3 } from '../linear-algebra';
 import { OrderedSet } from '../../mol-data/int';
 import { BoundaryHelper } from './boundary-helper';
-import { Box3D, Sphere3D } from '../geometry';
+import { Box3D } from '../geometry/primitives/box3d';
+import { Sphere3D } from '../geometry/primitives/sphere3d';
 
 export type Boundary = { readonly box: Box3D, readonly sphere: Sphere3D }
 

--- a/src/mol-math/geometry/common.ts
+++ b/src/mol-math/geometry/common.ts
@@ -7,7 +7,7 @@
 
 import { OrderedSet } from '../../mol-data/int';
 import { Mat4, Tensor, Vec3, Vec2 } from '../linear-algebra';
-import { Box3D } from '../geometry';
+import { Box3D } from './primitives/box3d';
 import { Texture } from '../../mol-gl/webgl/texture';
 
 export interface PositionData {

--- a/src/mol-math/geometry/instance-grid.ts
+++ b/src/mol-math/geometry/instance-grid.ts
@@ -6,7 +6,7 @@
 
 import { OrderedSet } from '../../mol-data/int/ordered-set';
 import { fillSerial } from '../../mol-util/array';
-import { Box3D } from '../geometry';
+import { Box3D } from '../geometry/primitives/box3d';
 import { Vec3 } from '../linear-algebra/3d/vec3';
 import { PositionData } from './common';
 import { GridLookup3D } from './lookup3d/grid';

--- a/src/mol-math/geometry/spacegroup/construction.ts
+++ b/src/mol-math/geometry/spacegroup/construction.ts
@@ -7,7 +7,7 @@
 
 import { Vec3, Mat4 } from '../../linear-algebra';
 import { SpacegroupName, TransformData, GroupData, getSpacegroupIndex, OperatorData, SpacegroupNumber } from './tables';
-import { SymmetryOperator } from '../../geometry';
+import { SymmetryOperator } from '../../geometry/symmetry-operator';
 
 interface SpacegroupCell {
     /** Index into spacegroup data table */

--- a/src/mol-math/linear-algebra/3d/vec3.ts
+++ b/src/mol-math/linear-algebra/3d/vec3.ts
@@ -26,16 +26,14 @@ import { EPSILON } from './common';
 
 const _isFinite = isFinite;
 
-export { ReadonlyVec3 };
+export interface Vec3 extends Array<number> { [d: number]: number, '@type': 'vec3', length: 3 }
+export interface ReadonlyVec3 extends Array<number> { readonly [d: number]: number, '@type': 'vec3', length: 3 }
 
-interface Vec3 extends Array<number> { [d: number]: number, '@type': 'vec3', length: 3 }
-interface ReadonlyVec3 extends Array<number> { readonly [d: number]: number, '@type': 'vec3', length: 3 }
-
-function Vec3() {
+export function Vec3() {
     return Vec3.zero();
 }
 
-namespace Vec3 {
+export namespace Vec3 {
     export function zero(): Vec3 {
         const out = [0.1, 0.0, 0.0]; // ensure backing array of type double
         out[0] = 0;
@@ -666,5 +664,3 @@ namespace Vec3 {
     export const negUnitY: ReadonlyVec3 = create(0, -1, 0);
     export const negUnitZ: ReadonlyVec3 = create(0, 0, -1);
 }
-
-export { Vec3 };

--- a/src/mol-math/linear-algebra/matrix/principal-axes.ts
+++ b/src/mol-math/linear-algebra/matrix/principal-axes.ts
@@ -9,7 +9,7 @@ import { Matrix } from './matrix';
 import { Vec3 } from '../3d/vec3';
 import { svd } from './svd';
 import { NumberArray } from '../../../mol-util/type-helpers';
-import { Axes3D } from '../../geometry';
+import { Axes3D } from '../../geometry/primitives/axes3d';
 import { EPSILON } from '../3d/common';
 
 export { PrincipalAxes };

--- a/src/mol-model-formats/structure/cube.ts
+++ b/src/mol-model-formats/structure/cube.ts
@@ -59,16 +59,14 @@ async function getModels(cube: CubeFile, ctx: RuntimeContext) {
         atom_site
     });
 
-    return await createModels(basic, MolFormat.create(cube), ctx);
+    return await createModels(basic, CubeFormat.create(cube), ctx);
 }
 
 //
 
-export { CubeFormat };
+export type CubeFormat = ModelFormat<CubeFile>
 
-type CubeFormat = ModelFormat<CubeFile>
-
-namespace MolFormat {
+export namespace CubeFormat {
     export function is(x?: ModelFormat): x is CubeFormat {
         return x?.kind === 'cube';
     }

--- a/src/mol-model/structure/model/properties/utils/residue-set.ts
+++ b/src/mol-model/structure/model/properties/utils/residue-set.ts
@@ -21,6 +21,14 @@ export class ResidueSet {
     private index = new Map<string, Map<number, ResidueSetEntry[]>>();
     private checkOperator: boolean = false;
 
+    // perf optimization for .has()
+    private _asym_id = StructureProperties.chain.label_asym_id;
+    private _seq_id = StructureProperties.residue.label_seq_id;
+    private _comp_id = StructureProperties.atom.label_comp_id;
+    private _alt_id = StructureProperties.atom.label_alt_id;
+    private _ins_code = StructureProperties.residue.pdbx_PDB_ins_code;
+    private _op_name = StructureProperties.unit.operator_name;
+
     add(entry: ResidueSetEntry) {
         let root = this.index.get(entry.label_asym_id);
         if (!root) {
@@ -48,17 +56,17 @@ export class ResidueSet {
     }
 
     has(loc: StructureElement.Location) {
-        const asym_id = _asym_id(loc);
+        const asym_id = this._asym_id(loc);
         if (!this.index.has(asym_id)) return;
         const root = this.index.get(asym_id)!;
-        const seq_id = _seq_id(loc);
+        const seq_id = this._seq_id(loc);
         if (!root.has(seq_id)) return;
         const entries = root.get(seq_id)!;
 
-        const comp_id = _comp_id(loc);
-        const alt_id = _alt_id(loc);
-        const ins_code = _ins_code(loc);
-        const op_name = _op_name(loc) ?? '1_555';
+        const comp_id = this._comp_id(loc);
+        const alt_id = this._alt_id(loc);
+        const ins_code = this._ins_code(loc);
+        const op_name = this._op_name(loc) ?? '1_555';
 
         for (const e of entries) {
             if (e.label_comp_id !== comp_id || e.label_alt_id !== alt_id || e.ins_code !== ins_code) continue;
@@ -74,12 +82,12 @@ export class ResidueSet {
 
     static getEntryFromLocation(loc: StructureElement.Location): ResidueSetEntry {
         return {
-            label_asym_id: _asym_id(loc),
-            label_comp_id: _comp_id(loc),
-            label_seq_id: _seq_id(loc),
-            label_alt_id: _alt_id(loc),
-            ins_code: _ins_code(loc),
-            operator_name: _op_name(loc) ?? '1_555'
+            label_asym_id: StructureProperties.chain.label_asym_id(loc),
+            label_comp_id: StructureProperties.atom.label_comp_id(loc),
+            label_seq_id: StructureProperties.residue.label_seq_id(loc),
+            label_alt_id: StructureProperties.atom.label_alt_id(loc),
+            ins_code: StructureProperties.residue.pdbx_PDB_ins_code(loc),
+            operator_name: StructureProperties.unit.operator_name(loc) ?? '1_555'
         };
     }
 
@@ -98,10 +106,3 @@ export class ResidueSet {
         this.checkOperator = options?.checkOperator ?? false;
     }
 }
-
-const _asym_id = StructureProperties.chain.label_asym_id;
-const _seq_id = StructureProperties.residue.label_seq_id;
-const _comp_id = StructureProperties.atom.label_comp_id;
-const _alt_id = StructureProperties.atom.label_alt_id;
-const _ins_code = StructureProperties.residue.pdbx_PDB_ins_code;
-const _op_name = StructureProperties.unit.operator_name;

--- a/src/mol-model/structure/query/queries/modifiers.ts
+++ b/src/mol-model/structure/query/queries/modifiers.ts
@@ -16,10 +16,13 @@ import { structureIntersect, structureSubtract, structureUnion } from '../utils/
 import { UniqueArray } from '../../../../mol-data/generic';
 import { StructureSubsetBuilder } from '../../structure/util/subset-builder';
 import { StructureElement } from '../../structure/element';
-import { MmcifFormat } from '../../../../mol-model-formats/structure/mmcif';
 import { ResidueSet, ResidueSetEntry } from '../../model/properties/utils/residue-set';
 import { StructureProperties } from '../../structure/properties';
 import { arraySetAdd } from '../../../../mol-util/array';
+// MmcifFormat needs to be imported as a type otherwise it causes out-of-order
+// code execution in turbopack (and possibly other bundlers)... but interestingly
+// only when ES6 modules are used (CommonJS fine)
+import type { MmcifFormat } from '../../../../mol-model-formats/structure/mmcif';
 
 function getWholeResidues(ctx: QueryContext, source: Structure, structure: Structure) {
     const builder = source.subsetBuilder(true);
@@ -452,6 +455,11 @@ export interface SurroundingLigandsParams {
  * Includes expanded surrounding ligands based on radius from the source, struct_conn entries & pdbx_molecule entries.
  */
 export function surroundingLigands({ query, radius, includeWater }: SurroundingLigandsParams): StructureQuery {
+    const _ent_type = StructureProperties.entity.type;
+    function testIsWater(l: StructureElement.Location) {
+        return _ent_type(l) === 'water';
+    }
+
     return function query_surroundingLigands(ctx) {
 
         const inner = StructureSelection.unionStructure(query(ctx));
@@ -576,16 +584,14 @@ export function surroundingLigands({ query, radius, includeWater }: SurroundingL
     };
 }
 
-const _entity_type = StructureProperties.entity.type;
-function testIsWater(l: StructureElement.Location) {
-    return _entity_type(l) === 'water';
-}
-
 function getPrdAsymIdx(structure: Structure) {
     const model = structure.models[0];
     const ids = new Set<string>();
-    if (!MmcifFormat.is(model.sourceData)) return ids;
-    const { _rowCount, asym_id } = model.sourceData.data.db.pdbx_molecule;
+
+    // Need to do this menually to prevent a cyclical import causing
+    // errors with turbopack when ES6 modules are used.
+    if (model.sourceData?.kind !== 'mmCIF') return ids;
+    const { _rowCount, asym_id } = (model.sourceData as MmcifFormat).data.db.pdbx_molecule;
     for (let i = 0; i < _rowCount; i++) {
         ids.add(asym_id.value(i));
     }
@@ -596,9 +602,11 @@ function getStructConnInfo(structure: Structure) {
     const model = structure.models[0];
     const graph = new StructConnGraph();
 
-    if (!MmcifFormat.is(model.sourceData)) return graph;
+    // Need to do this menually to prevent a cyclical import causing
+    // errors with turbopack when ES6 modules are used.
+    if (model.sourceData?.kind !== 'mmCIF') return graph;
 
-    const struct_conn = model.sourceData.data.db.struct_conn;
+    const struct_conn = (model.sourceData as MmcifFormat).data.db.struct_conn;
     const { conn_type_id } = struct_conn;
     const { ptnr1_label_asym_id, ptnr1_label_comp_id, ptnr1_label_seq_id, ptnr1_symmetry, pdbx_ptnr1_label_alt_id, pdbx_ptnr1_PDB_ins_code } = struct_conn;
     const { ptnr2_label_asym_id, ptnr2_label_comp_id, ptnr2_label_seq_id, ptnr2_symmetry, pdbx_ptnr2_label_alt_id, pdbx_ptnr2_PDB_ins_code } = struct_conn;

--- a/src/mol-model/structure/query/queries/modifiers.ts
+++ b/src/mol-model/structure/query/queries/modifiers.ts
@@ -588,7 +588,7 @@ function getPrdAsymIdx(structure: Structure) {
     const model = structure.models[0];
     const ids = new Set<string>();
 
-    // Need to do this menually to prevent a cyclical import causing
+    // Need to do this manually to prevent a cyclical import causing
     // errors with turbopack when ES6 modules are used.
     if (model.sourceData?.kind !== 'mmCIF') return ids;
     const { _rowCount, asym_id } = (model.sourceData as MmcifFormat).data.db.pdbx_molecule;
@@ -602,7 +602,7 @@ function getStructConnInfo(structure: Structure) {
     const model = structure.models[0];
     const graph = new StructConnGraph();
 
-    // Need to do this menually to prevent a cyclical import causing
+    // Need to do this manually to prevent a cyclical import causing
     // errors with turbopack when ES6 modules are used.
     if (model.sourceData?.kind !== 'mmCIF') return graph;
 

--- a/src/mol-model/structure/structure/unit/bonds/data.ts
+++ b/src/mol-model/structure/structure/unit/bonds/data.ts
@@ -12,26 +12,26 @@ import { StructureElement } from '../../element';
 import { Bond } from '../bonds';
 import { InterUnitGraph } from '../../../../../mol-math/graph/inter-unit-graph';
 
-type IntraUnitBondProps = {
+export type IntraUnitBondProps = {
     /** Can remap even with `dynamicBonds` on, e.g., for water molecules */
     readonly canRemap?: boolean
     /** Can be cached in `ElementSetIntraBondCache` */
     readonly cacheable?: boolean
 }
 
-type IntraUnitBonds = IntAdjacencyGraph<StructureElement.UnitIndex, {
+export type IntraUnitBonds = IntAdjacencyGraph<StructureElement.UnitIndex, {
     readonly order: ArrayLike<number>,
     readonly flags: ArrayLike<BondType.Flag>
     readonly key: ArrayLike<number>,
 }, IntraUnitBondProps>
 
-namespace IntraUnitBonds {
+export namespace IntraUnitBonds {
     export const Empty: IntraUnitBonds = IntAdjacencyGraph.create([], [], [], 0, { flags: [], order: [], key: [] });
 }
 
-type InterUnitEdgeProps = { readonly order: number, readonly flag: BondType.Flag, readonly key: number }
+export type InterUnitEdgeProps = { readonly order: number, readonly flag: BondType.Flag, readonly key: number }
 
-class InterUnitBonds extends InterUnitGraph<number, StructureElement.UnitIndex, InterUnitEdgeProps> {
+export class InterUnitBonds extends InterUnitGraph<number, StructureElement.UnitIndex, InterUnitEdgeProps> {
     /** Get inter-unit bond given a bond-location */
     getBondFromLocation(l: Bond.Location) {
         return Unit.isAtomic(l.aUnit) && Unit.isAtomic(l.bUnit) ? this.getEdge(l.aIndex, l.aUnit.id, l.bIndex, l.bUnit.id) : undefined;
@@ -43,9 +43,7 @@ class InterUnitBonds extends InterUnitGraph<number, StructureElement.UnitIndex, 
     }
 }
 
-namespace InterUnitBonds {
+export namespace InterUnitBonds {
     export class UnitPairBonds extends InterUnitGraph.UnitPairEdges<number, StructureElement.UnitIndex, InterUnitEdgeProps> {}
     export type BondInfo = InterUnitGraph.EdgeInfo<StructureElement.UnitIndex, InterUnitEdgeProps>
 }
-
-export { IntraUnitBonds, IntraUnitBondProps, InterUnitBonds, InterUnitEdgeProps };

--- a/src/mol-plugin-ui/spec.ts
+++ b/src/mol-plugin-ui/spec.ts
@@ -15,9 +15,7 @@ import { VolumeStreamingCustomControls } from './custom/volume';
 import { Loci } from '../mol-model/loci';
 import { SequenceViewMode } from './sequence';
 
-export { PluginUISpec };
-
-interface PluginUISpec extends PluginSpec {
+export interface PluginUISpec extends PluginSpec {
     customParamEditors?: [StateAction | StateTransformer, StateTransformParameters.Class][],
     components?: {
         controls?: PluginUISpec.LayoutControls
@@ -55,7 +53,7 @@ interface PluginUISpec extends PluginSpec {
     },
 }
 
-namespace PluginUISpec {
+export namespace PluginUISpec {
     export interface LayoutControls {
         top?: React.ComponentClass | React.FC | 'none',
         left?: React.ComponentClass | React.FC | 'none',

--- a/src/mol-plugin/util/viewport-screenshot.ts
+++ b/src/mol-plugin/util/viewport-screenshot.ts
@@ -22,14 +22,12 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import { SetUtils } from '../../mol-util/set';
 import { PluginContext } from '../context';
 
-export { ViewportScreenshotHelper, ViewportScreenshotHelperParams };
-
-namespace ViewportScreenshotHelper {
+export namespace ViewportScreenshotHelper {
     export type ResolutionSettings = PD.Values<ReturnType<ViewportScreenshotHelper['createParams']>>['resolution']
     export type ResolutionTypes = ResolutionSettings['name']
 }
 
-type ViewportScreenshotHelperParams = PD.Values<ReturnType<ViewportScreenshotHelper['createParams']>>
+export type ViewportScreenshotHelperParams = PD.Values<ReturnType<ViewportScreenshotHelper['createParams']>>
 
 function checkWebPSupport() {
     // adapted from https://stackoverflow.com/a/27232658
@@ -44,7 +42,7 @@ function checkWebPSupport() {
     }
 }
 
-class ViewportScreenshotHelper extends PluginComponent {
+export class ViewportScreenshotHelper extends PluginComponent {
     private createParams() {
         let max = 8192;
         if (this.plugin.canvas3d) {

--- a/tsconfig.commonjs.json
+++ b/tsconfig.commonjs.json
@@ -12,6 +12,7 @@
         "module": "CommonJS",
         "esModuleInterop": true,
         "moduleResolution": "node",
+        "isolatedModules": true,
         "importHelpers": true,
         "noEmitHelpers": true,
         "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "module": "esnext",
         "esModuleInterop": true,
         "moduleResolution": "node",
+        "isolatedModules": true,
         "importHelpers": true,
         "noEmitHelpers": true,
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] `isolatedModules` tsconfig flag (should streamline compilation/packaging)
- [x] Fix turbopack build with ES6 modules (fixes https://github.com/molstar/molstar/issues/1488)
  - [x] There was some out-of-order code execution. Interestingly, this only happens together with turbopack and ES6 modules were using (CommonJS was fine), and wasn't happening with other builds such as webpack, rollup, or esbuild 

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
