### PR TITLE
MVS operator_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Representation node: support custom property `molstar_reprepresentation_params`,
   - Canvas node: support custom properties `molstar_enable_outline`, `molstar_enable_shadow`, `molstar_enable_ssao`
   - `clip` node support for structure and volume representations
-  - Inline selectors and MVS annotations support `operator_name`
+  - Inline selectors and MVS annotations support `instance_id`
 - [Breaking] Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')
 - Added new color schemes, synchronized with D3.js ('inferno', 'magma', 'turbo', 'rainbow', 'sinebow', 'warm', 'cool', 'cubehelix-default', 'category-10', 'observable-10', 'tableau-10')
 - Snapshot Markdown improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Note that since we don't clearly distinguish between a public and private interf
   - Indicate external links with ⤴
 - Avoid calculating rings for coarse-grained structures
 - Fix isosurface compute shader normals when transformation matrix is applied to volume
-- Change symmetry operator naming for assemblies (ASM_1, ASM_2 -> 1, X0-1) - TODO update
 - Symmetry operator naming for spacegroup symmetry - parenthesize multi-character indices (1_111-1 -> 1_(11)1(-1))
+- Add canonical operator name (e.g. ASM-1, ASM-X0-1 for assemblies, 1_555, 1_(11)1(-1) for crystals)
 - [Breaking] `PluginContext.initViewer/initContainer/mount` are now async and have been renamed to include `Async` postfix
 - Mol2 Reader
     - Fix column count parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Annotation field remapping (`field_remapping` parameter for color_from_* nodes)
   - Representation node: support custom property `molstar_reprepresentation_params`,
   - Canvas node: support custom properties `molstar_enable_outline`, `molstar_enable_shadow`, `molstar_enable_ssao`
+  - Inline selectors and MVS annotations support `operator_name`
 - Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')
 - Added new color schemes, synchronized with D3.js ('inferno', 'magma', 'turbo', 'rainbow', 'sinebow', 'warm', 'cool', 'cubehelix-default', 'category-10', 'observable-10', 'tableau-10')
 - Avoid calculating rings for coarse-grained structures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Note that since we don't clearly distinguish between a public and private interf
 - Avoid calculating rings for coarse-grained structures
 - Fix isosurface compute shader normals when transformation matrix is applied to volume 
 - Breaking: `PluginContext.initViewer/initContainer/mount` are now async and have been renamed to include `Async` postfix
+- Change symmetry operator naming for assemblies (ASM_1, ASM_2 -> 1, X0-1)
+- Symmetry operator naming for spacegroup symmetry - parenthesize multi-character indices (1_111-1 -> 1_(11)1(-1))
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -25,7 +25,6 @@ markdown_extensions:
       generic: true
 # Scripts for rendering Latex equations (in addition to pymdownx.arithmatex):
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 nav:
   - 'index.md'

--- a/src/extensions/mvs/components/annotation-color-theme.ts
+++ b/src/extensions/mvs/components/annotation-color-theme.ts
@@ -116,7 +116,7 @@ export function MVSAnnotationColorTheme(ctx: ThemeDataContext, props: MVSAnnotat
 
     return {
         factory: MVSAnnotationColorTheme,
-        granularity: 'group',
+        granularity: 'groupInstance',
         preferSmoothing: true,
         color: color,
         props: props,

--- a/src/extensions/mvs/components/custom-label/visual.ts
+++ b/src/extensions/mvs/components/custom-label/visual.ts
@@ -75,7 +75,7 @@ function createLabelText(ctx: VisualContext, structure: Structure, theme: Theme,
                 break;
             case 'selection':
                 const substructure = substructureFromSelector(structure, item.position.params.selector);
-                const p = textPropsForSelection(substructure, theme.size.size, {});
+                const p = textPropsForSelection(substructure, theme.size.size, [{}]);
                 const group = serialIndexOfSubstructure(structure, substructure) ?? 0;
                 if (p) builder.add(item.text, p.center[0], p.center[1], p.center[2], p.depth, p.scale, group);
                 break;

--- a/src/extensions/mvs/components/multilayer-color-theme.ts
+++ b/src/extensions/mvs/components/multilayer-color-theme.ts
@@ -123,7 +123,7 @@ function makeMultilayerColorTheme(ctx: ThemeDataContext, props: MultilayerColorT
 
     return {
         factory: (ctx_, props_) => makeMultilayerColorTheme(ctx_, props_, colorThemeRegistry),
-        granularity: 'group',
+        granularity: 'groupInstance',
         preferSmoothing: true,
         color: color,
         props: props,

--- a/src/extensions/mvs/components/selector.ts
+++ b/src/extensions/mvs/components/selector.ts
@@ -10,8 +10,6 @@ import { StaticStructureComponentTypes, createStructureComponent } from '../../.
 import { PluginStateObject } from '../../../mol-plugin-state/objects';
 import { MolScriptBuilder } from '../../../mol-script/language/builder';
 import { Expression } from '../../../mol-script/language/expression';
-import { UUID } from '../../../mol-util';
-import { arrayExtend, sortIfNeeded } from '../../../mol-util/array';
 import { mapArrayToObject, pickObjectKeys } from '../../../mol-util/object';
 import { Choice } from '../../../mol-util/param-choice';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
@@ -47,28 +45,22 @@ export function isSelectorAll(props: Selector): props is typeof SelectorAll {
 
 
 /** Data structure for fast lookup of a structure element location in a substructure */
-export type ElementSet = { [modelId: UUID]: SortedArray<ElementIndex> }
+export type ElementSet = { [unitId: number]: SortedArray<ElementIndex> }
 
 export const ElementSet = {
     /** Create an `ElementSet` from the substructure of `structure` defined by `selector` */
     fromSelector(structure: Structure | undefined, selector: Selector): ElementSet {
         if (!structure) return {};
-        const arrays: { [modelId: UUID]: ElementIndex[] } = {};
         const selection = substructureFromSelector(structure, selector); // using `getAtomRangesForRow` might (might not) be faster here
+        const out: ElementSet = {};
         for (const unit of selection.units) {
-            arrayExtend(arrays[unit.model.id] ??= [], unit.elements);
+            out[unit.id] = unit.elements;
         }
-        const result: { [modelId: UUID]: SortedArray<ElementIndex> } = {};
-        for (const modelId in arrays) {
-            const array = arrays[modelId as UUID];
-            sortIfNeeded(array, (a, b) => a - b);
-            result[modelId as UUID] = SortedArray.ofSortedArray(array);
-        }
-        return result;
+        return out;
     },
     /** Decide if the element set `set` contains structure element location `location` */
     has(set: ElementSet, location: StructureElement.Location): boolean {
-        const array = set[location.unit.model.id];
+        const array = set[location.unit.id];
         return array ? SortedArray.has(array, location.element) : false;
     },
 };

--- a/src/extensions/mvs/components/selector.ts
+++ b/src/extensions/mvs/components/selector.ts
@@ -48,15 +48,20 @@ export function isSelectorAll(props: Selector): props is typeof SelectorAll {
 export type ElementSet = { [unitId: number]: SortedArray<ElementIndex> }
 
 export const ElementSet = {
+    /** Create an `ElementSet` from a structure */
+    fromStructure(structure: Structure | undefined): ElementSet {
+        if (!structure) return {};
+        const out: ElementSet = {};
+        for (const unit of structure.units) {
+            out[unit.id] = unit.elements;
+        }
+        return out;
+    },
     /** Create an `ElementSet` from the substructure of `structure` defined by `selector` */
     fromSelector(structure: Structure | undefined, selector: Selector): ElementSet {
         if (!structure) return {};
         const selection = substructureFromSelector(structure, selector); // using `getAtomRangesForRow` might (might not) be faster here
-        const out: ElementSet = {};
-        for (const unit of selection.units) {
-            out[unit.id] = unit.elements;
-        }
-        return out;
+        return this.fromStructure(selection);
     },
     /** Decide if the element set `set` contains structure element location `location` */
     has(set: ElementSet, location: StructureElement.Location): boolean {

--- a/src/extensions/mvs/helpers/label-text.ts
+++ b/src/extensions/mvs/helpers/label-text.ts
@@ -40,13 +40,13 @@ class AtomRangesCache {
     private readonly hasOperators: boolean;
 
     constructor(private readonly rows: MVSAnnotationRow[]) {
-        this.hasOperators = rows.some(row => isDefined(row.operator_name));
+        this.hasOperators = rows.some(row => isDefined(row.instance_id));
     }
 
     get(unit: Unit): AtomRanges {
-        const operatorName = unit.conformation.operator.name;
-        const key = this.hasOperators ? `${unit.model.id}:${operatorName}` : unit.model.id;
-        return this.cache[key] ??= getAtomRangesForRows(this.rows, unit.model, operatorName, IndicesAndSortings.get(unit.model));
+        const instanceId = unit.conformation.operator.canonicalName;
+        const key = this.hasOperators ? `${unit.model.id}:${instanceId}` : unit.model.id;
+        return this.cache[key] ??= getAtomRangesForRows(this.rows, unit.model, instanceId, IndicesAndSortings.get(unit.model));
     }
 }
 

--- a/src/extensions/mvs/helpers/schemas.ts
+++ b/src/extensions/mvs/helpers/schemas.ts
@@ -77,8 +77,9 @@ const AllAtomicCifAnnotationSchema = {
     atom_id: int,
     /** 0-based index of the atom in the source data */
     atom_index: int,
-    /** Symmetry operator name like 'X0-1' for assemblies or '1_555' for crystals */
-    operator_name: str,
+    /** Instance identifier to distinguish instances of the same chain created by applying different symmetry operators,
+     * like 'ASM-X0-1' for assemblies or '1_555' for crystals */
+    instance_id: str,
 } satisfies Table.Schema;
 
 /** Allowed fields (i.e. CIF columns or JSON keys) for each annotation schema

--- a/src/extensions/mvs/helpers/schemas.ts
+++ b/src/extensions/mvs/helpers/schemas.ts
@@ -77,6 +77,8 @@ const AllAtomicCifAnnotationSchema = {
     atom_id: int,
     /** 0-based index of the atom in the source data */
     atom_index: int,
+    /** Symmetry operator name like 'X0-1' for assemblies or '1_555' for crystals */
+    operator_name: str,
 } satisfies Table.Schema;
 
 /** Allowed fields (i.e. CIF columns or JSON keys) for each annotation schema

--- a/src/extensions/mvs/helpers/selections.ts
+++ b/src/extensions/mvs/helpers/selections.ts
@@ -19,7 +19,9 @@ const EmptyArray: readonly any[] = [];
 
 
 /** Return atom ranges in `model` which satisfy criteria given by `row` */
-export function getAtomRangesForRow(model: Model, row: MVSAnnotationRow, indices: IndicesAndSortings): AtomRanges {
+export function getAtomRangesForRow(row: MVSAnnotationRow, model: Model, operatorName: string, indices: IndicesAndSortings): AtomRanges {
+    if (isDefined(row.operator_name) && row.operator_name !== operatorName) return AtomRanges.empty();
+
     const h = model.atomicHierarchy;
     const nAtoms = h.atoms._rowCount;
 
@@ -70,12 +72,8 @@ export function getAtomRangesForRow(model: Model, row: MVSAnnotationRow, indices
 }
 
 /** Return atom ranges in `model` which satisfy criteria given by any of `rows` (atoms that satisfy more rows are still included only once) */
-export function getAtomRangesForRows(model: Model, rows: MVSAnnotationRow | MVSAnnotationRow[], indices: IndicesAndSortings): AtomRanges {
-    if (Array.isArray(rows)) {
-        return AtomRanges.union(rows.map(row => getAtomRangesForRow(model, row, indices)));
-    } else {
-        return getAtomRangesForRow(model, rows, indices);
-    }
+export function getAtomRangesForRows(rows: MVSAnnotationRow[], model: Model, operatorName: string, indices: IndicesAndSortings): AtomRanges {
+    return AtomRanges.union(rows.map(row => getAtomRangesForRow(row, model, operatorName, indices)));
 }
 
 

--- a/src/extensions/mvs/helpers/selections.ts
+++ b/src/extensions/mvs/helpers/selections.ts
@@ -19,8 +19,8 @@ const EmptyArray: readonly any[] = [];
 
 
 /** Return atom ranges in `model` which satisfy criteria given by `row` */
-export function getAtomRangesForRow(row: MVSAnnotationRow, model: Model, operatorName: string, indices: IndicesAndSortings): AtomRanges {
-    if (isDefined(row.operator_name) && row.operator_name !== operatorName) return AtomRanges.empty();
+export function getAtomRangesForRow(row: MVSAnnotationRow, model: Model, instanceId: string, indices: IndicesAndSortings): AtomRanges {
+    if (isDefined(row.instance_id) && row.instance_id !== instanceId) return AtomRanges.empty();
 
     const h = model.atomicHierarchy;
     const nAtoms = h.atoms._rowCount;
@@ -72,8 +72,8 @@ export function getAtomRangesForRow(row: MVSAnnotationRow, model: Model, operato
 }
 
 /** Return atom ranges in `model` which satisfy criteria given by any of `rows` (atoms that satisfy more rows are still included only once) */
-export function getAtomRangesForRows(rows: MVSAnnotationRow[], model: Model, operatorName: string, indices: IndicesAndSortings): AtomRanges {
-    return AtomRanges.union(rows.map(row => getAtomRangesForRow(row, model, operatorName, indices)));
+export function getAtomRangesForRows(rows: MVSAnnotationRow[], model: Model, instanceId: string, indices: IndicesAndSortings): AtomRanges {
+    return AtomRanges.union(rows.map(row => getAtomRangesForRow(row, model, instanceId, indices)));
 }
 
 

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -44,6 +44,8 @@ export const ComponentExpressionT = partial({
     type_symbol: str,
     atom_id: int,
     atom_index: int,
+    /** Symmetry operator name like 'X0-1' for assemblies or '1_555' for crystals */
+    operator_name: str,
 });
 export type ComponentExpressionT = ValueFor<typeof ComponentExpressionT>
 

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -44,8 +44,9 @@ export const ComponentExpressionT = partial({
     type_symbol: str,
     atom_id: int,
     atom_index: int,
-    /** Symmetry operator name like 'X0-1' for assemblies or '1_555' for crystals */
-    operator_name: str,
+    /** Instance identifier to distinguish instances of the same chain created by applying different symmetry operators,
+     * like 'ASM-X0-1' for assemblies or '1_555' for crystals */
+    instance_id: str,
 });
 export type ComponentExpressionT = ValueFor<typeof ComponentExpressionT>
 

--- a/src/mol-math/geometry/spacegroup/construction.ts
+++ b/src/mol-math/geometry/spacegroup/construction.ts
@@ -106,7 +106,7 @@ namespace Spacegroup {
 
     export function getSymmetryOperator(spacegroup: Spacegroup, spgrOp: number, i: number, j: number, k: number): SymmetryOperator {
         const operator = setOperatorMatrix(spacegroup, spgrOp, i, j, k, Mat4.zero());
-        return SymmetryOperator.create(`${spgrOp + 1}_${5 + i}${5 + j}${5 + k}`, operator, { hkl: Vec3.create(i, j, k), spgrOp });
+        return SymmetryOperator.create(SymmetryOperator.getSymmetryOperatorName(spgrOp, i, j, k), operator, { hkl: Vec3.create(i, j, k), spgrOp });
     }
 
     const _translationRef = Vec3();
@@ -145,7 +145,7 @@ namespace Spacegroup {
         const _k = k - _translationRefOffset[2];
 
         // const operator = setOperatorMatrixRef(spacegroup, spgrOp, i, j, k, ref, Mat4.zero());
-        return SymmetryOperator.create(`${spgrOp + 1}_${5 + _i}${5 + _j}${5 + _k}`, operator, { hkl: Vec3.create(_i, _j, _k), spgrOp });
+        return SymmetryOperator.create(SymmetryOperator.getSymmetryOperatorName(spgrOp, _i, _j, _k), operator, { hkl: Vec3.create(_i, _j, _k), spgrOp });
     }
 
     function getOperatorMatrix(ids: number[]) {

--- a/src/mol-math/geometry/symmetry-operator.ts
+++ b/src/mol-math/geometry/symmetry-operator.ts
@@ -14,7 +14,7 @@ import { Vec3 } from '../linear-algebra/3d/vec3';
 interface SymmetryOperator {
     /** Operator name, e.g. 1_555, ASM_1 */
     readonly name: string,
-    /** Canonical operator name, must follow symmetry instance naming rules (TODO link MVS docs).
+    /** Canonical operator name, must follow symmetry instance naming rules (https://molstar.org/mol-view-spec-docs/selectors/#instance_id).
      * E.g. 1_555, ASM-X0-5 */
     readonly canonicalName: string,
 

--- a/src/mol-math/geometry/symmetry-operator.ts
+++ b/src/mol-math/geometry/symmetry-operator.ts
@@ -55,7 +55,7 @@ namespace SymmetryOperator {
 
     export type CreateInfo = { assembly?: SymmetryOperator['assembly'], ncsId?: number, hkl?: Vec3, spgrOp?: number, key?: number }
     export function create(name: string, matrix: Mat4, info?: CreateInfo | SymmetryOperator): SymmetryOperator {
-        let { assembly, ncsId, hkl, spgrOp, key } = info || { };
+        let { assembly, ncsId, hkl, spgrOp, key } = info || {};
         const _hkl = hkl ? Vec3.clone(hkl) : Vec3();
         spgrOp = spgrOp ?? -1;
         key = key ?? -1;
@@ -73,6 +73,12 @@ namespace SymmetryOperator {
         return !!x && !!x.matrix && !!x.inverse && typeof x.name === 'string';
     }
 
+    /** Create spacegroup symmetry operator name, e.g. getSymmetryOperatorName(0, 0, 0, 0) -> '1_555' */
+    export function getSymmetryOperatorName(spgrOp: number, i: number, j: number, k: number): string {
+        const fmt = (n: number) => n >= 0 && n <= 9 ? `${n}` : `(${n})`;
+        return `${spgrOp + 1}_${fmt(i + 5)}${fmt(j + 5)}${fmt(k + 5)}`;
+    }
+
     function getSuffix(info?: CreateInfo | SymmetryOperator, isIdentity?: boolean) {
         if (!info) return '';
 
@@ -83,7 +89,7 @@ namespace SymmetryOperator {
 
         if (typeof info.spgrOp !== 'undefined' && typeof info.hkl !== 'undefined' && info.spgrOp !== -1) {
             const [i, j, k] = info.hkl;
-            return `-${info.spgrOp + 1}_${5 + i}${5 + j}${5 + k}`;
+            return `-${getSymmetryOperatorName(info.spgrOp, i, j, k)}`;
         }
 
         if (info.ncsId !== -1) {

--- a/src/mol-model-formats/structure/property/assembly.ts
+++ b/src/mol-model-formats/structure/property/assembly.ts
@@ -118,7 +118,8 @@ function getAssemblyOperators(matrices: Matrices, operatorNames: string[][], sta
             Mat4.mul(m, m, matrices.get(op[i])!);
         }
         index++;
-        operators[operators.length] = SymmetryOperator.create(`ASM_${index}`, m, { assembly: { id: assemblyId, operId: index, operList: op } });
+        const opName = op.join('-');
+        operators[operators.length] = SymmetryOperator.create(opName, m, { assembly: { id: assemblyId, operId: index, operList: op } });
     }
 
     return operators;

--- a/src/mol-model-formats/structure/property/assembly.ts
+++ b/src/mol-model-formats/structure/property/assembly.ts
@@ -59,10 +59,12 @@ export function operatorGroupsProvider(generators: Generator[], matrices: Matric
             const operatorList = parseOperatorList(gen.expression);
             const operatorNames = expandOperators(operatorList);
             const operators = getAssemblyOperators(matrices, operatorNames, operatorOffset, gen.assemblyId);
-            const selector = Q.generators.atoms({ chainTest: Q.pred.and(
-                Q.pred.eq(ctx => StructureProperties.unit.operator_name(ctx.element), SymmetryOperator.DefaultName),
-                Q.pred.inSet(ctx => StructureProperties.chain.label_asym_id(ctx.element), gen.asymIds)
-            ) });
+            const selector = Q.generators.atoms({
+                chainTest: Q.pred.and(
+                    Q.pred.eq(ctx => StructureProperties.unit.operator_name(ctx.element), SymmetryOperator.DefaultName),
+                    Q.pred.inSet(ctx => StructureProperties.chain.label_asym_id(ctx.element), gen.asymIds)
+                )
+            });
             groups[groups.length] = { selector, operators, asymIds: gen.asymIds };
             operatorOffset += operators.length;
         }
@@ -118,8 +120,9 @@ function getAssemblyOperators(matrices: Matrices, operatorNames: string[][], sta
             Mat4.mul(m, m, matrices.get(op[i])!);
         }
         index++;
-        const opName = op.join('-');
-        operators[operators.length] = SymmetryOperator.create(opName, m, { assembly: { id: assemblyId, operId: index, operList: op } });
+        const opName = `ASM_${index}`; // Kept mostly for compatibility reasons
+        const canonicalOpName = SymmetryOperator.getAssemblyOperatorName(op);
+        operators[operators.length] = SymmetryOperator.create(opName, m, { canonicalName: canonicalOpName, assembly: { id: assemblyId, operId: index, operList: op } });
     }
 
     return operators;

--- a/src/mol-model/structure/structure/element/schema.ts
+++ b/src/mol-model/structure/structure/element/schema.ts
@@ -13,7 +13,10 @@ import { Bundle } from './bundle';
 import { Loci } from './loci';
 
 export interface SchemaItem {
+    /** Corresponds to SymmetryOperator.name, e.g. 1_555, ASM_5 */
     operator_name?: string,
+    /** Corresponds to SymmetryOperator.canonicalName, e.g. 1_555, ASM-X0-5 */
+    instance_id?: string,
     label_entity_id?: string,
     label_asym_id?: string,
     auth_asym_id?: string,
@@ -69,6 +72,7 @@ function schemaItemToExpression(item: SchemaItem): Expression {
 
     const chainTests: Expression[] = [];
     if (isDefined(item.operator_name)) chainTests.push(eq([core.operatorName(), item.operator_name]));
+    if (isDefined(item.instance_id)) chainTests.push(eq([core.canonicalOperatorName(), item.instance_id]));
     if (isDefined(item.label_asym_id)) chainTests.push(eq([macromolecular.label_asym_id(), item.label_asym_id]));
     if (isDefined(item.auth_asym_id)) chainTests.push(eq([macromolecular.auth_asym_id(), item.auth_asym_id]));
 

--- a/src/mol-model/structure/structure/properties.ts
+++ b/src/mol-model/structure/structure/properties.ts
@@ -173,6 +173,7 @@ const unit = {
     multiChain: p(l => Unit.Traits.is(l.unit.traits, Unit.Trait.MultiChain)),
     object_primitive: p(l => l.unit.objectPrimitive),
     operator_name: p(l => l.unit.conformation.operator.name),
+    canonical_operator_name: p(l => l.unit.conformation.operator.canonicalName),
     operator_key: p(l => l.unit.conformation.operator.key),
     model_index: p(l => l.unit.model.modelNum),
     model_label: p(l => l.unit.model.label),

--- a/src/mol-script/language/symbol-table/structure-query.ts
+++ b/src/mol-script/language/symbol-table/structure-query.ts
@@ -273,6 +273,7 @@ const atomProperty = {
 
         sourceIndex: atomProp(Type.Num, 'Index of the atom/element in the input file.'),
         operatorName: atomProp(Type.Str, 'Name of the symmetry operator applied to this element.'),
+        canonicalOperatorName: atomProp(Type.Str, 'Canonical name of the symmetry operator applied to this element (aka instance_id).'),
         operatorKey: atomProp(Type.Num, 'Key of the symmetry operator applied to this element.'),
         modelIndex: atomProp(Type.Num, 'Index of the model in the input file.'),
         modelLabel: atomProp(Type.Str, 'Label/header of the model in the input file.')

--- a/src/mol-script/runtime/query/table.ts
+++ b/src/mol-script/runtime/query/table.ts
@@ -305,6 +305,7 @@ const symbols = [
     D(MolScript.structureQuery.atomProperty.core.z, atomProp(StructureProperties.atom.z)),
     D(MolScript.structureQuery.atomProperty.core.sourceIndex, atomProp(StructureProperties.atom.sourceIndex)),
     D(MolScript.structureQuery.atomProperty.core.operatorName, atomProp(StructureProperties.unit.operator_name)),
+    D(MolScript.structureQuery.atomProperty.core.canonicalOperatorName, atomProp(StructureProperties.unit.canonical_operator_name)),
     D(MolScript.structureQuery.atomProperty.core.operatorKey, atomProp(StructureProperties.unit.operator_key)),
     D(MolScript.structureQuery.atomProperty.core.modelIndex, atomProp(StructureProperties.unit.model_index)),
     D(MolScript.structureQuery.atomProperty.core.modelLabel, atomProp(StructureProperties.unit.model_label)),

--- a/src/mol-script/script/mol-script/symbols.ts
+++ b/src/mol-script/script/mol-script/symbols.ts
@@ -211,6 +211,7 @@ export const SymbolTable = [
             Alias(MolScript.structureQuery.atomProperty.core.z, 'atom.z'),
             Alias(MolScript.structureQuery.atomProperty.core.sourceIndex, 'atom.src-index'),
             Alias(MolScript.structureQuery.atomProperty.core.operatorName, 'atom.op-name'),
+            Alias(MolScript.structureQuery.atomProperty.core.canonicalOperatorName, 'atom.canonical-op-name'),
             Alias(MolScript.structureQuery.atomProperty.core.operatorKey, 'atom.op-key'),
             Alias(MolScript.structureQuery.atomProperty.core.modelIndex, 'atom.model-index'),
             Alias(MolScript.structureQuery.atomProperty.core.modelLabel, 'atom.model-label'),

--- a/src/mol-theme/label.ts
+++ b/src/mol-theme/label.ts
@@ -239,7 +239,7 @@ function _elementLabel(location: StructureElement.Location, granularity: LabelGr
         label.push(`<small>${entry}</small>`); // entry
         if (granularity !== 'structure') {
             label.push(`<small>Model ${location.unit.model.modelNum}</small>`); // model
-            label.push(`<small>Instance ${location.unit.conformation.operator.name}</small>`); // instance
+            label.push(`<small>Instance ${location.unit.conformation.operator.canonicalName}</small>`); // instance
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Support for `instance_id` in inline selectors and MVS annotations. This is used to select individual symmetry instances in crystal symmetry structures and assembly structures.

This goes together with https://github.com/molstar/mol-view-spec/pull/84.


This PR also changes the way symmetry instances are named (SymmetryOperator.name) and introduces alternative identifier (SymmetryOperator.canonicalName).

### Crystals

#### SymmetryOperator.name
- Stick to symmetry operators like `1_555` described in [mmCIF dictionary](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_struct_conn.ptnr1_symmetry.html):
- Any translation index <0 or >9 will always be enclosed in parenthesis:
    - e.g. `1_(11)15`, `1_1(11)5`, `1_11(15)` instead of ambiguous `1_1115`
    - e.g. `1_(-1)1(-1)`
    - e.g. `2_454` (stays unchanged)

#### SymmetryOperator.canonicalName
- Identical to SymmetryOperator.name

### Assemblies

#### SymmetryOperator.name
- Stay as is, e.g. `ASM_1`, `ASM_2`... `ASM_1680` (for compatibility reasons)

#### SymmetryOperator.canonicalName
- Where only one operator is applied to create the symmetry instance, the name of the symmetry instance will be `ASM-` plus the operator identifier ([pdbx_struct_oper_list.id](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_pdbx_struct_oper_list.id.html))
  - e.g. `ASM-1`, `ASM-2`, `ASM-3`, `ASM-4` from generator expression `1,2,3,4`
  - e.g. `ASM-1`, `ASM-2`, `ASM-3`, `ASM-4`, `ASM-5` from generator expression `(1-5)`
- Where multiple operators are applied, the name of the symmetry instance will be `ASM-` plus a dash-separated list of operator identifiers. The order of the operators is the same as in the [generator expression](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_pdbx_struct_assembly_gen.oper_expression.html), i.e. rightmost operator is applied first.
  - e.g. `ASM-X0-1`, `ASM-X0-2`... `ASM-X0-20` from generator expression `(X0)(1-20)`
  - e.g. `ASM-1-61`, `ASM-1-62`... `ASM-2-61`, `ASM-2-61`... `ASM-60-88` from generator expression `(1-60)(61-88)`

## Testing files

### Inline selectors

(component, color, label, tooltip, primitives)

- example-operator_name-inline-assembly-1m4x.mvsj
- example-operator_name-inline-crystal-1ejg.mvsj
- example-operator_name-inline-crystal-1ejg-big.mvsj

### MVS annotations

(component_from_uri, color_from_uri, label_from_uri, tooltip_from_uri)

- example-operator_name-in-annotation-1tqn.mvsx

[testing-files-v2.zip](https://github.com/user-attachments/files/21143737/testing-files-v2.zip)



## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`