### PR TITLE
improve transfer-function handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 - Fix size-only representation theme updates in `updateRepresentationsTheme`.
 - Fix ASA coloring for hydrogens
+- Add `histogramPercentile`, `histogramRobustStats`, `downsampleHistogram` to `mol-math/histogram`
+- Direct-volume transfer function improvements
+    - Add data-aware default control points and preset library
+    - Use log-scale on y-axis in control-points UI
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/src/mol-geo/geometry/direct-volume/direct-volume.ts
+++ b/src/mol-geo/geometry/direct-volume/direct-volume.ts
@@ -168,7 +168,7 @@ export namespace DirectVolume {
         controlPoints: PD.LineGraph([
             Vec2.create(0.19, 0.0), Vec2.create(0.2, 0.05), Vec2.create(0.25, 0.05), Vec2.create(0.26, 0.0),
             Vec2.create(0.79, 0.0), Vec2.create(0.8, 0.05), Vec2.create(0.85, 0.05), Vec2.create(0.86, 0.0),
-        ], { isEssential: true }),
+        ], { isEssential: true, yAxis: { scale: 'log' } }),
         stepsPerCell: PD.Numeric(3, { min: 1, max: 10, step: 1 }),
         jumpLength: PD.Numeric(0, { min: 0, max: 20, step: 0.1 }),
     };

--- a/src/mol-geo/geometry/direct-volume/transfer-function.ts
+++ b/src/mol-geo/geometry/direct-volume/transfer-function.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -22,7 +22,10 @@ export function getControlPointsFromVec2Array(array: Vec2[]): ControlPoint[] {
     return array.map(v => ({ x: v[0], alpha: v[1] }));
 }
 
-export function createTransferFunctionTexture(controlPoints: ControlPoint[], texture?: ValueCell<TextureImage<Uint8Array>>): ValueCell<TextureImage<Uint8Array>> {
+const TF_WIDTH = 256;
+
+/** Build the 1D alpha curve (length 256) from sorted control points using a Catmull-Rom spline. */
+function build1DAlphaArray(controlPoints: ControlPoint[], out?: Uint8Array): Uint8Array {
     const cp = [
         { x: 0, alpha: 0 },
         { x: 0, alpha: 0 },
@@ -31,8 +34,8 @@ export function createTransferFunctionTexture(controlPoints: ControlPoint[], tex
         { x: 1, alpha: 0 },
     ];
 
-    const n = 256;
-    const array = texture ? texture.ref.value.array : new Uint8Array(n);
+    const array = out ?? new Uint8Array(TF_WIDTH);
+    if (out) array.fill(0);
 
     let k = 0;
     let x1: number, x2: number;
@@ -48,15 +51,25 @@ export function createTransferFunctionTexture(controlPoints: ControlPoint[], tex
         a2 = cp[i + 2].alpha;
         a3 = cp[i + 3].alpha;
 
-        const jl = Math.round((x2 - x1) * n);
+        const jl = Math.round((x2 - x1) * TF_WIDTH);
         for (let j = 0; j < jl; ++j) {
             const t = j / jl;
-            array[k] = Math.max(0, spline(a0, a1, a2, a3, t, 0.5) * 255);
-            ++k;
+            if (k < TF_WIDTH) {
+                array[k] = Math.max(0, spline(a0, a1, a2, a3, t, 0.5) * 255);
+                ++k;
+            }
         }
     }
+    return array;
+}
 
-    const textureImage = { array, width: 256, height: 1 };
+export function createTransferFunctionTexture(controlPoints: ControlPoint[], texture?: ValueCell<TextureImage<Uint8Array>>): ValueCell<TextureImage<Uint8Array>> {
+    // If updating an existing 2D texture, fall back to creating a fresh image so the size matches.
+    const reuse = texture && texture.ref.value.height === 1 && texture.ref.value.array.length === TF_WIDTH;
+    const array = reuse ? texture!.ref.value.array : new Uint8Array(TF_WIDTH);
+    build1DAlphaArray(controlPoints, array);
+
+    const textureImage = { array, width: TF_WIDTH, height: 1 };
     if (texture) {
         ValueCell.update(texture, textureImage);
         return texture;

--- a/src/mol-math/_spec/histogram-stats.spec.ts
+++ b/src/mol-math/_spec/histogram-stats.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { calculateHistogram, downsampleHistogram, histogramPercentile, histogramRobustStats } from '../histogram';
+
+describe('histogram', () => {
+    it('histogramPercentile is approximately linear for a uniform distribution', () => {
+        const n = 10000;
+        const data = new Float32Array(n);
+        for (let i = 0; i < n; ++i) data[i] = i / n; // uniform on [0, 1)
+        const h = calculateHistogram(data, 100, { min: 0, max: 1 });
+        expect(histogramPercentile(h, 0.5)).toBeCloseTo(0.5, 1);
+        expect(histogramPercentile(h, 0.01)).toBeCloseTo(0.01, 1);
+        expect(histogramPercentile(h, 0.99)).toBeCloseTo(0.99, 1);
+    });
+
+    it('histogramRobustStats can ignore the zero bin', () => {
+        // Half zeros, half values uniformly in [1, 2].
+        const data: number[] = [];
+        for (let i = 0; i < 5000; ++i) data.push(0);
+        for (let i = 0; i < 5000; ++i) data.push(1 + i / 5000);
+        const h = calculateHistogram(data, 200, { min: 0, max: 2 });
+
+        const all = histogramRobustStats(h);
+        const noZero = histogramRobustStats(h, { ignoreZero: true });
+        // Without filtering, mean is dragged toward 0.
+        expect(all.mean).toBeLessThan(noZero.mean);
+        // With zero excluded, mean lands near 1.5.
+        expect(noZero.mean).toBeCloseTo(1.5, 1);
+    });
+
+    it('histogramPercentile handles a signed, symmetric distribution', () => {
+        const n = 10000;
+        const data = new Float32Array(n);
+        for (let i = 0; i < n; ++i) data[i] = -1 + 2 * i / n; // uniform on [-1, 1)
+        const h = calculateHistogram(data, 200, { min: -1, max: 1 });
+        expect(histogramPercentile(h, 0.5)).toBeCloseTo(0, 1);
+        expect(histogramPercentile(h, 0.25)).toBeCloseTo(-0.5, 1);
+        expect(histogramPercentile(h, 0.75)).toBeCloseTo(0.5, 1);
+    });
+
+    it('histogramPercentile is stable for an empty histogram', () => {
+        const h = calculateHistogram(new Float32Array(0), 16, { min: 0, max: 1 });
+        // No counts: falls back to the lower bound.
+        expect(histogramPercentile(h, 0.5)).toBe(h.min);
+    });
+
+    it('histogramPercentile ignores an out-of-range excludeBin', () => {
+        const n = 1000;
+        const data = new Float32Array(n);
+        for (let i = 0; i < n; ++i) data[i] = i / n;
+        const h = calculateHistogram(data, 50, { min: 0, max: 1 });
+        const ref = histogramPercentile(h, 0.5);
+        // excludeBin beyond the last index must not change the result or throw.
+        expect(histogramPercentile(h, 0.5, 9999)).toBeCloseTo(ref, 6);
+    });
+
+    it('histogramRobustStats keeps the zero bin for signed (difference-map-like) data', () => {
+        // Symmetric around 0: the zero bin is the mode and must not be dropped.
+        const n = 10000;
+        const data = new Float32Array(n);
+        for (let i = 0; i < n; ++i) data[i] = -1 + 2 * i / n;
+        const h = calculateHistogram(data, 200, { min: -1, max: 1 });
+        const all = histogramRobustStats(h);
+        const noZero = histogramRobustStats(h, { ignoreZero: true });
+        // ignoreZero only drops the first bin, so a centred zero is untouched.
+        expect(noZero.mean).toBeCloseTo(all.mean, 6);
+        expect(noZero.count).toBe(all.count);
+    });
+
+    it('downsampleHistogram preserves the total count and reduces bin count', () => {
+        const n = 4096;
+        const data = new Float32Array(n);
+        for (let i = 0; i < n; ++i) data[i] = i / n;
+        const fine = calculateHistogram(data, 1024, { min: 0, max: 1 });
+        const coarse = downsampleHistogram(fine, 40);
+        const sum = (a: ArrayLike<number>) => { let s = 0; for (let i = 0; i < a.length; ++i) s += a[i]; return s; };
+        expect(coarse.counts.length).toBe(40);
+        expect(sum(coarse.counts)).toBe(sum(fine.counts));
+        // Returns the input unchanged when the target is not coarser.
+        expect(downsampleHistogram(fine, 1024)).toBe(fine);
+    });
+});

--- a/src/mol-math/histogram.ts
+++ b/src/mol-math/histogram.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -11,6 +11,22 @@ export interface Histogram {
     max: number,
     binWidth: number,
     counts: Int32Array
+}
+
+export interface HistogramRobustStats {
+    /** Total voxel count contributing to the stats (after optional bin exclusion). */
+    count: number,
+    /** Minimum and maximum value over the contributing range. */
+    min: number,
+    max: number,
+    /** Mean and population standard deviation, recomputed from bin centers. */
+    mean: number,
+    sigma: number,
+    /** Approximate percentiles (linear interpolation across bin counts). */
+    p1: number,
+    p50: number,
+    p95: number,
+    p99: number,
 }
 
 export function calculateHistogram(data: ArrayLike<number>, binCount: number, options?: { min: number, max: number, }): Histogram {
@@ -36,4 +52,126 @@ function _calcHistogram(data: ArrayLike<number>, binCount: number, min: number, 
     }
 
     return { min, max, binWidth, counts };
+}
+
+/**
+ * Approximate `p`-th percentile (p in [0, 1]) of a histogram via linear
+ * interpolation across the cumulative bin counts. Bin centers are used as
+ * value samples. If `excludeBin` is provided, that bin is treated as having
+ * zero counts (useful to ignore an explicit "background" bin, e.g. the bin
+ * containing exact zeros for masked density maps).
+ */
+export function histogramPercentile(h: Histogram, p: number, excludeBin?: number): number {
+    const { counts, min, binWidth } = h;
+    const n = counts.length;
+    if (n === 0) return min;
+
+    let total = 0;
+    for (let i = 0; i < n; ++i) {
+        if (i === excludeBin) continue;
+        total += counts[i];
+    }
+    if (total === 0) return min;
+
+    const target = Math.max(0, Math.min(1, p)) * total;
+
+    let cum = 0;
+    for (let i = 0; i < n; ++i) {
+        if (i === excludeBin) continue;
+        const c = counts[i];
+        if (c === 0) continue;
+        const next = cum + c;
+        if (next >= target) {
+            // Linear interpolation within the bin.
+            const t = c > 0 ? (target - cum) / c : 0;
+            return min + (i + t) * binWidth;
+        }
+        cum = next;
+    }
+    return min + n * binWidth;
+}
+
+/**
+ * Compute robust summary statistics directly from a `Histogram`.
+ * Mean and sigma are recomputed from bin centers so they stay consistent
+ * with the percentiles when `ignoreZero` excludes the bin containing 0.
+ *
+ * Note: "robust" here means robust against a dominant zero/background bin,
+ * not against outliers. The histogram is still binned across the full
+ * `[min, max]` range, so a single extreme value coarsens every bin.
+ */
+export function histogramRobustStats(h: Histogram, opts?: { ignoreZero?: boolean }): HistogramRobustStats {
+    const { counts, min, binWidth } = h;
+    const n = counts.length;
+
+    let excludeBin: number | undefined;
+    if (opts?.ignoreZero && binWidth > 0) {
+        // Only treat zero as background when it sits in the first bin (masked/
+        // padded maps where 0 is the minimum). For signed maps where 0 is the
+        // centre of the distribution (e.g. difference maps) the zero bin is the
+        // mode and must not be removed, so leave it in place.
+        const b = Math.floor((0 - min) / binWidth);
+        if (b === 0) excludeBin = 0;
+    }
+
+    let count = 0;
+    let sum = 0;
+    let sumSq = 0;
+    let firstBin = -1;
+    let lastBin = -1;
+    for (let i = 0; i < n; ++i) {
+        if (i === excludeBin) continue;
+        const c = counts[i];
+        if (c === 0) continue;
+        const center = min + (i + 0.5) * binWidth;
+        count += c;
+        sum += c * center;
+        sumSq += c * center * center;
+        if (firstBin < 0) firstBin = i;
+        lastBin = i;
+    }
+
+    if (count === 0) {
+        return { count: 0, min, max: min, mean: min, sigma: 0, p1: min, p50: min, p95: min, p99: min };
+    }
+
+    const mean = sum / count;
+    const variance = Math.max(0, sumSq / count - mean * mean);
+    const sigma = Math.sqrt(variance);
+    const lo = min + firstBin * binWidth;
+    const hi = min + (lastBin + 1) * binWidth;
+
+    return {
+        count,
+        min: lo,
+        max: hi,
+        mean,
+        sigma,
+        p1: histogramPercentile(h, 0.01, excludeBin),
+        p50: histogramPercentile(h, 0.50, excludeBin),
+        p95: histogramPercentile(h, 0.95, excludeBin),
+        p99: histogramPercentile(h, 0.99, excludeBin),
+    };
+}
+
+/**
+ * Regroup a fine-grained histogram into a coarser one with `binCount` bins
+ * over the same `[min, max]` range. Counts are preserved (each source bin is
+ * mapped to a target bin by index), letting callers reuse an existing
+ * histogram for display instead of re-scanning the source data. When
+ * `binCount >= h.counts.length` the original histogram is returned unchanged.
+ */
+export function downsampleHistogram(h: Histogram, binCount: number): Histogram {
+    const srcN = h.counts.length;
+    if (binCount <= 0 || binCount >= srcN) return h;
+
+    const counts = new Int32Array(binCount);
+    for (let i = 0; i < srcN; ++i) {
+        let bin = Math.floor(i * binCount / srcN);
+        if (bin >= binCount) bin = binCount - 1;
+        counts[bin] += h.counts[i];
+    }
+
+    const binWidth = (h.max - h.min) / binCount || 1;
+    return { min: h.min, max: h.max, binWidth, counts };
 }

--- a/src/mol-model/volume/grid.ts
+++ b/src/mol-model/volume/grid.ts
@@ -7,7 +7,7 @@
 
 import { SpacegroupCell, Box3D, Sphere3D } from '../../mol-math/geometry';
 import { Tensor, Mat4, Vec3 } from '../../mol-math/linear-algebra';
-import { Histogram, calculateHistogram } from '../../mol-math/histogram';
+import { Histogram, HistogramRobustStats, calculateHistogram, histogramRobustStats } from '../../mol-math/histogram';
 import { lerp } from '../../mol-math/interpolate';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
@@ -103,14 +103,35 @@ namespace Grid {
      * Cached on the Grid object.
      */
     export function getHistogram(grid: Grid, binCount: number) {
-        let histograms = (grid as any)._historams as { [binCount: number]: Histogram };
+        let histograms = (grid as any)._histograms as { [binCount: number]: Histogram };
         if (!histograms) {
-            histograms = (grid as any)._historams = { };
+            histograms = (grid as any)._histograms = { };
         }
         if (!histograms[binCount]) {
             histograms[binCount] = calculateHistogram(grid.cells.data, binCount, { min: grid.stats.min, max: grid.stats.max });
         }
         return histograms[binCount];
+    }
+
+    /** Default bin count for histogram-derived robust statistics. */
+    export const RobustStatsBinCount = 1024;
+
+    /**
+     * Compute robust summary statistics (percentiles, mean, sigma) from the
+     * cached histogram. Set `ignoreZero` to skip the histogram bin that
+     * contains exact zero values (typical for masked/padded density maps).
+     * Cached on the Grid object.
+     */
+    export function getRobustStats(grid: Grid, opts?: { ignoreZero?: boolean, binCount?: number }): HistogramRobustStats {
+        const binCount = opts?.binCount ?? RobustStatsBinCount;
+        const ignoreZero = !!opts?.ignoreZero;
+        const key = `${binCount}|${ignoreZero ? 1 : 0}`;
+        let cache = (grid as any)._robustStats as { [key: string]: HistogramRobustStats };
+        if (!cache) cache = (grid as any)._robustStats = {};
+        if (!cache[key]) {
+            cache[key] = histogramRobustStats(getHistogram(grid, binCount), { ignoreZero });
+        }
+        return cache[key];
     }
 
     export function makeGetTrilinearlyInterpolated(grid: Grid, transform: 'none' | 'relative') {

--- a/src/mol-plugin-ui/controls/line-graph/line-graph-component.tsx
+++ b/src/mol-plugin-ui/controls/line-graph/line-graph-component.tsx
@@ -1,15 +1,24 @@
 /**
- * Copyright (c) 2018-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Paul Luna <paulluna0215@gmail.com>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 import { PointComponent } from './point-component';
 
 import * as React from 'react';
 import { Vec2 } from '../../../mol-math/linear-algebra';
 import { Grid } from '../../../mol-model/volume';
+import { downsampleHistogram } from '../../../mol-math/histogram';
 import { arrayMax } from '../../../mol-util/array';
+
+interface LineGraphYAxisOptions {
+    scale?: 'linear' | 'log',
+    logMin?: number
+}
+
+const DefaultLogMin = 1e-3;
 
 interface LineGraphComponentState {
     points: Vec2[],
@@ -80,6 +89,7 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
         const points = this.renderPoints();
         const lines = this.renderLines();
         const histogram = this.renderHistogram();
+        const axes = this.renderAxes();
 
         return ([
             <div key="LineGraph">
@@ -98,6 +108,7 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
 
                     <g stroke="black" fill="black">
                         {histogram}
+                        {axes}
                         {lines}
                         {points}
                     </g>
@@ -111,6 +122,26 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
 
     componentDidMount() {
         this.gElement = document.getElementsByClassName('ghost-points')[0] as SVGElement;
+    }
+
+    componentDidUpdate(prevProps: any) {
+        // Re-sync internal points when the parent provides a new `data` array
+        // (e.g. when the user picks a preset). The constructor seeds points
+        // only once, so changes from outside need to be merged in here.
+        if (prevProps.data !== this.props.data) {
+            const points: Vec2[] = [Vec2.create(0, 0), Vec2.create(1, 0)];
+            for (const p of this.props.data) points.push(p);
+            points.sort((a, b) => {
+                if (a[0] === b[0]) {
+                    if (a[0] === 0) return a[1] - b[1];
+                    if (a[1] === 1) return b[1] - a[1];
+                    return a[1] - b[1];
+                }
+                return a[0] - b[0];
+            });
+            this.selected = undefined;
+            this.setState({ points });
+        }
     }
 
     private change(points: Vec2[]) {
@@ -301,12 +332,44 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
         document.removeEventListener('mouseup', this.handlePointUpdate, true);
     }
 
+    private get yAxisOptions(): LineGraphYAxisOptions {
+        return (this.props.yAxis as LineGraphYAxisOptions | undefined) ?? {};
+    }
+
+    private get isLogY() {
+        return this.yAxisOptions.scale === 'log';
+    }
+
+    private get logMin() {
+        return this.yAxisOptions.logMin ?? DefaultLogMin;
+    }
+
+    /** Map a stored y in [0,1] to a display fraction in [0,1]. */
+    private yToDisplay(y: number) {
+        if (!this.isLogY) return y;
+        const lo = this.logMin;
+        if (y <= lo) return 0;
+        if (y >= 1) return 1;
+        const logLo = Math.log10(lo);
+        return (Math.log10(y) - logLo) / (0 - logLo); // log10(1) = 0
+    }
+
+    /** Inverse of yToDisplay: display fraction in [0,1] to stored y in [0,1]. */
+    private yFromDisplay(d: number) {
+        if (!this.isLogY) return d;
+        const lo = this.logMin;
+        if (d <= 0) return 0;
+        if (d >= 1) return 1;
+        const logLo = Math.log10(lo);
+        return Math.pow(10, logLo + d * (0 - logLo));
+    }
+
     private normalizePoint(point: Vec2) {
         const offset = this.padding / 2;
         const maxX = this.width + offset;
         const maxY = this.height + offset;
         const normalizedX = (point[0] * (maxX - offset)) + offset;
-        const normalizedY = (point[1] * (maxY - offset)) + offset;
+        const normalizedY = (this.yToDisplay(point[1]) * (maxY - offset)) + offset;
         const reverseY = (this.height + this.padding) - normalizedY;
         const newPoint = Vec2.create(normalizedX, reverseY);
         return newPoint;
@@ -319,7 +382,8 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
         const unNormalizedX = (point[0] - min) / (maxX - min);
 
         // we have to take into account that we reversed y when we first normalized it.
-        const unNormalizedY = ((this.height + this.padding) - point[1] - min) / (maxY - min);
+        const displayY = ((this.height + this.padding) - point[1] - min) / (maxY - min);
+        const unNormalizedY = this.yFromDisplay(displayY);
 
         return Vec2.create(unNormalizedX, unNormalizedY);
     }
@@ -333,19 +397,59 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
     private renderHistogram() {
         if (!this.props.volume) return null;
 
-        const histogram = Grid.getHistogram(this.props.volume.grid, 40);
+        // Reuse the histogram computed for robust stats (same bin count) and
+        // down-bin it for display, avoiding a second full scan of the volume.
+        const fine = Grid.getHistogram(this.props.volume.grid, Grid.RobustStatsBinCount);
+        const histogram = downsampleHistogram(fine, 40);
         const bars = [];
         const N = histogram.counts.length;
         const w = this.width / N;
         const offset = this.padding / 2;
         const max = arrayMax(histogram.counts) || 1;
+        const isLog = this.isLogY;
+        // For log scaling, compress counts in [1, max] to [0, 1]; counts of 0 map to 0.
+        const logMax = isLog ? Math.log10(Math.max(2, max)) : 0;
         for (let i = 0; i < N; i++) {
-            const x = this.width * i / (N - 1) + offset;
+            const x = this.width * (i + 0.5) / N + offset;
             const y1 = this.height + offset;
-            const y2 = this.height * (1 - histogram.counts[i] / max) + offset;
+            const c = histogram.counts[i];
+            let frac: number;
+            if (isLog) {
+                frac = c > 0 ? Math.log10(c) / logMax : 0;
+                if (frac < 0) frac = 0;
+                else if (frac > 1) frac = 1;
+            } else {
+                frac = c / max;
+            }
+            const y2 = this.height * (1 - frac) + offset;
             bars.push(<line key={`histogram${i}`} x1={x} x2={x} y1={y1} y2={y2} stroke="#ded9ca" strokeWidth={w} />);
         }
         return bars;
+    }
+
+    private renderAxes() {
+        const offset = 0; // this.padding / 2;
+        const elements: React.ReactNode[] = [];
+        const ticks: { y: number, label: string }[] = this.isLogY
+            ? [
+                { y: this.logMin, label: this.logMin.toString() },
+                { y: 0.01, label: '0.01' },
+                { y: 0.1, label: '0.1' },
+                { y: 1, label: '1' },
+            ]
+            : [
+                { y: 0, label: '0' },
+                { y: 0.5, label: '0.5' },
+                { y: 1, label: '1' },
+            ];
+        for (let i = 0; i < ticks.length; i++) {
+            const { y, label } = ticks[i];
+            const py = this.normalizePoint(Vec2.create(0, y))[1];
+            elements.push(
+                <text key={`ticklbl${i}`} x={offset + 4} y={py - 4} textAnchor="start" fontSize="22" fill="#888" stroke="none">{label}</text>
+            );
+        }
+        return elements;
     }
 
     private renderPoints() {
@@ -373,27 +477,13 @@ export class LineGraphComponent extends React.Component<any, LineGraphComponentS
     }
 
     private renderLines() {
-        const points: Vec2[] = [];
-        const lines = [];
-        let maxX: number;
-        let maxY: number;
-        let normalizedX: number;
-        let normalizedY: number;
-        let reverseY: number;
-
-        const o = this.padding / 2;
+        const data: Vec2[] = [];
         for (const point of this.state.points) {
-            maxX = this.width + o;
-            maxY = this.height + this.padding;
-            normalizedX = (point[0] * (maxX - o)) + o;
-            normalizedY = (point[1] * (maxY - o)) + o;
-            reverseY = this.height + this.padding - normalizedY;
-            points.push(Vec2.create(normalizedX, reverseY));
+            data.push(this.normalizePoint(point));
         }
 
-        const data = points;
+        const lines = [];
         const size = data.length;
-
         for (let i = 0; i < size - 1; i++) {
             const x1 = data[i][0];
             const y1 = data[i][1];

--- a/src/mol-plugin-ui/controls/parameters.tsx
+++ b/src/mol-plugin-ui/controls/parameters.tsx
@@ -311,10 +311,11 @@ export class BoolControl extends SimpleParam<PD.BooleanParam> {
     }
 }
 
-export class LineGraphControl extends React.PureComponent<ParamProps<PD.LineGraph>, { isExpanded: boolean, isOverPoint: boolean, message: string }> {
+export class LineGraphControl extends React.PureComponent<ParamProps<PD.LineGraph>, { isExpanded: boolean, isOverPoint: boolean, showPresets: boolean, message: string }> {
     state = {
         isExpanded: false,
         isOverPoint: false,
+        showPresets: false,
         message: `${this.props.param.defaultValue.length} points`,
     };
 
@@ -355,14 +356,36 @@ export class LineGraphControl extends React.PureComponent<ParamProps<PD.LineGrap
         e.currentTarget.blur();
     };
 
+    toggleShowPresets = (e: React.MouseEvent<HTMLButtonElement>) => {
+        this.setState({ showPresets: !this.state.showPresets });
+        e.currentTarget.blur();
+    };
+
+    onSelectPreset: ActionMenu.OnSelect = item => {
+        this.setState({ showPresets: false });
+        if (!item) return;
+        this.onChange(item.value as PD.LineGraph['defaultValue']);
+    };
+
     render() {
         const label = this.props.param.label || camelCaseToWords(this.props.name);
+        const hasPresets = !!this.props.param.getPresets;
+        const presetItems = hasPresets && this.state.showPresets
+            ? ActionMenu.createItemsFromSelectOptions(this.props.param.getPresets!())
+            : null;
         return <>
-            <ControlRow label={label} control={<button onClick={this.toggleExpanded} disabled={this.props.isDisabled}>{`${this.state.message}`}</button>} />
+            <ControlRow label={label} control={<div style={{ display: 'flex', textAlignLast: 'center' }}>
+                <button onClick={this.toggleExpanded} disabled={this.props.isDisabled} style={{ flex: '1 1 auto', overflow: 'hidden', textOverflow: 'ellipsis' }}>{`${this.state.message}`}</button>
+                {hasPresets && <IconButton svg={BookmarksOutlinedSvg} onClick={this.toggleShowPresets} toggleState={this.state.showPresets} title='Presets' disabled={this.props.isDisabled} flex />}
+            </div>} />
+            {presetItems && <div className='msp-control-offset'>
+                <ActionMenu items={presetItems} onSelect={this.onSelectPreset} />
+            </div>}
             <div className='msp-control-offset' style={{ display: this.state.isExpanded ? 'block' : 'none', marginTop: 1 }}>
                 <LineGraphComponent
                     data={this.props.value}
                     volume={this.props.param.getVolume?.()}
+                    yAxis={this.props.param.yAxis}
                     onChange={this.onChange}
                     onHover={this.onHover}
                     onDrag={this.onDrag} />

--- a/src/mol-repr/volume/direct-volume.ts
+++ b/src/mol-repr/volume/direct-volume.ts
@@ -5,7 +5,7 @@
  */
 
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
-import { Vec3, Mat4 } from '../../mol-math/linear-algebra';
+import { Vec2, Vec3, Mat4 } from '../../mol-math/linear-algebra';
 import { Box3D } from '../../mol-math/geometry';
 import { Grid, Volume } from '../../mol-model/volume';
 import { RuntimeContext } from '../../mol-task';
@@ -158,6 +158,8 @@ export type DirectVolumeParams = typeof DirectVolumeParams
 export function getDirectVolumeParams(ctx: ThemeRegistryContext, volume: Volume) {
     const params = PD.clone(DirectVolumeParams);
     params.controlPoints.getVolume = () => volume;
+    params.controlPoints.defaultValue = computeRampControlPoints(volume);
+    params.controlPoints.getPresets = () => buildPresets(volume);
     return params;
 }
 export type DirectVolumeProps = PD.Values<DirectVolumeParams>
@@ -195,3 +197,312 @@ export const DirectVolumeRepresentationProvider = VolumeRepresentationProvider({
     locationKinds: ['position-location', 'direct-location'],
     isApplicable: (volume: Volume) => !Volume.isEmpty(volume) && !Volume.Segmentation.get(volume)
 });
+
+//
+
+const PeakAlpha = 0.05;
+const PeakRamp = 0.005;
+const MinPeakX = 0.05;
+const MaxPeakX = 0.95;
+
+/**
+ * Compute data-aware default control points from the volume's histogram.
+ *
+ * Strategy:
+ *   - signed volumes (min < 0): symmetric ramps on both sides of 0
+ *     (−3σ → −σ on the negative side, +σ → +3σ on the positive side).
+ *   - unsigned volumes: a smooth ramp from μ → μ+σ → min(p99, μ+3σ)
+ *
+ * Robust stats are computed from the cached histogram with the bin
+ * containing 0 excluded (typical for masked/padded density maps).
+ */
+function computeRampControlPoints(volume: Volume): Vec2[] {
+    const { grid } = volume;
+    const { min, max } = grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range)) {
+        return fallbackControlPoints();
+    }
+
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
+    const { mean, sigma, p99 } = robust;
+    if (!isFinite(sigma) || sigma <= 0 || robust.count === 0) {
+        return fallbackControlPoints();
+    }
+
+    const toX = (v: number) => clamp((v - min) / range, 0.001, 0.999);
+
+    if (min < 0) {
+        // Signed volume: mirrored ramps around 0.
+        const points: Vec2[] = [];
+        const negOuter = toX(Math.min(mean - 3 * sigma, -sigma));
+        const negInner = toX(-sigma);
+        const zero = toX(0);
+        const posInner = toX(sigma);
+        const posOuter = toX(Math.max(mean + 3 * sigma, sigma));
+        const xs = [negOuter, negInner, zero, posInner, posOuter].sort((a, b) => a - b);
+        // Negative ramp: alpha PeakAlpha at outer, falls to 0 at zero.
+        points.push(Vec2.create(xs[0], PeakAlpha));
+        points.push(Vec2.create(xs[1], PeakAlpha * 0.5));
+        points.push(Vec2.create(xs[2], 0));
+        // Positive ramp: 0 at zero, rises to PeakAlpha at outer.
+        points.push(Vec2.create(xs[3], PeakAlpha * 0.5));
+        points.push(Vec2.create(xs[4], PeakAlpha));
+        return points;
+    }
+
+    // Unsigned: ramp from μ up to ~p99 (capped at μ+3σ).
+    const xStart = toX(mean);
+    const xMid = toX(mean + sigma);
+    const xEnd = toX(Math.min(mean + 3 * sigma, p99));
+    const ramp = buildRampPoints(xStart, xMid, xEnd, PeakAlpha);
+
+    return ramp;
+}
+
+/**
+ * Build a ramp described by three monotonic x positions:
+ *   xStart -> alpha 0
+ *   xMid   -> alpha maxAlpha/2
+ *   xEnd   -> alpha maxAlpha (then plateau briefly and close to 0)
+ */
+function buildRampPoints(xStart: number, xMid: number, xEnd: number, maxAlpha: number): Vec2[] {
+    const eps = 0.002;
+    const a = clamp(xStart, 0.001, 0.997);
+    let b = clamp(xMid, a + eps, 0.998);
+    let c = clamp(xEnd, b + eps, 0.999);
+    // Avoid collapsed ramps when sigma is tiny relative to range.
+    if (c - a < 3 * eps) {
+        b = a + eps;
+        c = a + 2 * eps;
+    }
+    const points: Vec2[] = [];
+    points.push(Vec2.create(a, 0));
+    points.push(Vec2.create(b, maxAlpha * 0.5));
+    points.push(Vec2.create(c, maxAlpha));
+    // Plateau plus close so the upper end of the volume range stays opaque
+    // until very near the top of the data range.
+    const dEnd = clamp(c + eps, c + 0.0001, 0.9995);
+    points.push(Vec2.create(dEnd, maxAlpha));
+    return points;
+}
+
+function fallbackControlPoints(): Vec2[] {
+    return [
+        Vec2.create(0.19, 0.0), Vec2.create(0.2, PeakAlpha), Vec2.create(0.25, PeakAlpha), Vec2.create(0.26, 0.0),
+        Vec2.create(0.79, 0.0), Vec2.create(0.8, PeakAlpha), Vec2.create(0.85, PeakAlpha), Vec2.create(0.86, 0.0),
+    ];
+}
+
+/**
+ * Build a single narrow peak (iso-surface-like) at `mean + sigmaOffset*sigma`.
+ * `halfWidth` is in normalized [0,1] x-space; `alpha` is the peak height.
+ */
+function buildSinglePeak(volume: Volume, sigmaOffset: number, halfWidth: number, alpha: number): Vec2[] {
+    const { min, max } = volume.grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range)) {
+        return fallbackControlPoints();
+    }
+    const robust = Grid.getRobustStats(volume.grid, { ignoreZero: true });
+    const { mean, sigma } = robust;
+    if (!isFinite(sigma) || sigma <= 0 || robust.count === 0) {
+        return fallbackControlPoints();
+    }
+    const cx = clamp((mean + sigmaOffset * sigma - min) / range, MinPeakX, MaxPeakX);
+    const dx = clamp(halfWidth, PeakRamp + 0.001, 0.2);
+    const x0 = clamp(cx - dx, 0.001, 0.999);
+    const x1 = clamp(cx - dx + PeakRamp, 0.001, 0.999);
+    const x2 = clamp(cx + dx - PeakRamp, 0.001, 0.999);
+    const x3 = clamp(cx + dx, 0.001, 0.999);
+    if (!(x0 < x1 && x1 < x2 && x2 < x3)) return fallbackControlPoints();
+    return [
+        Vec2.create(x0, 0),
+        Vec2.create(x1, alpha),
+        Vec2.create(x2, alpha),
+        Vec2.create(x3, 0),
+    ];
+}
+
+/** Sharp iso-surface-like peak around mean+2σ. */
+function computeSharpSurfaceControlPoints(volume: Volume): Vec2[] {
+    return buildSinglePeak(volume, 2, 0.012, PeakAlpha);
+}
+
+/** Narrow high-contour peak at mean+3σ with stronger alpha. */
+function computeHighContourControlPoints(volume: Volume): Vec2[] {
+    return buildSinglePeak(volume, 3, 0.015, 0.08);
+}
+
+/**
+ * Wide soft ramp starting at the mean, plateauing around mean+σ; reveals
+ * weak density (low-resolution maps, partial occupancy).
+ */
+function computeLowContourControlPoints(volume: Volume): Vec2[] {
+    const { grid } = volume;
+    const { min, max } = grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range)) {
+        return fallbackControlPoints();
+    }
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
+    const { mean, sigma } = robust;
+    if (!isFinite(sigma) || sigma <= 0 || robust.count === 0) {
+        return fallbackControlPoints();
+    }
+    const toX = (v: number) => clamp((v - min) / range, 0.001, 0.999);
+    const xStart = toX(mean - 0.5 * sigma);
+    const xMid = toX(mean + 0.5 * sigma);
+    const xEnd = toX(mean + 1.5 * sigma);
+    return buildRampPoints(xStart, xMid, xEnd, PeakAlpha);
+}
+
+/**
+ * Tomogram-style preset: emphasizes low values (typical of cryo-ET where
+ * matter is darker than background prior to inversion). Builds a ramp
+ * descending from p1 → mean−σ.
+ */
+function computeTomogramControlPoints(volume: Volume): Vec2[] {
+    const { grid } = volume;
+    const { min, max } = grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range)) return fallbackControlPoints();
+
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
+    const { mean, sigma, p1 } = robust;
+    if (!isFinite(sigma) || sigma <= 0 || robust.count === 0) return fallbackControlPoints();
+
+    const toX = (v: number) => clamp((v - min) / range, 0.001, 0.999);
+    // Mirror of the unsigned ramp, descending from low values.
+    const xStart = toX(Math.max(mean - 3 * sigma, p1));
+    const xMid = toX(mean - sigma);
+    const xEnd = toX(mean);
+    const a = clamp(xStart, 0.001, 0.997);
+    const b = clamp(xMid, a + 0.002, 0.998);
+    const c = clamp(xEnd, b + 0.002, 0.999);
+    return [
+        Vec2.create(a, PeakAlpha),
+        Vec2.create(b, PeakAlpha * 0.5),
+        Vec2.create(c, 0),
+    ];
+}
+
+/**
+ * Symmetric narrow peaks at ±3σ for signed difference maps (Fo−Fc, mFo−DFc).
+ * Falls back to the default control points when the volume is unsigned.
+ */
+function computeDifferenceMapControlPoints(volume: Volume): Vec2[] {
+    const { grid } = volume;
+    const { min, max } = grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range) || min >= 0) {
+        return fallbackControlPoints();
+    }
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
+    const { mean, sigma } = robust;
+    if (!isFinite(sigma) || sigma <= 0 || robust.count === 0) {
+        return fallbackControlPoints();
+    }
+    const toX = (v: number) => clamp((v - min) / range, MinPeakX, MaxPeakX);
+    const xs = [toX(mean - 3 * sigma), toX(mean + 3 * sigma)];
+    xs.sort((a, b) => a - b);
+
+    const points: Vec2[] = [];
+    let dx = 0.012;
+    if (xs[1] - xs[0] < 2 * (dx + PeakRamp)) {
+        dx = Math.max(PeakRamp + 0.001, (xs[1] - xs[0]) / 2 - PeakRamp);
+    }
+    for (const cx of xs) {
+        const x = clamp(cx, MinPeakX, MaxPeakX);
+        const x0 = clamp(x - dx, 0.001, 0.999);
+        const x1 = clamp(x - dx + PeakRamp, 0.001, 0.999);
+        const x2 = clamp(x + dx - PeakRamp, 0.001, 0.999);
+        const x3 = clamp(x + dx, 0.001, 0.999);
+        points.push(Vec2.create(x0, 0));
+        points.push(Vec2.create(x1, PeakAlpha));
+        points.push(Vec2.create(x2, PeakAlpha));
+        points.push(Vec2.create(x3, 0));
+    }
+    return points;
+}
+
+/**
+ * Linear ramp from p1 → p99 with monotonically increasing alpha. Suited for
+ * data normalized to [0,1] like occupancy or probability/mask volumes.
+ */
+function computeOccupancyControlPoints(volume: Volume): Vec2[] {
+    const { grid } = volume;
+    const { min, max } = grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range)) return fallbackControlPoints();
+
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
+    const { p1, p99 } = robust;
+    if (!isFinite(p99 - p1) || p99 <= p1) return fallbackControlPoints();
+
+    const toX = (v: number) => clamp((v - min) / range, 0.001, 0.999);
+    const a = toX(p1);
+    const c = toX(p99);
+    const b = clamp((a + c) * 0.5, a + 0.002, c - 0.002);
+    const points: Vec2[] = [
+        Vec2.create(a, 0),
+        Vec2.create(b, PeakAlpha * 0.5),
+        Vec2.create(c, PeakAlpha),
+    ];
+    // Hold alpha near the top of the range so the most-occupied voxels stay
+    // visible instead of fading out above p99.
+    if (c < 0.997) points.push(Vec2.create(0.999, PeakAlpha));
+    return points;
+}
+
+/**
+ * Soft, low-alpha ramp covering [μ, p99] for cloudy/accumulation-style
+ * rendering (MO densities, mesoscale fields).
+ */
+function computeWideVolumetricControlPoints(volume: Volume): Vec2[] {
+    const { grid } = volume;
+    const { min, max } = grid.stats;
+    const range = max - min;
+    if (range <= 0 || !isFinite(range)) return fallbackControlPoints();
+
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
+    const { mean, sigma, p99 } = robust;
+    if (!isFinite(sigma) || sigma <= 0) return fallbackControlPoints();
+
+    const toX = (v: number) => clamp((v - min) / range, 0.001, 0.999);
+    const xStart = toX(Math.max(mean - sigma, min));
+    const xMid = toX(mean + sigma);
+    const xEnd = toX(p99);
+    return buildRampPoints(xStart, xMid, xEnd, 0.02);
+}
+
+/**
+ * Build the list of presets exposed via the LineGraph control. Presets that
+ * don't apply to the current volume (e.g. difference-map preset on an
+ * unsigned volume) are filtered out rather than producing degenerate ramps.
+ */
+function buildPresets(volume: Volume): [Vec2[], string][] {
+    const { min, max } = volume.grid.stats;
+    const isSigned = min < 0;
+    const presets: [Vec2[], string][] = [
+        [computeRampControlPoints(volume), 'Ramp (auto)'],
+        [computeSharpSurfaceControlPoints(volume), 'Sharp surface (~+2σ)'],
+        [computeHighContourControlPoints(volume), 'High contour (~+3σ)'],
+        [computeLowContourControlPoints(volume), 'Low contour (~+1σ)'],
+    ];
+    // Tomogram preset: include when the data has meaningful negative spread
+    // (signed maps, or unsigned but strongly left-skewed).
+    if (isSigned || (isFinite(max - min) && volume.grid.stats.mean - min > max - volume.grid.stats.mean)) {
+        presets.push([computeTomogramControlPoints(volume), 'Tomogram (inverted)']);
+    }
+    if (isSigned) {
+        presets.push([computeDifferenceMapControlPoints(volume), 'Difference map (±3σ)']);
+    }
+    presets.push([computeOccupancyControlPoints(volume), 'Occupancy / probability']);
+    presets.push([computeWideVolumetricControlPoints(volume), 'Wide volumetric']);
+    return presets;
+}
+
+function clamp(v: number, lo: number, hi: number) {
+    return v < lo ? lo : v > hi ? hi : v;
+}

--- a/src/mol-repr/volume/direct-volume.ts
+++ b/src/mol-repr/volume/direct-volume.ts
@@ -23,6 +23,7 @@ import { Texture } from '../../mol-gl/webgl/texture';
 import { Interval } from '../../mol-data/int/interval';
 import { OrderedSet } from '../../mol-data/int/ordered-set';
 import { VolumeVisual } from './visual';
+import { clamp } from '../../mol-math/interpolate';
 
 function getBoundingBox(gridDimension: Vec3, transform: Mat4) {
     const bbox = Box3D();
@@ -158,8 +159,8 @@ export type DirectVolumeParams = typeof DirectVolumeParams
 export function getDirectVolumeParams(ctx: ThemeRegistryContext, volume: Volume) {
     const params = PD.clone(DirectVolumeParams);
     params.controlPoints.getVolume = () => volume;
-    params.controlPoints.defaultValue = computeRampControlPoints(volume);
-    params.controlPoints.getPresets = () => buildPresets(volume);
+    params.controlPoints.defaultValue = computeRampControlPoints(volume.grid);
+    params.controlPoints.getPresets = () => buildPresets(volume.grid);
     return params;
 }
 export type DirectVolumeProps = PD.Values<DirectVolumeParams>
@@ -216,8 +217,7 @@ const MaxPeakX = 0.95;
  * Robust stats are computed from the cached histogram with the bin
  * containing 0 excluded (typical for masked/padded density maps).
  */
-function computeRampControlPoints(volume: Volume): Vec2[] {
-    const { grid } = volume;
+function computeRampControlPoints(grid: Grid): Vec2[] {
     const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range)) {
@@ -298,13 +298,13 @@ function fallbackControlPoints(): Vec2[] {
  * Build a single narrow peak (iso-surface-like) at `mean + sigmaOffset*sigma`.
  * `halfWidth` is in normalized [0,1] x-space; `alpha` is the peak height.
  */
-function buildSinglePeak(volume: Volume, sigmaOffset: number, halfWidth: number, alpha: number): Vec2[] {
-    const { min, max } = volume.grid.stats;
+function buildSinglePeak(grid: Grid, sigmaOffset: number, halfWidth: number, alpha: number): Vec2[] {
+    const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range)) {
         return fallbackControlPoints();
     }
-    const robust = Grid.getRobustStats(volume.grid, { ignoreZero: true });
+    const robust = Grid.getRobustStats(grid, { ignoreZero: true });
     const { mean, sigma } = robust;
     if (!isFinite(sigma) || sigma <= 0 || robust.count === 0) {
         return fallbackControlPoints();
@@ -325,21 +325,20 @@ function buildSinglePeak(volume: Volume, sigmaOffset: number, halfWidth: number,
 }
 
 /** Sharp iso-surface-like peak around mean+2σ. */
-function computeSharpSurfaceControlPoints(volume: Volume): Vec2[] {
-    return buildSinglePeak(volume, 2, 0.012, PeakAlpha);
+function computeSharpSurfaceControlPoints(grid: Grid): Vec2[] {
+    return buildSinglePeak(grid, 2, 0.012, PeakAlpha);
 }
 
 /** Narrow high-contour peak at mean+3σ with stronger alpha. */
-function computeHighContourControlPoints(volume: Volume): Vec2[] {
-    return buildSinglePeak(volume, 3, 0.015, 0.08);
+function computeHighContourControlPoints(grid: Grid): Vec2[] {
+    return buildSinglePeak(grid, 3, 0.015, 0.08);
 }
 
 /**
  * Wide soft ramp starting at the mean, plateauing around mean+σ; reveals
  * weak density (low-resolution maps, partial occupancy).
  */
-function computeLowContourControlPoints(volume: Volume): Vec2[] {
-    const { grid } = volume;
+function computeLowContourControlPoints(grid: Grid): Vec2[] {
     const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range)) {
@@ -362,8 +361,7 @@ function computeLowContourControlPoints(volume: Volume): Vec2[] {
  * matter is darker than background prior to inversion). Builds a ramp
  * descending from p1 → mean−σ.
  */
-function computeTomogramControlPoints(volume: Volume): Vec2[] {
-    const { grid } = volume;
+function computeTomogramControlPoints(grid: Grid): Vec2[] {
     const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range)) return fallbackControlPoints();
@@ -391,8 +389,7 @@ function computeTomogramControlPoints(volume: Volume): Vec2[] {
  * Symmetric narrow peaks at ±3σ for signed difference maps (Fo−Fc, mFo−DFc).
  * Falls back to the default control points when the volume is unsigned.
  */
-function computeDifferenceMapControlPoints(volume: Volume): Vec2[] {
-    const { grid } = volume;
+function computeDifferenceMapControlPoints(grid: Grid): Vec2[] {
     const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range) || min >= 0) {
@@ -430,8 +427,7 @@ function computeDifferenceMapControlPoints(volume: Volume): Vec2[] {
  * Linear ramp from p1 → p99 with monotonically increasing alpha. Suited for
  * data normalized to [0,1] like occupancy or probability/mask volumes.
  */
-function computeOccupancyControlPoints(volume: Volume): Vec2[] {
-    const { grid } = volume;
+function computeOccupancyControlPoints(grid: Grid): Vec2[] {
     const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range)) return fallbackControlPoints();
@@ -459,8 +455,7 @@ function computeOccupancyControlPoints(volume: Volume): Vec2[] {
  * Soft, low-alpha ramp covering [μ, p99] for cloudy/accumulation-style
  * rendering (MO densities, mesoscale fields).
  */
-function computeWideVolumetricControlPoints(volume: Volume): Vec2[] {
-    const { grid } = volume;
+function computeWideVolumetricControlPoints(grid: Grid): Vec2[] {
     const { min, max } = grid.stats;
     const range = max - min;
     if (range <= 0 || !isFinite(range)) return fallbackControlPoints();
@@ -481,28 +476,27 @@ function computeWideVolumetricControlPoints(volume: Volume): Vec2[] {
  * don't apply to the current volume (e.g. difference-map preset on an
  * unsigned volume) are filtered out rather than producing degenerate ramps.
  */
-function buildPresets(volume: Volume): [Vec2[], string][] {
-    const { min, max } = volume.grid.stats;
+function buildPresets(grid: Grid): [Vec2[], string][] {
+    const cached = (grid as any)._directVolumeControlPointsPresets as [Vec2[], string][] | undefined;
+    if (cached) return cached;
+    const { min, max } = grid.stats;
     const isSigned = min < 0;
     const presets: [Vec2[], string][] = [
-        [computeRampControlPoints(volume), 'Ramp (auto)'],
-        [computeSharpSurfaceControlPoints(volume), 'Sharp surface (~+2σ)'],
-        [computeHighContourControlPoints(volume), 'High contour (~+3σ)'],
-        [computeLowContourControlPoints(volume), 'Low contour (~+1σ)'],
+        [computeRampControlPoints(grid), 'Ramp (auto)'],
+        [computeSharpSurfaceControlPoints(grid), 'Sharp surface (~+2σ)'],
+        [computeHighContourControlPoints(grid), 'High contour (~+3σ)'],
+        [computeLowContourControlPoints(grid), 'Low contour (~+1σ)'],
     ];
     // Tomogram preset: include when the data has meaningful negative spread
     // (signed maps, or unsigned but strongly left-skewed).
-    if (isSigned || (isFinite(max - min) && volume.grid.stats.mean - min > max - volume.grid.stats.mean)) {
-        presets.push([computeTomogramControlPoints(volume), 'Tomogram (inverted)']);
+    if (isSigned || (isFinite(max - min) && grid.stats.mean - min > max - grid.stats.mean)) {
+        presets.push([computeTomogramControlPoints(grid), 'Tomogram (inverted)']);
     }
     if (isSigned) {
-        presets.push([computeDifferenceMapControlPoints(volume), 'Difference map (±3σ)']);
+        presets.push([computeDifferenceMapControlPoints(grid), 'Difference map (±3σ)']);
     }
-    presets.push([computeOccupancyControlPoints(volume), 'Occupancy / probability']);
-    presets.push([computeWideVolumetricControlPoints(volume), 'Wide volumetric']);
+    presets.push([computeOccupancyControlPoints(grid), 'Occupancy / probability']);
+    presets.push([computeWideVolumetricControlPoints(grid), 'Wide volumetric']);
+    (grid as any)._directVolumeControlPointsPresets = presets;
     return presets;
-}
-
-function clamp(v: number, lo: number, hi: number) {
-    return v < lo ? lo : v > hi ? hi : v;
 }

--- a/src/mol-util/param-definition.ts
+++ b/src/mol-util/param-definition.ts
@@ -233,13 +233,23 @@ export namespace ParamDefinition {
         return setInfo<Interval>(setRange({ type: 'interval', defaultValue }, range), info);
     }
 
+    export interface LineGraphYAxis {
+        scale?: 'linear' | 'log',
+        /** Lower bound for log scale (alpha values below this are clamped for display only). Default 1e-3. */
+        logMin?: number
+    }
     export interface LineGraph extends Base<Vec2Data[]> {
         type: 'line-graph',
-        getVolume?: () => unknown
+        getVolume?: () => unknown,
+        yAxis?: LineGraphYAxis,
+        /** Optional preset provider. Called lazily when the user opens the presets menu so presets can be derived from current data (e.g. volume stats). */
+        getPresets?: () => Select<Vec2Data[]>['options']
     }
-    export function LineGraph(defaultValue: Vec2Data[], info?: Info & { getVolume?: (binCount?: number) => unknown }): LineGraph {
+    export function LineGraph(defaultValue: Vec2Data[], info?: Info & { getVolume?: () => unknown, yAxis?: LineGraphYAxis, getPresets?: () => Select<Vec2Data[]>['options'] }): LineGraph {
         const ret = setInfo<LineGraph>({ type: 'line-graph', defaultValue }, info);
         if (info?.getVolume) ret.getVolume = info.getVolume;
+        if (info?.yAxis) ret.yAxis = info.yAxis;
+        if (info?.getPresets) ret.getPresets = info.getPresets;
         return ret;
     }
 


### PR DESCRIPTION


<!-- Thank you for contributing to Mol* -->

# Description

- Add `histogramPercentile`, `histogramRobustStats`, `downsampleHistogram` to `mol-math/histogram`
- Direct-volume transfer function improvements
    - Add data-aware default control points and preset library
    - Use log-scale on y-axis in control-points UI

<img width="288" height="423" alt="image" src="https://github.com/user-attachments/assets/515e569e-c8ef-47bb-823b-f5d8bbd45641" />



## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`