### PR TITLE
Execute markdown commands on snapshot load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Support additional file formats (pdbqt, gro, xyz, mol, sdf, mol2, xtc, lammpstrj)
   - Support loading trajectory coordinates from separate nodes
   - Trigger markdown commands from primitives using `molstar_markdown_commands` custom extensions
+  - Support `molstar_on_load_markdown_commands` custom state on the `root` node
 - Added new color schemes, synchronized with D3.js ('inferno', 'magma', 'turbo', 'rainbow', 'sinebow', 'warm', 'cool', 'cubehelix-default', 'category-10', 'observable-10', 'tableau-10')
 - Snapshot Markdown improvements
   - Add `MarkdownExtensionManager` (`PluginContext.managers.markdownExtensions`)
@@ -51,6 +52,7 @@ Note that since we don't clearly distinguish between a public and private interf
   - Support loading images and audio from MVSX files
   - Indicate external links with ⤴
   - Audio support
+  - Add `PluginState.Snapshot.onLoadMarkdownCommands`
 - Avoid calculating rings for coarse-grained structures
 - Fix isosurface compute shader normals when transformation matrix is applied to volume
 - Symmetry operator naming for spacegroup symmetry - parenthesize multi-character indices (1_111-1 -> 1_(11)1(-1))

--- a/src/examples/mvs-stories/stories/audio.ts
+++ b/src/examples/mvs-stories/stories/audio.ts
@@ -26,6 +26,8 @@ const Steps = [
 
 A simple example showcasing audio playback.
 
+Basic controls:
+
 [Play](${encodeURIComponent(`!play-audio=${_Audio}`)})
 [Pause](!pause-audio)
 [Stop](!stop-audio)
@@ -43,7 +45,7 @@ A simple example showcasing audio playback.
                 label_opacity: 1,
                 custom: {
                     molstar_markdown_commands: {
-                        'apply-snapshot': 'playback',
+                        'apply-snapshot': 'interlude',
                         'play-audio': _Audio,
                     }
                 }
@@ -60,8 +62,10 @@ A simple example showcasing audio playback.
     },
     {
         header: 'Audio Demo',
-        key: 'playback',
-        description: `### Auto Playback
+        key: 'interlude',
+        description: `### Interlude
+
+If you clicked "Click to Play" in the previous snapshot, the audio should be playing now.
 
 [Stop](!stop-audio)
         `,
@@ -83,6 +87,37 @@ A simple example showcasing audio playback.
                 }
             });
             prims.label({ text: 'Stop', position: { label_asym_id: 'A' }, label_size: 10 });
+
+            return builder;
+        },
+        camera: {
+            position: [-11.49, -37.05, 15.78],
+            target: [15.85, 17.26, 24.32],
+            up: [-0.88, 0.4, 0.26],
+        } satisfies MVSNodeParams<'camera'>,
+    },
+     {
+        header: 'Audio Demo',
+        key: 'interlude',
+        description: `### Autoplay
+
+If you browser security permissions allow it, the audio should start playing automatically when the snapshot gets loaded
+
+[Stop](!stop-audio)
+        `,
+        linger_duration_ms: 2000,
+        transition_duration_ms: 500,
+        state: (): Root => {
+            const builder = createMVSBuilder();
+
+            builder.extendRootCustomState({
+                molstar_on_load_markdown_commands: {
+                    'play-audio': _Audio,
+                }
+            });
+
+            const _1cbs = structure(builder, '1cbs');
+            polymer(_1cbs, { color: 'violet' });
 
             return builder;
         },

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -179,6 +179,10 @@ function molstarTreeToEntry(
     }
     snapshot.durationInMs = metadata.linger_duration_ms + (metadata.previousTransitionDurationMs ?? 0);
 
+    if (tree.custom?.molstar_on_load_markdown_commands) {
+        snapshot.onLoadMarkdownCommands = tree.custom.molstar_on_load_markdown_commands;
+    }
+
     const entryParams: PluginStateSnapshotManager.EntryParams = {
         key: metadata.key,
         name: metadata.title,

--- a/src/extensions/mvs/tree/mvs/mvs-builder.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-builder.ts
@@ -98,6 +98,12 @@ export class Root extends _Base<'root'> implements FocusMixin, PrimitivesMixin {
         this._animation ??= new Animation(params);
         return this._animation;
     }
+
+    /** Modifies custom state of the root */
+    extendRootCustomState(custom: Record<string, any>): this {
+        this._node.custom = { ...this._node.custom, ...custom };
+        return this;
+    }
 }
 
 export class Animation {

--- a/src/mol-plugin/state.ts
+++ b/src/mol-plugin/state.ts
@@ -118,6 +118,11 @@ class PluginState extends PluginComponent {
                 durationMs: snapshot.camera.transitionStyle === 'animate' ? snapshot.camera.transitionDurationInMs : undefined,
             });
         }
+
+        if (typeof snapshot?.onLoadMarkdownCommands === 'object' && Object.keys(snapshot.onLoadMarkdownCommands).length > 0) {
+            this.plugin.managers.markdownExtensions.tryExecute('click', snapshot.onLoadMarkdownCommands);
+        }
+
         if (snapshot.startAnimation) {
             this.animation.start();
             return;
@@ -146,6 +151,10 @@ class PluginState extends PluginComponent {
                 snapshot: frame.camera.current,
                 durationMs: frame.camera.transitionStyle === 'animate' ? frame.camera.transitionDurationInMs : undefined,
             });
+        }
+
+        if (typeof snapshot?.onLoadMarkdownCommands === 'object' && Object.keys(snapshot.onLoadMarkdownCommands).length > 0) {
+            this.plugin.managers.markdownExtensions.tryExecute('click', snapshot.onLoadMarkdownCommands);
         }
     }
 
@@ -241,6 +250,7 @@ namespace PluginState {
         },
         durationInMs?: number,
         transition?: StateTransition,
+        onLoadMarkdownCommands?: Record<string, any>
     }
 
     export interface StateTransition {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- [x] Add `PluginState.Snapshot.onLoadMarkdownCommands`
- [x] MVS:  Support `molstar_on_load_markdown_commands` custom state on the `root` node

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files