### PR TITLE
Fix size-only updates in updateRepresentationsTheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix size-only representation theme updates in `updateRepresentationsTheme`.
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "Diego del Alamo <diego.delalamo@gmail.com>",
     "Tianzhen Lin (Tangent) <tangent@usa.net>",
     "Russ Taylor <russ@reliasolve.com>",
-    "Tadej Satler <tadej.satler@gmail.com>"
+    "Tadej Satler <tadej.satler@gmail.com>",
+    "Himanshu Raj <himanshuraj6771@gmail.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/mol-plugin-state/manager/structure/component.ts
+++ b/src/mol-plugin-state/manager/structure/component.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Himanshu Raj <himanshuraj6771@gmail.com>
  */
 
 import { VisualQualityOptions } from '../../../mol-geo/geometry/base';

--- a/src/mol-plugin-state/manager/structure/component.ts
+++ b/src/mol-plugin-state/manager/structure/component.ts
@@ -311,7 +311,7 @@ class StructureComponentManager extends StatefulPluginComponent<StructureCompone
                         : void 0;
                 const sizeTheme = params.size === 'default'
                     ? createStructureSizeThemeParams(this.plugin, c.structure.cell.obj?.data, old?.type.name)
-                    : params.color
+                    : params.size
                         ? createStructureSizeThemeParams(this.plugin, c.structure.cell.obj?.data, old?.type.name, params.size, params.sizeParams)
                         : void 0;
 


### PR DESCRIPTION
Fix size-only updates in `updateRepresentationsTheme()`.

The size theme update path incorrectly depended on `params.color`, causing size-only updates to be skipped for some representations. This change uses `params.size` instead.

Verified locally that calling `updateRepresentationsTheme(..., { size: 'physical' })` correctly updates all representations.
