### PR TITLE
handle empty `chem_comp.type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add `examples/react` that showcases few ways the Mol* can be used together with React
 - Fix default representation plugin option, which resulted in represenations not being shown automatically when using the default plugin spec
 - Track added custom props in `QueryRuntimeTable` to prevent excess "symbol already added" messages when creating multiple instances of a pluing
+- Handle empty `chem_comp.type`
 
 ## [v5.9.0] - 2026-05-03
 - Fix edge case when `PluginSpec.animations` is empty

--- a/src/mol-model-formats/structure/basic/properties.ts
+++ b/src/mol-model-formats/structure/basic/properties.ts
@@ -1,15 +1,15 @@
 /**
- * Copyright (c) 2017-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { Table } from '../../../mol-data/db';
+import { Column, Table } from '../../../mol-data/db';
 import { Model } from '../../../mol-model/structure/model/model';
 import { AtomicHierarchy } from '../../../mol-model/structure/model/properties/atomic';
 import { ChemicalComponent, MissingResidue, StructAsym } from '../../../mol-model/structure/model/properties/common';
-import { getDefaultChemicalComponent, getMoleculeType, MoleculeType } from '../../../mol-model/structure/model/types';
+import { getComponentType, getDefaultChemicalComponent, getMoleculeType, MoleculeType } from '../../../mol-model/structure/model/types';
 import { SaccharideCompIdMap, SaccharideComponent, SaccharideComponentMap, SaccharidesSnfgMap, UnknownSaccharideComponent } from '../../../mol-model/structure/structure/carbohydrates/constants';
 import { memoize1 } from '../../../mol-util/memoize';
 import { BasicData } from './schema';
@@ -41,9 +41,15 @@ export function getChemicalComponentMap(data: BasicData): Model['properties']['c
     const map = new Map<string, ChemicalComponent>();
 
     if (data.chem_comp._rowCount > 0) {
-        const { id } = data.chem_comp;
+        const { id, type } = data.chem_comp;
         for (let i = 0, il = id.rowCount; i < il; ++i) {
-            map.set(id.value(i), Table.getRow(data.chem_comp, i));
+            const _id = id.value(i);
+            const row = Table.getRow(data.chem_comp, i);
+            // some tools like gemmi list `chem_comp` rows without a meaningful `type`
+            if (type.valueKind(i) !== Column.ValueKinds.Present) {
+                row.type = getComponentType(_id);
+            }
+            map.set(_id, row);
         }
     } else {
         const uniqueNames = getUniqueComponentNames(data);

--- a/src/mol-model-formats/structure/basic/properties.ts
+++ b/src/mol-model-formats/structure/basic/properties.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
  */
 
 import { Column, Table } from '../../../mol-data/db';


### PR DESCRIPTION
# Description
- some writers (like gemmi) may produce a `chem_comp` category that lacks `type` for amino acids
- this will trip up downstream detection logic
- this PR changes the behavior to use internal heuristics if `type` is undefined

Example of problematic data:
```
loop_
_chem_comp.id
_chem_comp.type
ALA .
ARG .
ASN .
ASP .
CYS .
GLN .
GLU .
GLY .
ILE .
LEU .
LIG1 .
LYS .
MET .
PHE .
PRO .
SER .
THR .
TRP .
TYR .
VAL .
```

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`