### PR TITLE
Add `vertex` and `vertexInstance` granularity for size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@ Note that since we don't clearly distinguish between a public and private interf
     - Fix missing `usePalette` support
     - Fix vertex-based coloring for non-mesh geometries
     - Support line-strips
+    - Support vertex-based sizing
 - Support memory efficient line-strips in Lines geometry,
     - Add `StripLinesBuilder`
 - Add `computeFrenetFrames` helper
 - Fix `TextCtrl` always moving cursor to end position
+- Add `vertex` and `vertexInstance` granularity support for size themes
+- Add `transform` and `domain` parameters to volume-value size theme
 
 ## [v5.6.1] - 2026-01-23
 - Disable occlusion culling in `ImagePass` (#1758)

--- a/src/extensions/geo-export/mesh-exporter.ts
+++ b/src/extensions/geo-export/mesh-exporter.ts
@@ -91,7 +91,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
         return unpackRGBToInt(r, g, b) / sizeDataFactor;
     }
 
-    private static getSize(values: BaseValues & SizeValues, instanceIndex: number, group: number): number {
+    private static getSize(values: BaseValues & SizeValues, instanceIndex: number, group: number, vertexIndex: number): number {
         const tSize = values.tSize.ref.value;
         let size = 0;
         switch (values.dSizeType.ref.value) {
@@ -107,6 +107,13 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
             case 'groupInstance':
                 const groupCount = values.uGroupCount.ref.value;
                 size = MeshExporter.getSizeFromTexture(tSize, instanceIndex * groupCount + group);
+                break;
+            case 'vertex':
+                size = MeshExporter.getSizeFromTexture(tSize, vertexIndex);
+                break;
+            case 'vertexInstance':
+                const vertexCount = values.uVertexCount.ref.value;
+                size = MeshExporter.getSizeFromTexture(tSize, instanceIndex * vertexCount + vertexIndex);
                 break;
         }
         return size * values.uSizeFactor.ref.value;
@@ -465,7 +472,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
                     const v0 = segmentIndices[0];
                     arrayCopyOffset(curvePoints, aStart, 0, v0 * 3, 3);
                     curveOrigIndices.push(v0);
-                    const radius0 = MeshExporter.getSize(values, instanceIndex, aGroup[v0]) * 0.03;
+                    const radius0 = MeshExporter.getSize(values, instanceIndex, aGroup[v0], v0) * 0.03;
                     widthValues[0] = radius0;
                     heightValues[0] = radius0;
 
@@ -474,7 +481,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
                         const v = segmentIndices[j];
                         arrayCopyOffset(curvePoints, aEnd, (j + 1) * 3, v * 3, 3);
                         curveOrigIndices.push(v);
-                        const radius = MeshExporter.getSize(values, instanceIndex, aGroup[v]) * 0.03;
+                        const radius = MeshExporter.getSize(values, instanceIndex, aGroup[v], v) * 0.03;
                         widthValues[j + 1] = radius;
                         heightValues[j + 1] = radius;
                     }
@@ -574,7 +581,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
                     v3fromArray(end, aEnd, i * 3);
 
                     const group = aGroup[i / 4];
-                    const radius = MeshExporter.getSize(values, instanceIndex, group) * 0.03;
+                    const radius = MeshExporter.getSize(values, instanceIndex, group, i / 4) * 0.03;
 
                     const cylinderProps = { radiusTop: radius, radiusBottom: radius, topCap, bottomCap, radialSegments };
                     const vertexOffset = state.vertices.elementCount;
@@ -633,7 +640,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
                     v3fromArray(center, aPosition, i * 3);
 
                     const group = aGroup[i];
-                    const radius = MeshExporter.getSize(values, instanceIndex, group) * 0.03;
+                    const radius = MeshExporter.getSize(values, instanceIndex, group, i) * 0.03;
                     const vertexOffset = state.vertices.elementCount;
                     addSphere(state, center, radius, detail);
 
@@ -692,7 +699,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
                 v3fromArray(center, aPosition, i * 3);
 
                 const group = aGroup[i];
-                const radius = MeshExporter.getSize(values, instanceIndex, group);
+                const radius = MeshExporter.getSize(values, instanceIndex, group, i);
                 const vertexOffset = state.vertices.elementCount;
                 addSphere(state, center, radius, detail);
 
@@ -755,7 +762,7 @@ export abstract class MeshExporter<D extends RenderObjectExportData> implements 
                 v3sub(dir, end, start);
 
                 const group = aGroup[i];
-                const radius = MeshExporter.getSize(values, instanceIndex, group) * aScale[i];
+                const radius = MeshExporter.getSize(values, instanceIndex, group, i) * aScale[i];
                 const cap = aCap[i];
                 let topCap = cap === 1 || cap === 3;
                 let bottomCap = cap >= 2;

--- a/src/mol-geo/geometry/cylinders/cylinders.ts
+++ b/src/mol-geo/geometry/cylinders/cylinders.ts
@@ -221,7 +221,7 @@ export namespace Cylinders {
         const positionIt = createPositionIterator(cylinders, transform);
 
         const color = createColors(locationIt, positionIt, theme.color);
-        const size = createSizes(locationIt, theme.size);
+        const size = createSizes(locationIt, positionIt, theme.size);
         const marker = props.instanceGranularity
             ? createMarkers(instanceCount, 'instance')
             : createMarkers(instanceCount * groupCount, 'groupInstance');

--- a/src/mol-geo/geometry/lines/lines.ts
+++ b/src/mol-geo/geometry/lines/lines.ts
@@ -228,7 +228,7 @@ export namespace Lines {
         const positionIt = createPositionIterator(lines, transform);
 
         const color = createColors(locationIt, positionIt, theme.color);
-        const size = createSizes(locationIt, theme.size);
+        const size = createSizes(locationIt, positionIt, theme.size);
         const marker = props.instanceGranularity
             ? createMarkers(instanceCount, 'instance')
             : createMarkers(instanceCount * groupCount, 'groupInstance');

--- a/src/mol-geo/geometry/points/points.ts
+++ b/src/mol-geo/geometry/points/points.ts
@@ -174,7 +174,7 @@ export namespace Points {
         const positionIt = createPositionIterator(points, transform);
 
         const color = createColors(locationIt, positionIt, theme.color);
-        const size = createSizes(locationIt, theme.size);
+        const size = createSizes(locationIt, positionIt, theme.size);
         const marker = props.instanceGranularity
             ? createMarkers(instanceCount, 'instance')
             : createMarkers(instanceCount * groupCount, 'groupInstance');

--- a/src/mol-geo/geometry/spheres/spheres.ts
+++ b/src/mol-geo/geometry/spheres/spheres.ts
@@ -310,7 +310,7 @@ export namespace Spheres {
         const positionIt = createPositionIterator(spheres, transform);
 
         const color = createColors(locationIt, positionIt, theme.color);
-        const size = createSizes(locationIt, theme.size);
+        const size = createSizes(locationIt, positionIt, theme.size);
         const marker = props.instanceGranularity
             ? createMarkers(instanceCount, 'instance')
             : createMarkers(instanceCount * groupCount, 'groupInstance');

--- a/src/mol-geo/geometry/text/text.ts
+++ b/src/mol-geo/geometry/text/text.ts
@@ -216,7 +216,7 @@ export namespace Text {
         const positionIt = createPositionIterator(text, transform);
 
         const color = createColors(locationIt, positionIt, theme.color);
-        const size = createSizes(locationIt, theme.size);
+        const size = createSizes(locationIt, positionIt, theme.size);
         const marker = props.instanceGranularity
             ? createMarkers(instanceCount, 'instance')
             : createMarkers(instanceCount * groupCount, 'groupInstance');

--- a/src/mol-gl/shader/chunks/assign-size.glsl.ts
+++ b/src/mol-gl/shader/chunks/assign-size.glsl.ts
@@ -9,9 +9,13 @@ export const assign_size = `
     float size = unpackRGBToInt(readFromTexture(tSize, group, uSizeTexDim).rgb);
 #elif defined(dSizeType_groupInstance)
     float size = unpackRGBToInt(readFromTexture(tSize, aInstance * float(uGroupCount) + group, uSizeTexDim).rgb);
+#elif defined(dSizeType_vertex)
+    float size = unpackRGBToInt(readFromTexture(tSize, vertexId, uSizeTexDim).rgb);
+#elif defined(dSizeType_vertexInstance)
+    float size = unpackRGBToInt(readFromTexture(tSize, int(aInstance) * uVertexCount + vertexId, uSizeTexDim).rgb);
 #endif
 
-#if defined(dSizeType_instance) || defined(dSizeType_group) || defined(dSizeType_groupInstance)
+#if defined(dSizeType_instance) || defined(dSizeType_group) || defined(dSizeType_groupInstance) || defined(dSizeType_vertex) || defined(dSizeType_vertexInstance)
     size /= 100.0; // NOTE factor also set in TypeScript
 #endif
 

--- a/src/mol-gl/shader/chunks/size-vert-params.glsl.ts
+++ b/src/mol-gl/shader/chunks/size-vert-params.glsl.ts
@@ -3,7 +3,7 @@ export const size_vert_params = `
     uniform float uSize;
 #elif defined(dSizeType_attribute)
     attribute float aSize;
-#elif defined(dSizeType_instance) || defined(dSizeType_group) || defined(dSizeType_groupInstance)
+#elif defined(dSizeType_instance) || defined(dSizeType_group) || defined(dSizeType_groupInstance) || defined(dSizeType_vertex) || defined(dSizeType_vertexInstance)
     uniform vec2 uSizeTexDim;
     uniform sampler2D tSize;
 #endif

--- a/src/mol-repr/shape/representation.ts
+++ b/src/mol-repr/shape/representation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -161,7 +161,7 @@ export function ShapeRepresentation<D, G extends Geometry, P extends Geometry.Pa
                     // not all geometries have size data, so check here
                     if ('uSize' in _renderObject.values) {
                         // console.log('update size')
-                        createSizes(locationIt, _theme.size, _renderObject.values as SizeData);
+                        createSizes(locationIt, positionIt, _theme.size, _renderObject.values as SizeData);
                     }
                 }
 

--- a/src/mol-repr/structure/complex-visual.ts
+++ b/src/mol-repr/structure/complex-visual.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
@@ -197,7 +197,7 @@ export function ComplexVisual<G extends Geometry, P extends StructureParams & Ge
             if (updateState.updateSize) {
                 // not all geometries have size data, so check here
                 if ('uSize' in renderObject.values) {
-                    createSizes(locationIt, newTheme.size, renderObject.values as SizeData);
+                    createSizes(locationIt, positionIt, newTheme.size, renderObject.values as SizeData);
                 }
             }
 

--- a/src/mol-repr/structure/units-visual.ts
+++ b/src/mol-repr/structure/units-visual.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
@@ -249,7 +249,7 @@ export function UnitsVisual<G extends Geometry, P extends StructureParams & Geom
                 // not all geometries have size data, so check here
                 if ('uSize' in renderObject.values) {
                     // console.log('update size');
-                    createSizes(locationIt, newTheme.size, renderObject.values as SizeValues);
+                    createSizes(locationIt, positionIt, newTheme.size, renderObject.values as SizeValues);
                 }
             }
 

--- a/src/mol-repr/volume/dot.ts
+++ b/src/mol-repr/volume/dot.ts
@@ -344,5 +344,6 @@ export const DotRepresentationProvider = VolumeRepresentationProvider({
     defaultValues: PD.getDefaultValues(DotParams),
     defaultColorTheme: { name: 'uniform' },
     defaultSizeTheme: { name: 'uniform' },
+    locationKinds: ['cell-location', 'position-location'],
     isApplicable: (volume: Volume) => !Volume.isEmpty(volume) && !Volume.Segmentation.get(volume)
 });

--- a/src/mol-repr/volume/visual.ts
+++ b/src/mol-repr/volume/visual.ts
@@ -212,7 +212,7 @@ export function VolumeVisual<G extends Geometry, P extends VolumeParams & Geomet
                 // not all geometries have size data, so check here
                 if ('uSize' in renderObject.values) {
                     // console.log('update size');
-                    createSizes(locationIt, newTheme.size, renderObject.values as SizeValues);
+                    createSizes(locationIt, positionIt, newTheme.size, renderObject.values as SizeValues);
                 }
             }
 

--- a/src/mol-theme/size/volume-value.ts
+++ b/src/mol-theme/size/volume-value.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2025-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
@@ -11,11 +11,19 @@ import { ThemeDataContext } from '../../mol-theme/theme';
 import { LocationSize } from '../../mol-geo/geometry/size-data';
 import { Volume } from '../../mol-model/volume/volume';
 import { Location } from '../../mol-model/location';
+import { isPositionLocation } from '../../mol-geo/util/location-iterator';
+import { Grid } from '../../mol-model/volume/grid';
+import { clamp } from '../../mol-math/interpolate';
 
-const Description = 'Assign size based on the given value of a volume cell. Negative values are made positive.';
+const Description = 'Assign size based on the given value of a volume cell.';
 
 export const VolumeValueSizeThemeParams = {
-    scale: PD.Numeric(1, { min: 0.1, max: 5, step: 0.1 }),
+    scale: PD.Numeric(1, { min: 0.01, max: 10, step: 0.01 }),
+    transform: PD.Select('linear', [['linear', 'Linear'], ['quadratic', 'Quadratic'], ['cubic', 'Cubic']] as const, { description: 'Linear: value * scale, Quadratic: value * scale^2, Cubic: value * scale^3' }),
+    domain: PD.MappedStatic('auto', {
+        custom: PD.Interval([0, 1], { step: 0.001, min: 0 }),
+        auto: PD.Group({})
+    }),
 };
 export type VolumeValueSizeThemeParams = typeof VolumeValueSizeThemeParams
 export function getVolumeValueSizeThemeParams(ctx: ThemeDataContext) {
@@ -24,24 +32,52 @@ export function getVolumeValueSizeThemeParams(ctx: ThemeDataContext) {
 
 export function VolumeValueSizeTheme(ctx: ThemeDataContext, props: PD.Values<VolumeValueSizeThemeParams>): SizeTheme<VolumeValueSizeThemeParams> {
     if (ctx.volume) {
-        const { data } = ctx.volume.grid.cells;
+        const { min, max } = ctx.volume.grid.stats;
+        const domain: [number, number] = props.domain.name === 'custom' ? props.domain.params : [min, max];
+        const scaleFactor = props.transform === 'cubic' ? props.scale ** 3 : props.transform === 'quadratic' ? props.scale ** 2 : props.scale;
 
-        const isLocation = Volume.Cell.isLocation;
-        const size: LocationSize = (location: Location): number => {
-            if (isLocation(location)) {
-                return Math.abs(data[location.cell]) * props.scale;
-            } else {
-                return 0;
-            }
-        };
+        if (ctx.locationKinds?.includes('cell-location')) {
+            const { data } = ctx.volume.grid.cells;
 
-        return {
-            factory: VolumeValueSizeTheme,
-            granularity: 'group',
-            size,
-            props,
-            description: Description
-        };
+            const isLocation = Volume.Cell.isLocation;
+            const size: LocationSize = (location: Location): number => {
+                if (isLocation(location)) {
+                    const v = clamp(Math.abs(data[location.cell]), domain[0], domain[1]);
+                    return v * scaleFactor;
+                } else {
+                    return 0;
+                }
+            };
+
+            return {
+                factory: VolumeValueSizeTheme,
+                granularity: 'group',
+                size,
+                props,
+                description: Description
+            };
+        } else {
+            const getTrilinearlyInterpolated = Grid.makeGetTrilinearlyInterpolated(ctx.volume.grid, 'none');
+
+            const size: LocationSize = (location: Location): number => {
+                if (isPositionLocation(location)) {
+                    const value = getTrilinearlyInterpolated(location.position);
+                    if (Number.isNaN(value)) return 0;
+                    const v = clamp(Math.abs(value), domain[0], domain[1]);
+                    return v * scaleFactor;
+                } else {
+                    return 0;
+                }
+            };
+
+            return {
+                factory: VolumeValueSizeTheme,
+                granularity: 'vertex',
+                size,
+                props,
+                description: Description
+            };
+        }
     } else {
         return {
             factory: VolumeValueSizeTheme,


### PR DESCRIPTION


<!-- Thank you for contributing to Mol* -->

# Description

- Add `vertex` and `vertexInstance` granularity support for size themes
- Geometry export: Support vertex-based sizing
- Add `transform` and `domain` parameters to volume-value size theme

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`