### PR TITLE
Avoid calculating rings for coarse-grained structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ Note that since we don't clearly distinguish between a public and private interf
 - MolViewSpec extension:
   - Generic color schemes (`palette` parameter for color_from_* nodes)
   - Annotation field remapping (`field_remapping` parameter for color_from_* nodes)
-  - Representation node: support custom property `molstar_reprepresentation_params`, 
+  - Representation node: support custom property `molstar_reprepresentation_params`,
   - Canvas node: support custom properties `molstar_enable_outline`, `molstar_enable_shadow`, `molstar_enable_ssao`
 - Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')
 - Added new color schemes, synchronized with D3.js ('inferno', 'magma', 'turbo', 'rainbow', 'sinebow', 'warm', 'cool', 'cubehelix-default', 'category-10', 'observable-10', 'tableau-10')
+- Avoid calculating rings for coarse-grained structures
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-model/structure/structure/structure.ts
+++ b/src/mol-model/structure/structure/structure.ts
@@ -814,6 +814,7 @@ namespace Structure {
             let traits = Unit.Trait.None;
             if (isMultiChain) traits |= Unit.Trait.MultiChain;
             if (isWater) traits |= Unit.Trait.Water;
+            if (Model.isCoarseGrained(model)) traits |= Unit.Trait.CoarseGrained;
 
             builder.addUnit(Unit.Kind.Atomic, model, operator, elements, traits);
         }

--- a/src/mol-model/structure/structure/unit.ts
+++ b/src/mol-model/structure/structure/unit.ts
@@ -131,6 +131,7 @@ namespace Unit {
         Partitioned = 0x2,
         FastBoundary = 0x4,
         Water = 0x8,
+        CoarseGrained = 0x10,
     }
     export namespace Traits {
         export const is: (t: Traits, f: Trait) => boolean = BitFlags.has;

--- a/src/mol-model/structure/structure/unit/resonance.ts
+++ b/src/mol-model/structure/structure/unit/resonance.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -25,7 +25,18 @@ export type UnitResonance = {
     }
 }
 
+const EmptyUnitResonance: UnitResonance = {
+    delocalizedTriplets: {
+        getThirdElement: () => undefined,
+        getTripletIndices: () => undefined,
+        triplets: []
+    }
+};
+
 export function getResonance(unit: Unit.Atomic): UnitResonance {
+    if (Unit.Traits.is(unit.traits, Unit.Trait.Water) || Unit.Traits.is(unit.traits, Unit.Trait.CoarseGrained)) {
+        return EmptyUnitResonance;
+    }
     return {
         delocalizedTriplets: getDelocalizedTriplets(unit)
     };

--- a/src/mol-model/structure/structure/unit/rings.ts
+++ b/src/mol-model/structure/structure/unit/rings.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -151,6 +151,9 @@ namespace UnitRings {
     export type ComponentIndex = { readonly '@type': 'unit-ring-component-index' } & number
 
     export function create(unit: Unit.Atomic): UnitRings {
+        if (Unit.Traits.is(unit.traits, Unit.Trait.Water) || Unit.Traits.is(unit.traits, Unit.Trait.CoarseGrained)) {
+            return new UnitRings([], unit);
+        }
         const rings = computeRings(unit);
         return new UnitRings(rings, unit);
     }


### PR DESCRIPTION

<!-- Thank you for contributing to Mol* -->

# Description
Avoid calculating rings for coarse-grained structures via new `Unit.Traits.CoarseGrained`. Use the a trait on purpose instead of just checking unit.model to allow individual units to be caorse-grained or not.


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`