### PR TITLE
Pull Request - feat-defaultSnapshotIndex into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note that since we don't clearly distinguish between a public and private interf
 ## [Unreleased]
 - Fix size-only representation theme updates in `updateRepresentationsTheme`.
 - Fix ASA coloring for hydrogens
+- Add `defaultSnapshotIndex` argument to `MVSLoadOptions` to enable loading a snapshot other than the first one by default
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "Tianzhen Lin (Tangent) <tangent@usa.net>",
     "Russ Taylor <russ@reliasolve.com>",
     "Tadej Satler <tadej.satler@gmail.com>",
-    "Himanshu Raj <himanshuraj6771@gmail.com>"
+    "Himanshu Raj <himanshuraj6771@gmail.com>",
+    "Marek Eibel <108737044+kerrambit@users.noreply.github.com>"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -57,7 +57,7 @@ export interface MVSLoadOptions {
     /** Base for resolving relative URLs/URIs. May itself be a relative URL (relative to the window URL). */
     sourceUrl?: string,
     /** The index of the snapshot to apply initially. Defaults to 0. */
-    defaultSnapshotIndex?: number;
+    defaultSnapshotIndex?: number,
 
     doNotReportErrors?: boolean
 }

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -4,6 +4,7 @@
  * @author Adam Midlik <midlik@gmail.com>
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Aliaksei Chareshneu <chareshneu.tech@gmail.com>
+ * @author Marek Eibel <108737044+kerrambit@users.noreply.github.com>
  */
 
 import { PluginStateSnapshotManager } from '../../mol-plugin-state/manager/snapshots';

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -55,6 +55,8 @@ export interface MVSLoadOptions {
     sanityChecks?: boolean,
     /** Base for resolving relative URLs/URIs. May itself be a relative URL (relative to the window URL). */
     sourceUrl?: string,
+    /** The index of the snapshot to apply initially. Defaults to 0. */
+    defaultSnapshotIndex?: number;
 
     doNotReportErrors?: boolean
 }
@@ -115,7 +117,11 @@ async function _loadMVS(ctx: RuntimeContext, plugin: PluginContext, data: MVSDat
         }
 
         if (entries.length > 0) {
-            await PluginCommands.State.Snapshots.Apply(plugin, { id: entries[0].snapshot.id });
+            let indexToApply = options.defaultSnapshotIndex ?? 0;
+            if (indexToApply < 0 || indexToApply >= entries.length) {
+                indexToApply = 0;
+            }
+            await PluginCommands.State.Snapshots.Apply(plugin, { id: entries[indexToApply].snapshot.id });
         }
     } catch (err) {
         plugin.log.error(`${err}`);


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
I enhanced `MVSLoadOptions` by new argument `defaultSnapshotIndex` to enable loading other than the first snapshot as the default. The default value is set to 0.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [] (Optional but encouraged) Improved documentation in `docs`