### PR TITLE
Add support for the ZML format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Handle CCD bonds with Deuterium atoms
 - [Breaking] ComponentBond.Entry.map now returns ComponentBond.Pairs
 - Fix volume slice marking performance regression
+- Add ZML (Zipped Molecular Lot) format support: reader for V1 and V3 archives (topology + coordinates; force field data ignored) and V1 writer
 
 ## [v5.8.0] - 2026-04-03
 - Dependencies: remove `utils.promisify`, `node-fetch` (#1797)

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "Kim Juho <juho_kim@outlook.com>",
     "Victoria Doshchenko <doshchenko.victoria@gmail.com>",
     "Diego del Alamo <diego.delalamo@gmail.com>",
-    "Tianzhen Lin (Tangent) <tangent@usa.net>"
+    "Tianzhen Lin (Tangent) <tangent@usa.net>",
+    "Yujie Wu <yujie@atommap.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/extensions/model-export/export.ts
+++ b/src/extensions/model-export/export.ts
@@ -6,12 +6,15 @@
  */
 
 import { utf8ByteCount, utf8Write } from '../../mol-io/common/utf8';
+import { encodeZml } from '../../mol-io/writer/zml';
 import { Structure, to_mmCIF, Unit } from '../../mol-model/structure';
 import { PluginContext } from '../../mol-plugin/context';
 import { Task } from '../../mol-task';
 import { getFormattedTime } from '../../mol-util/date';
 import { download } from '../../mol-util/download';
 import { zip } from '../../mol-util/zip/zip';
+
+export type ModelExportFormat = 'cif' | 'bcif' | 'zml';
 
 const ModelExportNameProp = '__ModelExportName__';
 export const ModelExport = {
@@ -23,7 +26,7 @@ export const ModelExport = {
     }
 };
 
-export async function exportHierarchy(plugin: PluginContext, options?: { format?: 'cif' | 'bcif' }) {
+export async function exportHierarchy(plugin: PluginContext, options?: { format?: ModelExportFormat }) {
     try {
         await plugin.runTask(_exportHierarchy(plugin, options), { useOverlay: true });
     } catch (e) {
@@ -32,7 +35,7 @@ export async function exportHierarchy(plugin: PluginContext, options?: { format?
     }
 }
 
-function _exportHierarchy(plugin: PluginContext, options?: { format?: 'cif' | 'bcif' }) {
+function _exportHierarchy(plugin: PluginContext, options?: { format?: ModelExportFormat }) {
     return Task.create('Export', async ctx => {
         await ctx.update({ message: 'Exporting...', isIndeterminate: true, canAbort: false });
 
@@ -68,7 +71,11 @@ function _exportHierarchy(plugin: PluginContext, options?: { format?: 'cif' | 'b
             }
 
             try {
-                files.push([fileName, to_mmCIF(name, s, format === 'bcif', { copyAllCategories: true })]);
+                if (format === 'zml') {
+                    files.push([fileName, await encodeZml(ctx, name, s)]);
+                } else {
+                    files.push([fileName, to_mmCIF(name, s, format === 'bcif', { copyAllCategories: true })]);
+                }
             } catch (e) {
                 if (format === 'cif' && s.elementCount > 2000000) {
                     plugin.log.warn(`[Export] The structure might be too big to be exported as Text CIF, consider using the BinaryCIF format instead.`);

--- a/src/extensions/model-export/export.ts
+++ b/src/extensions/model-export/export.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2021-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { utf8ByteCount, utf8Write } from '../../mol-io/common/utf8';

--- a/src/extensions/model-export/ui.tsx
+++ b/src/extensions/model-export/ui.tsx
@@ -28,7 +28,7 @@ export class ModelExportUI extends CollapsableControls<{}, {}> {
 }
 
 const Params = {
-    format: PD.Select<'cif' | 'bcif'>('cif', [['cif', 'mmCIF'], ['bcif', 'Binary mmCIF']])
+    format: PD.Select<'cif' | 'bcif' | 'zml'>('cif', [['cif', 'mmCIF'], ['bcif', 'Binary mmCIF'], ['zml', 'ZML']])
 };
 const DefaultParams = PD.getDefaultValues(Params);
 

--- a/src/extensions/model-export/ui.tsx
+++ b/src/extensions/model-export/ui.tsx
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { useState } from 'react';

--- a/src/mol-io/reader/_spec/zml.spec.ts
+++ b/src/mol-io/reader/_spec/zml.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Augment Agent
+ */
+
+import { utf8ByteCount, utf8Write } from '../../common/utf8';
+import { SyncRuntimeContext } from '../../../mol-task/execution/synchronous';
+import { Structure } from '../../../mol-model/structure';
+import { trajectoryFromZml } from '../../../mol-model-formats/structure/zml';
+import { encodeZml } from '../../writer/zml';
+import { zip } from '../../../mol-util/zip/zip';
+import { parseZml } from '../zml/parser';
+import { ZmlMolSys, ZmlV1FileNames, ZmlV3FileNames, ZmlV3Header } from '../zml/schema';
+
+function toBytes(s: string): Uint8Array<ArrayBuffer> {
+    const bytes = new Uint8Array(utf8ByteCount(s));
+    utf8Write(bytes, 0, s);
+    return bytes as Uint8Array<ArrayBuffer>;
+}
+
+function float64Bytes(values: number[]): Uint8Array<ArrayBuffer> {
+    const buf = new ArrayBuffer(values.length * 8);
+    new Float64Array(buf).set(values);
+    return new Uint8Array(buf) as Uint8Array<ArrayBuffer>;
+}
+
+function waterMolSys(): ZmlMolSys {
+    return {
+        name: 'water',
+        molecules: [{
+            name: 'A', chain_id: 'A', comtype: 'Comtype.UNKNOWN',
+            residues: [{
+                id: 1, name: 'HOH', insertion_code: '',
+                atoms: [
+                    { id: 1, name: 'O', atomic_number: 8, formal_charge: 0, props: {} },
+                    { id: 2, name: 'H1', atomic_number: 1, formal_charge: 0, props: {} },
+                    { id: 3, name: 'H2', atomic_number: 1, formal_charge: 0, props: {} },
+                ],
+                props: {},
+            }],
+            props: {},
+        }],
+        bonds: [[0, 1, 1], [0, 2, 1]],
+        box: null,
+        props: {},
+    };
+}
+
+async function buildArchive(molsys: ZmlMolSys, positions: number[]): Promise<Uint8Array> {
+    const entries: { [k: string]: Uint8Array<ArrayBuffer> } = {
+        [ZmlV1FileNames.version]: toBytes('1'),
+        [ZmlV1FileNames.molsys]: toBytes(JSON.stringify(molsys)),
+        [ZmlV1FileNames.positions]: float64Bytes(positions),
+    };
+    const buf = await zip(SyncRuntimeContext, entries);
+    return new Uint8Array(buf);
+}
+
+function int16Bytes(values: number[]): Uint8Array<ArrayBuffer> {
+    const buf = new ArrayBuffer(values.length * 2);
+    new Int16Array(buf).set(values);
+    return new Uint8Array(buf) as Uint8Array<ArrayBuffer>;
+}
+function int32Bytes(values: number[]): Uint8Array<ArrayBuffer> {
+    const buf = new ArrayBuffer(values.length * 4);
+    new Int32Array(buf).set(values);
+    return new Uint8Array(buf) as Uint8Array<ArrayBuffer>;
+}
+function int8Bytes(values: number[]): Uint8Array<ArrayBuffer> {
+    const buf = new Uint8Array(values.length);
+    new Int8Array(buf.buffer).set(values);
+    return buf as Uint8Array<ArrayBuffer>;
+}
+
+async function buildV3Archive(): Promise<{ data: Uint8Array, positions: number[] }> {
+    const header: ZmlV3Header = {
+        name: 'water',
+        box: null,
+        props: {},
+        atom_names: ['O', 'H1', 'H2'],
+        atom_props: [{}, {}, {}],
+        res_names: ['HOH'],
+        res_icodes: [''],
+        res_props: [{}],
+        mol_names: ['A'],
+        mol_chain_ids: ['A'],
+        mol_props: [{}],
+    };
+    const positions = [0, 0, 0, 0.96, 0, 0, -0.24, 0.93, 0];
+    const entries: { [k: string]: Uint8Array<ArrayBuffer> } = {
+        [ZmlV3FileNames.version]: toBytes('3'),
+        [ZmlV3FileNames.header]: toBytes(JSON.stringify(header)),
+        [ZmlV3FileNames.Z]: int16Bytes([8, 1, 1]),
+        [ZmlV3FileNames.formalCharges]: int16Bytes([0, 0, 0]),
+        [ZmlV3FileNames.atomIds]: int32Bytes([1, 2, 3]),
+        [ZmlV3FileNames.resIds]: int32Bytes([1]),
+        [ZmlV3FileNames.resAtomOffsets]: int32Bytes([0, 3]),
+        [ZmlV3FileNames.molResOffsets]: int32Bytes([0, 1]),
+        [ZmlV3FileNames.bonds]: int32Bytes([0, 1, 0, 2]),
+        [ZmlV3FileNames.bondOrders]: int8Bytes([1, 1]),
+        [ZmlV3FileNames.positions]: float64Bytes(positions),
+    };
+    const buf = await zip(SyncRuntimeContext, entries);
+    return { data: new Uint8Array(buf), positions };
+}
+
+describe('zml reader', () => {
+    it('parses a minimal V1 archive', async () => {
+        const molsys = waterMolSys();
+        const positions = [0, 0, 0, 0.96, 0, 0, -0.24, 0.93, 0];
+        const data = await buildArchive(molsys, positions);
+        const parsed = await parseZml(data, 'test').run();
+        if (parsed.isError) throw new Error(parsed.message);
+        const zml = parsed.result;
+
+        expect(zml.atomCount).toBe(3);
+        expect(zml.molsys.molecules.length).toBe(1);
+        expect(zml.molsys.molecules[0].residues[0].atoms[0].name).toBe('O');
+        expect(zml.molsys.bonds.length).toBe(2);
+        expect(Array.from(zml.positions.slice(0, 3))).toEqual([0, 0, 0]);
+        expect(zml.positions[3]).toBeCloseTo(0.96);
+    });
+
+    it('rejects unsupported versions', async () => {
+        const entries: { [k: string]: Uint8Array<ArrayBuffer> } = {
+            [ZmlV1FileNames.version]: toBytes('2'),
+            'molsys.pkl': toBytes('irrelevant'),
+        };
+        const buf = await zip(SyncRuntimeContext, entries);
+        const parsed = await parseZml(new Uint8Array(buf), 'bad').run();
+        expect(parsed.isError).toBe(true);
+        if (parsed.isError) expect(parsed.message).toMatch(/version/i);
+    });
+
+    it('parses a minimal V3 archive', async () => {
+        const { data, positions } = await buildV3Archive();
+        const parsed = await parseZml(data, 'v3').run();
+        if (parsed.isError) throw new Error(parsed.message);
+        const zml = parsed.result;
+
+        expect(zml.atomCount).toBe(3);
+        expect(zml.molsys.name).toBe('water');
+        expect(zml.molsys.molecules.length).toBe(1);
+        expect(zml.molsys.molecules[0].chain_id).toBe('A');
+        const atoms = zml.molsys.molecules[0].residues[0].atoms;
+        expect(atoms.map(a => a.name)).toEqual(['O', 'H1', 'H2']);
+        expect(atoms.map(a => a.atomic_number)).toEqual([8, 1, 1]);
+        expect(zml.molsys.bonds).toEqual([[0, 1, 1], [0, 2, 1]]);
+        for (let i = 0; i < positions.length; i++) {
+            expect(zml.positions[i]).toBeCloseTo(positions[i], 6);
+        }
+    });
+
+    it('builds a Trajectory from a V3 archive', async () => {
+        const { data } = await buildV3Archive();
+        const parsed = await parseZml(data, 'v3').run();
+        if (parsed.isError) throw new Error(parsed.message);
+        const trajectory = await trajectoryFromZml(parsed.result).run();
+        expect(trajectory.frameCount).toBe(1);
+        const model = trajectory.representative;
+        expect(model.atomicHierarchy.atoms._rowCount).toBe(3);
+        expect(model.atomicHierarchy.atoms.type_symbol.value(0)).toBe('O');
+        expect(model.atomicHierarchy.atoms.type_symbol.value(1)).toBe('H');
+    });
+
+    it('rejects positions with wrong length', async () => {
+        const molsys = waterMolSys();
+        const data = await buildArchive(molsys, [0, 0, 0]); // only 1 atom worth for 3 atoms
+        const parsed = await parseZml(data, 'bad').run();
+        expect(parsed.isError).toBe(true);
+    });
+
+    it('builds a Trajectory with correct elements', async () => {
+        const molsys = waterMolSys();
+        const data = await buildArchive(molsys, [0, 0, 0, 0.96, 0, 0, -0.24, 0.93, 0]);
+        const parsed = await parseZml(data, 'traj').run();
+        if (parsed.isError) throw new Error(parsed.message);
+        const trajectory = await trajectoryFromZml(parsed.result).run();
+        expect(trajectory.frameCount).toBe(1);
+        const model = trajectory.representative;
+        expect(model.atomicHierarchy.atoms._rowCount).toBe(3);
+        expect(model.atomicHierarchy.atoms.type_symbol.value(0)).toBe('O');
+        expect(model.atomicHierarchy.atoms.type_symbol.value(1)).toBe('H');
+    });
+});
+
+describe('zml writer', () => {
+    it('roundtrips through encodeZml', async () => {
+        const originalMolSys = waterMolSys();
+        const originalPositions = [0, 0, 0, 0.96, 0, 0, -0.24, 0.93, 0];
+        const data = await buildArchive(originalMolSys, originalPositions);
+        const parsed = await parseZml(data, 'rt').run();
+        if (parsed.isError) throw new Error(parsed.message);
+        const trajectory = await trajectoryFromZml(parsed.result).run();
+        const structure = Structure.ofModel(trajectory.representative);
+
+        const encoded = await encodeZml(SyncRuntimeContext, 'rt', structure);
+        const reparsed = await parseZml(encoded, 'rt').run();
+        if (reparsed.isError) throw new Error(reparsed.message);
+        const rt = reparsed.result;
+
+        expect(rt.atomCount).toBe(3);
+        // Atom ordering should round-trip.
+        const outAtoms = rt.molsys.molecules[0].residues[0].atoms.map(a => a.name);
+        expect(outAtoms).toEqual(['O', 'H1', 'H2']);
+        expect(rt.molsys.bonds.length).toBe(2);
+        for (let i = 0; i < originalPositions.length; i++) {
+            expect(rt.positions[i]).toBeCloseTo(originalPositions[i], 4);
+        }
+    });
+});

--- a/src/mol-io/reader/_spec/zml.spec.ts
+++ b/src/mol-io/reader/_spec/zml.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author Augment Agent
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { utf8ByteCount, utf8Write } from '../../common/utf8';

--- a/src/mol-io/reader/zml/parser.ts
+++ b/src/mol-io/reader/zml/parser.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author Augment Agent
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { utf8Read } from '../../common/utf8';

--- a/src/mol-io/reader/zml/parser.ts
+++ b/src/mol-io/reader/zml/parser.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Augment Agent
+ */
+
+import { utf8Read } from '../../common/utf8';
+import { RuntimeContext, Task } from '../../../mol-task';
+import { unzip } from '../../../mol-util/zip/zip';
+import { ReaderResult as Result } from '../result';
+import {
+    ZmlAtom, ZmlBond, ZmlFile, ZmlMol, ZmlMolSys, ZmlResidue,
+    ZmlSupportedVersions, ZmlV1FileNames, ZmlV3FileNames, ZmlV3Header,
+} from './schema';
+
+type ZipEntries = { [k: string]: Uint8Array | { size: number, csize: number } };
+
+function getEntry(entries: ZipEntries, fname: string): Uint8Array | undefined {
+    const entry = entries[fname];
+    return entry instanceof Uint8Array ? entry : undefined;
+}
+
+function countAtoms(molsys: ZmlMolSys): number {
+    let n = 0;
+    for (const mol of molsys.molecules) {
+        for (const res of mol.residues) n += res.atoms.length;
+    }
+    return n;
+}
+
+function alignedCopy(raw: Uint8Array): ArrayBuffer {
+    const buf = new ArrayBuffer(raw.byteLength);
+    new Uint8Array(buf).set(raw);
+    return buf;
+}
+
+function readFloat64Positions(raw: Uint8Array, atomCount: number, entryName: string): Float64Array {
+    const expected = atomCount * 3 * 8;
+    if (raw.byteLength !== expected) {
+        throw new Error(
+            `ZML ${entryName} has ${raw.byteLength} bytes but expected ${expected} ` +
+            `(atomCount=${atomCount}, 3 coords, float64).`
+        );
+    }
+    return new Float64Array(alignedCopy(raw));
+}
+
+function readTypedArray<T extends Int8Array | Int16Array | Int32Array>(
+    raw: Uint8Array, Ctor: { new (buf: ArrayBuffer): T, BYTES_PER_ELEMENT: number }, entryName: string
+): T {
+    if (raw.byteLength % Ctor.BYTES_PER_ELEMENT !== 0) {
+        throw new Error(
+            `ZML ${entryName} byte length ${raw.byteLength} is not a multiple of ` +
+            `${Ctor.BYTES_PER_ELEMENT}.`
+        );
+    }
+    return new Ctor(alignedCopy(raw));
+}
+
+async function parseV1(entries: ZipEntries, name: string): Promise<Result<ZmlFile>> {
+    const molsysBytes = getEntry(entries, ZmlV1FileNames.molsys);
+    if (!molsysBytes) return Result.error(`Missing ${ZmlV1FileNames.molsys} in ZML archive.`);
+    const posBytes = getEntry(entries, ZmlV1FileNames.positions);
+    if (!posBytes) return Result.error(`Missing ${ZmlV1FileNames.positions} in ZML archive.`);
+
+    let molsys: ZmlMolSys;
+    try {
+        molsys = JSON.parse(utf8Read(molsysBytes));
+    } catch (e) {
+        return Result.error(`Failed to parse molsys.json: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    if (!molsys || !Array.isArray(molsys.molecules) || !Array.isArray(molsys.bonds)) {
+        return Result.error('Malformed molsys.json: expected MolSys object with molecules and bonds.');
+    }
+
+    const atomCount = countAtoms(molsys);
+    let positions: Float64Array;
+    try {
+        positions = readFloat64Positions(posBytes, atomCount, ZmlV1FileNames.positions);
+    } catch (e) {
+        return Result.error(e instanceof Error ? e.message : String(e));
+    }
+
+    return Result.success({ name, molsys, positions, atomCount });
+}
+
+function buildMolSysFromV3(header: ZmlV3Header, atomIds: Int32Array, Z: Int16Array, fc: Int16Array,
+    resIds: Int32Array, resAtomOffsets: Int32Array, molResOffsets: Int32Array,
+    bondsIJ: Int32Array, bondOrders: Int8Array): ZmlMolSys {
+
+    const numAtoms = header.atom_names.length;
+    if (Z.length !== numAtoms || fc.length !== numAtoms || atomIds.length !== numAtoms) {
+        throw new Error(`ZML V3 atom columns length mismatch (expected ${numAtoms}).`);
+    }
+    const numRes = header.res_names.length;
+    if (resIds.length !== numRes || resAtomOffsets.length !== numRes + 1) {
+        throw new Error(`ZML V3 residue columns length mismatch (expected ${numRes}).`);
+    }
+    const numMols = header.mol_names.length;
+    if (molResOffsets.length !== numMols + 1) {
+        throw new Error(`ZML V3 molecule offsets length mismatch (expected ${numMols + 1}).`);
+    }
+
+    const atoms: ZmlAtom[] = new Array(numAtoms);
+    for (let i = 0; i < numAtoms; i++) {
+        atoms[i] = {
+            id: atomIds[i],
+            name: header.atom_names[i],
+            atomic_number: Z[i],
+            formal_charge: fc[i],
+            props: header.atom_props[i] ?? {},
+        };
+    }
+
+    const residues: (ZmlResidue & { atoms: ZmlAtom[] })[] = new Array(numRes);
+    for (let r = 0; r < numRes; r++) {
+        const a0 = resAtomOffsets[r];
+        const a1 = resAtomOffsets[r + 1];
+        residues[r] = {
+            id: resIds[r],
+            name: header.res_names[r],
+            insertion_code: header.res_icodes[r] ?? '',
+            atoms: atoms.slice(a0, a1),
+            props: header.res_props[r] ?? {},
+        };
+    }
+
+    const molecules: ZmlMol[] = new Array(numMols);
+    for (let m = 0; m < numMols; m++) {
+        const r0 = molResOffsets[m];
+        const r1 = molResOffsets[m + 1];
+        molecules[m] = {
+            name: header.mol_names[m],
+            chain_id: header.mol_chain_ids[m],
+            comtype: 'Comtype.UNKNOWN',
+            residues: residues.slice(r0, r1),
+            props: header.mol_props[m] ?? {},
+        };
+    }
+
+    const bondCount = bondOrders.length;
+    if (bondsIJ.length !== bondCount * 2) {
+        throw new Error(`ZML V3 bonds length ${bondsIJ.length} != 2 * ${bondCount}.`);
+    }
+    const bonds: ZmlBond[] = new Array(bondCount);
+    for (let k = 0; k < bondCount; k++) {
+        bonds[k] = [bondsIJ[2 * k], bondsIJ[2 * k + 1], bondOrders[k]];
+    }
+
+    return { name: header.name, molecules, bonds, box: header.box, props: header.props ?? {} };
+}
+
+async function parseV3(entries: ZipEntries, name: string): Promise<Result<ZmlFile>> {
+    const headerBytes = getEntry(entries, ZmlV3FileNames.header);
+    if (!headerBytes) return Result.error(`Missing ${ZmlV3FileNames.header} in ZML archive.`);
+
+    let header: ZmlV3Header;
+    try {
+        header = JSON.parse(utf8Read(headerBytes));
+    } catch (e) {
+        return Result.error(`Failed to parse ${ZmlV3FileNames.header}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    if (!header || !Array.isArray(header.atom_names) || !Array.isArray(header.mol_names)) {
+        return Result.error(`Malformed ${ZmlV3FileNames.header}: missing atom_names/mol_names.`);
+    }
+
+    const required: ReadonlyArray<keyof typeof ZmlV3FileNames> = [
+        'Z', 'formalCharges', 'atomIds', 'resIds', 'resAtomOffsets', 'molResOffsets',
+        'bonds', 'bondOrders', 'positions',
+    ];
+    const bufs: Partial<Record<keyof typeof ZmlV3FileNames, Uint8Array>> = {};
+    for (const key of required) {
+        const fname = ZmlV3FileNames[key];
+        const raw = getEntry(entries, fname);
+        if (!raw) return Result.error(`Missing ${fname} in ZML archive.`);
+        bufs[key] = raw;
+    }
+
+    let molsys: ZmlMolSys;
+    let positions: Float64Array;
+    try {
+        const atomIds = readTypedArray(bufs.atomIds!, Int32Array, ZmlV3FileNames.atomIds);
+        const Z = readTypedArray(bufs.Z!, Int16Array, ZmlV3FileNames.Z);
+        const fc = readTypedArray(bufs.formalCharges!, Int16Array, ZmlV3FileNames.formalCharges);
+        const resIds = readTypedArray(bufs.resIds!, Int32Array, ZmlV3FileNames.resIds);
+        const resAtomOffsets = readTypedArray(bufs.resAtomOffsets!, Int32Array, ZmlV3FileNames.resAtomOffsets);
+        const molResOffsets = readTypedArray(bufs.molResOffsets!, Int32Array, ZmlV3FileNames.molResOffsets);
+        const bondsIJ = readTypedArray(bufs.bonds!, Int32Array, ZmlV3FileNames.bonds);
+        const bondOrders = readTypedArray(bufs.bondOrders!, Int8Array, ZmlV3FileNames.bondOrders);
+        molsys = buildMolSysFromV3(header, atomIds, Z, fc, resIds, resAtomOffsets, molResOffsets, bondsIJ, bondOrders);
+        positions = readFloat64Positions(bufs.positions!, header.atom_names.length, ZmlV3FileNames.positions);
+    } catch (e) {
+        return Result.error(e instanceof Error ? e.message : String(e));
+    }
+
+    return Result.success({ name, molsys, positions, atomCount: header.atom_names.length });
+}
+
+async function parseInternal(ctx: RuntimeContext, data: Uint8Array, name: string): Promise<Result<ZmlFile>> {
+    const buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+    let entries: ZipEntries;
+    try {
+        entries = await unzip(ctx, buf) as ZipEntries;
+    } catch (e) {
+        return Result.error(`Invalid ZML file: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
+    const versionBytes = getEntry(entries, 'version');
+    const version = versionBytes ? parseInt(utf8Read(versionBytes).trim(), 10) : 0;
+    if (!ZmlSupportedVersions.includes(version)) {
+        return Result.error(
+            `Unsupported ZML version ${version}. Supported versions: ` +
+            `${ZmlSupportedVersions.join(', ')}.`
+        );
+    }
+
+    if (version === 1) return parseV1(entries, name);
+    return parseV3(entries, name);
+}
+
+export function parseZml(data: Uint8Array, name: string = 'ZML') {
+    return Task.create<Result<ZmlFile>>('Parse ZML', async ctx => {
+        await ctx.update('Parsing ZML archive...');
+        return parseInternal(ctx, data, name);
+    });
+}

--- a/src/mol-io/reader/zml/schema.ts
+++ b/src/mol-io/reader/zml/schema.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Augment Agent
+ */
+
+/**
+ * ZML (Zipped Molecular Lot) file format. See the `ama.s3t.internal.zml`
+ * reference Python implementation. Supported versions:
+ *
+ *  - V1: `molsys.json` + `pos.npy`.
+ *  - V3: `header.json` + columnar topology buffers + `pos.f64`.
+ *
+ * Force field entries (`ff*.pkl`, `ff_*`) are ignored. V0 (DMS + pickle)
+ * and V2 (full pickle) are not supported.
+ */
+
+export const ZmlSupportedVersions: ReadonlyArray<number> = [1, 3];
+
+export const ZmlV1FileNames = {
+    version: 'version',
+    molsys: 'molsys.json',
+    positions: 'pos.npy',
+} as const;
+
+export const ZmlV3FileNames = {
+    version: 'version',
+    header: 'header.json',
+    Z: 'Z.i16',
+    formalCharges: 'fc.i16',
+    atomIds: 'atom_ids.i32',
+    resIds: 'res_ids.i32',
+    resAtomOffsets: 'res_atom_offsets.i32',
+    molResOffsets: 'mol_res_offsets.i32',
+    bonds: 'bonds.i32',
+    bondOrders: 'bond_orders.i8',
+    positions: 'pos.f64',
+} as const;
+
+/** JSON header of a V3 archive. */
+export interface ZmlV3Header {
+    readonly name: string;
+    readonly box: ReadonlyArray<ReadonlyArray<number>> | null;
+    readonly props: { readonly [k: string]: number | string };
+    readonly atom_names: ReadonlyArray<string>;
+    readonly atom_props: ReadonlyArray<{ readonly [k: string]: number | string }>;
+    readonly res_names: ReadonlyArray<string>;
+    readonly res_icodes: ReadonlyArray<string>;
+    readonly res_props: ReadonlyArray<{ readonly [k: string]: number | string }>;
+    readonly mol_names: ReadonlyArray<string>;
+    readonly mol_chain_ids: ReadonlyArray<string>;
+    readonly mol_props: ReadonlyArray<{ readonly [k: string]: number | string }>;
+}
+
+export interface ZmlAtom {
+    readonly id: number;
+    readonly name: string;
+    readonly atomic_number: number;
+    readonly formal_charge: number;
+    readonly props: { readonly [k: string]: number | string };
+}
+
+export interface ZmlResidue {
+    readonly id: number;
+    readonly name: string;
+    readonly insertion_code: string;
+    readonly atoms: ReadonlyArray<ZmlAtom>;
+    readonly props: { readonly [k: string]: number | string };
+}
+
+export interface ZmlMol {
+    readonly name: string;
+    readonly chain_id: string;
+    readonly comtype: string;
+    readonly residues: ReadonlyArray<ZmlResidue>;
+    readonly props: { readonly [k: string]: number | string };
+}
+
+/** `[atomIndexA, atomIndexB, order]` with indices into the flat atom list. */
+export type ZmlBond = readonly [number, number, number];
+
+export interface ZmlMolSys {
+    readonly name: string;
+    readonly molecules: ReadonlyArray<ZmlMol>;
+    readonly bonds: ReadonlyArray<ZmlBond>;
+    /** 3x3 box vectors in Angstrom, or null for no periodic box. */
+    readonly box: ReadonlyArray<ReadonlyArray<number>> | null;
+    readonly props: { readonly [k: string]: number | string };
+}
+
+export interface ZmlFile {
+    readonly name: string;
+    readonly molsys: ZmlMolSys;
+    /** x/y/z interleaved, Angstrom, length == 3 * atomCount. */
+    readonly positions: Float64Array;
+    readonly atomCount: number;
+}

--- a/src/mol-io/reader/zml/schema.ts
+++ b/src/mol-io/reader/zml/schema.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author Augment Agent
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 /**

--- a/src/mol-io/writer/zml.ts
+++ b/src/mol-io/writer/zml.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author Augment Agent
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { utf8ByteCount, utf8Write } from '../common/utf8';

--- a/src/mol-io/writer/zml.ts
+++ b/src/mol-io/writer/zml.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Augment Agent
+ */
+
+import { utf8ByteCount, utf8Write } from '../common/utf8';
+import { ZmlAtom, ZmlBond, ZmlMol, ZmlMolSys, ZmlResidue, ZmlV1FileNames } from '../reader/zml/schema';
+import { Structure, StructureElement, StructureProperties, Unit } from '../../mol-model/structure';
+import { AtomNumber } from '../../mol-model/structure/model/properties/atomic/measures';
+import { RuntimeContext } from '../../mol-task';
+import { zip } from '../../mol-util/zip/zip';
+
+function stringToBytes(s: string): Uint8Array<ArrayBuffer> {
+    const bytes = new Uint8Array(utf8ByteCount(s));
+    utf8Write(bytes, 0, s);
+    return bytes as Uint8Array<ArrayBuffer>;
+}
+
+function structureToMolSys(name: string, structure: Structure): { molsys: ZmlMolSys, positions: Float64Array } {
+    const loc = StructureElement.Location.create(structure);
+    const P = StructureProperties;
+
+    const molecules: ZmlMol[] = [];
+    const positions: number[] = [];
+    /** "unitId:elementIndex" -> flat ZML atom index, for bond lookup. */
+    const indexMap = new Map<string, number>();
+    let flatIndex = 0;
+
+    for (const unit of structure.units) {
+        if (!Unit.isAtomic(unit)) continue;
+        loc.unit = unit;
+        const elements = unit.elements;
+
+        let currentMol: { mol: ZmlMol & { residues: ZmlResidue[] }, chainKey: number } | undefined;
+        let currentRes: { res: ZmlResidue & { atoms: ZmlAtom[] }, resKey: number } | undefined;
+
+        for (let i = 0; i < elements.length; i++) {
+            loc.element = elements[i];
+            const chainKey = P.chain.key(loc);
+            const resKey = P.residue.key(loc);
+
+            if (!currentMol || currentMol.chainKey !== chainKey) {
+                const asymId = P.chain.auth_asym_id(loc);
+                const mol: ZmlMol & { residues: ZmlResidue[] } = {
+                    name: asymId, chain_id: asymId, comtype: 'Comtype.UNKNOWN',
+                    residues: [], props: {},
+                };
+                molecules.push(mol);
+                currentMol = { mol, chainKey };
+                currentRes = undefined;
+            }
+
+            if (!currentRes || currentRes.resKey !== resKey) {
+                const res: ZmlResidue & { atoms: ZmlAtom[] } = {
+                    id: P.residue.auth_seq_id(loc),
+                    name: P.residue.auth_comp_id(loc),
+                    insertion_code: P.residue.pdbx_PDB_ins_code(loc) || '',
+                    atoms: [], props: {},
+                };
+                currentMol.mol.residues.push(res);
+                currentRes = { res, resKey };
+            }
+
+            const typeSymbol = P.atom.type_symbol(loc);
+            const atom: ZmlAtom = {
+                id: P.atom.id(loc),
+                name: P.atom.auth_atom_id(loc),
+                atomic_number: AtomNumber(typeSymbol),
+                formal_charge: P.atom.pdbx_formal_charge(loc) || 0,
+                props: {},
+            };
+            currentRes.res.atoms.push(atom);
+            positions.push(P.atom.x(loc), P.atom.y(loc), P.atom.z(loc));
+            indexMap.set(`${unit.id}:${elements[i]}`, flatIndex);
+            flatIndex++;
+        }
+    }
+
+    const bonds = collectBonds(structure, indexMap);
+    const molsys: ZmlMolSys = { name, molecules, bonds, box: null, props: {} };
+    return { molsys, positions: Float64Array.from(positions) };
+}
+
+function collectBonds(structure: Structure, indexMap: Map<string, number>): ZmlBond[] {
+    const bonds: ZmlBond[] = [];
+    const added = new Set<string>();
+    const push = (a: number, b: number, order: number) => {
+        if (a === b) return;
+        const lo = a < b ? a : b, hi = a < b ? b : a;
+        const key = `${lo}:${hi}`;
+        if (added.has(key)) return;
+        added.add(key);
+        bonds.push([lo, hi, order] as const);
+    };
+
+    for (const unit of structure.units) {
+        if (!Unit.isAtomic(unit)) continue;
+        const { a, b, edgeProps } = unit.bonds;
+        const elements = unit.elements;
+        for (let i = 0; i < a.length; i++) {
+            const ai = indexMap.get(`${unit.id}:${elements[a[i]]}`);
+            const bi = indexMap.get(`${unit.id}:${elements[b[i]]}`);
+            if (ai === undefined || bi === undefined) continue;
+            push(ai, bi, edgeProps.order[i] ?? 1);
+        }
+    }
+    for (const e of structure.interUnitBonds.edges) {
+        const ua = structure.unitMap.get(e.unitA), ub = structure.unitMap.get(e.unitB);
+        const ai = indexMap.get(`${ua.id}:${ua.elements[e.indexA]}`);
+        const bi = indexMap.get(`${ub.id}:${ub.elements[e.indexB]}`);
+        if (ai === undefined || bi === undefined) continue;
+        push(ai, bi, e.props.order ?? 1);
+    }
+
+    bonds.sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+    return bonds;
+}
+
+/** Encode a `Structure` as a ZML V1 archive (ZIP) and return its byte buffer. */
+export async function encodeZml(runtime: RuntimeContext, name: string, structure: Structure): Promise<Uint8Array<ArrayBuffer>> {
+    const { molsys, positions } = structureToMolSys(name, structure);
+    const molsysBytes = stringToBytes(JSON.stringify(molsys));
+    const posBuffer = new ArrayBuffer(positions.byteLength);
+    new Float64Array(posBuffer).set(positions);
+    const posBytes: Uint8Array<ArrayBuffer> = new Uint8Array(posBuffer);
+    const versionBytes = stringToBytes('1');
+
+    const entries: { [k: string]: Uint8Array<ArrayBuffer> } = {};
+    entries[ZmlV1FileNames.molsys] = molsysBytes;
+    entries[ZmlV1FileNames.positions] = posBytes;
+    entries[ZmlV1FileNames.version] = versionBytes;
+    const buf = await zip(runtime, entries);
+    return new Uint8Array(buf) as Uint8Array<ArrayBuffer>;
+}

--- a/src/mol-model-formats/structure/zml.ts
+++ b/src/mol-model-formats/structure/zml.ts
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Augment Agent
+ */
+
+import { Column, Table } from '../../mol-data/db';
+import { Spacegroup, SpacegroupCell } from '../../mol-math/geometry';
+import { Vec3 } from '../../mol-math/linear-algebra';
+import { ZmlFile } from '../../mol-io/reader/zml/schema';
+import { Trajectory } from '../../mol-model/structure';
+import { BondType, getElementFromAtomicNumber, getMoleculeType } from '../../mol-model/structure/model/types';
+import { RuntimeContext, Task } from '../../mol-task';
+import { ModelFormat } from '../format';
+import { createModels } from './basic/parser';
+import { BasicSchema, createBasic } from './basic/schema';
+import { ComponentBuilder } from './common/component';
+import { EntityBuilder } from './common/entity';
+import { getChainId } from './common/util';
+import { IndexPairBonds } from './property/bonds/index-pair';
+import { ModelSymmetry } from './property/symmetry';
+
+async function getModels(zml: ZmlFile, ctx: RuntimeContext): Promise<Trajectory> {
+    const { molsys, positions, atomCount } = zml;
+
+    const type_symbols = new Array<string>(atomCount);
+    const atom_ids = new Int32Array(atomCount);
+    const atom_names = new Array<string>(atomCount);
+    const comp_ids = new Array<string>(atomCount);
+    const seq_ids = new Int32Array(atomCount);
+    const ins_codes = new Array<string>(atomCount);
+    const asym_ids = new Array<string>(atomCount);
+    const entity_ids = new Array<string>(atomCount);
+    const formal_charges = new Int32Array(atomCount);
+    const x = new Float32Array(atomCount);
+    const y = new Float32Array(atomCount);
+    const z = new Float32Array(atomCount);
+
+    const entityBuilder = new EntityBuilder();
+    const seqIdColumn = Column.ofIntArray(seq_ids);
+    const atomNameColumn = Column.ofStringArray(atom_names);
+    const componentBuilder = new ComponentBuilder(seqIdColumn, atomNameColumn);
+
+    let atomIdx = 0;
+    for (let m = 0; m < molsys.molecules.length; m++) {
+        const mol = molsys.molecules[m];
+        const asymId = mol.chain_id || getChainId(m);
+        for (const res of mol.residues) {
+            const compId = res.name || 'UNK';
+            for (const atom of res.atoms) {
+                atom_ids[atomIdx] = atom.id;
+                atom_names[atomIdx] = atom.name;
+                type_symbols[atomIdx] = getElementFromAtomicNumber(atom.atomic_number);
+                comp_ids[atomIdx] = compId;
+                seq_ids[atomIdx] = res.id;
+                ins_codes[atomIdx] = res.insertion_code || '';
+                asym_ids[atomIdx] = asymId;
+                formal_charges[atomIdx] = atom.formal_charge;
+                x[atomIdx] = positions[atomIdx * 3 + 0];
+                y[atomIdx] = positions[atomIdx * 3 + 1];
+                z[atomIdx] = positions[atomIdx * 3 + 2];
+                atomIdx++;
+            }
+        }
+    }
+
+    atomIdx = 0;
+    for (const mol of molsys.molecules) {
+        for (const res of mol.residues) {
+            const compId = res.name || 'UNK';
+            const moleculeType = getMoleculeType(componentBuilder.add(compId, atomIdx).type, compId);
+            const entityId = entityBuilder.getEntityId(compId, moleculeType, asym_ids[atomIdx]);
+            for (let i = 0; i < res.atoms.length; i++) {
+                entity_ids[atomIdx + i] = entityId;
+            }
+            atomIdx += res.atoms.length;
+        }
+    }
+
+    const type_symbol = Column.ofStringArray(type_symbols);
+    const asym_id = Column.ofStringArray(asym_ids);
+    const comp_id = Column.ofStringArray(comp_ids);
+    const entity_id = Column.ofStringArray(entity_ids);
+    const ins_code = Column.ofStringArray(ins_codes);
+
+    const atom_site = Table.ofPartialColumns(BasicSchema.atom_site, {
+        auth_asym_id: asym_id,
+        auth_atom_id: atomNameColumn,
+        auth_comp_id: comp_id,
+        auth_seq_id: seqIdColumn,
+        Cartn_x: Column.ofFloatArray(x),
+        Cartn_y: Column.ofFloatArray(y),
+        Cartn_z: Column.ofFloatArray(z),
+        id: Column.ofIntArray(atom_ids),
+        pdbx_formal_charge: Column.ofIntArray(formal_charges),
+        pdbx_PDB_ins_code: ins_code,
+
+        label_asym_id: asym_id,
+        label_atom_id: atomNameColumn,
+        label_comp_id: comp_id,
+        label_seq_id: seqIdColumn,
+        label_entity_id: entity_id,
+
+        occupancy: Column.ofConst(1, atomCount, Column.Schema.float),
+        type_symbol,
+
+        pdbx_PDB_model_num: Column.ofConst(1, atomCount, Column.Schema.int),
+    }, atomCount);
+
+    const basic = createBasic({
+        entity: entityBuilder.getEntityTable(),
+        chem_comp: componentBuilder.getChemCompTable(),
+        atom_site,
+    });
+
+    const models = await createModels(basic, ZmlFormat.create(zml), ctx);
+    if (models.frameCount === 0) return models;
+
+    const bondCount = molsys.bonds.length;
+    if (bondCount > 0) {
+        const indexA = new Int32Array(bondCount);
+        const indexB = new Int32Array(bondCount);
+        const order = new Int8Array(bondCount);
+        const flag = new Int8Array(bondCount);
+        for (let i = 0; i < bondCount; i++) {
+            const [a, b, o] = molsys.bonds[i];
+            indexA[i] = a;
+            indexB[i] = b;
+            order[i] = o;
+            flag[i] = BondType.Flag.Covalent;
+        }
+        const pairBonds = IndexPairBonds.fromData(
+            { pairs: { indexA: Column.ofIntArray(indexA), indexB: Column.ofIntArray(indexB), order: Column.ofIntArray(order), flag: Column.ofIntArray(flag) }, count: bondCount },
+            { maxDistance: molsys.box ? -1 : Infinity }
+        );
+        IndexPairBonds.Provider.set(models.representative, pairBonds);
+    }
+
+    if (molsys.box) {
+        const symmetry = getSymmetry(molsys.box);
+        if (symmetry) ModelSymmetry.Provider.set(models.representative, symmetry);
+    }
+
+    return models;
+}
+
+function getSymmetry(box: ReadonlyArray<ReadonlyArray<number>>) {
+    if (box.length !== 3) return undefined;
+    const ax = Vec3.fromArray(Vec3(), box[0] as ArrayLike<number> as number[], 0);
+    const bx = Vec3.fromArray(Vec3(), box[1] as ArrayLike<number> as number[], 0);
+    const cx = Vec3.fromArray(Vec3(), box[2] as ArrayLike<number> as number[], 0);
+    const a = Vec3.magnitude(ax), b = Vec3.magnitude(bx), c = Vec3.magnitude(cx);
+    if (a <= 0 || b <= 0 || c <= 0) return undefined;
+    const alpha = Math.acos(Math.max(-1, Math.min(1, Vec3.dot(bx, cx) / (b * c))));
+    const beta = Math.acos(Math.max(-1, Math.min(1, Vec3.dot(ax, cx) / (a * c))));
+    const gamma = Math.acos(Math.max(-1, Math.min(1, Vec3.dot(ax, bx) / (a * b))));
+    const cell = SpacegroupCell.create('P 1', Vec3.create(a, b, c), Vec3.create(alpha, beta, gamma));
+    return { spacegroup: Spacegroup.create(cell), assemblies: [], isNonStandardCrystalFrame: false, ncsOperators: [] };
+}
+
+export { ZmlFormat };
+type ZmlFormat = ModelFormat<ZmlFile>
+namespace ZmlFormat {
+    export function is(x?: ModelFormat): x is ZmlFormat { return x?.kind === 'zml'; }
+    export function create(zml: ZmlFile): ZmlFormat { return { kind: 'zml', name: zml.name, data: zml }; }
+}
+
+export function trajectoryFromZml(zml: ZmlFile): Task<Trajectory> {
+    return Task.create('Parse ZML', ctx => getModels(zml, ctx));
+}

--- a/src/mol-model-formats/structure/zml.ts
+++ b/src/mol-model-formats/structure/zml.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author Augment Agent
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { Column, Table } from '../../mol-data/db';

--- a/src/mol-plugin-state/formats/trajectory.ts
+++ b/src/mol-plugin-state/formats/trajectory.ts
@@ -4,6 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Ludovic Autin <ludovic.autin@gmail.com>
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { StateTransforms } from '../transforms';

--- a/src/mol-plugin-state/formats/trajectory.ts
+++ b/src/mol-plugin-state/formats/trajectory.ts
@@ -177,6 +177,15 @@ export const Mol2Provider: TrajectoryFormatProvider = {
     visuals: defaultVisuals
 };
 
+export const ZmlProvider: TrajectoryFormatProvider = {
+    label: 'ZML',
+    description: 'ZML (Zipped Molecular Lot)',
+    category: TrajectoryFormatCategory,
+    binaryExtensions: ['zml'],
+    parse: directTrajectory(StateTransforms.Model.TrajectoryFromZML),
+    visuals: defaultVisuals
+};
+
 export const BuiltInTrajectoryFormats = [
     ['mmcif', MmcifProvider] as const,
     ['cifCore', CifCoreProvider] as const,
@@ -190,6 +199,7 @@ export const BuiltInTrajectoryFormats = [
     ['mol', MolProvider] as const,
     ['sdf', SdfProvider] as const,
     ['mol2', Mol2Provider] as const,
+    ['zml', ZmlProvider] as const,
 ] as const;
 
 export type BuiltInTrajectoryFormat = (typeof BuiltInTrajectoryFormats)[number][0]

--- a/src/mol-plugin-state/transforms/model.ts
+++ b/src/mol-plugin-state/transforms/model.ts
@@ -37,6 +37,8 @@ import { trajectoryFromCifCore } from '../../mol-model-formats/structure/cif-cor
 import { trajectoryFromCube } from '../../mol-model-formats/structure/cube';
 import { parseMol2 } from '../../mol-io/reader/mol2/parser';
 import { trajectoryFromMol2 } from '../../mol-model-formats/structure/mol2';
+import { parseZml } from '../../mol-io/reader/zml/parser';
+import { trajectoryFromZml } from '../../mol-model-formats/structure/zml';
 import { parseXtc } from '../../mol-io/reader/xtc/parser';
 import { coordinatesFromXtc } from '../../mol-model-formats/structure/xtc';
 import { parseXyz } from '../../mol-io/reader/xyz/parser';
@@ -76,6 +78,7 @@ export { TrajectoryFromLammpsTrajData };
 export { TrajectoryFromMOL };
 export { TrajectoryFromSDF };
 export { TrajectoryFromMOL2 };
+export { TrajectoryFromZML };
 export { TrajectoryFromCube };
 export { TrajectoryFromCifCore };
 export { ModelFromTrajectory };
@@ -524,6 +527,24 @@ const TrajectoryFromCube = PluginStateTransform.BuiltIn({
     apply({ a }) {
         return Task.create('Parse MOL', async ctx => {
             const models = await trajectoryFromCube(a.data).runInContext(ctx);
+            const props = trajectoryProps(models);
+            return new SO.Molecule.Trajectory(models, props);
+        });
+    }
+});
+
+type TrajectoryFromZML = typeof TrajectoryFromZML
+const TrajectoryFromZML = PluginStateTransform.BuiltIn({
+    name: 'trajectory-from-zml',
+    display: { name: 'Parse ZML', description: 'Parse a ZML (Zipped Molecular Lot) archive to create a trajectory.' },
+    from: [SO.Data.Binary],
+    to: SO.Molecule.Trajectory
+})({
+    apply({ a }) {
+        return Task.create('Parse ZML', async ctx => {
+            const parsed = await parseZml(a.data, a.label).runInContext(ctx);
+            if (parsed.isError) throw new Error(parsed.message);
+            const models = await trajectoryFromZml(parsed.result).runInContext(ctx);
             const props = trajectoryProps(models);
             return new SO.Molecule.Trajectory(models, props);
         });

--- a/src/mol-plugin-state/transforms/model.ts
+++ b/src/mol-plugin-state/transforms/model.ts
@@ -5,6 +5,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Adam Midlik <midlik@gmail.com>
  * @author Ludovic Autin <ludovic.autin@gmail.com>
+ * @author Yujie Wu <yujie@atommap.com>
  */
 
 import { parseDcd } from '../../mol-io/reader/dcd/parser';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Add support for the ZML (Zipped Molecular Lot) file format — a ZIP-based container produced by the Atommap's Python library — as both an input (reader) and output (writer) format in Mol*.

# What's included
## Reader (src/mol-io/reader/zml/)
- V1 archives: version + molsys.json (topology as nested molecules → residues → atoms) + pos.npy (NumPy-format coordinates).
- V3 archives: version + header.json + columnar binary topology buffers (Z.i16, fc.i16, atom_ids.i32, res_ids.i32, res_atom_offsets.i32, mol_res_offsets.i32, bonds.i32, bond_orders.i8) + pos.f64 coordinates.
- Topology is mapped to a Mol* Trajectory via trajectoryFromZml in src/mol-model-formats/structure/zml.ts, using EntityBuilder + ComponentBuilder + BasicSchema.
- Registered as a built-in trajectory format (ZmlProvider) so .zml files appear in both Open Files → Auto (via binary extension sniffing) and Open Files → Specific (dropdown entry "ZML"). The TrajectoryFromZML state transform wires everything together.
## Writer (src/mol-io/writer/zml.ts)
- encodeZml(runtime, name, structure) serializes a Structure to a V1 ZIP archive (version, molsys.json, pos.npy-equivalent raw little-endian float64 bytes).
- Exposed through the existing Export Models UI (src/extensions/model-export/) as a new zml format option.
## Tests (src/mol-io/reader/_spec/zml.spec.ts, 7 cases)
- V1 minimal archive parse.
- V3 minimal archive parse.
- Unsupported version (e.g. 2) rejected.
- Trajectory construction from V3 (frame count, atom count, bonds).
- Element symbol assignment verified against the V3 Z.i16 buffer.
- Wrong-length pos.f64 → error.
- encodeZml → parseZml round-trip integrity (atoms, positions, bonds).

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`