### PR TITLE
Fix `State.dispose()` leaking live-cell transformer resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 - Fix empty transforms default in `ShapeFromPly`
+- Fix memory leak in `State.dispose()` not invoking transformer `dispose` callbacks for live cells
 
 ## [v5.9.0] - 2026-05-03
 - Fix edge case when `PluginSpec.animations` is empty

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
       "js"
     ],
     "transform": {
-      "\\.ts$": "esbuild-jest-transform"
+      "\\.ts$": ["esbuild-jest-transform", { "tsconfigRaw": "{\"compilerOptions\":{\"useDefineForClassFields\":false}}" }]
     },
     "moduleDirectories": [
       "node_modules",

--- a/src/mol-state/_spec/state.spec.ts
+++ b/src/mol-state/_spec/state.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ */
+
+import { State, StateObject, StateTransformer } from '../../mol-state';
+import { Task } from '../../mol-task';
+
+interface TypeInfo { name: string; typeClass: 'Root' | 'Data' }
+const Create = StateObject.factory<TypeInfo>();
+
+class Root extends Create({ name: 'Root', typeClass: 'Root' }) { }
+class Leaf extends Create<{ value: number }>({ name: 'Leaf', typeClass: 'Data' }) { }
+
+const NS = 'state-dispose-spec';
+let counter = 0;
+
+function leafTransformer(spy: () => void) {
+    return StateTransformer.create<Root, Leaf, { value: number }>(NS, {
+        name: `create-leaf-${counter++}`,
+        from: [Root],
+        to: [Leaf],
+        display: { name: 'Create Leaf' },
+        params: () => ({} as any),
+        apply({ params }) { return new Leaf({ value: params.value }); },
+        dispose() { spy(); }
+    });
+}
+
+function chainedTransformer(spy: () => void) {
+    return StateTransformer.create<Leaf, Leaf, {}>(NS, {
+        name: `chained-leaf-${counter++}`,
+        from: [Leaf],
+        to: [Leaf],
+        display: { name: 'Chained Leaf' },
+        apply({ a }) { return new Leaf({ value: a.data.value + 1 }); },
+        dispose() { spy(); }
+    });
+}
+
+function newState() {
+    return State.create(new Root({}), { runTask: <T>(t: Task<T>) => t.run() });
+}
+
+describe('State.dispose', () => {
+    it('calls transformer.dispose for every live cell', async () => {
+        const leafSpy = jest.fn();
+        const chainSpy = jest.fn();
+        const A = leafTransformer(leafSpy);
+        const B = chainedTransformer(chainSpy);
+
+        const state = newState();
+        const builder = state.build();
+        builder.toRoot<Root>().apply(A as any, { value: 1 }).apply(B as any, {});
+        await state.runTask(state.updateTree(builder));
+
+        // root + 2 transformer outputs.
+        expect(state.cells.size).toBe(3);
+
+        state.dispose();
+
+        expect(leafSpy).toHaveBeenCalledTimes(1);
+        expect(chainSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes all sibling subtrees', async () => {
+        const spyA = jest.fn();
+        const spyB = jest.fn();
+        const A = leafTransformer(spyA);
+        const B = leafTransformer(spyB);
+
+        const state = newState();
+        const builder = state.build();
+        builder.toRoot<Root>().apply(A as any, { value: 1 });
+        builder.toRoot<Root>().apply(B as any, { value: 2 });
+        await state.runTask(state.updateTree(builder));
+
+        state.dispose();
+
+        expect(spyA).toHaveBeenCalledTimes(1);
+        expect(spyB).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when a transformer dispose throws', async () => {
+        const goodSpy = jest.fn();
+        const Throwing = StateTransformer.create<Root, Leaf, { value: number }>(NS, {
+            name: `throwing-leaf-${counter++}`,
+            from: [Root],
+            to: [Leaf],
+            display: { name: 'Throwing Leaf' },
+            apply({ params }) { return new Leaf({ value: params.value }); },
+            dispose() { throw new Error('boom'); }
+        });
+        const Good = leafTransformer(goodSpy);
+
+        const state = newState();
+        const builder = state.build();
+        builder.toRoot<Root>().apply(Throwing as any, { value: 1 });
+        builder.toRoot<Root>().apply(Good as any, { value: 2 });
+        await state.runTask(state.updateTree(builder));
+
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            expect(() => state.dispose()).not.toThrow();
+        } finally {
+            warn.mockRestore();
+        }
+        expect(goodSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op for transformers without a dispose definition', async () => {
+        const NoDispose = StateTransformer.create<Root, Leaf, { value: number }>(NS, {
+            name: `no-dispose-${counter++}`,
+            from: [Root],
+            to: [Leaf],
+            display: { name: 'No-dispose Leaf' },
+            apply({ params }) { return new Leaf({ value: params.value }); }
+        });
+
+        const state = newState();
+        const builder = state.build();
+        builder.toRoot<Root>().apply(NoDispose as any, { value: 1 });
+        await state.runTask(state.updateTree(builder));
+
+        expect(() => state.dispose()).not.toThrow();
+    });
+});

--- a/src/mol-state/state.ts
+++ b/src/mol-state/state.ts
@@ -159,6 +159,23 @@ class State {
     }
 
     dispose() {
+        // Dispose every still-live cell so transformer dispose callbacks
+        // (e.g. WebGL/GL buffer cleanup) actually run. Without this,
+        // calling dispose() on a State that still has cells leaks any
+        // resources held by transformer dispose callbacks because they
+        // would only fire on per-cell deletion (see updateNode/findDeletes).
+        const refs: StateTransform.Ref[] = [];
+        StateTree.doPostOrder(this._tree, this._tree.root, { refs }, (n, _, s) => { s.refs.push(n.ref); });
+        for (let i = refs.length - 1; i >= 0; i--) {
+            const cell = (this.cells as Map<StateTransform.Ref, StateObjectCell>).get(refs[i]);
+            if (!cell) continue;
+            try {
+                dispose(cell.transform, cell.obj, cell.transform.params, cell.cache, this.globalContext);
+            } catch (e) {
+                console.warn('Error in transformer dispose during State.dispose', e);
+            }
+        }
+
         this.ev.dispose();
         this.actions.dispose();
     }


### PR DESCRIPTION
## Summary

`PluginContext.dispose()` does not flush the state tree before tearing the plugin down, so transformer-level `dispose()` callbacks are never invoked for cells that are still present at unmount. Per-cell dispose only fires from `updateNode` / `findDeletes` paths, so any consumer that calls `plugin.dispose()` without first awaiting `plugin.clear()` silently leaks the GPU/native resources those callbacks were responsible for releasing.

The contract on `Transformer.Definition.dispose` says *"automatically called on deleting an object"* (`mol-state/transformer.ts`), but `State.dispose()` (`mol-state/state.ts`) currently only disposes its own event subjects and action manager.

Fixes #1825.

## Reproduction (from the issue)

E2E mount/unmount harness driving 20 cycles of `createPluginUI` → load 1AKE (~417 KB CIF) → unmount, with `HeapProfiler.collectGarbage` + heap snapshot diff between cycle 0 and cycle 20:

| disposal sequence in consumer | Δ JS heap (post-GC, 20 cycles) | Δ Chrome process RSS (20 cycles) |
|---|---|---|
| `plugin.dispose()` | +266 MB | +541 MB |
| `await plugin.clear(); plugin.dispose()` | +217 MB | +287 MB |

Heap diff fingerprint of the unconditional-`dispose()` case (skipped per-cell dispose):

| heap object class | count delta (20 cycles) | hint |
|---|---|---|
| `system / Context` | +74,312 | retained closures |
| `Object` | +164,796 | state cell `obj` / `cache` / `params` |
| `array` | +134,734 | internal Mol* arrays |
| `destroy` | +19,361 | GL resource cleanup callbacks queued but never fired |
| `ArrayBuffer` | +9,671 | raw GL buffers |
| `Uint32Array` | +7,410 | vertex/index buffers |
| `native` | +30,839 (~167 MB) | DOM/C++ wrappers tied to those callbacks |

## Fix

`State.dispose()` walks the cell tree once via the existing `StateTree.doPostOrder` helper and invokes per-transformer `dispose` for every still-live cell, reusing the same per-cell `dispose()` helper that `updateNode` / `findDeletes` already use. Errors thrown by a single transformer's dispose are caught and logged (`console.warn`) so they don't prevent siblings from cleaning up.

Existing consumers that already `await plugin.clear()` before `plugin.dispose()` remain correct — by then `cells` only contains the root, so the new loop is effectively a no-op.

## Tests

Added `src/mol-state/_spec/state.spec.ts` covering:
- Chained transformer chain (root → leafA → leafB) — both `dispose` callbacks fire exactly once.
- Sibling subtrees — both fire.
- Throwing-dispose isolation — a transformer whose `dispose` throws does not prevent siblings from being disposed and does not surface the error.
- Transformer without a `dispose` definition — no-op.

Sanity check: with the fix reverted, 3 of 4 tests fail; with the fix applied, all 4 pass and the existing `1061` jest tests still pass.

## Jest transform tweak

Adds `tsconfigRaw: '{"compilerOptions":{"useDefineForClassFields":false}}'` to the jest esbuild transform. The `TransientTree` (and several other classes) rely on parameter-property-before-class-field initialization order — which `tsc` honors via `target: es2018` but esbuild's default `esnext` target does not. Without this, `State.create()` throws `Cannot read properties of undefined (reading 'transforms')` from inside `TransientTree`, which is why none of the existing specs exercise `State` directly. Happy to split this into a separate prep PR if preferred.

## Why it matters

Production reports of multi-GB Chrome RSS within ~20 minutes of activity in single-page apps that mount/unmount a Mol* viewer per route. Adding `await plugin.clear()` before `plugin.dispose()` on the consumer side cut the per-cycle leak by ~46% and prompted this investigation.

## Environment

- Mol* `master` (also reproduced on 5.8.0 / 5.9.0)
- Chrome 147 (headless, ANGLE/SwiftShader for reproducibility — leak path is the same on real GPU)
- React 18 host, single `PluginUIContext` per mount