### PR TITLE
VolumeStreaming - avoid re-download on node update

### DIFF
--- a/src/mol-plugin/behavior/dynamic/volume-streaming/transformers.ts
+++ b/src/mol-plugin/behavior/dynamic/volume-streaming/transformers.ts
@@ -18,6 +18,7 @@ import { VolumeRepresentationRegistry } from '../../../../mol-repr/volume/regist
 import { StateAction, StateObject, StateTransformer } from '../../../../mol-state';
 import { RuntimeContext, Task } from '../../../../mol-task';
 import { Theme } from '../../../../mol-theme/theme';
+import { deepEqual } from '../../../../mol-util';
 import { ParamDefinition as PD } from '../../../../mol-util/param-definition';
 import { urlCombine } from '../../../../mol-util/url';
 import { PluginConfig } from '../../../config';
@@ -216,7 +217,11 @@ const CreateVolumeStreamingInfo = PluginStateTransform.BuiltIn({
             defaultChannelParams: params.defaultChannelParams,
         };
         return new VolumeServerInfo(data, { label: 'Volume Server', description: `${entries.map(e => e.dataId).join(', ')}` });
-    })
+    }),
+    update({ a, b, oldParams, newParams }) {
+        if (a.data === b.data.structure && deepEqual(oldParams, newParams)) return StateTransformer.UpdateResult.Unchanged;
+        return StateTransformer.UpdateResult.Recreate;
+    },
 });
 
 export { CreateVolumeStreamingBehavior };


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

A little fix for https://github.com/molstar/molstar/pull/1793.
Avoids re-downloading volume streaming headers with every MVS state update.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`