### PR TITLE
Allow full-screen (not just full-page) mode

### DIFF
--- a/src/mol-plugin/layout.ts
+++ b/src/mol-plugin/layout.ts
@@ -115,7 +115,11 @@ export class PluginLayout extends StatefulPluginComponent<PluginLayoutStateProps
                 }
 
                 if (!hasExp) head.appendChild(this.expandedViewport);
-
+                
+                // TODO only use fullsceen mode if enabled in config
+                // if (state.requestFullscreen) {
+                body.requestFullscreen();
+                // }
 
                 const s = body.style;
 
@@ -157,6 +161,8 @@ export class PluginLayout extends StatefulPluginComponent<PluginLayoutStateProps
                         break;
                     }
                 }
+
+                document.exitFullscreen();
 
                 if (this.rootState) {
                     const t = this.rootState;


### PR DESCRIPTION
# Description

Enable true fullscreen mode using `requestFullscreen()`.

This is useful in two cases:

- When people want to enable users to see molstar in complete fullscreen mode
- When molstar is being used through an iframe, since full-page just means full-iframe in that case. When the iframe has `allow="fullscreen"`, this behavior will enable showing the viewer in fullscreen mode even if it sits inside the iframe.

## TODO

- [ ] Add a config attribute that controls this behavior and only run requestFullscreen if enabled. This is beyond my capabilities 😄  @dsehnal could you help with this if you agree with the PR?

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`