### PR TITLE
Update `to_mmCIF` function to accept multiple structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Add `PointerHelper` for rendering XR input devices
     - Add XR button to Viewer and Mesoscale Explorer
     - Add XR button to render-structure in tests/browser
+- Change the `to_mmCIF` function parameter from `structure` to `structures` to support either a single structure or an array of structures
 
 ## [v4.18.0] - 2025-06-08
 - MolViewSpec extension:

--- a/src/mol-model/structure/export/mmcif.ts
+++ b/src/mol-model/structure/export/mmcif.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Kim Juho <juho_kim@outlook.com>
  */
 
 import { CifWriter } from '../../../mol-io/writer/cif';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Change the `to_mmCIF` function parameter from `structure` to `structures` to support either a single structure or an array of structures.

Although this code doesn't change the behavior, it was modified for TypeScript type checking.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`