### PR TITLE
Fix ModelServer bugs for omitWater param in surroundingLigands endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add mesoscale representation preset
 - Add presets option to `ObjectList` param definition
 - Fix memory leak in `State.dispose()` not invoking transformer `dispose` callbacks for live cells
+- Fix bugs in ModelServer surroundingLigands endpoint, resulting in omitWater not honored
 
 ## [v5.9.0] - 2026-05-03
 - Fix edge case when `PluginSpec.animations` is empty

--- a/src/mol-model/structure/query/queries/modifiers.ts
+++ b/src/mol-model/structure/query/queries/modifiers.ts
@@ -545,6 +545,12 @@ export function surroundingLigands({ query, radius, includeWater }: SurroundingL
                     continue;
                 }
 
+                // Water is handled exclusively by the `includeWater` 3D-lookup branch below.
+                // A single water pulled in via a struct_conn metalc/covale edge would
+                // otherwise match every other water in the chain (all share label_seq_id
+                // and label_comp_id) and leak the entire chain.
+                if (StructureProperties.entity.type(l) === 'water') continue;
+
                 residuesIt.setSegment(chainSegment);
                 while (residuesIt.hasNext) {
                     const residueSegment = residuesIt.move();

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.9.13
+* /surroundingLigands: honor `omit_water=true|false` for REST GET requests (boolean parser previously coerced both to `false`)
+
 # 0.9.12
 * add `health-check` endpoint + `healthCheckPath` config prop to report service health
 

--- a/src/servers/model/CHANGELOG.md
+++ b/src/servers/model/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.9.13
 * /surroundingLigands: honor `omit_water=true|false` for REST GET requests (boolean parser previously coerced both to `false`)
+* /surroundingLigands: stop leaking the asymmetric unit's water chain into the result when `omit_water=true` (water residues pulled in via struct_conn covale/metalc edges no longer match every other water in the chain)
 
 # 0.9.12
 * add `health-check` endpoint + `healthCheckPath` config prop to report service health

--- a/src/servers/model/server/api.ts
+++ b/src/servers/model/server/api.ts
@@ -295,7 +295,7 @@ function _normalizeQueryParams(params: { [p: string]: string }, paramList: Query
                 case QueryParamType.String: el = value; break;
                 case QueryParamType.Integer: el = parseInt(value); break;
                 case QueryParamType.Float: el = parseFloat(value); break;
-                case QueryParamType.Boolean: el = Boolean(+value); break;
+                case QueryParamType.Boolean: el = isTrue(value); break;
             }
 
             if (p.validation) p.validation(el);

--- a/src/servers/model/version.ts
+++ b/src/servers/model/version.ts
@@ -4,4 +4,4 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  */
 
-export const VERSION = '0.9.12';
+export const VERSION = '0.9.13';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

The `omit_water` parameter in ModelServer `/v1/<id>/surroundingLigands` was ignored: water atoms were returned regardless of value or method (GET/POST). 

Entirely analysed, debugged and fixed by Claude. I double checked with a few tests and it all looks good. I don't fully understand the fix for Bug 2, but hopefully the description below will make sense to the maintainers.

### Bug 1 — REST GET boolean parser

`src/servers/model/server/api.ts:298` parsed per-query Boolean params with `Boolean(+value)`. `+'true'` is `NaN`, so both `'true'` and `'false'` coerced to `false`. `omit_water` was the only per-query Boolean param affected; common Booleans (`copy_all_categories`, `download`) already used the correct `isTrue()` helper.

**Fix:** use `isTrue()` for `QueryParamType.Boolean` in `_normalizeQueryParams`.

### Bug 2 — water leak in `surroundingLigands` modifier

In `src/mol-model/structure/query/queries/modifiers.ts`, the modifier BFS-traverses `struct_conn` covale/metalc edges to expand ligand components. For 1TQN, the HEM-Fe metalc bond pulls one water residue into `componentResidues`. Then `ResidueSet.has()` keys by `(asym_id, label_seq_id, comp_id, alt_id, ins_code)` — all waters in a chain share null `label_seq_id` and comp_id `'HOH'`, so the single bonded entry matches every other water and the entire chain leaks into the result. Polymer residues weren't affected because each has a unique `label_seq_id`.

**Fix:** skip water chains in the assembly loop. Water remains the exclusive responsibility of the `if (includeWater)` 3D-lookup branch.

### Verification

Comparison master vs this branch for query using `1TQN`, `label_comp_id=ALA&label_seq_id=284&radius=5`:

| Request                      | Before    | After       |
| ---------------------------- | --------- | ----------- |
| GET `omit_water=1`           | 190 HOH   | **0 HOH**   |
| GET `omit_water=true`        | 203 HOH   | **0 HOH**   |
| GET `omit_water=0`           | 203 HOH   | **13 HOH**  |
| GET `omit_water=false`       | 203 HOH   | **13 HOH**  |
| POST `"omit_water": true`    | 190 HOH   | **0 HOH**   |
| POST `"omit_water": false`   | 203 HOH   | **13 HOH**  |

Sanity check at `radius=8`, `omit_water=0`: 27 HOH (waters now scale with the actual proximity radius, as intended).

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`