### PR TITLE
fix ASA for hydrogens: inherit color from residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix ASA coloring for hydrogens
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/radii.ts
@@ -3,6 +3,7 @@
  *
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { MaxAsa, ShrakeRupleyContext, VdWLookup } from './common';
@@ -40,22 +41,22 @@ export function assignRadiusForHeavyAtoms(ctx: ShrakeRupleyContext) {
             if (prevResidueIdx !== residueIdx) ++serialResidueIdx;
             prevResidueIdx = residueIdx;
 
-            const element = type_symbol(l);
-            const elementIdx = getElementIdx(element);
-
-            // skip hydrogen atoms
-            if (isHydrogen(elementIdx)) {
-                atomRadiusType[mj] = 0;
-                serialResidueIndex[mj] = -1;
-                continue;
-            }
-
             const atomId = label_atom_id(l);
             const moleculeType = getElementMoleculeType(unit, eI);
             // skip water and optionally non-polymer groups
             if (moleculeType === MoleculeType.Water || (!ctx.nonPolymer && !isPolymer(moleculeType))) {
                 atomRadiusType[mj] = 0;
                 serialResidueIndex[mj] = -1;
+                continue;
+            }
+
+            const element = type_symbol(l);
+            const elementIdx = getElementIdx(element);
+
+            // skip hydrogen atoms for computation (parent atoms implicitly account for hydrogens), assign color from residue
+            if (isHydrogen(elementIdx)) {
+                atomRadiusType[mj] = 0;
+                serialResidueIndex[mj] = serialResidueIdx;
                 continue;
             }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
This PR fixes an issue wrt ASA coloring for structures that contain hydrogen atoms. Hydrogen atoms are discarded from the computation of the accessible surface area by increasing heavy atoms radius. But currently they are also ignored in the coloration:
Example with PDB 3L2L. Note that the hydrogen atoms appear as white patches.
<img width="609" height="839" alt="3L2L-ASA" src="https://github.com/user-attachments/assets/a34c45d7-c5bf-4911-abd4-22246dca664c" />

The change here is to map hydrogen atoms to their residues so that they inherit the color from it. Computation is unchanged.
<img width="593" height="849" alt="3L2L-ASA-fix" src="https://github.com/user-attachments/assets/18358504-e908-4c25-8d20-c625cd1d93d3" />


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`