### PR TITLE
Fix `unitSymmetryGroups` for representations with `includeParent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix `TextCtrl` always moving cursor to end position
 - Add `vertex` and `vertexInstance` granularity support for size themes
 - Add `transform` and `domain` parameters to volume-value size theme
+- Fix `unitSymmetryGroups` for representations with `includeParent` enabled
 
 ## [v5.6.1] - 2026-01-23
 - Disable occlusion culling in `ImagePass` (#1758)


### PR DESCRIPTION

<!-- Thank you for contributing to Mol* -->

# Description

Fix `unitSymmetryGroups` for representations with `includeParent` enabled.

Units that are in different transform groups in the child must also be in different transform groups in the parent.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`