### PR TITLE
Update example to use mol* v5

### DIFF
--- a/docs/docs/plugin/instance.md
+++ b/docs/docs/plugin/instance.md
@@ -247,7 +247,7 @@ async function init() {
     const canvas = <HTMLCanvasElement> document.getElementById('molstar-canvas');
     const parent = <HTMLDivElement> document.getElementById('molstar-parent');
 
-    if (!(await plugin.initViewer(canvas, parent))) {
+    if (!(await plugin.initViewerAsync(canvas, parent))) {
         console.error('Failed to init Mol*');
         return;
     }


### PR DESCRIPTION
Rename initViewer to initViewerAsync in documentation

<!-- Thank you for contributing to Mol* -->

# Description


## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [x] (Optional but encouraged) Improved documentation in `docs`