### PR TITLE
add https support for dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tsconfig.commonjs.tsbuildinfo
 
 .DS_Store
 tmp/
+
+dev.pem
+dev-key.pem

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -273,19 +273,27 @@ async function main() {
 
     console.log('Initial build complete.');
 
+    const certfile = './dev.pem';
+    const keyfile = './dev-key.pem';
+
+    const sslEnabled = fs.existsSync(certfile) && fs.existsSync(keyfile);
+    const protocol = sslEnabled ? 'https' : 'http';
+
     const ctx = await esbuild.context({});
     ctx.serve({
         servedir: './',
         port: args.port,
         host: '0.0.0.0', // Always listen on all interfaces
+        certfile: sslEnabled ? certfile : undefined,
+        keyfile: sslEnabled ? keyfile : undefined,
     });
 
     console.log('');
-    console.log(`Server URL: http://localhost:${args.port}`);
+    console.log(`Server URL: ${protocol}://localhost:${args.port}`);
     if (args.host) {
         console.log('Available host addresses:');
         const ips = getLocalIPs();
-        ips.forEach(ip => console.log(`  http://${ip}:${args.port}`));
+        ips.forEach(ip => console.log(`  ${protocol}://${ip}:${args.port}`));
     }
     console.log('');
     console.log('Watching for changes...');


### PR DESCRIPTION
Some browsers features require https (when not viewed on localhost). This adds support for it in the dev server. You need to create your own cert/key file, see https://esbuild.github.io/api/#https.