### PR TITLE
Update Representation.Empty creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 - Update production build to use `esbuils`
 - Emit explicit paths in `import`s in `lib/`
+- Change `Representation.Empty` to a lazy property to avoid issue with some bundlers
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-repr/representation.ts
+++ b/src/mol-repr/representation.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../mol-util/param-definition';
@@ -251,17 +252,31 @@ namespace Representation {
     export const StateBuilder: StateBuilder<State> = { create: createState, update: updateState };
 
     export type Any<P extends PD.Params = PD.Params, S extends State = State> = Representation<any, P, S>
-    export const Empty: Any = {
-        label: '', groupCount: 0, renderObjects: [], geometryVersion: -1, props: {}, params: {}, updated: new Subject(), state: createState(), theme: Theme.createEmpty(),
-        createOrUpdate: () => Task.constant('', undefined),
-        setState: () => {},
-        setTheme: () => {},
-        getLoci: () => EmptyLoci,
-        getAllLoci: () => [],
-        eachLocation: () => {},
-        mark: () => false,
-        destroy: () => {}
-    };
+
+
+    export declare const Empty: Any
+
+    export function createEmpty(): Any {
+        return {
+            label: '',
+            groupCount: 0,
+            renderObjects: [],
+            geometryVersion: -1,
+            props: {},
+            params: {},
+            updated: new Subject(),
+            state: createState(),
+            theme: Theme.createEmpty(),
+            createOrUpdate: () => Task.constant('', undefined),
+            setState: () => {},
+            setTheme: () => {},
+            getLoci: () => EmptyLoci,
+            getAllLoci: () => [],
+            eachLocation: () => {},
+            mark: () => false,
+            destroy: () => {}
+        };
+    }
 
     export type Def<D, P extends PD.Params = PD.Params, S extends State = State> = { [k: string]: RepresentationFactory<D, P, S> }
 
@@ -490,3 +505,10 @@ namespace Representation {
         };
     }
 }
+
+let _EmptyRepresentation: Representation.Any | undefined = undefined;
+Object.defineProperty(Representation, "Empty", {
+    get: () => {
+        return _EmptyRepresentation ??= Representation.createEmpty();
+    }
+});


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

In response to https://github.com/molstar/molstar/issues/1545

Some bundlers execute code out of import order, sometimes causing namespaces to have undefined members when code is eagerly evaluated. This change creates the empty representation lazily, hopefully fixing the issue.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files