### PR TITLE
add `enable` param for post-processing effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Add `ray: Ray3D` property to `DragInput`, `ClickInput`, and `MoveInput`
 - Add async, non-blocking picking (only WebGL2)
     - Refactor `Canvas3dInteractionHelper` internals to use async picking for move events
+- Add `enable` param for post-processing effects. If false, no effects are applied.
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-canvas3d/passes/background.ts
+++ b/src/mol-canvas3d/passes/background.ts
@@ -26,6 +26,7 @@ import { Vec4 } from '../../mol-math/linear-algebra/3d/vec4';
 import { degToRad, isPowerOfTwo } from '../../mol-math/misc';
 import { Mat3 } from '../../mol-math/linear-algebra/3d/mat3';
 import { Euler } from '../../mol-math/linear-algebra/3d/euler';
+import { PostprocessingProps } from './postprocessing';
 
 const SharedParams = {
     opacity: PD.Numeric(1, { min: 0.0, max: 1.0, step: 0.01 }),
@@ -296,13 +297,17 @@ export class BackgroundPass {
         ValueCell.update(this.renderable.values.uViewport, Vec4.set(this.renderable.values.uViewport.ref.value, x, y, width, height));
     }
 
-    isEnabled(props: BackgroundProps) {
+    private _isEnabled(props: BackgroundProps) {
         return !!(
             (this.skybox && this.skybox.loaded) ||
             (this.image && this.image.loaded) ||
             props.variant.name === 'horizontalGradient' ||
             props.variant.name === 'radialGradient'
         );
+    }
+
+    isEnabled(props: PostprocessingProps) {
+        return props.enabled && this._isEnabled(props.background);
     }
 
     private isReady() {
@@ -319,7 +324,7 @@ export class BackgroundPass {
     clear(props: BackgroundProps, transparentBackground: boolean, backgroundColor: Color) {
         const { gl, state } = this.webgl;
 
-        if (this.isEnabled(props)) {
+        if (this._isEnabled(props)) {
             if (transparentBackground) {
                 state.clearColor(0, 0, 0, 0);
             } else {
@@ -336,7 +341,7 @@ export class BackgroundPass {
     }
 
     render(props: BackgroundProps) {
-        if (!this.isEnabled(props) || !this.isReady()) return;
+        if (!this._isEnabled(props) || !this.isReady()) return;
 
         if (this.renderable.values.dVariant.ref.value === 'image') {
             this.updateImageScaling();

--- a/src/mol-canvas3d/passes/bloom.ts
+++ b/src/mol-canvas3d/passes/bloom.ts
@@ -38,7 +38,7 @@ export type BloomProps = PD.Values<typeof BloomParams>
 
 export class BloomPass {
     static isEnabled(props: PostprocessingProps) {
-        return props.bloom.name === 'on';
+        return props.enabled && props.bloom.name === 'on';
     }
 
     readonly emissiveTarget: RenderTarget;

--- a/src/mol-canvas3d/passes/dof.ts
+++ b/src/mol-canvas3d/passes/dof.ts
@@ -37,7 +37,7 @@ export type DofProps = PD.Values<typeof DofParams>
 
 export class DofPass {
     static isEnabled(props: PostprocessingProps) {
-        return props.dof.name !== 'off';
+        return props.enabled && props.dof.name !== 'off';
     }
 
     readonly target: RenderTarget;
@@ -119,6 +119,7 @@ export class DofPass {
             needsUpdate = true;
         }
 
+        // TODO: camara.state.scale
         const wolrdCenter = (props.center === 'scene-center' ? sphere.center : camera.state.target);
         const distance = Vec3.distance(camera.state.position, wolrdCenter);
         const inFocus = distance + props.inFocus;

--- a/src/mol-canvas3d/passes/draw.ts
+++ b/src/mol-canvas3d/passes/draw.ts
@@ -377,6 +377,7 @@ export class DrawPass {
         const antialiasingEnabled = AntialiasingPass.isEnabled(props.postprocessing);
         const markingEnabled = MarkingPass.isEnabled(props.marking);
         const dofEnabled = DofPass.isEnabled(props.postprocessing);
+        const bloomEnabled = BloomPass.isEnabled(props.postprocessing);
 
         const { x, y, width, height } = camera.viewport;
         renderer.setViewport(x, y, width, height);
@@ -446,7 +447,7 @@ export class DrawPass {
             needsTargetCopy = true;
         }
 
-        if (props.postprocessing.dof.name === 'on') {
+        if (dofEnabled && props.postprocessing.dof.name === 'on') {
             const input = AntialiasingPass.isEnabled(props.postprocessing)
                 ? this.antialiasing.target.texture
                 : PostprocessingPass.isEnabled(props.postprocessing)
@@ -469,7 +470,7 @@ export class DrawPass {
             }
         }
 
-        if (props.postprocessing.bloom.name === 'on') {
+        if (bloomEnabled && props.postprocessing.bloom.name === 'on') {
             const emissiveBloom = props.postprocessing.bloom.params.mode === 'emissive';
 
             if (emissiveBloom && scene.emissiveAverage > 0) {
@@ -493,7 +494,7 @@ export class DrawPass {
         const { renderer, camera, scene, helper } = ctx;
 
         this.postprocessing.setTransparentBackground(props.transparentBackground);
-        const transparentBackground = props.transparentBackground || this.postprocessing.background.isEnabled(props.postprocessing.background);
+        const transparentBackground = props.transparentBackground || this.postprocessing.background.isEnabled(props.postprocessing);
 
         renderer.setTransparentBackground(transparentBackground);
         renderer.setDrawingBufferSize(this.colorTarget.getWidth(), this.colorTarget.getHeight());

--- a/src/mol-canvas3d/passes/outline.ts
+++ b/src/mol-canvas3d/passes/outline.ts
@@ -36,7 +36,7 @@ export type OutlineProps = PD.Values<typeof OutlineParams>
 
 export class OutlinePass {
     static isEnabled(props: PostprocessingProps) {
-        return props.outline.name !== 'off';
+        return props.enabled && props.outline.name !== 'off';
     }
 
     readonly target: RenderTarget;

--- a/src/mol-canvas3d/passes/shadow.ts
+++ b/src/mol-canvas3d/passes/shadow.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Áron Samuel Kovács <aron.kovacs@mail.muni.cz>
@@ -35,7 +35,7 @@ export type ShadowProps = PD.Values<typeof ShadowParams>
 
 export class ShadowPass {
     static isEnabled(props: PostprocessingProps) {
-        return props.shadow.name !== 'off';
+        return props.enabled && props.shadow.name !== 'off';
     }
 
     readonly target: RenderTarget;


### PR DESCRIPTION


<!-- Thank you for contributing to Mol* -->

# Description

Add `enable` param for post-processing effects. If false, no effects are applied.

One use case is for upcoming webxr support. The post-processing effects are often prohibitively expensive in XR so we want an easy way to toggle them.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`