### PR TITLE
Trying to fix fuzzy point postprocessing when alpha is 1

### DIFF
--- a/src/mol-gl/shader/chunks/assign-material-color.glsl.ts
+++ b/src/mol-gl/shader/chunks/assign-material-color.glsl.ts
@@ -69,10 +69,10 @@ export const assign_material_color = `
             alpha *= dta;
         #endif
 
-        #if defined(dPointStyle_fuzzy)
-            alpha *= fuzzyAlpha;
-        #elif defined(dXrayShaded)
+        
+        #if defined(dXrayShaded)
             alpha = calcXrayShadedAlpha(alpha, normal);
+        #elif defined(dPointStyle_fuzzy)
         #else
             if (alpha == 1.0) {
                 discard;

--- a/src/mol-gl/shader/points.frag.ts
+++ b/src/mol-gl/shader/points.frag.ts
@@ -21,6 +21,7 @@ void main(){
     #include clip_pixel
 
     float fragmentDepth = gl_FragCoord.z;
+    #include assign_material_color
 
     #if defined(dPointStyle_circle)
         float dist = distance(gl_PointCoord, center);
@@ -30,8 +31,6 @@ void main(){
         float fuzzyAlpha = 1.0 - smoothstep(0.0, radius, dist);
         if (fuzzyAlpha < 0.0001) discard;
     #endif
-
-    #include assign_material_color
 
     #if defined(dPointStyle_fuzzy) && (defined(dRenderVariant_color) || defined(dRenderVariant_tracing))
         material.a *= fuzzyAlpha;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Triyng to fix fuzzy point when alpha is 1 (still not working properly). Something changes but postprocessing isn't working properly. Outlines are strange and ssao is nearly invisible.  Not sure what is causing this. 

<img width="1117" height="1056" alt="image" src="https://github.com/user-attachments/assets/629f3715-fe50-4bd7-a1f0-c085deca1136" />


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`