### PR TITLE
Download from AFDB - allow IDs with version suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add axis param to camera spin/rock animation
 - Fix SSAO half/quarter resolution textures for multi-scale
 - Non-covalent interactions: water bridge support
+- Download Structure From AlphaFoldDB allows IDs with version suffix (version is ignored)
 
 ## [v5.9.0] - 2026-05-03
 - Fix edge case when `PluginSpec.animations` is empty

--- a/src/mol-plugin-state/actions/structure.ts
+++ b/src/mol-plugin-state/actions/structure.ts
@@ -78,15 +78,7 @@ const DownloadStructure = StateAction.build({
                     provider: PD.Group({
                         id: PD.Text('Q8W3K0', {
                             label: 'ID(s)',
-                            description: 'One or more comma/space separated IDs. Each ID can be either UniProt accession (e.g. Q14676, Q14676-2) or AlphaFoldDB model entity ID (e.g. AF-Q14676-F1, AF-Q14676-2-F1, AF-0000000066074510). Do NOT include version suffix (e.g. -v6).',
-                            // Q14676                 OK   (bare Uniprot acc, returns all isoforms)
-                            // Q14676-4               OK   (isoform Uniprot acc)
-                            // AF-Q14676-F1           OK   (model entity id, canonical isoform)
-                            // AF-Q14676-4-F1         OK   (model entity id, other isoform)
-                            // AF-0000000066074510    OK   (model entity id, NVIDIA)
-                            // AF-Q14676-4-F1-v6      FAIL (model version)
-                            // AF-0000000066074510-v1 FAIL (model version)
-                            // 0000000066074510       FAIL (not a complete model entity id)
+                            description: 'One or more comma/space separated IDs. Each ID can be either UniProt accession (e.g. Q14676, Q14676-2) or AlphaFoldDB model entity ID (e.g. AF-Q14676-F1, AF-Q14676-2-F1, AF-0000000066074510). Version suffixes (e.g. -v1) will be ignored and the newest model version will be downloaded.',
                         }),
                         encoding: PD.Select('bcif', PD.arrayToOptions(['cif', 'bcif'] as const)),
                     }, { pivot: 'id' }),
@@ -163,7 +155,11 @@ const DownloadStructure = StateAction.build({
         case 'alphafolddb':
             downloadParams = await getDownloadParams(src.params.provider.id,
                 async id => {
-                    const url = `https://www.alphafold.ebi.ac.uk/api/prediction/${id.toUpperCase()}`;
+                    // id = UniProt accession: Q14676, Q14676-4
+                    // id = model entity ID: AF-Q14676-F1, AF-Q14676-4-F1, AF-0000000066074510
+                    // id = model entity ID + version to be ignored: AF-Q14676-4-F1-v6, AF-0000000066074510-v1
+                    const cleanId = id.replace(/-v\d+$/i, '').toUpperCase(); // Ignore version suffix (e.g. "-v6") because it is not a part of the ID, but displayed on AFDB page and people often copy-paste it
+                    const url = `https://www.alphafold.ebi.ac.uk/api/prediction/${cleanId}`;
                     const info = await plugin.runTask(plugin.fetch({ url, type: 'json' }));
                     if (Array.isArray(info) && info.length > 0) {
                         const prop = src.params.provider.encoding === 'bcif' ? 'bcifUrl' : 'cifUrl';

--- a/src/mol-plugin-state/actions/structure.ts
+++ b/src/mol-plugin-state/actions/structure.ts
@@ -76,7 +76,18 @@ const DownloadStructure = StateAction.build({
                 }, { isFlat: true, label: 'SWISS-MODEL', description: 'Loads the best homology model or experimental structure' }),
                 'alphafolddb': PD.Group({
                     provider: PD.Group({
-                        id: PD.Text('Q8W3K0', { label: 'UniProtKB AC(s)', description: 'One or more comma/space separated ACs.' }),
+                        id: PD.Text('Q8W3K0', {
+                            label: 'ID(s)',
+                            description: 'One or more comma/space separated IDs. Each ID can be either UniProt accession (e.g. Q14676, Q14676-2) or AlphaFoldDB model entity ID (e.g. AF-Q14676-F1, AF-Q14676-2-F1, AF-0000000066074510). Do NOT include version suffix (e.g. -v6).',
+                            // Q14676                 OK   (bare Uniprot acc, returns all isoforms)
+                            // Q14676-4               OK   (isoform Uniprot acc)
+                            // AF-Q14676-F1           OK   (model entity id, canonical isoform)
+                            // AF-Q14676-4-F1         OK   (model entity id, other isoform)
+                            // AF-0000000066074510    OK   (model entity id, NVIDIA)
+                            // AF-Q14676-4-F1-v6      FAIL (model version)
+                            // AF-0000000066074510-v1 FAIL (model version)
+                            // 0000000066074510       FAIL (not a complete model entity id)
+                        }),
                         encoding: PD.Select('bcif', PD.arrayToOptions(['cif', 'bcif'] as const)),
                     }, { pivot: 'id' }),
                     options

--- a/src/mol-plugin-state/actions/structure.ts
+++ b/src/mol-plugin-state/actions/structure.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { PluginContext } from '../../mol-plugin/context';


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This allows pasting AFDB model entity ID with version suffix in the Download Structure From AlphaFold ID. 
This will make life easier for many people who copy-paste the IDs from AFDB pages (where they are displayed with the version suffix, e.g. `AF-Q9I1F6-F1-v6`). 
The implementation is actually to ignore the version suffix (as the older versions are not available anyway, except for bulk download).

I updated parameter label and help text accordingly.

Before:
<img width="310" height="218" alt="Download-AFDB-current" src="https://github.com/user-attachments/assets/e1d8b001-b210-4370-bcd0-2924c7500e94" />

After: 
<img width="304" height="358" alt="Download-AFDB-new" src="https://github.com/user-attachments/assets/9f9c7eff-adce-484b-ac23-c70814b678e9" />



## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`