### PR TITLE
Update field-schema.ts to point directly to PathReporter

### DIFF
--- a/src/extensions/mvs/tree/generic/field-schema.ts
+++ b/src/extensions/mvs/tree/generic/field-schema.ts
@@ -6,7 +6,7 @@
  */
 
 import * as iots from 'io-ts';
-import { PathReporter } from 'io-ts/PathReporter';
+import { PathReporter } from "io-ts/lib/PathReporter";
 import { onelinerJsonString } from '../../../../mol-util/json';
 
 


### PR DESCRIPTION

# Description

- Attempting to address an import issue in Deno/TS. Raised in #1572 
- Previously PathReporter pointed to a directory with a package.json
- Here we are pointing directly to the file.

```json
{
  "main": "../lib/PathReporter.js",
  "module": "../es6/PathReporter.js",
  "typings": "../lib/PathReporter.d.ts",
  "sideEffects": false
}
```