### PR TITLE
MVS: coarse annotations bugfix

### DIFF
--- a/src/extensions/mvs/helpers/selections.ts
+++ b/src/extensions/mvs/helpers/selections.ts
@@ -208,6 +208,7 @@ function getQualifyingResidues(model: Model, row: MVSAnnotationRow, indices: Ato
         }
         arrayExtend(result, residuesHere);
     }
+    sortIfNeeded(result, (a, b) => a - b);
     return result;
 }
 
@@ -419,7 +420,7 @@ function getQualifyingCoarseElements(coarseElements: CoarseElements, row: MVSAnn
         // This implementation can yield some elements even when queryStart>queryEnd (e.g. { beg_label_seq_id: 70, end_label_seq_id: 58, label_seq_id: 60 } -> sphere 51-100 qualifies ).
         // This is on purpose, to have the same behavior as MolScript.
     }
-    sortIfNeeded(result, iElem => iElem);
+    sortIfNeeded(result, (a, b) => a - b);
     return result;
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Fixing a sneaky bug in MVS annotations with coarse structures. 
It worked on Chrome only thanks to a lucky coincidence related to `.sort` implementation.
This might solve @victoria-dos 's issues on Firefox.



## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`