### PR TITLE
Allow tsc-alias to modify all files under src/

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
         "outDir": "lib"
     },
     "include": [ "src/**/*" ],
-    "exclude": [ "src/**/_spec/*" ],
     "tsc-alias": {
         "resolveFullPaths": true,
         "verbose": true


### PR DESCRIPTION

# Description

Attempt to address the issue in raised in  #1572 where aliases have not been fixed for ESM imports in deno/stypescript environments. 

