### PR TITLE
MVS: clip node support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Annotation field remapping (`field_remapping` parameter for color_from_* nodes)
   - Representation node: support custom property `molstar_reprepresentation_params`, 
   - Canvas node: support custom properties `molstar_enable_outline`, `molstar_enable_shadow`, `molstar_enable_ssao`
+  - `clip` node support for structure and volume representations
 - Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')
 - Added new color schemes, synchronized with D3.js ('inferno', 'magma', 'turbo', 'rainbow', 'sinebow', 'warm', 'cool', 'cubehelix-default', 'category-10', 'observable-10', 'tableau-10')
 

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -250,6 +250,11 @@ export class Representation extends _Base<'representation'> {
         this.addChild('opacity', params);
         return this;
     }
+    /** Add a 'clip' node and return builder pointing back to the representation node. 'clip' node instructs to apply clipping to a visual representation. */
+    clip(params: MVSNodeParams<'clip'> & CustomAndRef): Representation {
+        this.addChild('clip', params);
+        return this;
+    }
 }
 
 
@@ -277,6 +282,11 @@ export class VolumeRepresentation extends _Base<'volume_representation'> impleme
         return this;
     }
     focus = bindMethod(this, FocusMixinImpl, 'focus');
+    /** Add a 'clip' node and return builder pointing back to the representation node. 'clip' node instructs to apply clipping to a visual representation. */
+    clip(params: MVSNodeParams<'clip'> & CustomAndRef): VolumeRepresentation {
+        this.addChild('clip', params);
+        return this;
+    }
 }
 
 

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -5,7 +5,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-import { dict, float, int, list, literal, nullable, OptionalField, RequiredField, str, tuple, union } from '../generic/field-schema';
+import { bool, dict, float, int, list, literal, nullable, OptionalField, RequiredField, str, tuple, union } from '../generic/field-schema';
 import { SimpleParamsSchema } from '../generic/params-schema';
 import { NodeFor, ParamsOfKind, SubtreeOfKind, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
 import { MVSRepresentationParams, MVSVolumeRepresentationParams } from './mvs-tree-representations';
@@ -199,6 +199,29 @@ export const MVSTreeSchema = TreeSchema({
                 field_name: OptionalField(str, 'color', 'Name of the column in CIF or field name (key) in JSON that contains the color.'),
                 /** Customize mapping of annotation values to colors. */
                 palette: OptionalField(nullable(Palette), null, 'Customize mapping of annotation values to colors.'),
+            }),
+        },
+        /** This node instructs to apply clipping to a visual representation. */
+        clip: {
+            description: 'This node instructs to apply clipping to a visual representation.',
+            parent: ['representation', 'volume_representation'],
+            params: SimpleParamsSchema({
+                /** Kind of clipping region, i.e. cube, sphere, cylinder, plane, or infinite cone. */
+                type: RequiredField(literal('cube', 'sphere', 'cylinder', 'plane', 'infinite-cone'), 'Kind of clipping region, i.e. box, sphere, cylinder, plane, or infinite cone.'),
+                /** Position of the clipping region. */
+                position: OptionalField(Vector3, [0, 0, 0], 'Position of the clipping region.'),
+                /** Axis of rotation of the clipping region. Default is (1, 0, 0). */
+                rotation_axis: OptionalField(Vector3, [1, 0, 0], 'Axis of rotation of the clipping region. Default is (1, 0, 0).'),
+                /** Rotation angle of the clipping region in radians. Default is 0. */
+                rotation_angle: OptionalField(float, 0.0, 'Rotation angle of the clipping region in radians. Default is 0.'),
+                /** Scale of the clipping region. Default is (1, 1, 1). */
+                scale: OptionalField(Vector3, [1, 1, 1], 'Scale of the clipping region. Default is (1, 1, 1).'),
+                /** Transformation matrix to apply to the clipping region. */
+                transform: OptionalField(nullable(Matrix), null, 'Transformation matrix to apply to the clipping region'),
+                /** Inverts the clipping region. Default is false. */
+                invert: OptionalField(bool, false, 'Inverts the clipping region. Default is false'),
+                /** Variant of the clip node, either "object" or "pixel". */
+                variant: OptionalField(literal('object', 'pixel'), 'pixel', 'Variant of the clip node, either "object" or "pixel"'),
             }),
         },
         /** This node instructs to apply opacity/transparency to a visual representation. */


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] MVS: `clip` node support for structure and volume representations

Example:

```py
builder = create_builder()
model = builder.download(url=_url_for_mmcif("1cbs")).parse(format="mmcif").model_structure()

(
    model.component(selector="polymer")
    .representation()
    .clip(type="sphere", position=(22.03, 25.62, 21.05), scale=(20, 20, 20))
)
(model.component(selector="ligand").representation(type="ball_and_stick").color(color="red"))
```

![image](https://github.com/user-attachments/assets/437897dd-d050-4926-84d2-de6be2f98d4f)


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
