### PR TITLE
Fix group count calculation on geometry update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix isosurface compute shader normals when transformation matrix is applied to volume
 - Breaking: `PluginContext.initViewer/initContainer/mount` are now async and have been renamed to include `Async` postfix
 - Fix shader error when clipping flags are set without clip objects present
+- Fix wrong group count calculation on geometry update (#1562)
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Breaking: `PluginContext.initViewer/initContainer/mount` are now async and have been renamed to include `Async` postfix
 - Fix shader error when clipping flags are set without clip objects present
 - Fix wrong group count calculation on geometry update (#1562)
+- Fix wrong instance index in `calcMeshColorSmoothing`
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-model/shape/shape.ts
+++ b/src/mol-model/shape/shape.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -49,7 +49,10 @@ export namespace Shape {
             sourceData,
             geometry,
             transforms: transforms || [Mat4.identity()],
-            get groupCount() { return Geometry.getGroupCount(geometry); },
+            get groupCount() {
+                // TODO: consider adding an way provide the group count explicitely
+                return Geometry.getGroupCount(geometry);
+            },
             getColor,
             getSize,
             getLabel

--- a/src/mol-repr/shape/representation.ts
+++ b/src/mol-repr/shape/representation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -149,7 +149,7 @@ export function ShapeRepresentation<D, G extends Geometry, P extends Geometry.Pa
                     // console.log('update geometry')
                     ValueCell.updateIfChanged(_renderObject.values.drawCount, Geometry.getDrawCount(_shape.geometry));
                     ValueCell.updateIfChanged(_renderObject.values.uVertexCount, Geometry.getVertexCount(_shape.geometry));
-                    ValueCell.updateIfChanged(_renderObject.values.uGroupCount, Geometry.getGroupCount(_shape.geometry));
+                    ValueCell.updateIfChanged(_renderObject.values.uGroupCount, locationIt.groupCount);
                 }
 
                 if (updateState.updateTransform || updateState.createGeometry) {

--- a/src/mol-repr/structure/complex-visual.ts
+++ b/src/mol-repr/structure/complex-visual.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
@@ -183,7 +183,7 @@ export function ComplexVisual<G extends Geometry, P extends StructureParams & Ge
                 if (newGeometry) {
                     ValueCell.updateIfChanged(renderObject.values.drawCount, Geometry.getDrawCount(newGeometry));
                     ValueCell.updateIfChanged(renderObject.values.uVertexCount, Geometry.getVertexCount(newGeometry));
-                    ValueCell.updateIfChanged(renderObject.values.uGroupCount, Geometry.getGroupCount(newGeometry));
+                    ValueCell.updateIfChanged(renderObject.values.uGroupCount, locationIt.groupCount);
                 } else {
                     throw new Error('expected geometry to be given');
                 }

--- a/src/mol-repr/structure/units-visual.ts
+++ b/src/mol-repr/structure/units-visual.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
@@ -234,7 +234,7 @@ export function UnitsVisual<G extends Geometry, P extends StructureParams & Geom
                 if (newGeometry) {
                     ValueCell.updateIfChanged(renderObject.values.drawCount, Geometry.getDrawCount(newGeometry));
                     ValueCell.updateIfChanged(renderObject.values.uVertexCount, Geometry.getVertexCount(newGeometry));
-                    ValueCell.updateIfChanged(renderObject.values.uGroupCount, Geometry.getGroupCount(newGeometry));
+                    ValueCell.updateIfChanged(renderObject.values.uGroupCount, locationIt.groupCount);
                 } else {
                     throw new Error('expected geometry to be given');
                 }

--- a/src/mol-repr/volume/representation.ts
+++ b/src/mol-repr/volume/representation.ts
@@ -163,7 +163,7 @@ export function VolumeVisual<G extends Geometry, P extends VolumeParams & Geomet
                 if (newGeometry) {
                     ValueCell.updateIfChanged(renderObject.values.drawCount, Geometry.getDrawCount(newGeometry));
                     ValueCell.updateIfChanged(renderObject.values.uVertexCount, Geometry.getVertexCount(newGeometry));
-                    ValueCell.updateIfChanged(renderObject.values.uGroupCount, Geometry.getGroupCount(newGeometry));
+                    ValueCell.updateIfChanged(renderObject.values.uGroupCount, Geometry.getGroupCount(newGeometry)); // TODO: use locationIt.groupCount instead when updated for volume visuals
                 } else {
                     throw new Error('expected geometry to be given');
                 }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Fix group count calculation on visual update. This caused the marking (highlight/select) to be wrong. Only happened after a geometry update.

Fix wrong instance index in `calcMeshColorSmoothing`. This caused overpaint and other themes to be wrong. Only happened for GPU based color smoothing and only if they were enough instances to trigger a instance reordering for the instanceGrid.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`