### PR TITLE
add jsdoc TODO for not implemented PluginCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Remove outdated `gl_FrontFacing` workaround for buggy drivers
 - Fix clip objects for deirect-volume rendering
 - Support "magic window" style AR (via WebXR)
+- Add jsdoc `TODO` for not implementeds(`PluginCommands.Interactivity.Structure.Highlight`, `PluginCommands.Interactivity.Structure.Select`).
 
 ## [v5.0.0] - 2025-09-28
 - [Breaking] Renamed some color schemes ('inferno' -> 'inferno-no-black', 'magma' -> 'magma-no-black', 'turbo' -> 'turbo-no-black', 'rainbow' -> 'simple-rainbow')

--- a/src/mol-plugin/commands.ts
+++ b/src/mol-plugin/commands.ts
@@ -4,6 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Adam Midlik <midlik@gmail.com>
+ * @author Kim Juho <juho_kim@outlook.com>
  */
 
 import { Camera } from '../mol-canvas3d/camera';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Add JsDoc todo for not implemented `PluginCommand` 

- PluginCommands.Interactivity.Structure.Highlight
- PluginCommands.Interactivity.Structure.Select

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`