### PR TITLE
add tests for box3D nearestIntersectionWithRay3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 - [Breaking] Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')
-- [Breaking] `Box3D.nearestIntersectionWithRay` -> `nearestIntersectionWithRay3D` (use `Ray3D`)
+- [Breaking] `Box3D.nearestIntersectionWithRay` -> `Ray3D.intersectBox3D`
 - [Breaking] `Plane3D.distanceToSpher3D` -> `distanceToSphere3D` (fix spelling)
 - [Breaking] fix typo `MarchinCubes` -> `MarchingCubes`
 - [Breaking] `PluginContext.initViewer/initContainer/mount` are now async and have been renamed to include `Async` postfix
@@ -59,7 +59,6 @@ Note that since we don't clearly distinguish between a public and private interf
     - Add `ray: Ray3D` property to `DragInput`, `ClickInput`, and `MoveInput`
 - Add async, non-blocking picking (only WebGL2)
     - Refactor `Canvas3dInteractionHelper` internals to use async picking for move events
-- Add tests for Box3D -> nearestIntersectionWithRay3D
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - [Breaking] `Box3D.nearestIntersectionWithRay` -> `nearestIntersectionWithRay3D` (use `Ray3D`)
 - [Breaking] `Plane3D.distanceToSpher3D` -> `distanceToSphere3D` (fix spelling)
 - [Breaking] fix typo `MarchinCubes` -> `MarchingCubes`
+- Add tests for Box3D -> nearestIntersectionWithRay3D
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-math/geometry/_spec/box3d.spec.ts
+++ b/src/mol-math/geometry/_spec/box3d.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Gianluca Tomasello <giagitom@gmail.com>
+ */
+
+import { Vec3 } from '../../linear-algebra';
+import { Box3D } from '../primitives/box3d';
+import { Ray3D } from '../primitives/ray3d';
+
+describe('box3D', () => {
+    it('nearestIntersectionWithRay3D', () => {
+        const box = Box3D.create(Vec3.create(-1, -1, -1), Vec3.create(1, 1, 1));
+        const out = Vec3();
+
+        // 1. Ray starts outside and hits the box frontally
+        const ray1 = Ray3D.create(Vec3.create(-2, 0, 0), Vec3.create(1, 0, 0));
+        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray1)).toEqual(Vec3.create(-1, 0, 0));
+
+        // 2. Ray grazes along the top edge (tangential)
+        const ray2 = Ray3D.create(Vec3.create(-2, 1, 0), Vec3.create(1, 0, 0));
+        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray2)).toEqual(Vec3.create(-1, 1, 0));
+
+        // 3. Ray starts exactly on the surface and goes inward
+        const ray3 = Ray3D.create(Vec3.create(-1, 0, 0), Vec3.create(1, 0, 0));
+        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray3)).toEqual(Vec3.create(-1, 0, 0));
+
+        // 4. Ray grazes a corner exactly
+        const ray4 = Ray3D.create(Vec3.create(-2, -2, -2), Vec3.create(1, 1, 1));
+        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray4)).toEqual(Vec3.create(-1, -1, -1));
+
+    });
+});

--- a/src/mol-math/geometry/_spec/box3d.spec.ts
+++ b/src/mol-math/geometry/_spec/box3d.spec.ts
@@ -9,25 +9,36 @@ import { Box3D } from '../primitives/box3d';
 import { Ray3D } from '../primitives/ray3d';
 
 describe('box3D', () => {
-    it('nearestIntersectionWithRay3D', () => {
+    it('intersectWithRay3D', () => {
         const box = Box3D.create(Vec3.create(-1, -1, -1), Vec3.create(1, 1, 1));
         const out = Vec3();
 
         // 1. Ray starts outside and hits the box frontally
         const ray1 = Ray3D.create(Vec3.create(-2, 0, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray1)).toEqual(Vec3.create(-1, 0, 0));
+        expect(Box3D.intersectWithRay3D(out, box, ray1)).toBe(true);
+        expect(out).toEqual(Vec3.create(-1, 0, 0));
 
         // 2. Ray grazes along the top edge (tangential)
         const ray2 = Ray3D.create(Vec3.create(-2, 1, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray2)).toEqual(Vec3.create(-1, 1, 0));
+        expect(Box3D.intersectWithRay3D(out, box, ray2)).toBe(true);
+        expect(out).toEqual(Vec3.create(-1, 1, 0));
 
         // 3. Ray starts exactly on the surface and goes inward
         const ray3 = Ray3D.create(Vec3.create(-1, 0, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray3)).toEqual(Vec3.create(-1, 0, 0));
+        expect(Box3D.intersectWithRay3D(out, box, ray3)).toBe(true);
+        expect(out).toEqual(Vec3.create(-1, 0, 0));
 
         // 4. Ray grazes a corner exactly
         const ray4 = Ray3D.create(Vec3.create(-2, -2, -2), Vec3.create(1, 1, 1));
-        expect(Box3D.nearestIntersectionWithRay3D(out, box, ray4)).toEqual(Vec3.create(-1, -1, -1));
+        expect(Box3D.intersectWithRay3D(out, box, ray4)).toBe(true);
+        expect(out).toEqual(Vec3.create(-1, -1, -1));
 
+        // 5. Ray starts inside the box and exits
+        const ray5 = Ray3D.create(Vec3.create(0, 0, 0), Vec3.create(1, 0, 0));
+        expect(Box3D.intersectWithRay3D(out, box, ray5)).toBe(false);
+
+        // 6. Ray starts outside and points away (misses box completely)
+        const ray6 = Ray3D.create(Vec3.create(-2, 2, 0), Vec3.create(1, 0, 0));
+        expect(Box3D.intersectWithRay3D(out, box, ray6)).toBe(false);
     });
 });

--- a/src/mol-math/geometry/_spec/ray3d.spec.ts
+++ b/src/mol-math/geometry/_spec/ray3d.spec.ts
@@ -8,37 +8,37 @@ import { Vec3 } from '../../linear-algebra';
 import { Box3D } from '../primitives/box3d';
 import { Ray3D } from '../primitives/ray3d';
 
-describe('box3D', () => {
-    it('intersectWithRay3D', () => {
+describe('ray3d', () => {
+    it('intersectBox3D', () => {
         const box = Box3D.create(Vec3.create(-1, -1, -1), Vec3.create(1, 1, 1));
         const out = Vec3();
 
         // 1. Ray starts outside and hits the box frontally
         const ray1 = Ray3D.create(Vec3.create(-2, 0, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.intersectWithRay3D(out, box, ray1)).toBe(true);
+        expect(Ray3D.intersectBox3D(out, ray1, box)).toBe(true);
         expect(out).toEqual(Vec3.create(-1, 0, 0));
 
         // 2. Ray grazes along the top edge (tangential)
         const ray2 = Ray3D.create(Vec3.create(-2, 1, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.intersectWithRay3D(out, box, ray2)).toBe(true);
+        expect(Ray3D.intersectBox3D(out, ray2, box)).toBe(true);
         expect(out).toEqual(Vec3.create(-1, 1, 0));
 
         // 3. Ray starts exactly on the surface and goes inward
         const ray3 = Ray3D.create(Vec3.create(-1, 0, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.intersectWithRay3D(out, box, ray3)).toBe(true);
+        expect(Ray3D.intersectBox3D(out, ray3, box)).toBe(true);
         expect(out).toEqual(Vec3.create(-1, 0, 0));
 
         // 4. Ray grazes a corner exactly
         const ray4 = Ray3D.create(Vec3.create(-2, -2, -2), Vec3.create(1, 1, 1));
-        expect(Box3D.intersectWithRay3D(out, box, ray4)).toBe(true);
+        expect(Ray3D.intersectBox3D(out, ray4, box)).toBe(true);
         expect(out).toEqual(Vec3.create(-1, -1, -1));
 
         // 5. Ray starts inside the box and exits
         const ray5 = Ray3D.create(Vec3.create(0, 0, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.intersectWithRay3D(out, box, ray5)).toBe(false);
+        expect(Ray3D.intersectBox3D(out, ray5, box)).toBe(false);
 
         // 6. Ray starts outside and points away (misses box completely)
         const ray6 = Ray3D.create(Vec3.create(-2, 2, 0), Vec3.create(1, 0, 0));
-        expect(Box3D.intersectWithRay3D(out, box, ray6)).toBe(false);
+        expect(Ray3D.intersectBox3D(out, ray6, box)).toBe(false);
     });
 });

--- a/src/mol-math/geometry/lookup3d/grid.ts
+++ b/src/mol-math/geometry/lookup3d/grid.ts
@@ -418,7 +418,7 @@ function queryNearest<T extends number = number>(ctx: QueryContext, result: Resu
     if (!Box3D.containsVec3(box, tmpRay.origin)) {
         // intersect ray pointing to box center
         Ray3D.targetTo(tmpRay, tmpRay, center);
-        Box3D.nearestIntersectionWithRay3D(tmpRay.origin, box, tmpRay);
+        Box3D.intersectWithRay3D(tmpRay.origin, box, tmpRay);
         gX = Math.max(0, Math.min(sX - 1, Math.floor((tmpRay.origin[0] - min[0]) / delta[0])));
         gY = Math.max(0, Math.min(sY - 1, Math.floor((tmpRay.origin[1] - min[1]) / delta[1])));
         gZ = Math.max(0, Math.min(sZ - 1, Math.floor((tmpRay.origin[2] - min[2]) / delta[2])));

--- a/src/mol-math/geometry/lookup3d/grid.ts
+++ b/src/mol-math/geometry/lookup3d/grid.ts
@@ -418,7 +418,7 @@ function queryNearest<T extends number = number>(ctx: QueryContext, result: Resu
     if (!Box3D.containsVec3(box, tmpRay.origin)) {
         // intersect ray pointing to box center
         Ray3D.targetTo(tmpRay, tmpRay, center);
-        Box3D.intersectWithRay3D(tmpRay.origin, box, tmpRay);
+        Ray3D.intersectBox3D(tmpRay.origin, tmpRay, box);
         gX = Math.max(0, Math.min(sX - 1, Math.floor((tmpRay.origin[0] - min[0]) / delta[0])));
         gY = Math.max(0, Math.min(sY - 1, Math.floor((tmpRay.origin[1] - min[1]) / delta[1])));
         gZ = Math.max(0, Math.min(sZ - 1, Math.floor((tmpRay.origin[2] - min[2]) / delta[2])));

--- a/src/mol-math/geometry/primitives/box3d.ts
+++ b/src/mol-math/geometry/primitives/box3d.ts
@@ -10,7 +10,6 @@ import { OrderedSet } from '../../../mol-data/int';
 import { Sphere3D } from './sphere3d';
 import { Vec3 } from '../../linear-algebra/3d/vec3';
 import { Mat4 } from '../../linear-algebra/3d/mat4';
-import { Ray3D } from './ray3d';
 
 interface Box3D { min: Vec3, max: Vec3 }
 
@@ -189,57 +188,6 @@ namespace Box3D {
             c[1] - r < box.min[1] || c[1] + r > box.max[1] ||
             c[2] - r < box.min[2] || c[2] + r > box.max[2]
         ) ? false : true;
-    }
-
-    function _intersectRay3D(box: Box3D, ray: Ray3D): number {
-        const { origin, direction } = ray;
-        const [minX, minY, minZ] = box.min;
-        const [maxX, maxY, maxZ] = box.max;
-        const [x, y, z] = origin;
-        const invDirX = 1.0 / direction[0];
-        const invDirY = 1.0 / direction[1];
-        const invDirZ = 1.0 / direction[2];
-        let tmin, tmax, tymin, tymax, tzmin, tzmax;
-        if (invDirX >= 0) {
-            tmin = (minX - x) * invDirX;
-            tmax = (maxX - x) * invDirX;
-        } else {
-            tmin = (maxX - x) * invDirX;
-            tmax = (minX - x) * invDirX;
-        }
-        if (invDirY >= 0) {
-            tymin = (minY - y) * invDirY;
-            tymax = (maxY - y) * invDirY;
-        } else {
-            tymin = (maxY - y) * invDirY;
-            tymax = (minY - y) * invDirY;
-        }
-        if ((tmin > tymax) || (tymin > tmax)) return -1;
-        if (tymin > tmin) tmin = tymin;
-        if (tymax < tmax) tmax = tymax;
-        if (invDirZ >= 0) {
-            tzmin = (minZ - z) * invDirZ;
-            tzmax = (maxZ - z) * invDirZ;
-        } else {
-            tzmin = (maxZ - z) * invDirZ;
-            tzmax = (minZ - z) * invDirZ;
-        }
-        if ((tmin > tzmax) || (tzmin > tmax)) return -1;
-        if (tzmin > tmin) tmin = tzmin;
-        if (tzmax < tmax) tmax = tzmax;
-        return tmin >= 0 ? tmin : -1;
-    }
-
-    export function intersectWithRay3D(out: Vec3, box: Box3D, ray: Ray3D): boolean {
-        const t = _intersectRay3D(box, ray);
-        if (t < 0) return false;
-
-        Vec3.scaleAndAdd(out, ray.origin, ray.direction, t);
-        return true;
-    }
-
-    export function isIntersectingWithRay3D(box: Box3D, ray: Ray3D): boolean {
-        return _intersectRay3D(box, ray) >= 0;
     }
 
     export function center(out: Vec3, box: Box3D): Vec3 {

--- a/src/mol-math/geometry/primitives/box3d.ts
+++ b/src/mol-math/geometry/primitives/box3d.ts
@@ -191,7 +191,7 @@ namespace Box3D {
         ) ? false : true;
     }
 
-    export function nearestIntersectionWithRay3D(out: Vec3, box: Box3D, ray: Ray3D): Vec3 {
+    function _intersectRay3D(box: Box3D, ray: Ray3D): number {
         const { origin, direction } = ray;
         const [minX, minY, minZ] = box.min;
         const [maxX, maxY, maxZ] = box.max;
@@ -214,6 +214,9 @@ namespace Box3D {
             tymin = (maxY - y) * invDirY;
             tymax = (minY - y) * invDirY;
         }
+        if ((tmin > tymax) || (tymin > tmax)) return -1;
+        if (tymin > tmin) tmin = tymin;
+        if (tymax < tmax) tmax = tymax;
         if (invDirZ >= 0) {
             tzmin = (minZ - z) * invDirZ;
             tzmax = (maxZ - z) * invDirZ;
@@ -221,16 +224,22 @@ namespace Box3D {
             tzmin = (maxZ - z) * invDirZ;
             tzmax = (minZ - z) * invDirZ;
         }
-        if (tymin > tmin)
-            tmin = tymin;
-        if (tymax < tmax)
-            tmax = tymax;
-        if (tzmin > tmin)
-            tmin = tzmin;
-        if (tzmax < tmax)
-            tmax = tzmax;
-        Vec3.scale(out, direction, tmin);
-        return Vec3.set(out, out[0] + x, out[1] + y, out[2] + z);
+        if ((tmin > tzmax) || (tzmin > tmax)) return -1;
+        if (tzmin > tmin) tmin = tzmin;
+        if (tzmax < tmax) tmax = tzmax;
+        return tmin >= 0 ? tmin : -1;
+    }
+
+    export function intersectWithRay3D(out: Vec3, box: Box3D, ray: Ray3D): boolean {
+        const t = _intersectRay3D(box, ray);
+        if (t < 0) return false;
+
+        Vec3.scaleAndAdd(out, ray.origin, ray.direction, t);
+        return true;
+    }
+
+    export function isIntersectingWithRay3D(box: Box3D, ray: Ray3D): boolean {
+        return _intersectRay3D(box, ray) >= 0;
     }
 
     export function center(out: Vec3, box: Box3D): Vec3 {

--- a/src/mol-math/geometry/primitives/ray3d.ts
+++ b/src/mol-math/geometry/primitives/ray3d.ts
@@ -2,10 +2,12 @@
  * Copyright (c) 2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { Mat4 } from '../../linear-algebra/3d/mat4';
 import { Vec3 } from '../../linear-algebra/3d/vec3';
+import { Box3D } from './box3d';
 import { Sphere3D } from './sphere3d';
 
 interface Ray3D { origin: Vec3, direction: Vec3 }
@@ -40,6 +42,8 @@ namespace Ray3D {
         return out;
     }
 
+    //
+
     const tmpIR = Vec3();
     function _intersectSphere3D(ray: Ray3D, sphere: Sphere3D): number {
         const { center, radius } = sphere;
@@ -73,6 +77,59 @@ namespace Ray3D {
 
     export function isInsideSphere3D(ray: Ray3D, sphere: Sphere3D): boolean {
         return Vec3.distance(ray.origin, sphere.center) < sphere.radius;
+    }
+
+    //
+
+    function _intersectBox3D(ray: Ray3D, box: Box3D): number {
+        const { origin, direction } = ray;
+        const [minX, minY, minZ] = box.min;
+        const [maxX, maxY, maxZ] = box.max;
+        const [x, y, z] = origin;
+        const invDirX = 1.0 / direction[0];
+        const invDirY = 1.0 / direction[1];
+        const invDirZ = 1.0 / direction[2];
+        let tmin, tmax, tymin, tymax, tzmin, tzmax;
+        if (invDirX >= 0) {
+            tmin = (minX - x) * invDirX;
+            tmax = (maxX - x) * invDirX;
+        } else {
+            tmin = (maxX - x) * invDirX;
+            tmax = (minX - x) * invDirX;
+        }
+        if (invDirY >= 0) {
+            tymin = (minY - y) * invDirY;
+            tymax = (maxY - y) * invDirY;
+        } else {
+            tymin = (maxY - y) * invDirY;
+            tymax = (minY - y) * invDirY;
+        }
+        if ((tmin > tymax) || (tymin > tmax)) return -1;
+        if (tymin > tmin) tmin = tymin;
+        if (tymax < tmax) tmax = tymax;
+        if (invDirZ >= 0) {
+            tzmin = (minZ - z) * invDirZ;
+            tzmax = (maxZ - z) * invDirZ;
+        } else {
+            tzmin = (maxZ - z) * invDirZ;
+            tzmax = (minZ - z) * invDirZ;
+        }
+        if ((tmin > tzmax) || (tzmin > tmax)) return -1;
+        if (tzmin > tmin) tmin = tzmin;
+        if (tzmax < tmax) tmax = tzmax;
+        return tmin >= 0 ? tmin : -1;
+    }
+
+    export function intersectBox3D(out: Vec3, ray: Ray3D, box: Box3D): boolean {
+        const t = _intersectBox3D(ray, box);
+        if (t < 0) return false;
+
+        Vec3.scaleAndAdd(out, ray.origin, ray.direction, t);
+        return true;
+    }
+
+    export function isIntersectingBox3D(ray: Ray3D, box: Box3D): boolean {
+        return _intersectBox3D(ray, box) >= 0;
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This adds tests for box3D nearestIntersectionWithRay3D. 

@arose, I'm not sure if (and how) you want to handle also special cases like 

**1. ray origin inside the box
2. ray missing the box**


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`