### PR TITLE
Use new validation/view endpoint at files.rcsb.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - VolumeServer & "VolumeCIF": default to P 1 spacegroup
 - Fix `ColorScale` for continuous case without offsets (broke in v4.13.0)
 - Experimental: support for custom color themes in Sequence Panel
+- Switch files.rcsb.org validation report URL to new endpoint /validation/view
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/extensions/rcsb/validation-report/prop.ts
+++ b/src/extensions/rcsb/validation-report/prop.ts
@@ -85,10 +85,10 @@ namespace ValidationReport {
         Clashes = 'rcsb-clashes',
     }
 
-    export const DefaultBaseUrl = 'https://files.rcsb.org/pub/pdb/validation_reports';
+    export const DefaultBaseUrl = 'https://files.rcsb.org/validation/view';
     export function getEntryUrl(pdbId: string, baseUrl: string) {
         const id = pdbId.toLowerCase();
-        return `${baseUrl}/${id.substr(1, 2)}/${id}/${id}_validation.xml.gz`;
+        return `${baseUrl}/${id}_validation.xml`;
     }
 
     export function isApplicable(model?: Model): boolean {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
A new endpoint is now available that provides the validation xml files in plain text (optionally transmitted with gzip encoding). This will allow removing the old endpoint in rcsb infrastructure.

## Actions

- [X] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`