### PR TITLE
MVS: grid-slice volume representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Representation node: support custom property `molstar_reprepresentation_params`,
   - Canvas node: support custom properties `molstar_enable_outline`, `molstar_enable_shadow`, `molstar_enable_ssao`
   - `clip` node support for structure and volume representations
+  - `grid-slice` representation support for volumes
 - [Breaking] Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')
 - Added new color schemes, synchronized with D3.js ('inferno', 'magma', 'turbo', 'rainbow', 'sinebow', 'warm', 'cool', 'cubehelix-default', 'category-10', 'observable-10', 'tableau-10')
 - Snapshot Markdown improvements
@@ -38,6 +39,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - [Breaking] `Box3D.nearestIntersectionWithRay` -> `nearestIntersectionWithRay3D` (use `Ray3D`)
 - [Breaking] `Plane3D.distanceToSpher3D` -> `distanceToSphere3D` (fix spelling)
 - [Breaking] fix typo `MarchinCubes` -> `MarchingCubes`
+- Volume slice representation: add `relativeX/Y/Z` options for dimension
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/extensions/mvs/load-helpers.ts
+++ b/src/extensions/mvs/load-helpers.ts
@@ -651,14 +651,24 @@ export function volumeRepresentationProps(node: MolstarSubtree<'volume_represent
     const alpha = alphaForNode(node);
     const clip = clippingForNode(node);
     const params = node.params;
+
+    const isoValue = typeof params.absolute_isovalue === 'number' ? Volume.IsoValue.absolute(params.absolute_isovalue) : Volume.IsoValue.relative(params.relative_isovalue ?? 0);
     switch (params.type) {
         case 'isosurface':
-            const isoValue = typeof params.absolute_isovalue === 'number' ? Volume.IsoValue.absolute(params.absolute_isovalue) : Volume.IsoValue.relative(params.relative_isovalue ?? 0);
             const visuals: ('wireframe' | 'solid')[] = [];
             if (params.show_wireframe) visuals.push('wireframe');
             if (params.show_faces) visuals.push('solid');
             return {
                 type: { name: 'isosurface', params: { alpha, isoValue, visuals, clip } },
+            };
+        case 'grid-slice':
+            const isRelative = params.relative_index !== undefined;
+            const dimension = {
+                name: isRelative ? `relative${params.dimension.toUpperCase()}` : params.dimension,
+                params: params.relative_index ?? params.relative_index
+            };
+            return {
+                type: { name: 'slice', params: { alpha, dimension, isoValue, clip } },
             };
         default:
             throw new Error('NotImplementedError');

--- a/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree-representations.ts
@@ -4,7 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-import { bool, float, literal, nullable, OptionalField, RequiredField } from '../generic/field-schema';
+import { bool, float, int, literal, nullable, OptionalField, RequiredField } from '../generic/field-schema';
 import { SimpleParamsSchema, UnionParamsSchema } from '../generic/params-schema';
 import { Matrix, Vector3 } from './param-types';
 
@@ -64,11 +64,25 @@ const VolumeIsoSurface = {
     show_faces: OptionalField(bool, true, 'Show mesh faces. Defaults to true.'),
 };
 
+const VolumeGridSlice = {
+    /** Dimension of the grid slice, i.e. 'x', 'y', or 'z'. */
+    dimension: RequiredField(literal('x', 'y', 'z'), 'Dimension of the grid slice, i.e. \'x\', \'y\', or \'z\'.'),
+    /** Index of the grid slice in the specified dimension. 0-based index, i.e. 0 is the first slice. */
+    absolute_index: OptionalField(nullable(int), null, 'Index of the grid slice in the specified dimension. 0-based index, i.e. 0 is the first slice.'),
+    /** Relative index of the grid slice in the specified dimension. 0.0 is the first slice, 1.0 is the last slice. Overrides `absolute_index`. */
+    relative_index: OptionalField(nullable(float), null, 'Relative index of the grid slice in the specified dimension. 0.0 is the first slice, 1.0 is the last slice. Overrides `absolute_index`.'),
+    /** Relative isovalue. */
+    relative_isovalue: OptionalField(nullable(float), null, 'Relative isovalue.'),
+    /** Absolute isovalue. Overrides `relative_isovalue`. */
+    absolute_isovalue: OptionalField(nullable(float), null, 'Absolute isovalue. Overrides `relative_isovalue`.'),
+};
+
 export const MVSVolumeRepresentationParams = UnionParamsSchema(
     'type',
     'Representation type',
     {
         'isosurface': SimpleParamsSchema(VolumeIsoSurface),
+        'grid-slice': SimpleParamsSchema(VolumeGridSlice),
     },
 );
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Goes with https://github.com/molstar/mol-view-spec/pull/86

- [x] MVS:  `grid-slice` representation support for volumes
- [x] Volume slice representation: add `relativeX/Y/Z` options for dimension

Example: 
```py
download = builder.download(url="https://www.ebi.ac.uk/pdbe/entry-files/1tqn.ccp4")
volume = download.parse(format="map").volume()

(
    volume.representation(type="grid-slice", dimension="x", relative_index=0.5, relative_isovalue=1)
    .color(color="red")
    .opacity(opacity=0.75)
)
(
    volume.representation(type="grid-slice", dimension="y", relative_index=0.5, relative_isovalue=1)
    .color(color="green")
    .opacity(opacity=0.75)
)
(
    volume.representation(type="grid-slice", dimension="z", relative_index=0.5, relative_isovalue=1)
    .color(color="blue")
    .opacity(opacity=0.75)
)
```

<img width="869" height="743" alt="image" src="https://github.com/user-attachments/assets/8fbb8060-5a47-4754-97e3-5032f05ff7b5" />




## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files