### PR TITLE
improve picking of objects with many groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix `ColorScale` for continuous case without offsets (broke in v4.13.0)
 - Experimental: support for custom color themes in Sequence Panel
 - Switch files.rcsb.org validation report URL to new endpoint /validation/view
+- Improve picking of objects with too many groups, pick whole instance/object
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-canvas3d/passes/pick.ts
+++ b/src/mol-canvas3d/passes/pick.ts
@@ -22,8 +22,6 @@ import { ICamera } from '../camera';
 import { Viewport } from '../camera/util';
 import { Helper } from '../helper/helper';
 
-const NullId = Math.pow(2, 24) - 2;
-
 export type PickData = { id: PickingId, position: Vec3 }
 
 export type AsyncPickData = {
@@ -450,15 +448,15 @@ export class PickBuffers {
     getPickingId(x: number, y: number): PickingId | undefined {
         const objectId = this.getObjectId(x, y);
         // console.log('objectId', objectId);
-        if (objectId === -1 || objectId === NullId) return;
+        if (objectId === -1 || objectId === PickingId.Null) return;
 
         const instanceId = this.getInstanceId(x, y);
         // console.log('instanceId', instanceId);
-        if (instanceId === -1 || instanceId === NullId) return;
+        if (instanceId === -1 || instanceId === PickingId.Null) return;
 
         const groupId = this.getGroupId(x, y);
         // console.log('groupId', groupId);
-        if (groupId === -1 || groupId === NullId) return;
+        if (groupId === -1) return;
 
         return { objectId, instanceId, groupId };
     }

--- a/src/mol-geo/geometry/picking.ts
+++ b/src/mol-geo/geometry/picking.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -11,6 +11,8 @@ export interface PickingId {
 }
 
 export namespace PickingId {
+    export const Null = 16777214 as const; // Math.pow(2, 24) - 2
+
     export function areSame(a: PickingId, b: PickingId) {
         return a.objectId === b.objectId && a.instanceId === b.instanceId && a.groupId === b.groupId;
     }

--- a/src/mol-repr/shape/representation.ts
+++ b/src/mol-repr/shape/representation.ts
@@ -225,7 +225,11 @@ export function ShapeRepresentation<D, G extends Geometry, P extends Geometry.Pa
         getLoci(pickingId: PickingId) {
             const { objectId, groupId, instanceId } = pickingId;
             if (_renderObject && _renderObject.id === objectId) {
-                return ShapeGroup.Loci(_shape, [{ ids: OrderedSet.ofSingleton(groupId), instance: instanceId }]);
+                if (groupId === PickingId.Null) {
+                    return Shape.Loci(_shape);
+                } else {
+                    return ShapeGroup.Loci(_shape, [{ ids: OrderedSet.ofSingleton(groupId), instance: instanceId }]);
+                }
             }
             return EmptyLoci;
         },

--- a/src/mol-repr/structure/visual/carbohydrate-link-cylinder.ts
+++ b/src/mol-repr/structure/visual/carbohydrate-link-cylinder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -99,14 +99,18 @@ function CarbohydrateLinkIterator(structure: Structure): LocationIterator {
 function getLinkLoci(pickingId: PickingId, structure: Structure, id: number) {
     const { objectId, groupId } = pickingId;
     if (id === objectId) {
-        const { links, elements } = structure.carbohydrates;
-        const l = links[groupId];
-        const carbA = elements[l.carbohydrateIndexA];
-        const carbB = elements[l.carbohydrateIndexB];
-        return StructureElement.Loci.union(
-            getAltResidueLociFromId(structure, carbA.unit, carbA.residueIndex, carbA.altId),
-            getAltResidueLociFromId(structure, carbB.unit, carbB.residueIndex, carbB.altId)
-        );
+        if (groupId === PickingId.Null) {
+            return Structure.Loci(structure);
+        } else {
+            const { links, elements } = structure.carbohydrates;
+            const l = links[groupId];
+            const carbA = elements[l.carbohydrateIndexA];
+            const carbB = elements[l.carbohydrateIndexB];
+            return StructureElement.Loci.union(
+                getAltResidueLociFromId(structure, carbA.unit, carbA.residueIndex, carbA.altId),
+                getAltResidueLociFromId(structure, carbB.unit, carbB.residueIndex, carbB.altId)
+            );
+        }
     }
     return EmptyLoci;
 }

--- a/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
+++ b/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -206,8 +206,12 @@ function CarbohydrateElementIterator(structure: Structure): LocationIterator {
 function getCarbohydrateLoci(pickingId: PickingId, structure: Structure, id: number) {
     const { objectId, groupId } = pickingId;
     if (id === objectId) {
-        const carb = structure.carbohydrates.elements[Math.floor(groupId / 2)];
-        return getAltResidueLociFromId(structure, carb.unit, carb.residueIndex, carb.altId);
+        if (groupId === PickingId.Null) {
+            return Structure.Loci(structure);
+        } else {
+            const carb = structure.carbohydrates.elements[Math.floor(groupId / 2)];
+            return getAltResidueLociFromId(structure, carb.unit, carb.residueIndex, carb.altId);
+        }
     }
     return EmptyLoci;
 }

--- a/src/mol-repr/structure/visual/carbohydrate-terminal-link-cylinder.ts
+++ b/src/mol-repr/structure/visual/carbohydrate-terminal-link-cylinder.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -121,14 +121,18 @@ function CarbohydrateTerminalLinkIterator(structure: Structure): LocationIterato
 function getTerminalLinkLoci(pickingId: PickingId, structure: Structure, id: number) {
     const { objectId, groupId } = pickingId;
     if (id === objectId) {
-        const { terminalLinks, elements } = structure.carbohydrates;
-        const l = terminalLinks[groupId];
-        const carb = elements[l.carbohydrateIndex];
+        if (groupId === PickingId.Null) {
+            return Structure.Loci(structure);
+        } else {
+            const { terminalLinks, elements } = structure.carbohydrates;
+            const l = terminalLinks[groupId];
+            const carb = elements[l.carbohydrateIndex];
 
-        return StructureElement.Loci.union(
-            getAltResidueLociFromId(structure, carb.unit, carb.residueIndex, carb.altId),
-            getAltResidueLoci(structure, l.elementUnit, l.elementUnit.elements[l.elementIndex])
-        );
+            return StructureElement.Loci.union(
+                getAltResidueLociFromId(structure, carb.unit, carb.residueIndex, carb.altId),
+                getAltResidueLoci(structure, l.elementUnit, l.elementUnit.elements[l.elementIndex])
+            );
+        }
     }
     return EmptyLoci;
 }

--- a/src/mol-repr/structure/visual/util/bond.ts
+++ b/src/mol-repr/structure/visual/util/bond.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -236,14 +236,19 @@ export function getIntraBondLoci(pickingId: PickingId, structureGroup: Structure
     if (id === objectId) {
         const { structure, group } = structureGroup;
         const unit = group.units[instanceId];
-        if (Unit.isAtomic(unit)) {
-            const { target } = structure;
-            const iA = unit.bonds.a[groupId];
-            const iB = unit.bonds.b[groupId];
-            return Bond.Loci(target, [
-                Bond.Location(target, unit, iA, target, unit, iB),
-                Bond.Location(target, unit, iB, target, unit, iA)
-            ]);
+        if (groupId === PickingId.Null) {
+            const indices = OrderedSet.ofRange(0, unit.elements.length) as OrderedSet<StructureElement.UnitIndex>;
+            return StructureElement.Loci(structure.target, [{ unit, indices }]);
+        } else {
+            if (Unit.isAtomic(unit)) {
+                const { target } = structure;
+                const iA = unit.bonds.a[groupId];
+                const iB = unit.bonds.b[groupId];
+                return Bond.Loci(target, [
+                    Bond.Location(target, unit, iA, target, unit, iB),
+                    Bond.Location(target, unit, iB, target, unit, iA)
+                ]);
+            }
         }
     }
     return EmptyLoci;
@@ -296,13 +301,17 @@ export function getInterBondLoci(pickingId: PickingId, structure: Structure, id:
     const { objectId, groupId } = pickingId;
     if (id === objectId) {
         const { target } = structure;
-        const b = structure.interUnitBonds.edges[groupId];
-        const uA = structure.unitMap.get(b.unitA);
-        const uB = structure.unitMap.get(b.unitB);
-        return Bond.Loci(target, [
-            Bond.Location(target, uA, b.indexA, target, uB, b.indexB),
-            Bond.Location(target, uB, b.indexB, target, uA, b.indexA)
-        ]);
+        if (groupId === PickingId.Null) {
+            return Structure.Loci(target);
+        } else {
+            const b = structure.interUnitBonds.edges[groupId];
+            const uA = structure.unitMap.get(b.unitA);
+            const uB = structure.unitMap.get(b.unitB);
+            return Bond.Loci(target, [
+                Bond.Location(target, uA, b.indexA, target, uB, b.indexB),
+                Bond.Location(target, uB, b.indexB, target, uA, b.indexA)
+            ]);
+        }
     }
     return EmptyLoci;
 }

--- a/src/mol-repr/structure/visual/util/element.ts
+++ b/src/mol-repr/structure/visual/util/element.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -210,7 +210,9 @@ export function getElementLoci(pickingId: PickingId, structureGroup: StructureGr
     if (id === objectId) {
         const { structure, group } = structureGroup;
         const unit = group.units[instanceId];
-        const indices = OrderedSet.ofSingleton(groupId as StructureElement.UnitIndex);
+        const indices = groupId === PickingId.Null
+            ? OrderedSet.ofRange(0, unit.elements.length) as OrderedSet<StructureElement.UnitIndex>
+            : OrderedSet.ofSingleton(groupId as StructureElement.UnitIndex);
         return StructureElement.Loci(structure.target, [{ unit, indices }]);
     }
     return EmptyLoci;
@@ -371,12 +373,16 @@ export function eachSerialElement(loci: Loci, structure: Structure, apply: (inte
 export function getSerialElementLoci(pickingId: PickingId, structure: Structure, id: number) {
     const { objectId, groupId } = pickingId;
     if (id === objectId) {
-        const { unitIndices, cumulativeUnitElementCount } = structure.serialMapping;
-        const unitIdx = unitIndices[groupId];
-        const unit = structure.units[unitIdx];
-        const idx = groupId - cumulativeUnitElementCount[unitIdx];
-        const indices = OrderedSet.ofSingleton(idx as StructureElement.UnitIndex);
-        return StructureElement.Loci(structure, [{ unit, indices }]);
+        if (groupId === PickingId.Null) {
+            return Structure.Loci(structure);
+        } else {
+            const { unitIndices, cumulativeUnitElementCount } = structure.serialMapping;
+            const unitIdx = unitIndices[groupId];
+            const unit = structure.units[unitIdx];
+            const idx = groupId - cumulativeUnitElementCount[unitIdx];
+            const indices = OrderedSet.ofSingleton(idx as StructureElement.UnitIndex);
+            return StructureElement.Loci(structure, [{ unit, indices }]);
+        }
     }
     return EmptyLoci;
 }

--- a/src/mol-repr/structure/visual/util/nucleotide.ts
+++ b/src/mol-repr/structure/visual/util/nucleotide.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -38,7 +38,12 @@ export function getNucleotideElementLoci(pickingId: PickingId, structureGroup: S
         const { structure, group } = structureGroup;
         const unit = group.units[instanceId];
         if (Unit.isAtomic(unit)) {
-            return getResidueLoci(structure, unit, unit.nucleotideElements[groupId]);
+            if (groupId === PickingId.Null) {
+                const indices = Interval.ofRange(0, unit.elements.length) as Interval<StructureElement.UnitIndex>;
+                return StructureElement.Loci(structure.target, [{ unit, indices }]);
+            } else {
+                return getResidueLoci(structure, unit, unit.nucleotideElements[groupId]);
+            }
         }
     }
     return EmptyLoci;

--- a/src/mol-repr/structure/visual/util/polymer.ts
+++ b/src/mol-repr/structure/visual/util/polymer.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -88,15 +88,20 @@ export function getPolymerElementLoci(pickingId: PickingId, structureGroup: Stru
     if (id === objectId) {
         const { structure, group } = structureGroup;
         const unit = group.units[instanceId];
-        if (Unit.isAtomic(unit)) {
-            return getResidueLoci(structure, unit, unit.polymerElements[groupId]);
+        if (groupId === PickingId.Null) {
+            const indices = OrderedSet.ofRange(0, unit.elements.length) as OrderedSet<StructureElement.UnitIndex>;
+            return StructureElement.Loci(structure.target, [{ unit, indices }]);
         } else {
-            const { elements } = unit;
-            const elementIndex = unit.polymerElements[groupId];
-            const unitIndex = OrderedSet.indexOf(elements, elementIndex) as StructureElement.UnitIndex | -1;
-            if (unitIndex !== -1) {
-                const indices = OrderedSet.ofSingleton(unitIndex);
-                return StructureElement.Loci(structure, [{ unit, indices }]);
+            if (Unit.isAtomic(unit)) {
+                return getResidueLoci(structure, unit, unit.polymerElements[groupId]);
+            } else {
+                const { elements } = unit;
+                const elementIndex = unit.polymerElements[groupId];
+                const unitIndex = OrderedSet.indexOf(elements, elementIndex) as StructureElement.UnitIndex | -1;
+                if (unitIndex !== -1) {
+                    const indices = OrderedSet.ofSingleton(unitIndex);
+                    return StructureElement.Loci(structure, [{ unit, indices }]);
+                }
             }
         }
     }

--- a/src/mol-repr/volume/dot.ts
+++ b/src/mol-repr/volume/dot.ts
@@ -292,7 +292,7 @@ function getDotLoci(pickingId: PickingId, volume: Volume, key: number, props: Vo
         const instances = OrderedSet.ofSingleton(instanceId as Volume.InstanceIndex);
         if (granularity === 'volume') {
             return Volume.Loci(volume, instances);
-        } else if (granularity === 'object') {
+        } else if (granularity === 'object' || groupId === PickingId.Null) {
             return Volume.Isosurface.Loci(volume, props.isoValue, instances);
         } else {
             const indices = Interval.ofSingleton(groupId as Volume.CellIndex);

--- a/src/mol-repr/volume/isosurface.ts
+++ b/src/mol-repr/volume/isosurface.ts
@@ -78,7 +78,7 @@ function getIsosurfaceLoci(pickingId: PickingId, volume: Volume, key: number, pr
         const instances = OrderedSet.ofSingleton(instanceId as Volume.InstanceIndex);
         if (granularity === 'volume') {
             return Volume.Loci(volume, instances);
-        } else if (granularity === 'object') {
+        } else if (granularity === 'object' || groupId === PickingId.Null) {
             return Volume.Isosurface.Loci(volume, props.isoValue, instances);
         } else {
             const indices = Interval.ofSingleton(groupId as Volume.CellIndex);

--- a/src/mol-repr/volume/segment.ts
+++ b/src/mol-repr/volume/segment.ts
@@ -83,7 +83,7 @@ function getSegmentLoci(pickingId: PickingId, volume: Volume, key: number, props
         const instances = OrderedSet.ofSingleton(instanceId as Volume.InstanceIndex);
         if (granularity === 'volume') {
             return Volume.Loci(volume, instances);
-        } else if (granularity === 'object') {
+        } else if (granularity === 'object' || groupId === PickingId.Null) {
             const segments = OrderedSet.ofSingleton(key as Volume.SegmentIndex);
             return Volume.Segment.Loci(volume, [{ segments, instances }]);
         } else {

--- a/src/mol-repr/volume/slice.ts
+++ b/src/mol-repr/volume/slice.ts
@@ -495,7 +495,7 @@ function getSliceLoci(pickingId: PickingId, volume: Volume, key: number, props: 
         const instances = OrderedSet.ofSingleton(instanceId as Volume.InstanceIndex);
         if (granularity === 'volume') {
             return Volume.Loci(volume, instances);
-        } if (granularity === 'object') {
+        } if (granularity === 'object' || groupId === PickingId.Null) {
             return getObjectLoci(volume, instances, props);
         } else {
             const indices = Interval.ofSingleton(groupId as Volume.CellIndex);


### PR DESCRIPTION

<!-- Thank you for contributing to Mol* -->

# Description

Improve picking of objects with many groups. If there are too many groups (currently >=2^24-2) pick whole instance/object instead of picking nothing.

Partly addresses #1623.


## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`