### PR TITLE
Handle CCD bonds with Deuterium atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Add `VolumeStreamingExtension` (`molstar_volume_streaming` custom property)
     - Fix focusing empty selections
 - Handle CCD bonds with Deuterium atoms
+- [Breaking] ComponentBond.Entry.map now returns ComponentBond.Pairs
 
 ## [v5.7.0] - 2026-02-28
 - Text label improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - MolViewSpec
     - Add `VolumeStreamingExtension` (`molstar_volume_streaming` custom property)
     - Fix focusing empty selections
+- Handle CCD bonds with Deuterium atoms
 
 ## [v5.7.0] - 2026-02-28
 - Text label improvements

--- a/docs/docs/misc/interesting-pdb-entries.md
+++ b/docs/docs/misc/interesting-pdb-entries.md
@@ -49,3 +49,6 @@
 * Assembly symmetries
     * 5M30 (Assembly 1, C3 local and pseudo)
     * 1RB8 (Assembly 1, I global)
+* Deuterium atoms
+    * 3CWH (XUL with D and DOD)
+    * 8TT8 (HOH and other with D)

--- a/src/mol-io/writer/mol/encoder.ts
+++ b/src/mol-io/writer/mol/encoder.ts
@@ -61,7 +61,7 @@ export class MolEncoder extends LigandEncoder {
 
             // no data for metal ions
             if (!bondMap?.map) return;
-            bondMap.map.get(label_atom_id1)!.forEach((bond, label_atom_id2) => {
+            bondMap.map.get(label_atom_id1)!.map.forEach((bond, label_atom_id2) => {
                 const atom2 = atoms.get(label_atom_id2);
                 if (!atom2) return;
 

--- a/src/mol-io/writer/mol2/encoder.ts
+++ b/src/mol-io/writer/mol2/encoder.ts
@@ -52,7 +52,7 @@ export class Mol2Encoder extends LigandEncoder {
             }
 
             if (bondMap?.map) {
-                bondMap.map.get(label_atom_id1)!.forEach((bond, label_atom_id2) => {
+                bondMap.map.get(label_atom_id1)!.map.forEach((bond, label_atom_id2) => {
                     const atom2 = atoms.get(label_atom_id2);
                     if (!atom2) return;
 
@@ -132,7 +132,7 @@ export class Mol2Encoder extends LigandEncoder {
         if (type_symbol1 === 'P') return 'P.3'; // 1.4, 4mpo/ligand?encoding=mol2&auth_seq_id=203 (PO4)
         if (type_symbol1 === 'Co' || type_symbol1 === 'Ru') return type_symbol1 + '.oh'; // 1.5
 
-        const bonds = bondMap.map.get(label_atom_id1)!;
+        const bonds = bondMap.map.get(label_atom_id1)!.map;
         const numBonds = bonds.size;
 
         if (type_symbol1 === 'Ti' || type_symbol1 === 'Cr') { // 1.10
@@ -192,7 +192,7 @@ export class Mol2Encoder extends LigandEncoder {
         let result = iter.next();
         while (!result.done) {
             const label_atom_id = result.value;
-            const adjacentBonds = bondMap.map.get(label_atom_id)!;
+            const adjacentBonds = bondMap.map.get(label_atom_id)!.map;
             if (this.count(adjacentBonds, this, (_k, v) => v.order > 1 || BondType.is(BondType.Flag.Aromatic, v.flags))) {
                 // TODO check accurately for 2nd criterion with coordinates
                 return true;
@@ -207,7 +207,7 @@ export class Mol2Encoder extends LigandEncoder {
     private isOC(nonmets: BondMap, bondMap: ComponentBond.Entry): boolean {
         const nonmet = nonmets.entries().next()!.value as [string, { order: number, flags: number }];
         if (!nonmet[0].startsWith('C')) return false;
-        const carbonBonds = bondMap.map.get(nonmet[0])!;
+        const carbonBonds = bondMap.map.get(nonmet[0])!.map;
         if (carbonBonds.size !== 3) return false;
 
         let count = 0;
@@ -216,7 +216,7 @@ export class Mol2Encoder extends LigandEncoder {
         while (!result.done) {
             const label_atom_id = result.value;
             if (label_atom_id.startsWith('O')) {
-                const adjacentBonds = bondMap.map.get(label_atom_id)!;
+                const adjacentBonds = bondMap.map.get(label_atom_id)!.map;
                 if (this.count(adjacentBonds, this, (k, _v, ctx) => ctx.isNonMetalBond(k)) === 1) count++;
             }
             result = iter.next();
@@ -229,7 +229,7 @@ export class Mol2Encoder extends LigandEncoder {
     private isOP(nonmets: BondMap, bondMap: ComponentBond.Entry): boolean {
         const nonmet = nonmets.entries().next()!.value as [string, { order: number, flags: number }];
         if (!nonmet[0].startsWith('P')) return false;
-        const phosphorusBonds = bondMap.map.get(nonmet[0])!;
+        const phosphorusBonds = bondMap.map.get(nonmet[0])!.map;
         if (phosphorusBonds.size < 2) return false;
 
         let count = 0;
@@ -238,7 +238,7 @@ export class Mol2Encoder extends LigandEncoder {
         while (!result.done) {
             const label_atom_id = result.value;
             if (label_atom_id.startsWith('O')) {
-                const adjacentBonds = bondMap.map.get(label_atom_id)!;
+                const adjacentBonds = bondMap.map.get(label_atom_id)!.map;
                 if (this.count(adjacentBonds, this, (k, _v, ctx) => ctx.isNonMetalBond(k)) === 1) count++;
             }
             result = iter.next();
@@ -255,7 +255,7 @@ export class Mol2Encoder extends LigandEncoder {
             const label_atom_id = result1.value;
             if (!label_atom_id.startsWith('N')) return false;
 
-            const adjacentBonds = bondMap.map.get(label_atom_id)!;
+            const adjacentBonds = bondMap.map.get(label_atom_id)!.map;
             if (adjacentBonds.size < 2) return false;
 
             const iter2 = adjacentBonds.keys();
@@ -277,7 +277,7 @@ export class Mol2Encoder extends LigandEncoder {
         while (!result.done) {
             const label_atom_id = result.value;
             if (label_atom_id.startsWith('O')) {
-                const adjacentBonds = bondMap.map.get(label_atom_id)!;
+                const adjacentBonds = bondMap.map.get(label_atom_id)!.map;
                 if (this.count(adjacentBonds, this, (k, _v, ctx) => ctx.isNonMetalBond(k))) count++;
             }
             result = iter.next();
@@ -292,7 +292,7 @@ export class Mol2Encoder extends LigandEncoder {
         while (!result.done) {
             const label_atom_id = result.value;
             if (label_atom_id.startsWith('C')) {
-                const adjacentBonds = bondMap.map.get(label_atom_id)!;
+                const adjacentBonds = bondMap.map.get(label_atom_id)!.map;
                 if (this.count(adjacentBonds, this, (k, v) => k.startsWith('O') || k.startsWith('S') && v.order === 2)) return true;
             }
             result = iter.next();

--- a/src/mol-model-formats/structure/property/bonds/chem_comp.ts
+++ b/src/mol-model-formats/structure/property/bonds/chem_comp.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2022 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -76,7 +76,7 @@ export namespace ComponentBond {
             const aromatic = pdbx_aromatic_flag.value(i) === 'y';
             const key = pdbx_ordinal.value(i);
 
-            if (entry.id !== id) {
+            if (entry.compId !== id) {
                 entry = addEntry(id);
             }
 
@@ -96,25 +96,48 @@ export namespace ComponentBond {
         return entries;
     }
 
+    function getNormalized<T>(map: Map<string, T>, compId: string, atomId: string, isHydrogen: boolean) {
+        // handle deuterium -> hydrogen mapping for CCD bonds
+        // in DOD deuterium bonds are explicitly defined
+        if (isHydrogen && atomId.startsWith('D') && compId !== 'DOD') {
+            atomId = 'H' + atomId.substring(1);
+        }
+        return map.get(atomId);
+    }
+
+    export class Pairs {
+        readonly map: Map<string, { order: number, flags: number, key: number }> = new Map();
+
+        get(otherAtomId: string, isHydrogen: boolean) {
+            return getNormalized(this.map, this.compId, otherAtomId, isHydrogen);
+        }
+
+        constructor(readonly atomId: string, readonly compId: string) { }
+    }
+
     export class Entry {
-        readonly map: Map<string, Map<string, { order: number, flags: number, key: number }>> = new Map();
+        readonly map: Map<string, Pairs> = new Map();
 
         add(a: string, b: string, order: number, flags: number, key: number, swap = true) {
             const e = this.map.get(a);
             if (e !== void 0) {
-                const f = e.get(b);
+                const f = e.map.get(b);
                 if (f === void 0) {
-                    e.set(b, { order, flags, key });
+                    e.map.set(b, { order, flags, key });
                 }
             } else {
-                const map = new Map<string, { order: number, flags: number, key: number }>();
-                map.set(b, { order, flags, key });
-                this.map.set(a, map);
+                const pairs = new Pairs(a, this.compId);
+                pairs.map.set(b, { order, flags, key });
+                this.map.set(a, pairs);
             }
 
             if (swap) this.add(b, a, order, flags, key, false);
         }
 
-        constructor(public readonly id: string) { }
+        get(a: string, isHydrogen: boolean): Pairs | undefined {
+            return getNormalized(this.map, this.compId, a, isHydrogen);
+        }
+
+        constructor(public readonly compId: string) { }
     }
 }

--- a/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
+++ b/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2025 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -213,11 +213,14 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
         lastResidue = raI;
 
         const aeI = getElementIdx(elemA);
-        const atomIdA = label_atom_id.value(aI);
+        const isHa = isHydrogen(aeI);
+        let atomIdA = label_atom_id.value(aI);
+        if (isHa && atomIdA.startsWith('D') && compId !== 'DOD') {
+            atomIdA = 'H' + atomIdA.substring(1);
+        }
         const componentPairs = componentMap ? componentMap.get(atomIdA) : void 0;
 
         const { indices, count, squaredDistances } = query3d.find(x[aI], y[aI], z[aI], maxRadius);
-        const isHa = isHydrogen(aeI);
         const thresholdA = getElementThreshold(aeI);
         const altA = label_alt_id.value(aI);
         const metalA = MetalsSet.has(aeI);
@@ -248,7 +251,11 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
             const rbI = residueIndex[bI];
             // handle "component dictionary" bonds.
             if (raI === rbI && componentPairs) {
-                const e = componentPairs.get(label_atom_id.value(bI)!);
+                let atomIdB = label_atom_id.value(bI)!;
+                if (isHb && atomIdB.startsWith('D') && compId !== 'DOD') {
+                    atomIdB = 'H' + atomIdB.substring(1);
+                }
+                const e = componentPairs.get(atomIdB);
                 if (e) {
                     atomA[atomA.length] = _aI;
                     atomB[atomB.length] = _bI;
@@ -284,7 +291,7 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
             if (flag) {
                 atomA[atomA.length] = _aI;
                 atomB[atomB.length] = _bI;
-                order[order.length] = getIntraBondOrderFromTable(compId, atomIdA, label_atom_id.value(bI));
+                order[order.length] = getIntraBondOrderFromTable(compId, label_atom_id.value(aI), label_atom_id.value(bI));
                 flags[flags.length] = (isMetal ? BondType.Flag.MetallicCoordination : BondType.Flag.Covalent) | BondType.Flag.Computed;
                 key[key.length] = -1;
 

--- a/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
+++ b/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
@@ -155,7 +155,7 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
     const key: number[] = [];
 
     let lastResidue = -1;
-    let componentMap: Map<string, Map<string, { flags: number, order: number, key: number }>> | undefined = void 0;
+    let componentEntry: ComponentBond.Entry | undefined = void 0;
 
     let isWatery = true, isDictionaryBased = true, isSequenced = true;
 
@@ -202,23 +202,20 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
                 const entitySeq = byEntityKey[index.getEntityFromChain(chainIndex[aI])];
                 if (entitySeq && entitySeq.sequence.microHet.has(seqIdA)) {
                     // compute for sequence positions with micro-heterogeneity
-                    componentMap = void 0;
+                    componentEntry = void 0;
                 } else {
-                    componentMap = component.entries.get(compId)!.map;
+                    componentEntry = component.entries.get(compId)!;
                 }
             } else {
-                componentMap = void 0;
+                componentEntry = void 0;
             }
         }
         lastResidue = raI;
 
         const aeI = getElementIdx(elemA);
         const isHa = isHydrogen(aeI);
-        let atomIdA = label_atom_id.value(aI);
-        if (isHa && atomIdA.startsWith('D') && compId !== 'DOD') {
-            atomIdA = 'H' + atomIdA.substring(1);
-        }
-        const componentPairs = componentMap ? componentMap.get(atomIdA) : void 0;
+        const atomIdA = label_atom_id.value(aI);
+        const componentPairs = componentEntry ? componentEntry.get(atomIdA, isHa) : void 0;
 
         const { indices, count, squaredDistances } = query3d.find(x[aI], y[aI], z[aI], maxRadius);
         const thresholdA = getElementThreshold(aeI);
@@ -251,11 +248,8 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
             const rbI = residueIndex[bI];
             // handle "component dictionary" bonds.
             if (raI === rbI && componentPairs) {
-                let atomIdB = label_atom_id.value(bI)!;
-                if (isHb && atomIdB.startsWith('D') && compId !== 'DOD') {
-                    atomIdB = 'H' + atomIdB.substring(1);
-                }
-                const e = componentPairs.get(atomIdB);
+                const atomIdB = label_atom_id.value(bI)!;
+                const e = componentPairs.get(atomIdB, isHb);
                 if (e) {
                     atomA[atomA.length] = _aI;
                     atomB[atomB.length] = _bI;
@@ -291,7 +285,7 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
             if (flag) {
                 atomA[atomA.length] = _aI;
                 atomB[atomB.length] = _bI;
-                order[order.length] = getIntraBondOrderFromTable(compId, label_atom_id.value(aI), label_atom_id.value(bI));
+                order[order.length] = getIntraBondOrderFromTable(compId, atomIdA, label_atom_id.value(bI));
                 flags[flags.length] = (isMetal ? BondType.Flag.MetallicCoordination : BondType.Flag.Covalent) | BondType.Flag.Computed;
                 key[key.length] = -1;
 

--- a/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
+++ b/src/mol-model/structure/structure/unit/bonds/intra-compute.ts
@@ -248,8 +248,7 @@ function findBonds(unit: Unit.Atomic, props: BondComputationProps): IntraUnitBon
             const rbI = residueIndex[bI];
             // handle "component dictionary" bonds.
             if (raI === rbI && componentPairs) {
-                const atomIdB = label_atom_id.value(bI)!;
-                const e = componentPairs.get(atomIdB, isHb);
+                const e = componentPairs.get(label_atom_id.value(bI), isHb);
                 if (e) {
                     atomA[atomA.length] = _aI;
                     atomB[atomB.length] = _bI;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Handle CCD bonds with Deuterium atoms, for example:

* 3CWH (XUL with D and DOD)
* 8TT8 (HOH and other with D)

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`