### PR TITLE
Ligand alignments by MCCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Note that since we don't clearly distinguish between a public and private interf
     - Use log-scale on y-axis in control-points UI
 - Add `defaultSnapshotIndex` argument to `MVSLoadOptions` to enable loading a snapshot other than the first one by default
 - Fix `loaders.loadMvs*` options type
+- Rework Superposition panel
+- Add Ligand alignments by maximum common connected subgraphs (MCCS)
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/src/mol-math/graph/_spec/mccs.spec.ts
+++ b/src/mol-math/graph/_spec/mccs.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
+ */
+
+import { IntAdjacencyGraph } from '../int-adjacency-graph';
+import { Mccs } from '../mccs';
+
+type Edge = [number, number, number?]; // [a, b, order = 1]
+
+/** Build an IntAdjacencyGraph with a per-edge `order` property from an undirected edge list. */
+function graph(vertexCount: number, edges: Edge[]) {
+    const xs = edges.map(e => e[0]);
+    const ys = edges.map(e => e[1]);
+    const builder = new IntAdjacencyGraph.EdgeBuilder(vertexCount, xs, ys);
+    const order = new Int32Array(builder.slotCount);
+    for (let i = 0; i < builder.edgeCount; i++) {
+        builder.addNextEdge();
+        builder.assignProperty(order, edges[i][2] ?? 1);
+    }
+    return builder.createGraph({ order });
+}
+
+function ring(n: number, order = 1): Edge[] {
+    const edges: Edge[] = [];
+    for (let i = 0; i < n; i++) edges.push([i, (i + 1) % n, order]);
+    return edges;
+}
+
+function path(n: number): Edge[] {
+    const edges: Edge[] = [];
+    for (let i = 0; i + 1 < n; i++) edges.push([i, i + 1]);
+    return edges;
+}
+
+describe('Mccs', () => {
+    it('finds the maximum common connected subgraph (6-ring in ring vs ring+pendant)', () => {
+        const a = graph(6, ring(6));
+        const b = graph(7, [...ring(6), [0, 6]]); // 6-ring plus a pendant on vertex 0
+        const cliques = Mccs.find(a, b);
+        expect(cliques[0].length).toBe(6);
+    });
+
+    it('returns symmetry-degenerate maxima for an identical ring', () => {
+        const a = graph(6, ring(6));
+        const b = graph(6, ring(6));
+        const cliques = Mccs.find(a, b);
+        expect(cliques.length).toBeGreaterThan(1); // ring symmetry -> several equally-sized mappings
+        expect(cliques[0].length).toBe(6);
+    });
+
+    it('vertexTest restricts which vertices may pair', () => {
+        const labelsA = ['C', 'C', 'C', 'N'];
+        const labelsB = ['C', 'C', 'C', 'O'];
+        const a = graph(4, path(4));
+        const b = graph(4, path(4));
+        const cliques = Mccs.find(a, b, { vertexTest: (i, j) => labelsA[i] === labelsB[j] });
+        expect(cliques[0].length).toBe(3); // shared C-C-C prefix; terminal N/O incompatible
+    });
+
+    it('edgeTest gates c-edges (mismatched edge labels prevent a connected match)', () => {
+        const a = graph(6, ring(6, 2)); // "order 2"
+        const b = graph(6, ring(6, 1)); // "order 1"
+        const aOrder = a.edgeProps.order, bOrder = b.edgeProps.order;
+        const cliques = Mccs.find(a, b, {
+            edgeTest: (ea, eb) => aOrder[ea] === bOrder[eb],
+            minMatchedVertices: 3
+        });
+        // no c-edges survive the edge test, so the only connected cliques are singletons
+        expect(cliques).toHaveLength(0);
+    });
+
+    it('pathCutoff 0 disables d-edges, collapsing a ring to a single edge', () => {
+        const a = graph(6, ring(6));
+        const b = graph(6, ring(6));
+        const cliques = Mccs.find(a, b, { pathCutoff: 0, minMatchedVertices: 1 });
+        // without d-edges a clique must be a complete subgraph; a 6-cycle has no triangle
+        expect(cliques[0].length).toBe(2);
+    });
+
+    it('does not bridge disconnected components (connected-only)', () => {
+        const a = graph(4, [[0, 1], [2, 3]]);
+        const b = graph(4, [[0, 1], [2, 3]]);
+        const cliques = Mccs.find(a, b, { minMatchedVertices: 1 });
+        // cross-component pairs are unreachable -> no d-edges across the gap -> max connected match is one edge
+        expect(cliques[0].length).toBe(2);
+    });
+
+    it('is deterministic across runs', () => {
+        const a = graph(6, ring(6));
+        const b = graph(7, [...ring(6), [0, 6]]);
+        expect(JSON.stringify(Mccs.find(a, b))).toEqual(JSON.stringify(Mccs.find(a, b)));
+    });
+
+    it('honors a tiny search budget and reports truncation via the status out-parameter', () => {
+        const a = graph(6, ring(6));
+        const b = graph(6, ring(6));
+
+        const clipped: Mccs.Status = { truncated: false };
+        expect(() => Mccs.find(a, b, { maxIterations: 1, minMatchedVertices: 1 }, clipped)).not.toThrow();
+        expect(clipped.truncated).toBe(true); // budget hit -> best-so-far
+
+        const full: Mccs.Status = { truncated: false };
+        Mccs.find(a, b, { minMatchedVertices: 1 }, full);
+        expect(full.truncated).toBe(false); // completed within budget
+    });
+
+    it('returns nothing below minMatchedVertices', () => {
+        const a = graph(2, [[0, 1]]);
+        const b = graph(2, [[0, 1]]);
+        expect(Mccs.find(a, b, { minMatchedVertices: 3 })).toHaveLength(0);
+    });
+});

--- a/src/mol-math/graph/int-adjacency-graph.ts
+++ b/src/mol-math/graph/int-adjacency-graph.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2018-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
  */
 
 import { arrayPickIndices, cantorPairing } from '../../mol-data/util';
@@ -411,6 +412,30 @@ export namespace IntAdjacencyGraph {
         }
 
         return areVertexSetsConnectedImpl(graph, verticesA, verticesB, maxDistance, visited);
+    }
+
+    /** BFS all-pairs shortest paths (edge count) within a graph; -1 marks unreachable. */
+    export function graphShortestPaths(g: IntAdjacencyGraph<any, any>): Int32Array[] {
+        const n = g.vertexCount;
+        const { offset, b } = g;
+        const dist: Int32Array[] = new Array(n);
+        const queue = new Int32Array(n);
+        for (let s = 0; s < n; s++) {
+            const d = new Int32Array(n).fill(-1);
+            let head = 0, tail = 0;
+            queue[tail++] = s;
+            d[s] = 0;
+            while (head < tail) {
+                const u = queue[head++];
+                const du = d[u];
+                for (let t = offset[u], end = offset[u + 1]; t < end; t++) {
+                    const w = b[t];
+                    if (d[w] < 0) { d[w] = du + 1; queue[tail++] = w; }
+                }
+            }
+            dist[s] = d;
+        }
+        return dist;
     }
 }
 

--- a/src/mol-math/graph/mccs.ts
+++ b/src/mol-math/graph/mccs.ts
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
+ */
+
+import { BitSet } from '../../mol-util/bit-set';
+import { IntAdjacencyGraph } from './int-adjacency-graph';
+
+export { Mccs };
+
+/**
+ * Maximum common connected subgraph (MCCS) matching between two graphs.
+ *
+ * Builds the modular-product (compatibility) graph and enumerates its connected cliques (Koch's
+ * connected-clique variant of Bron-Kerbosch): product vertices are compatible vertex pairs
+ * (`a` in graph A, `b` in graph B); two product vertices are joined by a "c-edge" when the
+ * underlying vertices are adjacent in both graphs with compatible edges, or by a "d-edge" when they
+ * are non-adjacent in both with similar topological distance. A clique connected via c-edges is a
+ * common *connected* subgraph, and the maximum such clique is the MCCS. The vertex/edge
+ * compatibility predicates are supplied by the caller, so the routine is domain-agnostic.
+ */
+namespace Mccs {
+    export interface Options {
+        /** Whether vertex `a` of graph A may be paired with vertex `b` of graph B. */
+        vertexTest: (a: number, b: number) => boolean;
+        /** Whether edge `edgeA` of A may be paired with edge `edgeB` of B (indices into the graphs' edge arrays). */
+        edgeTest: (edgeA: number, edgeB: number) => boolean;
+        /**
+         * Topological-distance tolerance for "d-edges" (vertex pairs non-adjacent in both graphs).
+         * These are required for the clique formulation to represent non-complete subgraphs (e.g.
+         * rings), so the default is 1: two non-adjacent pairs may be matched iff their shortest-path
+         * distances differ by at most this much. Higher values allow more topological stretch; 0
+         * disables d-edges (only complete-subgraph matches survive, rarely useful).
+         */
+        pathCutoff: number;
+        /** Wall-clock budget; the search returns the best cliques found so far once exceeded. */
+        maxTimeMs: number;
+        /** Hard backstop on recursion steps. */
+        maxIterations: number;
+        /** Discard cliques smaller than this. */
+        minMatchedVertices: number;
+        /** Number of equally-sized maximum cliques to retain. */
+        maxCliques: number;
+    }
+
+    export const DefaultOptions: Options = {
+        vertexTest: () => true,
+        edgeTest: () => true,
+        pathCutoff: 1,
+        maxTimeMs: 400,
+        maxIterations: 10000000,
+        minMatchedVertices: 1,
+        maxCliques: 64
+    };
+
+    /** Optional out-parameter reporting whether the search hit its time/iteration budget. */
+    export interface Status {
+        truncated: boolean;
+    }
+
+    /**
+     * Enumerate the maximum-size common-connected-subgraph correspondences between `a` and `b`.
+     * Several equally sized candidates may be returned when the maximum is symmetry-degenerate; each
+     * is a list of `[vertexA, vertexB]` pairs sorted by `vertexA`. Empty if nothing meets
+     * `minMatchedVertices`.
+     *
+     * Best-effort: the search stops at `maxTimeMs`/`maxIterations` and returns the best cliques found
+     * so far. Pass `status` to learn whether that budget was hit (`status.truncated`).
+     */
+    export function find(a: IntAdjacencyGraph<any, any>, b: IntAdjacencyGraph<any, any>, options: Partial<Options> = {}, status?: Status): Array<Array<[number, number]>> {
+        const opts: Options = { ...DefaultOptions, ...options };
+        const g = buildCompatGraph(a, b, opts);
+        if (g.n === 0) return [];
+
+        const collector = new CliqueCollector(opts.maxCliques);
+        const truncated = enumerateConnectedCliques(g, opts, collector);
+        if (status) status.truncated = truncated;
+        if (collector.bestSize < opts.minMatchedVertices) return [];
+
+        return collector.cliques.map(clique => cliqueToPairs(g, clique));
+    }
+}
+
+type Graph = IntAdjacencyGraph<any, any>;
+
+/**
+ * Compatibility (modular product) graph. Vertices are vertex pairs (pairA[k] in A, pairB[k] in B)
+ * that pass the vertex test; c-edges join pairs adjacent in both graphs with compatible edges,
+ * d-edges join pairs non-adjacent in both with similar topological distance.
+ */
+interface CompatGraph {
+    readonly n: number;
+    readonly pairA: Int32Array;
+    readonly pairB: Int32Array;
+    readonly adj: BitSet[]; // c-edges and d-edges
+    readonly cadj: BitSet[]; // c-edges only
+}
+
+/** LIFO pool of fixed-size BitSets so the (heavily recursive) clique search does not allocate per call. */
+class BitSetPool {
+    private readonly free: BitSet[] = [];
+    constructor(private readonly nbits: number) {}
+    acquire(): BitSet {
+        const b = this.free.pop();
+        return b !== void 0 ? b : new BitSet(this.nbits);
+    }
+    acquireCopy(src: BitSet): BitSet {
+        const b = this.acquire();
+        b.words.set(src.words);
+        return b;
+    }
+    release(b: BitSet) { this.free.push(b); }
+}
+
+/** BFS all-pairs shortest paths (edge count) within a graph; -1 marks unreachable. */
+function graphShortestPaths(g: Graph): Int32Array[] {
+    const n = g.vertexCount;
+    const { offset, b } = g;
+    const dist: Int32Array[] = new Array(n);
+    const queue = new Int32Array(n);
+    for (let s = 0; s < n; s++) {
+        const d = new Int32Array(n).fill(-1);
+        let head = 0, tail = 0;
+        queue[tail++] = s;
+        d[s] = 0;
+        while (head < tail) {
+            const u = queue[head++];
+            const du = d[u];
+            for (let t = offset[u], end = offset[u + 1]; t < end; t++) {
+                const w = b[t];
+                if (d[w] < 0) { d[w] = du + 1; queue[tail++] = w; }
+            }
+        }
+        dist[s] = d;
+    }
+    return dist;
+}
+
+function buildCompatGraph(a: Graph, b: Graph, opts: Mccs.Options): CompatGraph {
+    const nA = a.vertexCount, nB = b.vertexCount;
+
+    const pa: number[] = [], pb: number[] = [];
+    for (let i = 0; i < nA; i++) {
+        for (let j = 0; j < nB; j++) {
+            if (opts.vertexTest(i, j)) { pa.push(i); pb.push(j); }
+        }
+    }
+
+    const n = pa.length;
+    const pairA = Int32Array.from(pa);
+    const pairB = Int32Array.from(pb);
+
+    const adj: BitSet[] = new Array(n);
+    const cadj: BitSet[] = new Array(n);
+    for (let i = 0; i < n; i++) { adj[i] = new BitSet(n); cadj[i] = new BitSet(n); }
+
+    const useD = opts.pathCutoff > 0;
+    const distA = useD ? graphShortestPaths(a) : undefined;
+    const distB = useD ? graphShortestPaths(b) : undefined;
+
+    for (let i = 0; i < n; i++) {
+        const ai = pairA[i], bi = pairB[i];
+        for (let j = i + 1; j < n; j++) {
+            const aj = pairA[j], bj = pairB[j];
+
+            // 1:1 constraint: a given vertex may not be matched twice within one clique
+            if (ai === aj || bi === bj) continue;
+
+            const eaIdx = a.getDirectedEdgeIndex(ai, aj);
+            const ebIdx = b.getDirectedEdgeIndex(bi, bj);
+            const adjA = eaIdx >= 0;
+            const adjB = ebIdx >= 0;
+
+            let cEdge = false;
+            if (adjA && adjB) cEdge = opts.edgeTest(eaIdx, ebIdx);
+
+            let dEdge = false;
+            if (!cEdge && useD && !adjA && !adjB) {
+                const dA = distA![ai][aj];
+                const dB = distB![bi][bj];
+                if (dA >= 0 && dB >= 0 && Math.abs(dA - dB) <= opts.pathCutoff) dEdge = true;
+            }
+
+            if (cEdge || dEdge) {
+                adj[i].set(j); adj[j].set(i);
+                if (cEdge) { cadj[i].set(j); cadj[j].set(i); }
+            }
+        }
+    }
+
+    return { n, pairA, pairB, adj, cadj };
+}
+
+/** Retains every maximum-size clique encountered (up to a cap). */
+class CliqueCollector {
+    bestSize = 0;
+    cliques: number[][] = [];
+    private readonly cap: number;
+    constructor(cap: number) { this.cap = Math.max(1, cap); }
+    offer(clique: number[]) {
+        const size = clique.length;
+        if (size < this.bestSize) return;
+        if (size > this.bestSize) { this.bestSize = size; this.cliques = [clique]; return; }
+        if (this.cliques.length < this.cap) this.cliques.push(clique);
+    }
+}
+
+/**
+ * Enumerate maximal c-connected cliques of the compatibility graph (Koch's connected-clique variant
+ * of Bron-Kerbosch). c-edges keep the match a single connected fragment; d-edges may appear inside a
+ * clique but never seed connectivity. Bounded by a wall-clock and a recursion-step budget; returns
+ * true if that budget was hit (the result is a best-so-far, not proven maximal).
+ */
+function enumerateConnectedCliques(g: CompatGraph, opts: Mccs.Options, collector: CliqueCollector): boolean {
+    const n = g.n;
+    if (n === 0) return false;
+
+    const minK = Math.max(1, opts.minMatchedVertices);
+    const adj = g.adj, cadj = g.cadj;
+
+    const dAdj: BitSet[] = new Array(n);
+    for (let i = 0; i < n; i++) { const d = adj[i].clone(); d.andNot(cadj[i]); dAdj[i] = d; }
+
+    const all = BitSet.full(n);
+    const t = new BitSet(n); // already-processed seeds, so each maximal clique is found once
+    const pool = new BitSetPool(n);
+
+    const deadline = Date.now() + opts.maxTimeMs;
+    const maxIter = opts.maxIterations;
+    let iters = 0;
+    let aborted = false;
+
+    const checkAbort = () => {
+        if (aborted) return true;
+        if ((maxIter > 0 && iters > maxIter) || Date.now() > deadline) { aborted = true; return true; }
+        return false;
+    };
+
+    const cClique = (R: BitSet, P: BitSet, Q: BitSet, X: BitSet, Y: BitSet) => {
+        if (checkAbort()) return;
+        iters++;
+
+        if (P.isEmpty() && X.isEmpty()) {
+            const size = R.cardinality();
+            if (size >= minK) {
+                const clique: number[] = new Array(size);
+                let idx = 0;
+                for (let v = R.nextSetBit(0); v >= 0; v = R.nextSetBit(v + 1)) clique[idx++] = v;
+                collector.offer(clique);
+            }
+            return;
+        }
+
+        // scratch sets are drawn from a pool and returned at the end of each iteration/frame
+        const pIter = pool.acquireCopy(P);
+        for (let ui = pIter.nextSetBit(0); ui >= 0; ui = pIter.nextSetBit(ui + 1)) {
+            P.clear(ui);
+
+            const dN = dAdj[ui], cN = cadj[ui], neigh = adj[ui];
+
+            const rNew = pool.acquireCopy(R); rNew.set(ui);
+            const qNew = pool.acquireCopy(Q); qNew.and(dN);
+            const yNew = pool.acquireCopy(Y); yNew.and(dN);
+            const pNew = pool.acquireCopy(P); pNew.and(neigh);
+            const xNew = pool.acquireCopy(X); xNew.and(neigh);
+            const tmp = pool.acquireCopy(Q); tmp.and(cN); pNew.or(tmp); // P' = (P ∩ neigh) ∪ (Q ∩ cN)
+            tmp.words.set(Y.words); tmp.and(cN); xNew.or(tmp); // X' = (X ∩ neigh) ∪ (Y ∩ cN)
+            pool.release(tmp);
+
+            cClique(rNew, pNew, qNew, xNew, yNew);
+
+            pool.release(xNew); pool.release(pNew); pool.release(yNew); pool.release(qNew); pool.release(rNew);
+
+            X.set(ui);
+            if (checkAbort()) break;
+        }
+        pool.release(pIter);
+    };
+
+    for (let ui = 0; ui < n; ui++) {
+        const dN = dAdj[ui], cN = cadj[ui];
+
+        const r = pool.acquire(); r.zero(); r.set(ui);
+        const q = pool.acquireCopy(all); q.andNot(t); q.and(dN);
+        const p = pool.acquireCopy(all); p.andNot(t); p.and(cN);
+        const y = pool.acquireCopy(dN); y.and(t);
+        const x = pool.acquireCopy(cN); x.and(t);
+
+        cClique(r, p, q, x, y);
+
+        pool.release(x); pool.release(y); pool.release(p); pool.release(q); pool.release(r);
+
+        t.set(ui);
+        if (checkAbort()) break;
+    }
+    return aborted;
+}
+
+function cliqueToPairs(g: CompatGraph, clique: number[]): Array<[number, number]> {
+    const pairs: Array<[number, number]> = clique.map(ci => [g.pairA[ci], g.pairB[ci]] as [number, number]);
+    pairs.sort((p, q) => p[0] - q[0]);
+    return pairs;
+}

--- a/src/mol-math/graph/mccs.ts
+++ b/src/mol-math/graph/mccs.ts
@@ -93,8 +93,10 @@ interface CompatGraph {
     readonly n: number;
     readonly pairA: Int32Array;
     readonly pairB: Int32Array;
-    readonly adj: BitSet[]; // c-edges and d-edges
-    readonly cadj: BitSet[]; // c-edges only
+    /** c-edges and d-edges */
+    readonly adj: BitSet[];
+    /** c-edges only */
+    readonly cadj: BitSet[];
 }
 
 /** LIFO pool of fixed-size BitSets so the (heavily recursive) clique search does not allocate per call. */

--- a/src/mol-math/graph/mccs.ts
+++ b/src/mol-math/graph/mccs.ts
@@ -115,30 +115,6 @@ class BitSetPool {
     release(b: BitSet) { this.free.push(b); }
 }
 
-/** BFS all-pairs shortest paths (edge count) within a graph; -1 marks unreachable. */
-function graphShortestPaths(g: Graph): Int32Array[] {
-    const n = g.vertexCount;
-    const { offset, b } = g;
-    const dist: Int32Array[] = new Array(n);
-    const queue = new Int32Array(n);
-    for (let s = 0; s < n; s++) {
-        const d = new Int32Array(n).fill(-1);
-        let head = 0, tail = 0;
-        queue[tail++] = s;
-        d[s] = 0;
-        while (head < tail) {
-            const u = queue[head++];
-            const du = d[u];
-            for (let t = offset[u], end = offset[u + 1]; t < end; t++) {
-                const w = b[t];
-                if (d[w] < 0) { d[w] = du + 1; queue[tail++] = w; }
-            }
-        }
-        dist[s] = d;
-    }
-    return dist;
-}
-
 function buildCompatGraph(a: Graph, b: Graph, opts: Mccs.Options): CompatGraph {
     const nA = a.vertexCount, nB = b.vertexCount;
 
@@ -158,8 +134,8 @@ function buildCompatGraph(a: Graph, b: Graph, opts: Mccs.Options): CompatGraph {
     for (let i = 0; i < n; i++) { adj[i] = new BitSet(n); cadj[i] = new BitSet(n); }
 
     const useD = opts.pathCutoff > 0;
-    const distA = useD ? graphShortestPaths(a) : undefined;
-    const distB = useD ? graphShortestPaths(b) : undefined;
+    const distA = useD ? IntAdjacencyGraph.graphShortestPaths(a) : undefined;
+    const distB = useD ? IntAdjacencyGraph.graphShortestPaths(b) : undefined;
 
     for (let i = 0; i < n; i++) {
         const ai = pairA[i], bi = pairB[i];

--- a/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
+++ b/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
@@ -153,11 +153,17 @@ describe('Ligand MCCS', () => {
         expect(first).toEqual(second);
     });
 
-    it('honors a tiny search budget without throwing', () => {
+    it('honors a tiny search budget without throwing, and reports truncation via status', () => {
         const a = carbonRing(6, 1);
         const b = carbonRing(6, 1);
 
-        expect(() => findMccsCliques(a, b, { maxTimeMs: 0, maxIterations: 1 })).not.toThrow();
+        const clipped = { truncated: false };
+        expect(() => findMccsCliques(a, b, { maxIterations: 1, minMatchedAtoms: 1 }, clipped)).not.toThrow();
+        expect(clipped.truncated).toBe(true); // budget hit -> best-so-far
+
+        const full = { truncated: false };
+        findMccsCliques(a, b, { minMatchedAtoms: 1 }, full);
+        expect(full.truncated).toBe(false); // completed within budget
     });
 
     it('matches aromatic rings across differing Kekulé bond-order assignments', () => {

--- a/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
+++ b/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { ElementIndex } from '../../../model';
+import { BondType } from '../../../model/types';
 import {
     DefaultLigandMccsOptions, findMccsCliques, findMccsPairs,
     LigandGraph, LigandGraphEdge, LigandGraphVertex
@@ -17,7 +18,7 @@ import {
  * test against a real structure.
  */
 
-type Bond = [number, number, number?]; // [a, b, order = 1]
+type Bond = [number, number, number?, number?]; // [a, b, order = 1, flags = 0]
 
 function makeGraph(elements: string[], bonds: Bond[]): LigandGraph {
     const vertices: LigandGraphVertex[] = elements.map((elementSymbol, index) => ({
@@ -28,13 +29,25 @@ function makeGraph(elements: string[], bonds: Bond[]): LigandGraph {
     }));
 
     const adj: Map<number, LigandGraphEdge>[] = elements.map(() => new Map<number, LigandGraphEdge>());
-    for (const [a, b, order] of bonds) {
+    for (const [a, b, order, flags] of bonds) {
         const o = order ?? 1;
-        adj[a].set(b, { a, b, order: o, flags: 0, key: -1 });
-        adj[b].set(a, { a: b, b: a, order: o, flags: 0, key: -1 });
+        const f = flags ?? 0;
+        adj[a].set(b, { a, b, order: o, flags: f, key: -1 });
+        adj[b].set(a, { a: b, b: a, order: o, flags: f, key: -1 });
     }
 
     return { structure: undefined, unit: undefined, compId: 'LIG', residueKey: 0, vertices, adj } as unknown as LigandGraph;
+}
+
+const AR = BondType.Flag.Aromatic;
+
+/** A monocycle of `n` aromatic carbons with the given per-bond Kekulé orders (length n). */
+function aromaticRing(kekuleOrders: number[]): LigandGraph {
+    const n = kekuleOrders.length;
+    const elements = new Array<string>(n).fill('C');
+    const bonds: Bond[] = [];
+    for (let i = 0; i < n; i++) bonds.push([i, (i + 1) % n, kekuleOrders[i], AR]);
+    return makeGraph(elements, bonds);
 }
 
 /** A monocycle of `n` carbons with the given bond order. */
@@ -140,6 +153,24 @@ describe('Ligand MCCS', () => {
         const b = carbonRing(6, 1);
 
         expect(() => findMccsCliques(a, b, { maxTimeMs: 0, maxIterations: 1 })).not.toThrow();
+    });
+
+    it('matches aromatic rings across differing Kekulé bond-order assignments', () => {
+        // two benzene rings flagged aromatic but with opposite single/double placements
+        const a = aromaticRing([2, 1, 2, 1, 2, 1]);
+        const b = aromaticRing([1, 2, 1, 2, 1, 2]);
+
+        const pairs = findMccsPairs(a, b); // default edgeTest is aromatic-aware
+        expect(pairs!.length).toBe(6);
+    });
+
+    it('does not match an aromatic ring to an aliphatic ring of equal bond orders', () => {
+        // identical integer orders, but only one ring is flagged aromatic
+        const aromatic = aromaticRing([1, 1, 1, 1, 1, 1]);
+        const aliphatic = carbonRing(6, 1); // no aromatic flag
+
+        const cliques = findMccsCliques(aromatic, aliphatic);
+        expect(cliques).toHaveLength(0);
     });
 
     it('returns nothing when the overlap is below minMatchedAtoms', () => {

--- a/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
+++ b/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
@@ -4,18 +4,19 @@
  * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
  */
 
+import { IntAdjacencyGraph } from '../../../../../mol-math/graph';
 import { ElementIndex } from '../../../model';
 import { BondType } from '../../../model/types';
 import {
     DefaultLigandMccsOptions, findMccsCliques, findMccsPairs,
-    LigandGraph, LigandGraphEdge, LigandGraphVertex
+    LigandGraph, LigandGraphVertex
 } from '../superposition-ligand';
 
 /**
- * The MCCS matcher operates purely on a LigandGraph's `vertices` and `adj`, so it can be exercised
+ * The MCCS matcher operates purely on a LigandGraph's `vertices` and `bonds`, so it can be exercised
  * with hand-built graphs (no Structure/Unit needed). The subsequent superpose/RMSD step reuses the
- * already-tested `superpose`/`MinimizeRmsd` machinery and is best covered by an in-app integration
- * test against a real structure.
+ * already-tested `MinimizeRmsd` machinery and is best covered by an in-app integration test against
+ * a real structure.
  */
 
 type Bond = [number, number, number?, number?]; // [a, b, order = 1, flags = 0]
@@ -28,15 +29,19 @@ function makeGraph(elements: string[], bonds: Bond[]): LigandGraph {
         elementSymbol
     }));
 
-    const adj: Map<number, LigandGraphEdge>[] = elements.map(() => new Map<number, LigandGraphEdge>());
-    for (const [a, b, order, flags] of bonds) {
-        const o = order ?? 1;
-        const f = flags ?? 0;
-        adj[a].set(b, { a, b, order: o, flags: f, key: -1 });
-        adj[b].set(a, { a: b, b: a, order: o, flags: f, key: -1 });
+    const xs = bonds.map(e => e[0]);
+    const ys = bonds.map(e => e[1]);
+    const builder = new IntAdjacencyGraph.EdgeBuilder(elements.length, xs, ys);
+    const order = new Int32Array(builder.slotCount);
+    const flags = new Int32Array(builder.slotCount);
+    for (let i = 0; i < builder.edgeCount; i++) {
+        builder.addNextEdge();
+        builder.assignProperty(order, bonds[i][2] ?? 1);
+        builder.assignProperty(flags, bonds[i][3] ?? 0);
     }
+    const graph = builder.createGraph({ order, flags });
 
-    return { structure: undefined, unit: undefined, compId: 'LIG', residueKey: 0, vertices, adj } as unknown as LigandGraph;
+    return { structure: undefined, unit: undefined, compId: 'LIG', residueKey: 0, vertices, bonds: graph } as unknown as LigandGraph;
 }
 
 const AR = BondType.Flag.Aromatic;
@@ -65,7 +70,7 @@ function chain(elements: string[]): LigandGraph {
     return makeGraph(elements, bonds);
 }
 
-const strictBondOrder = (a: LigandGraphEdge, b: LigandGraphEdge) => (a.order | 0) === (b.order | 0);
+const strictBondOrder = (orderA: number, flagsA: number, orderB: number, flagsB: number) => (orderA | 0) === (orderB | 0);
 
 describe('Ligand MCCS', () => {
     it('benzene vs toluene: ring MCCS of size 6', () => {

--- a/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
+++ b/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
+ */
+
+import { ElementIndex } from '../../../model';
+import {
+    DefaultLigandMccsOptions, findMccsCliques, findMccsPairs,
+    LigandGraph, LigandGraphEdge, LigandGraphVertex
+} from '../superposition-ligand';
+
+/**
+ * The MCCS matcher operates purely on a LigandGraph's `vertices` and `adj`, so it can be exercised
+ * with hand-built graphs (no Structure/Unit needed). The subsequent superpose/RMSD step reuses the
+ * already-tested `superpose`/`MinimizeRmsd` machinery and is best covered by an in-app integration
+ * test against a real structure.
+ */
+
+type Bond = [number, number, number?]; // [a, b, order = 1]
+
+function makeGraph(elements: string[], bonds: Bond[]): LigandGraph {
+    const vertices: LigandGraphVertex[] = elements.map((elementSymbol, index) => ({
+        index,
+        element: index as unknown as ElementIndex,
+        atomName: `${elementSymbol}${index}`,
+        elementSymbol
+    }));
+
+    const adj: Map<number, LigandGraphEdge>[] = elements.map(() => new Map<number, LigandGraphEdge>());
+    for (const [a, b, order] of bonds) {
+        const o = order ?? 1;
+        adj[a].set(b, { a, b, order: o, flags: 0, key: -1 });
+        adj[b].set(a, { a: b, b: a, order: o, flags: 0, key: -1 });
+    }
+
+    return { structure: undefined, unit: undefined, compId: 'LIG', residueKey: 0, vertices, adj } as unknown as LigandGraph;
+}
+
+/** A monocycle of `n` carbons with the given bond order. */
+function carbonRing(n: number, order: number): LigandGraph {
+    const elements = new Array<string>(n).fill('C');
+    const bonds: Bond[] = [];
+    for (let i = 0; i < n; i++) bonds.push([i, (i + 1) % n, order]);
+    return makeGraph(elements, bonds);
+}
+
+/** A linear chain of the given element symbols (single bonds). */
+function chain(elements: string[]): LigandGraph {
+    const bonds: Bond[] = [];
+    for (let i = 0; i + 1 < elements.length; i++) bonds.push([i, i + 1]);
+    return makeGraph(elements, bonds);
+}
+
+const strictBondOrder = (a: LigandGraphEdge, b: LigandGraphEdge) => (a.order | 0) === (b.order | 0);
+
+describe('Ligand MCCS', () => {
+    it('benzene vs toluene: ring MCCS of size 6', () => {
+        const benzene = carbonRing(6, 1);
+        const toluene = makeGraph(
+            ['C', 'C', 'C', 'C', 'C', 'C', 'C'],
+            [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0], [0, 6]]
+        );
+
+        const pairs = findMccsPairs(benzene, toluene);
+        expect(pairs).toBeDefined();
+        expect(pairs!.length).toBe(6);
+    });
+
+    it('benzene vs cyclohexane: no MCCS when bond orders must match (aromatic vs aliphatic)', () => {
+        const benzene = carbonRing(6, 2); // stand-in for aromatic
+        const cyclohexane = carbonRing(6, 1);
+
+        const cliques = findMccsCliques(benzene, cyclohexane, {
+            vertexTest: (a, b) => a.elementSymbol === b.elementSymbol,
+            edgeTest: strictBondOrder
+        });
+        // no c-edges survive the bond-order test, so the only c-connected cliques are singletons
+        expect(cliques).toHaveLength(0);
+    });
+
+    it('identical benzene: full ring match with symmetry-related candidates', () => {
+        const a = carbonRing(6, 1);
+        const b = carbonRing(6, 1);
+
+        const cliques = findMccsCliques(a, b);
+        expect(cliques.length).toBeGreaterThan(1); // ring symmetry -> several equally-sized mappings
+        expect(cliques[0]).toHaveLength(6);
+    });
+
+    it('linear chain C-C-C-O matches itself fully', () => {
+        const a = chain(['C', 'C', 'C', 'O']);
+        const b = chain(['C', 'C', 'C', 'O']);
+
+        const pairs = findMccsPairs(a, b);
+        expect(pairs!.length).toBe(4);
+    });
+
+    it('element mismatch trims the correspondence (C-C-C-N vs C-C-C-O)', () => {
+        const a = chain(['C', 'C', 'C', 'N']);
+        const b = chain(['C', 'C', 'C', 'O']);
+
+        const pairs = findMccsPairs(a, b);
+        expect(pairs!.length).toBe(3); // shared C-C-C backbone; terminal N/O are incompatible
+    });
+
+    it('pathCutoff 0 disables d-edges, collapsing a ring to a single bond', () => {
+        const a = carbonRing(6, 1);
+        const b = carbonRing(6, 1);
+
+        const cliques = findMccsCliques(a, b, { pathCutoff: 0, minMatchedAtoms: 1 });
+        // without d-edges a clique must be a complete subgraph; a 6-cycle has no triangle
+        expect(cliques[0]).toHaveLength(2);
+    });
+
+    it('does not bridge disconnected fragments (connected-only)', () => {
+        // two separate C-C dimers in each graph
+        const a = makeGraph(['C', 'C', 'C', 'C'], [[0, 1], [2, 3]]);
+        const b = makeGraph(['C', 'C', 'C', 'C'], [[0, 1], [2, 3]]);
+
+        const cliques = findMccsCliques(a, b, { minMatchedAtoms: 1 });
+        // cross-fragment pairs are unreachable -> no d-edges across the gap -> max connected match is one dimer
+        expect(cliques[0]).toHaveLength(2);
+    });
+
+    it('is deterministic across runs', () => {
+        const a = carbonRing(6, 1);
+        const toluene = makeGraph(
+            ['C', 'C', 'C', 'C', 'C', 'C', 'C'],
+            [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0], [0, 6]]
+        );
+
+        const first = JSON.stringify(findMccsPairs(a, toluene));
+        const second = JSON.stringify(findMccsPairs(a, toluene));
+        expect(first).toEqual(second);
+    });
+
+    it('honors a tiny search budget without throwing', () => {
+        const a = carbonRing(6, 1);
+        const b = carbonRing(6, 1);
+
+        expect(() => findMccsCliques(a, b, { maxTimeMs: 0, maxIterations: 1 })).not.toThrow();
+    });
+
+    it('returns nothing when the overlap is below minMatchedAtoms', () => {
+        const a = chain(['C', 'O']); // only 2 atoms
+        const b = chain(['C', 'O']);
+
+        expect(findMccsPairs(a, b, { minMatchedAtoms: 3 })).toBeUndefined();
+        expect(DefaultLigandMccsOptions.minMatchedAtoms).toBe(3);
+    });
+});

--- a/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
+++ b/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
@@ -20,7 +20,7 @@ import {
  * already-tested MinimizeRmsd machinery and is best covered by an in-app integration test.
  */
 
-type Bond = [number, number, number?, number?]; // [a, b, order = 1, flags = 0]
+type Bond = [a: number, b: number, order?: number, flags?: number];
 
 function makeGraph(elements: string[], bonds: Bond[]): LigandGraph {
     const vertices: LigandGraphVertex[] = elements.map((elementSymbol, index) => ({

--- a/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
+++ b/src/mol-model/structure/structure/util/_spec/superposition-ligand.spec.ts
@@ -13,10 +13,11 @@ import {
 } from '../superposition-ligand';
 
 /**
- * The MCCS matcher operates purely on a LigandGraph's `vertices` and `bonds`, so it can be exercised
- * with hand-built graphs (no Structure/Unit needed). The subsequent superpose/RMSD step reuses the
- * already-tested `MinimizeRmsd` machinery and is best covered by an in-app integration test against
- * a real structure.
+ * These cover the ligand-domain layer: the default vertex/edge tests (element identity, aromatic-aware
+ * bond matching), hydrogen skipping, and the atom-count gate. The generic graph algorithm underneath
+ * (connectivity, symmetry, d-edges, budget/truncation) is tested in mol-math/graph/_spec/mccs.spec.ts.
+ * Graphs are hand-built LigandGraphs (no Structure/Unit needed); the RMSD/superpose step reuses the
+ * already-tested MinimizeRmsd machinery and is best covered by an in-app integration test.
  */
 
 type Bond = [number, number, number?, number?]; // [a, b, order = 1, flags = 0]
@@ -55,7 +56,7 @@ function aromaticRing(kekuleOrders: number[]): LigandGraph {
     return makeGraph(elements, bonds);
 }
 
-/** A monocycle of `n` carbons with the given bond order. */
+/** A monocycle of `n` carbons with the given bond order (not aromatic-flagged). */
 function carbonRing(n: number, order: number): LigandGraph {
     const elements = new Array<string>(n).fill('C');
     const bonds: Bond[] = [];
@@ -70,10 +71,8 @@ function chain(elements: string[]): LigandGraph {
     return makeGraph(elements, bonds);
 }
 
-const strictBondOrder = (orderA: number, flagsA: number, orderB: number, flagsB: number) => (orderA | 0) === (orderB | 0);
-
 describe('Ligand MCCS', () => {
-    it('benzene vs toluene: ring MCCS of size 6', () => {
+    it('matches a shared ring (benzene vs toluene) via the default options', () => {
         const benzene = carbonRing(6, 1);
         const toluene = makeGraph(
             ['C', 'C', 'C', 'C', 'C', 'C', 'C'],
@@ -85,103 +84,35 @@ describe('Ligand MCCS', () => {
         expect(pairs!.length).toBe(6);
     });
 
-    it('benzene vs cyclohexane: no MCCS when bond orders must match (aromatic vs aliphatic)', () => {
-        const benzene = carbonRing(6, 2); // stand-in for aromatic
-        const cyclohexane = carbonRing(6, 1);
-
-        const cliques = findMccsCliques(benzene, cyclohexane, {
-            vertexTest: (a, b) => a.elementSymbol === b.elementSymbol,
-            edgeTest: strictBondOrder
-        });
-        // no c-edges survive the bond-order test, so the only c-connected cliques are singletons
-        expect(cliques).toHaveLength(0);
-    });
-
-    it('identical benzene: full ring match with symmetry-related candidates', () => {
-        const a = carbonRing(6, 1);
-        const b = carbonRing(6, 1);
-
-        const cliques = findMccsCliques(a, b);
-        expect(cliques.length).toBeGreaterThan(1); // ring symmetry -> several equally-sized mappings
-        expect(cliques[0]).toHaveLength(6);
-    });
-
-    it('linear chain C-C-C-O matches itself fully', () => {
-        const a = chain(['C', 'C', 'C', 'O']);
-        const b = chain(['C', 'C', 'C', 'O']);
-
-        const pairs = findMccsPairs(a, b);
-        expect(pairs!.length).toBe(4);
-    });
-
-    it('element mismatch trims the correspondence (C-C-C-N vs C-C-C-O)', () => {
+    it('default vertex test is element identity (C-C-C-N vs C-C-C-O trims to the shared backbone)', () => {
         const a = chain(['C', 'C', 'C', 'N']);
         const b = chain(['C', 'C', 'C', 'O']);
 
         const pairs = findMccsPairs(a, b);
-        expect(pairs!.length).toBe(3); // shared C-C-C backbone; terminal N/O are incompatible
+        expect(pairs!.length).toBe(3); // shared C-C-C; terminal N/O are different elements
     });
 
-    it('pathCutoff 0 disables d-edges, collapsing a ring to a single bond', () => {
-        const a = carbonRing(6, 1);
-        const b = carbonRing(6, 1);
-
-        const cliques = findMccsCliques(a, b, { pathCutoff: 0, minMatchedAtoms: 1 });
-        // without d-edges a clique must be a complete subgraph; a 6-cycle has no triangle
-        expect(cliques[0]).toHaveLength(2);
-    });
-
-    it('does not bridge disconnected fragments (connected-only)', () => {
-        // two separate C-C dimers in each graph
-        const a = makeGraph(['C', 'C', 'C', 'C'], [[0, 1], [2, 3]]);
-        const b = makeGraph(['C', 'C', 'C', 'C'], [[0, 1], [2, 3]]);
-
-        const cliques = findMccsCliques(a, b, { minMatchedAtoms: 1 });
-        // cross-fragment pairs are unreachable -> no d-edges across the gap -> max connected match is one dimer
-        expect(cliques[0]).toHaveLength(2);
-    });
-
-    it('is deterministic across runs', () => {
-        const a = carbonRing(6, 1);
-        const toluene = makeGraph(
-            ['C', 'C', 'C', 'C', 'C', 'C', 'C'],
-            [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [5, 0], [0, 6]]
-        );
-
-        const first = JSON.stringify(findMccsPairs(a, toluene));
-        const second = JSON.stringify(findMccsPairs(a, toluene));
-        expect(first).toEqual(second);
-    });
-
-    it('honors a tiny search budget without throwing, and reports truncation via status', () => {
-        const a = carbonRing(6, 1);
-        const b = carbonRing(6, 1);
-
-        const clipped = { truncated: false };
-        expect(() => findMccsCliques(a, b, { maxIterations: 1, minMatchedAtoms: 1 }, clipped)).not.toThrow();
-        expect(clipped.truncated).toBe(true); // budget hit -> best-so-far
-
-        const full = { truncated: false };
-        findMccsCliques(a, b, { minMatchedAtoms: 1 }, full);
-        expect(full.truncated).toBe(false); // completed within budget
-    });
-
-    it('matches aromatic rings across differing Kekulé bond-order assignments', () => {
+    it('default edge test matches aromatic rings across differing Kekulé assignments', () => {
         // two benzene rings flagged aromatic but with opposite single/double placements
         const a = aromaticRing([2, 1, 2, 1, 2, 1]);
         const b = aromaticRing([1, 2, 1, 2, 1, 2]);
 
-        const pairs = findMccsPairs(a, b); // default edgeTest is aromatic-aware
-        expect(pairs!.length).toBe(6);
+        expect(findMccsPairs(a, b)!.length).toBe(6);
     });
 
-    it('does not match an aromatic ring to an aliphatic ring of equal bond orders', () => {
-        // identical integer orders, but only one ring is flagged aromatic
-        const aromatic = aromaticRing([1, 1, 1, 1, 1, 1]);
-        const aliphatic = carbonRing(6, 1); // no aromatic flag
+    it('default edge test does not match an aromatic ring to an aliphatic ring of equal bond orders', () => {
+        const aromatic = aromaticRing([1, 1, 1, 1, 1, 1]); // flagged aromatic
+        const aliphatic = carbonRing(6, 1); // same integer orders, not aromatic
 
-        const cliques = findMccsCliques(aromatic, aliphatic);
-        expect(cliques).toHaveLength(0);
+        expect(findMccsCliques(aromatic, aliphatic)).toHaveLength(0);
+    });
+
+    it('ignoreHydrogens (default) excludes hydrogens from the correspondence', () => {
+        const a = makeGraph(['C', 'C', 'H'], [[0, 1], [1, 2]]);
+        const b = makeGraph(['C', 'C', 'H'], [[0, 1], [1, 2]]);
+
+        expect(findMccsPairs(a, b, { minMatchedAtoms: 1 })!.length).toBe(2); // H skipped
+        expect(findMccsPairs(a, b, { minMatchedAtoms: 1, ignoreHydrogens: false })!.length).toBe(3); // H included
     });
 
     it('returns nothing when the overlap is below minMatchedAtoms', () => {

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -6,6 +6,7 @@
 
 import { OrderedSet, SortedArray } from '../../../../mol-data/int';
 import { ElementIndex } from '../../model';
+import { BondType } from '../../model/types';
 import { Mat4 } from '../../../../mol-math/linear-algebra';
 import { RuntimeContext } from '../../../../mol-task';
 import { Structure, StructureElement, StructureProperties, Unit } from '../../structure';
@@ -71,6 +72,11 @@ export interface LigandMccsOptions {
 export const DefaultLigandMccsOptions: LigandMccsOptions = {
     vertexTest: (a, b) => a.elementSymbol === b.elementSymbol,
     edgeTest: (a, b) => {
+        // aromatic bonds match each other regardless of the (arbitrary) Kekulé order the CCD assigns,
+        // but an aromatic bond is not compatible with an aliphatic one
+        const aArom = (a.flags & BondType.Flag.Aromatic) !== 0;
+        const bArom = (b.flags & BondType.Flag.Aromatic) !== 0;
+        if (aArom || bArom) return aArom === bArom;
         // unknown/0 bond orders are treated as compatible
         const ao = a.order | 0, bo = b.order | 0;
         if (ao > 0 && bo > 0) return ao === bo;
@@ -141,18 +147,22 @@ export function buildLigandGraphFromLoci(loci: StructureElement.Loci): LigandGra
     }
 
     indices.sort((a, b) => a - b);
-    const vertices: LigandGraphVertex[] = indices.map((uIdx, i) => {
-        loc.element = uIdx;
+
+    // intra-unit bonds are keyed by unit-local UnitIndex, not the global ElementIndex, so track both
+    const unitIndices: number[] = new Array(indices.length);
+    const unitIndexToVertex = new Map<number, number>();
+    const vertices: LigandGraphVertex[] = indices.map((el, i) => {
+        loc.element = el;
+        const uIndex = SortedArray.indexOf(unit.elements, el);
+        unitIndices[i] = uIndex;
+        unitIndexToVertex.set(uIndex, i);
         return {
             index: i,
-            element: uIdx,
+            element: el,
             atomName: StructureProperties.atom.label_atom_id(loc),
             elementSymbol: StructureProperties.atom.type_symbol(loc)
         };
     });
-
-    const mapElToV = new Map<number, number>();
-    for (let i = 0; i < vertices.length; i++) mapElToV.set(vertices[i].element, i);
 
     const adj: Map<number, LigandGraphEdge>[] = [];
     for (let i = 0; i < vertices.length; i++) adj.push(new Map());
@@ -161,14 +171,13 @@ export function buildLigandGraphFromLoci(loci: StructureElement.Loci): LigandGra
     const { order, flags, key } = edgeProps;
 
     for (let vi = 0; vi < vertices.length; vi++) {
-        const aEl = vertices[vi].element;
-        const start = offset[aEl];
-        const end = offset[aEl + 1];
+        const uIndex = unitIndices[vi];
+        const start = offset[uIndex];
+        const end = offset[uIndex + 1];
 
         for (let ei = start; ei < end; ei++) {
-            const bEl = b[ei];
-            const vj = mapElToV.get(bEl);
-            if (vj === void 0) continue;
+            const vj = unitIndexToVertex.get(b[ei]); // b[ei] is a UnitIndex
+            if (vj === void 0) continue; // neighbor outside the selected ligand
 
             const edge: LigandGraphEdge = {
                 a: vi,

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -8,9 +8,9 @@ import { SortedArray } from '../../../../mol-data/int';
 import { ElementIndex } from '../../model';
 import { BondType } from '../../model/types';
 import { IntAdjacencyGraph } from '../../../../mol-math/graph';
+import { Mccs } from '../../../../mol-math/graph/mccs';
 import { Mat4 } from '../../../../mol-math/linear-algebra';
 import { MinimizeRmsd, RmsdTransformState } from '../../../../mol-math/linear-algebra/3d/minimize-rmsd';
-import { BitSet } from '../../../../mol-util/bit-set';
 import { Structure, StructureElement, StructureProperties, Unit } from '../../structure';
 
 /**
@@ -237,236 +237,9 @@ export function matchLigandsByAtomName(a: LigandGraph, b: LigandGraph): Array<[n
     return pairs;
 }
 
-/** LIFO pool of fixed-size BitSets so the (heavily recursive) clique search does not allocate per call. */
-class BitSetPool {
-    private readonly free: BitSet[] = [];
-    constructor(private readonly nbits: number) {}
-    acquire(): BitSet {
-        const b = this.free.pop();
-        return b !== void 0 ? b : new BitSet(this.nbits);
-    }
-    acquireCopy(src: BitSet): BitSet {
-        const b = this.acquire();
-        b.words.set(src.words);
-        return b;
-    }
-    release(b: BitSet) { this.free.push(b); }
-}
-
-/**
- * Compatibility (modular product) graph. Vertices are atom pairs (pairA[k] in A, pairB[k] in B)
- * that pass the vertex test. Two vertices are joined by a c-edge when their atoms are bonded in
- * both ligands with compatible bonds, or by a d-edge when they are non-bonded in both with similar
- * topological distance. A c-connected clique of this graph is a connected common substructure.
- */
-interface CompatGraph {
-    readonly n: number;
-    readonly pairA: Int32Array;
-    readonly pairB: Int32Array;
-    readonly adj: BitSet[]; // c-edges and d-edges
-    readonly cadj: BitSet[]; // c-edges only
-}
-
 function isHydrogenVertex(v: LigandGraphVertex): boolean {
     const s = v.elementSymbol.toUpperCase();
     return s === 'H' || s === 'D';
-}
-
-/** BFS all-pairs shortest paths (edge count) within a ligand graph; -1 marks unreachable. */
-function ligandShortestPaths(g: LigandGraph): Int32Array[] {
-    const n = g.vertices.length;
-    const { offset, b } = g.bonds;
-    const dist: Int32Array[] = new Array(n);
-    const queue = new Int32Array(n);
-    for (let s = 0; s < n; s++) {
-        const d = new Int32Array(n).fill(-1);
-        let head = 0, tail = 0;
-        queue[tail++] = s;
-        d[s] = 0;
-        while (head < tail) {
-            const u = queue[head++];
-            const du = d[u];
-            for (let t = offset[u], end = offset[u + 1]; t < end; t++) {
-                const w = b[t];
-                if (d[w] < 0) { d[w] = du + 1; queue[tail++] = w; }
-            }
-        }
-        dist[s] = d;
-    }
-    return dist;
-}
-
-function buildCompatGraph(a: LigandGraph, b: LigandGraph, opts: LigandMccsOptions): CompatGraph {
-    const nA = a.vertices.length, nB = b.vertices.length;
-    const ignoreH = opts.ignoreHydrogens;
-
-    const pa: number[] = [], pb: number[] = [];
-    for (let i = 0; i < nA; i++) {
-        if (ignoreH && isHydrogenVertex(a.vertices[i])) continue;
-        for (let j = 0; j < nB; j++) {
-            if (ignoreH && isHydrogenVertex(b.vertices[j])) continue;
-            if (opts.vertexTest(a.vertices[i], b.vertices[j])) { pa.push(i); pb.push(j); }
-        }
-    }
-
-    const n = pa.length;
-    const pairA = Int32Array.from(pa);
-    const pairB = Int32Array.from(pb);
-
-    const adj: BitSet[] = new Array(n);
-    const cadj: BitSet[] = new Array(n);
-    for (let i = 0; i < n; i++) { adj[i] = new BitSet(n); cadj[i] = new BitSet(n); }
-
-    const useD = opts.pathCutoff > 0;
-    const distA = useD ? ligandShortestPaths(a) : undefined;
-    const distB = useD ? ligandShortestPaths(b) : undefined;
-
-    const aBonds = a.bonds, bBonds = b.bonds;
-    const aOrder = aBonds.edgeProps.order, aFlags = aBonds.edgeProps.flags;
-    const bOrder = bBonds.edgeProps.order, bFlags = bBonds.edgeProps.flags;
-
-    for (let i = 0; i < n; i++) {
-        const ai = pairA[i], bi = pairB[i];
-        for (let j = i + 1; j < n; j++) {
-            const aj = pairA[j], bj = pairB[j];
-
-            // 1:1 constraint: a given atom may not be matched twice within one clique
-            if (ai === aj || bi === bj) continue;
-
-            const eaIdx = aBonds.getDirectedEdgeIndex(ai, aj);
-            const ebIdx = bBonds.getDirectedEdgeIndex(bi, bj);
-            const adjA = eaIdx >= 0;
-            const adjB = ebIdx >= 0;
-
-            let cEdge = false;
-            if (adjA && adjB) cEdge = opts.edgeTest(aOrder[eaIdx], aFlags[eaIdx], bOrder[ebIdx], bFlags[ebIdx]);
-
-            let dEdge = false;
-            if (!cEdge && useD && !adjA && !adjB) {
-                const dA = distA![ai][aj];
-                const dB = distB![bi][bj];
-                if (dA >= 0 && dB >= 0 && Math.abs(dA - dB) <= opts.pathCutoff) dEdge = true;
-            }
-
-            if (cEdge || dEdge) {
-                adj[i].set(j); adj[j].set(i);
-                if (cEdge) { cadj[i].set(j); cadj[j].set(i); }
-            }
-        }
-    }
-
-    return { n, pairA, pairB, adj, cadj };
-}
-
-/** Retains every maximum-size clique encountered (up to a cap) for downstream RMSD pose selection. */
-class CliqueCollector {
-    bestSize = 0;
-    cliques: number[][] = [];
-    private readonly cap: number;
-    constructor(cap: number) { this.cap = Math.max(1, cap); }
-    offer(clique: number[]) {
-        const size = clique.length;
-        if (size < this.bestSize) return;
-        if (size > this.bestSize) { this.bestSize = size; this.cliques = [clique]; return; }
-        if (this.cliques.length < this.cap) this.cliques.push(clique);
-    }
-}
-
-/**
- * Enumerate maximal c-connected cliques of the compatibility graph (Koch's connected-clique variant
- * of Bron-Kerbosch). c-edges keep the match a single connected fragment; d-edges may appear inside a
- * clique but never seed connectivity. Bounded by a wall-clock and a recursion-step budget.
- */
-/** Returns true if the search stopped on its time/iteration budget (the result is a best-so-far, not proven maximal). */
-function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, collector: CliqueCollector): boolean {
-    const n = g.n;
-    if (n === 0) return false;
-
-    const minK = Math.max(1, opts.minMatchedAtoms);
-    const adj = g.adj, cadj = g.cadj;
-
-    const dAdj: BitSet[] = new Array(n);
-    for (let i = 0; i < n; i++) { const d = adj[i].clone(); d.andNot(cadj[i]); dAdj[i] = d; }
-
-    const all = BitSet.full(n);
-    const t = new BitSet(n); // already-processed seeds, so each maximal clique is found once
-    const pool = new BitSetPool(n);
-
-    const deadline = Date.now() + opts.maxTimeMs;
-    const maxIter = opts.maxIterations;
-    let iters = 0;
-    let aborted = false;
-
-    const checkAbort = () => {
-        if (aborted) return true;
-        if ((maxIter > 0 && iters > maxIter) || Date.now() > deadline) { aborted = true; return true; }
-        return false;
-    };
-
-    const cClique = (R: BitSet, P: BitSet, Q: BitSet, X: BitSet, Y: BitSet) => {
-        if (checkAbort()) return;
-        iters++;
-
-        if (P.isEmpty() && X.isEmpty()) {
-            const size = R.cardinality();
-            if (size >= minK) {
-                const clique: number[] = new Array(size);
-                let idx = 0;
-                for (let v = R.nextSetBit(0); v >= 0; v = R.nextSetBit(v + 1)) clique[idx++] = v;
-                collector.offer(clique);
-            }
-            return;
-        }
-
-        // scratch sets are drawn from a pool and returned at the end of each iteration/frame
-        const pIter = pool.acquireCopy(P);
-        for (let ui = pIter.nextSetBit(0); ui >= 0; ui = pIter.nextSetBit(ui + 1)) {
-            P.clear(ui);
-
-            const dN = dAdj[ui], cN = cadj[ui], neigh = adj[ui];
-
-            const rNew = pool.acquireCopy(R); rNew.set(ui);
-            const qNew = pool.acquireCopy(Q); qNew.and(dN);
-            const yNew = pool.acquireCopy(Y); yNew.and(dN);
-            const pNew = pool.acquireCopy(P); pNew.and(neigh);
-            const xNew = pool.acquireCopy(X); xNew.and(neigh);
-            const tmp = pool.acquireCopy(Q); tmp.and(cN); pNew.or(tmp); // P' = (P ∩ neigh) ∪ (Q ∩ cN)
-            tmp.words.set(Y.words); tmp.and(cN); xNew.or(tmp); // X' = (X ∩ neigh) ∪ (Y ∩ cN)
-            pool.release(tmp);
-
-            cClique(rNew, pNew, qNew, xNew, yNew);
-
-            pool.release(xNew); pool.release(pNew); pool.release(yNew); pool.release(qNew); pool.release(rNew);
-
-            X.set(ui);
-            if (checkAbort()) break;
-        }
-        pool.release(pIter);
-    };
-
-    for (let ui = 0; ui < n; ui++) {
-        const dN = dAdj[ui], cN = cadj[ui];
-
-        const r = pool.acquire(); r.zero(); r.set(ui);
-        const q = pool.acquireCopy(all); q.andNot(t); q.and(dN);
-        const p = pool.acquireCopy(all); p.andNot(t); p.and(cN);
-        const y = pool.acquireCopy(dN); y.and(t);
-        const x = pool.acquireCopy(cN); x.and(t);
-
-        cClique(r, p, q, x, y);
-
-        pool.release(x); pool.release(y); pool.release(p); pool.release(q); pool.release(r);
-
-        t.set(ui);
-        if (checkAbort()) break;
-    }
-    return aborted;
-}
-
-function cliqueToPairs(g: CompatGraph, clique: number[]): Array<[number, number]> {
-    const pairs: Array<[number, number]> = clique.map(ci => [g.pairA[ci], g.pairB[ci]] as [number, number]);
-    pairs.sort((p, q) => p[0] - q[0]);
-    return pairs;
 }
 
 /** Optional out-parameter reporting whether the MCCS search hit its time/iteration budget. */
@@ -484,15 +257,25 @@ export interface LigandMccsStatus {
  */
 export function findMccsCliques(a: LigandGraph, b: LigandGraph, options: Partial<LigandMccsOptions> = {}, status?: LigandMccsStatus): Array<Array<[number, number]>> {
     const opts: LigandMccsOptions = { ...DefaultLigandMccsOptions, ...options };
-    const g = buildCompatGraph(a, b, opts);
-    if (g.n === 0) return [];
 
-    const collector = new CliqueCollector(opts.maxCliquesForPose);
-    const truncated = enumerateConnectedCliques(g, opts, collector);
-    if (status) status.truncated = truncated;
-    if (collector.bestSize < opts.minMatchedAtoms) return [];
+    // adapt the ligand-domain options to the generic MCCS predicates: fold hydrogen skipping + the
+    // element-based vertex test into vertexTest(i, j), and read bond order/flags for edgeTest(ea, eb)
+    const ignoreH = opts.ignoreHydrogens;
+    const aOrder = a.bonds.edgeProps.order, aFlags = a.bonds.edgeProps.flags;
+    const bOrder = b.bonds.edgeProps.order, bFlags = b.bonds.edgeProps.flags;
 
-    return collector.cliques.map(clique => cliqueToPairs(g, clique));
+    return Mccs.find(a.bonds, b.bonds, {
+        vertexTest: (ia, ib) => {
+            if (ignoreH && (isHydrogenVertex(a.vertices[ia]) || isHydrogenVertex(b.vertices[ib]))) return false;
+            return opts.vertexTest(a.vertices[ia], b.vertices[ib]);
+        },
+        edgeTest: (ea, eb) => opts.edgeTest(aOrder[ea], aFlags[ea], bOrder[eb], bFlags[eb]),
+        pathCutoff: opts.pathCutoff,
+        maxTimeMs: opts.maxTimeMs,
+        maxIterations: opts.maxIterations,
+        minMatchedVertices: opts.minMatchedAtoms,
+        maxCliques: opts.maxCliquesForPose
+    }, status);
 }
 
 /** Convenience wrapper returning a single (the first) maximum MCCS correspondence. */

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -4,14 +4,14 @@
  * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
  */
 
-import { OrderedSet, SortedArray } from '../../../../mol-data/int';
+import { SortedArray } from '../../../../mol-data/int';
 import { ElementIndex } from '../../model';
 import { BondType } from '../../model/types';
+import { IntAdjacencyGraph } from '../../../../mol-math/graph';
 import { Mat4 } from '../../../../mol-math/linear-algebra';
+import { MinimizeRmsd, RmsdTransformState } from '../../../../mol-math/linear-algebra/3d/minimize-rmsd';
 import { RuntimeContext } from '../../../../mol-task';
 import { Structure, StructureElement, StructureProperties, Unit } from '../../structure';
-import { superpose } from './superposition';
-import { UnitIndex } from '../element/util';
 
 /**
  * Ligand MCCS utilities:
@@ -25,13 +25,11 @@ export interface LigandGraphVertex {
     readonly elementSymbol: string;
 }
 
-export interface LigandGraphEdge {
-    readonly a: number;
-    readonly b: number;
-    readonly order: number;
-    readonly flags: number;
-    readonly key: number;
-}
+/** Bond order and BondType flags, stored as parallel per-edge arrays on the adjacency graph. */
+export type LigandBondProps = { readonly order: ArrayLike<number>, readonly flags: ArrayLike<number> };
+
+/** Local-vertex-indexed adjacency of one ligand residue (an induced subgraph of `unit.bonds`). */
+export type LigandBondGraph = IntAdjacencyGraph<number, LigandBondProps>;
 
 export interface LigandGraph {
     readonly structure: Structure;
@@ -39,11 +37,11 @@ export interface LigandGraph {
     readonly compId: string;
     readonly residueKey: number;
     readonly vertices: readonly LigandGraphVertex[];
-    readonly adj: readonly Map<number, LigandGraphEdge>[];
+    readonly bonds: LigandBondGraph;
 }
 
 export type LigandMccsVertexTest = (a: LigandGraphVertex, b: LigandGraphVertex) => boolean;
-export type LigandMccsEdgeTest = (a: LigandGraphEdge, b: LigandGraphEdge) => boolean;
+export type LigandMccsEdgeTest = (orderA: number, flagsA: number, orderB: number, flagsB: number) => boolean;
 
 export interface LigandMccsOptions {
     /** Whether atom i of A may be paired with atom j of B (default: same element symbol). */
@@ -71,14 +69,14 @@ export interface LigandMccsOptions {
 
 export const DefaultLigandMccsOptions: LigandMccsOptions = {
     vertexTest: (a, b) => a.elementSymbol === b.elementSymbol,
-    edgeTest: (a, b) => {
+    edgeTest: (orderA, flagsA, orderB, flagsB) => {
         // aromatic bonds match each other regardless of the (arbitrary) Kekulé order the CCD assigns,
         // but an aromatic bond is not compatible with an aliphatic one
-        const aArom = (a.flags & BondType.Flag.Aromatic) !== 0;
-        const bArom = (b.flags & BondType.Flag.Aromatic) !== 0;
+        const aArom = (flagsA & BondType.Flag.Aromatic) !== 0;
+        const bArom = (flagsB & BondType.Flag.Aromatic) !== 0;
         if (aArom || bArom) return aArom === bArom;
         // unknown/0 bond orders are treated as compatible
-        const ao = a.order | 0, bo = b.order | 0;
+        const ao = orderA | 0, bo = orderB | 0;
         if (ao > 0 && bo > 0) return ao === bo;
         return true;
     },
@@ -164,47 +162,32 @@ export function buildLigandGraphFromLoci(loci: StructureElement.Loci): LigandGra
         };
     });
 
-    const adj: Map<number, LigandGraphEdge>[] = [];
-    for (let i = 0; i < vertices.length; i++) adj.push(new Map());
-
+    // collect the ligand's intra-residue bonds as local-vertex edge pairs (each undirected edge once)
     const { offset, b, edgeProps } = unit.bonds;
-    const { order, flags, key } = edgeProps;
+    const srcOrder = edgeProps.order, srcFlags = edgeProps.flags;
 
+    const xs: number[] = [], ys: number[] = [], orders: number[] = [], flags: number[] = [];
     for (let vi = 0; vi < vertices.length; vi++) {
         const uIndex = unitIndices[vi];
-        const start = offset[uIndex];
-        const end = offset[uIndex + 1];
-
-        for (let ei = start; ei < end; ei++) {
+        for (let ei = offset[uIndex], end = offset[uIndex + 1]; ei < end; ei++) {
             const vj = unitIndexToVertex.get(b[ei]); // b[ei] is a UnitIndex
-            if (vj === void 0) continue; // neighbor outside the selected ligand
-
-            const edge: LigandGraphEdge = {
-                a: vi,
-                b: vj,
-                order: order[ei],
-                flags: flags[ei],
-                key: key ? key[ei] : -1
-            };
-
-            if (!adj[vi].has(vj)) adj[vi].set(vj, edge);
-            if (!adj[vj].has(vi)) adj[vj].set(vi, { ...edge, a: vj, b: vi });
+            if (vj === void 0 || vj <= vi) continue; // neighbor outside the ligand, or already added (vj < vi)
+            xs.push(vi); ys.push(vj);
+            orders.push(srcOrder[ei]); flags.push(srcFlags[ei]);
         }
     }
 
-    return { structure: loci.structure, unit, compId, residueKey, vertices, adj };
-}
-
-function lociFromVertexOrder(graph: LigandGraph, vertexOrder: readonly number[]): StructureElement.Loci {
-    // one element per atom so the A/B atom correspondence (and thus the RMSD pairing) is preserved
-    // in order; grouping all indices into a single OrderedSet would re-sort them and break it
-    const elements: StructureElement.Loci['elements'][0][] = [];
-    for (let i = 0; i < vertexOrder.length; i++) {
-        const v = graph.vertices[vertexOrder[i]];
-        const uIdx = SortedArray.indexOf(graph.unit.elements, v.element) as UnitIndex;
-        elements.push({ unit: graph.unit, indices: OrderedSet.ofSingleton(uIdx) });
+    const builder = new IntAdjacencyGraph.EdgeBuilder(vertices.length, xs, ys);
+    const order = new Int32Array(builder.slotCount);
+    const flag = new Int32Array(builder.slotCount);
+    for (let i = 0; i < builder.edgeCount; i++) {
+        builder.addNextEdge();
+        builder.assignProperty(order, orders[i]);
+        builder.assignProperty(flag, flags[i]);
     }
-    return StructureElement.Loci(graph.structure, elements);
+    const bonds = builder.createGraph({ order, flags: flag });
+
+    return { structure: loci.structure, unit, compId, residueKey, vertices, bonds };
 }
 
 /** Fast path: same compId -> match by atom name (preferring same element symbol). */
@@ -278,6 +261,8 @@ class BitSet {
         return b;
     }
 
+    zero() { this.words.fill(0); }
+
     set(i: number) { this.words[i >>> 5] |= (1 << (i & 31)); }
     clear(i: number) { this.words[i >>> 5] &= ~(1 << (i & 31)); }
     get(i: number): boolean { return (this.words[i >>> 5] & (1 << (i & 31))) !== 0; }
@@ -322,6 +307,22 @@ function bitCount(n: number): number {
     return (((n + (n >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
 }
 
+/** LIFO pool of fixed-size BitSets so the (heavily recursive) clique search does not allocate per call. */
+class BitSetPool {
+    private readonly free: BitSet[] = [];
+    constructor(private readonly nbits: number) {}
+    acquire(): BitSet {
+        const b = this.free.pop();
+        return b !== void 0 ? b : new BitSet(this.nbits);
+    }
+    acquireCopy(src: BitSet): BitSet {
+        const b = this.acquire();
+        b.words.set(src.words);
+        return b;
+    }
+    release(b: BitSet) { this.free.push(b); }
+}
+
 /**
  * Compatibility (modular product) graph. Vertices are atom pairs (pairA[k] in A, pairB[k] in B)
  * that pass the vertex test. Two vertices are joined by a c-edge when their atoms are bonded in
@@ -344,6 +345,7 @@ function isHydrogenVertex(v: LigandGraphVertex): boolean {
 /** BFS all-pairs shortest paths (edge count) within a ligand graph; -1 marks unreachable. */
 function ligandShortestPaths(g: LigandGraph): Int32Array[] {
     const n = g.vertices.length;
+    const { offset, b } = g.bonds;
     const dist: Int32Array[] = new Array(n);
     const queue = new Int32Array(n);
     for (let s = 0; s < n; s++) {
@@ -354,7 +356,8 @@ function ligandShortestPaths(g: LigandGraph): Int32Array[] {
         while (head < tail) {
             const u = queue[head++];
             const du = d[u];
-            for (const w of g.adj[u].keys()) {
+            for (let t = offset[u], end = offset[u + 1]; t < end; t++) {
+                const w = b[t];
                 if (d[w] < 0) { d[w] = du + 1; queue[tail++] = w; }
             }
         }
@@ -388,6 +391,10 @@ function buildCompatGraph(a: LigandGraph, b: LigandGraph, opts: LigandMccsOption
     const distA = useD ? ligandShortestPaths(a) : undefined;
     const distB = useD ? ligandShortestPaths(b) : undefined;
 
+    const aBonds = a.bonds, bBonds = b.bonds;
+    const aOrder = aBonds.edgeProps.order, aFlags = aBonds.edgeProps.flags;
+    const bOrder = bBonds.edgeProps.order, bFlags = bBonds.edgeProps.flags;
+
     for (let i = 0; i < n; i++) {
         const ai = pairA[i], bi = pairB[i];
         for (let j = i + 1; j < n; j++) {
@@ -396,13 +403,13 @@ function buildCompatGraph(a: LigandGraph, b: LigandGraph, opts: LigandMccsOption
             // 1:1 constraint: a given atom may not be matched twice within one clique
             if (ai === aj || bi === bj) continue;
 
-            const ea = a.adj[ai].get(aj);
-            const eb = b.adj[bi].get(bj);
-            const adjA = ea !== void 0;
-            const adjB = eb !== void 0;
+            const eaIdx = aBonds.getDirectedEdgeIndex(ai, aj);
+            const ebIdx = bBonds.getDirectedEdgeIndex(bi, bj);
+            const adjA = eaIdx >= 0;
+            const adjB = ebIdx >= 0;
 
             let cEdge = false;
-            if (adjA && adjB) cEdge = opts.edgeTest(ea!, eb!);
+            if (adjA && adjB) cEdge = opts.edgeTest(aOrder[eaIdx], aFlags[eaIdx], bOrder[ebIdx], bFlags[ebIdx]);
 
             let dEdge = false;
             if (!cEdge && useD && !adjA && !adjB) {
@@ -452,6 +459,7 @@ function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, coll
 
     const all = BitSet.full(n);
     const t = new BitSet(n); // already-processed seeds, so each maximal clique is found once
+    const pool = new BitSetPool(n);
 
     const deadline = Date.now() + opts.maxTimeMs;
     const maxIter = opts.maxIterations;
@@ -479,37 +487,44 @@ function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, coll
             return;
         }
 
-        const pIter = P.clone();
+        // scratch sets are drawn from a pool and returned at the end of each iteration/frame
+        const pIter = pool.acquireCopy(P);
         for (let ui = pIter.nextSetBit(0); ui >= 0; ui = pIter.nextSetBit(ui + 1)) {
             P.clear(ui);
 
             const dN = dAdj[ui], cN = cadj[ui], neigh = adj[ui];
 
-            const rNew = R.clone(); rNew.set(ui);
-            const qNew = Q.clone(); qNew.and(dN);
-            const pNew = P.clone(); pNew.and(neigh);
-            const qCapC = Q.clone(); qCapC.and(cN); pNew.or(qCapC);
-            const yNew = Y.clone(); yNew.and(dN);
-            const xNew = X.clone(); xNew.and(neigh);
-            const yCapC = Y.clone(); yCapC.and(cN); xNew.or(yCapC);
+            const rNew = pool.acquireCopy(R); rNew.set(ui);
+            const qNew = pool.acquireCopy(Q); qNew.and(dN);
+            const yNew = pool.acquireCopy(Y); yNew.and(dN);
+            const pNew = pool.acquireCopy(P); pNew.and(neigh);
+            const xNew = pool.acquireCopy(X); xNew.and(neigh);
+            const tmp = pool.acquireCopy(Q); tmp.and(cN); pNew.or(tmp); // P' = (P ∩ neigh) ∪ (Q ∩ cN)
+            tmp.words.set(Y.words); tmp.and(cN); xNew.or(tmp); // X' = (X ∩ neigh) ∪ (Y ∩ cN)
+            pool.release(tmp);
 
             cClique(rNew, pNew, qNew, xNew, yNew);
 
+            pool.release(xNew); pool.release(pNew); pool.release(yNew); pool.release(qNew); pool.release(rNew);
+
             X.set(ui);
-            if (checkAbort()) return;
+            if (checkAbort()) break;
         }
+        pool.release(pIter);
     };
 
     for (let ui = 0; ui < n; ui++) {
-        const r = new BitSet(n); r.set(ui);
         const dN = dAdj[ui], cN = cadj[ui];
 
-        const q = all.clone(); q.andNot(t); q.and(dN);
-        const p = all.clone(); p.andNot(t); p.and(cN);
-        const y = dN.clone(); y.and(t);
-        const x = cN.clone(); x.and(t);
+        const r = pool.acquire(); r.zero(); r.set(ui);
+        const q = pool.acquireCopy(all); q.andNot(t); q.and(dN);
+        const p = pool.acquireCopy(all); p.andNot(t); p.and(cN);
+        const y = pool.acquireCopy(dN); y.and(t);
+        const x = pool.acquireCopy(cN); x.and(t);
 
         cClique(r, p, q, x, y);
+
+        pool.release(x); pool.release(y); pool.release(p); pool.release(q); pool.release(r);
 
         t.set(ui);
         if (checkAbort()) break;
@@ -560,36 +575,27 @@ export interface LigandSuperposeResult {
     targetElements: ElementIndex[];
 }
 
-interface PairedSuperposition {
-    rmsd: number;
-    bTransform: Mat4;
-    referenceElements: ElementIndex[];
-    targetElements: ElementIndex[];
+type MutablePositions = { x: Float64Array, y: Float64Array, z: Float64Array };
+
+/** Write the paired atom coordinates into reused position buffers, in correspondence order. */
+function fillPairPositions(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number, number]>, posA: MutablePositions, posB: MutablePositions) {
+    const ca = gA.unit.conformation, cb = gB.unit.conformation;
+    for (let i = 0; i < pairs.length; i++) {
+        const ea = gA.vertices[pairs[i][0]].element;
+        const eb = gB.vertices[pairs[i][1]].element;
+        posA.x[i] = ca.x(ea); posA.y[i] = ca.y(ea); posA.z[i] = ca.z(ea);
+        posB.x[i] = cb.x(eb); posB.y[i] = cb.y(eb); posB.z[i] = cb.z(eb);
+    }
 }
 
-/** Superpose target onto reference using a fixed atom correspondence; returns the RMSD-minimizing transform. */
-function superposeFromPairs(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number, number]>): PairedSuperposition | undefined {
-    if (pairs.length === 0) return;
-
-    const aOrder: number[] = [];
-    const bOrder: number[] = [];
-    const referenceElements: ElementIndex[] = [];
-    const targetElements: ElementIndex[] = [];
+function pairsToElements(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number, number]>) {
+    const referenceElements: ElementIndex[] = new Array(pairs.length);
+    const targetElements: ElementIndex[] = new Array(pairs.length);
     for (let i = 0; i < pairs.length; i++) {
-        const [ai, bi] = pairs[i];
-        aOrder.push(ai);
-        bOrder.push(bi);
-        referenceElements.push(gA.vertices[ai].element);
-        targetElements.push(gB.vertices[bi].element);
+        referenceElements[i] = gA.vertices[pairs[i][0]].element;
+        targetElements[i] = gB.vertices[pairs[i][1]].element;
     }
-
-    const lociA = lociFromVertexOrder(gA, aOrder);
-    const lociB = lociFromVertexOrder(gB, bOrder);
-
-    const results = superpose([lociA, lociB]);
-    if (!results.length) return;
-    const { bTransform, rmsd } = results[0];
-    return { bTransform, rmsd, referenceElements, targetElements };
+    return { referenceElements, targetElements };
 }
 
 /**
@@ -613,19 +619,40 @@ export function superposeLigandsByMccs(
     // fast path: identical compId -> match by atom name
     const namePairs = matchLigandsByAtomName(gA, gB);
     if (namePairs && namePairs.length >= opts.minMatchedAtoms) {
-        const res = superposeFromPairs(gA, gB, namePairs);
-        if (res) return { method: 'atom-name', atomCount: namePairs.length, ...res };
+        const n = namePairs.length;
+        const posA = MinimizeRmsd.Positions.empty(n);
+        const posB = MinimizeRmsd.Positions.empty(n);
+        fillPairPositions(gA, gB, namePairs, posA, posB);
+        const { bTransform, rmsd } = MinimizeRmsd.compute({ a: posA, b: posB, length: n });
+        const { referenceElements, targetElements } = pairsToElements(gA, gB, namePairs);
+        return { method: 'atom-name', atomCount: n, rmsd, bTransform, referenceElements, targetElements };
     }
 
-    // MCCS: superpose each maximum-size correspondence and keep the lowest-RMSD pose
-    let best: LigandSuperposeResult | undefined;
-    for (const pairs of findMccsCliques(gA, gB, opts)) {
-        if (pairs.length < opts.minMatchedAtoms) continue;
-        const res = superposeFromPairs(gA, gB, pairs);
-        if (!res) continue;
-        if (!best || res.rmsd < best.rmsd) {
-            best = { method: 'mccs', atomCount: pairs.length, ...res };
+    // MCCS: superpose each maximum-size correspondence and keep the lowest-RMSD pose. Every clique
+    // shares the maximum size, so one set of reused buffers (and a reused RMSD state) fits all of them.
+    const cliques = findMccsCliques(gA, gB, opts);
+    if (cliques.length === 0) return;
+
+    const n = cliques[0].length;
+    const posA = MinimizeRmsd.Positions.empty(n);
+    const posB = MinimizeRmsd.Positions.empty(n);
+    const result: MinimizeRmsd.Result = { bTransform: Mat4.zero(), rmsd: 0, nAlignedElements: 0 };
+    const state = new RmsdTransformState({ a: posA, b: posB, length: n }, result);
+
+    let bestRmsd = Number.POSITIVE_INFINITY;
+    let bestPairs: Array<[number, number]> | undefined;
+    const bestTransform = Mat4.zero();
+    for (const pairs of cliques) {
+        fillPairPositions(gA, gB, pairs, posA, posB);
+        MinimizeRmsd.compute({ a: posA, b: posB, length: n }, result, state);
+        if (result.rmsd < bestRmsd) {
+            bestRmsd = result.rmsd;
+            Mat4.copy(bestTransform, result.bTransform);
+            bestPairs = pairs;
         }
     }
-    return best;
+    if (!bestPairs) return;
+
+    const { referenceElements, targetElements } = pairsToElements(gA, gB, bestPairs);
+    return { method: 'mccs', atomCount: bestPairs.length, rmsd: bestRmsd, bTransform: bestTransform, referenceElements, targetElements };
 }

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -552,17 +552,35 @@ export interface LigandSuperposeResult {
     atomCount: number;
     rmsd: number;
     bTransform: Mat4;
+    /**
+     * matched atoms as model ElementIndex, paired 1:1 (by array position) with `targetElements`
+     */
+    referenceElements: ElementIndex[];
+    /** matched atoms in the target ligand as model ElementIndex, paired 1:1 with `referenceElements` */
+    targetElements: ElementIndex[];
+}
+
+interface PairedSuperposition {
+    rmsd: number;
+    bTransform: Mat4;
+    referenceElements: ElementIndex[];
+    targetElements: ElementIndex[];
 }
 
 /** Superpose target onto reference using a fixed atom correspondence; returns the RMSD-minimizing transform. */
-function superposeFromPairs(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number, number]>): { rmsd: number, bTransform: Mat4 } | undefined {
+function superposeFromPairs(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number, number]>): PairedSuperposition | undefined {
     if (pairs.length === 0) return;
 
     const aOrder: number[] = [];
     const bOrder: number[] = [];
+    const referenceElements: ElementIndex[] = [];
+    const targetElements: ElementIndex[] = [];
     for (let i = 0; i < pairs.length; i++) {
-        aOrder.push(pairs[i][0]);
-        bOrder.push(pairs[i][1]);
+        const [ai, bi] = pairs[i];
+        aOrder.push(ai);
+        bOrder.push(bi);
+        referenceElements.push(gA.vertices[ai].element);
+        targetElements.push(gB.vertices[bi].element);
     }
 
     const lociA = lociFromVertexOrder(gA, aOrder);
@@ -571,7 +589,7 @@ function superposeFromPairs(gA: LigandGraph, gB: LigandGraph, pairs: Array<[numb
     const results = superpose([lociA, lociB]);
     if (!results.length) return;
     const { bTransform, rmsd } = results[0];
-    return { bTransform, rmsd };
+    return { bTransform, rmsd, referenceElements, targetElements };
 }
 
 /**
@@ -596,7 +614,7 @@ export function superposeLigandsByMccs(
     const namePairs = matchLigandsByAtomName(gA, gB);
     if (namePairs && namePairs.length >= opts.minMatchedAtoms) {
         const res = superposeFromPairs(gA, gB, namePairs);
-        if (res) return { method: 'atom-name', atomCount: namePairs.length, rmsd: res.rmsd, bTransform: res.bTransform };
+        if (res) return { method: 'atom-name', atomCount: namePairs.length, ...res };
     }
 
     // MCCS: superpose each maximum-size correspondence and keep the lowest-RMSD pose
@@ -606,7 +624,7 @@ export function superposeLigandsByMccs(
         const res = superposeFromPairs(gA, gB, pairs);
         if (!res) continue;
         if (!best || res.rmsd < best.rmsd) {
-            best = { method: 'mccs', atomCount: pairs.length, rmsd: res.rmsd, bTransform: res.bTransform };
+            best = { method: 'mccs', atomCount: pairs.length, ...res };
         }
     }
     return best;

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -11,6 +11,7 @@ import { IntAdjacencyGraph } from '../../../../mol-math/graph';
 import { Mat4 } from '../../../../mol-math/linear-algebra';
 import { MinimizeRmsd, RmsdTransformState } from '../../../../mol-math/linear-algebra/3d/minimize-rmsd';
 import { RuntimeContext } from '../../../../mol-task';
+import { BitSet } from '../../../../mol-util/bit-set';
 import { Structure, StructureElement, StructureProperties, Unit } from '../../structure';
 
 /**
@@ -235,76 +236,6 @@ export function matchLigandsByAtomName(a: LigandGraph, b: LigandGraph): Array<[n
     if (!pairs.length) return;
     pairs.sort((p, q) => p[0] - q[0]);
     return pairs;
-}
-
-/** Minimal fixed-size bit set backed by a Uint32Array, used by the clique search. */
-class BitSet {
-    readonly nbits: number;
-    readonly words: Uint32Array;
-
-    constructor(nbits: number) {
-        this.nbits = nbits;
-        this.words = new Uint32Array((nbits + 31) >>> 5);
-    }
-
-    static full(nbits: number): BitSet {
-        const b = new BitSet(nbits);
-        b.words.fill(0xffffffff);
-        const rem = nbits & 31;
-        if (rem !== 0) b.words[b.words.length - 1] = ~(0xffffffff << rem);
-        return b;
-    }
-
-    clone(): BitSet {
-        const b = new BitSet(this.nbits);
-        b.words.set(this.words);
-        return b;
-    }
-
-    zero() { this.words.fill(0); }
-
-    set(i: number) { this.words[i >>> 5] |= (1 << (i & 31)); }
-    clear(i: number) { this.words[i >>> 5] &= ~(1 << (i & 31)); }
-    get(i: number): boolean { return (this.words[i >>> 5] & (1 << (i & 31))) !== 0; }
-
-    and(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] &= x[k]; }
-    andNot(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] &= ~x[k]; }
-    or(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] |= x[k]; }
-
-    isEmpty(): boolean {
-        const w = this.words;
-        for (let k = 0, n = w.length; k < n; k++) if (w[k] !== 0) return false;
-        return true;
-    }
-
-    cardinality(): number {
-        const w = this.words;
-        let c = 0;
-        for (let k = 0, n = w.length; k < n; k++) c += bitCount(w[k]);
-        return c;
-    }
-
-    nextSetBit(from: number): number {
-        if (from < 0) from = 0;
-        if (from >= this.nbits) return -1;
-        const w = this.words;
-        let wi = from >>> 5;
-        let word = w[wi] & (0xffffffff << (from & 31));
-        while (true) {
-            if (word !== 0) {
-                const bit = (wi << 5) + (31 - Math.clz32(word & -word));
-                return bit < this.nbits ? bit : -1;
-            }
-            if (++wi >= w.length) return -1;
-            word = w[wi];
-        }
-    }
-}
-
-function bitCount(n: number): number {
-    n = n - ((n >>> 1) & 0x55555555);
-    n = (n & 0x33333333) + ((n >>> 2) & 0x33333333);
-    return (((n + (n >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
 }
 
 /** LIFO pool of fixed-size BitSets so the (heavily recursive) clique search does not allocate per call. */

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -10,7 +10,6 @@ import { BondType } from '../../model/types';
 import { IntAdjacencyGraph } from '../../../../mol-math/graph';
 import { Mat4 } from '../../../../mol-math/linear-algebra';
 import { MinimizeRmsd, RmsdTransformState } from '../../../../mol-math/linear-algebra/3d/minimize-rmsd';
-import { RuntimeContext } from '../../../../mol-task';
 import { BitSet } from '../../../../mol-util/bit-set';
 import { Structure, StructureElement, StructureProperties, Unit } from '../../structure';
 
@@ -378,9 +377,10 @@ class CliqueCollector {
  * of Bron-Kerbosch). c-edges keep the match a single connected fragment; d-edges may appear inside a
  * clique but never seed connectivity. Bounded by a wall-clock and a recursion-step budget.
  */
-function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, collector: CliqueCollector) {
+/** Returns true if the search stopped on its time/iteration budget (the result is a best-so-far, not proven maximal). */
+function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, collector: CliqueCollector): boolean {
     const n = g.n;
-    if (n === 0) return;
+    if (n === 0) return false;
 
     const minK = Math.max(1, opts.minMatchedAtoms);
     const adj = g.adj, cadj = g.cadj;
@@ -460,6 +460,7 @@ function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, coll
         t.set(ui);
         if (checkAbort()) break;
     }
+    return aborted;
 }
 
 function cliqueToPairs(g: CompatGraph, clique: number[]): Array<[number, number]> {
@@ -468,18 +469,27 @@ function cliqueToPairs(g: CompatGraph, clique: number[]): Array<[number, number]
     return pairs;
 }
 
+/** Optional out-parameter reporting whether the MCCS search hit its time/iteration budget. */
+export interface LigandMccsStatus {
+    truncated: boolean;
+}
+
 /**
  * Enumerate the maximum-size MCCS atom correspondences between two ligand graphs. Several equally
  * sized candidates may be returned (symmetry-related mappings, e.g. ring flips) so the caller can
  * pick the best pose by RMSD. Each correspondence is a list of [aVertexIndex, bVertexIndex] pairs.
+ *
+ * The search is best-effort: it stops at `maxTimeMs`/`maxIterations` and returns the best cliques
+ * found so far. Pass `status` to learn whether that budget was hit (`status.truncated`).
  */
-export function findMccsCliques(a: LigandGraph, b: LigandGraph, options: Partial<LigandMccsOptions> = {}): Array<Array<[number, number]>> {
+export function findMccsCliques(a: LigandGraph, b: LigandGraph, options: Partial<LigandMccsOptions> = {}, status?: LigandMccsStatus): Array<Array<[number, number]>> {
     const opts: LigandMccsOptions = { ...DefaultLigandMccsOptions, ...options };
     const g = buildCompatGraph(a, b, opts);
     if (g.n === 0) return [];
 
     const collector = new CliqueCollector(opts.maxCliquesForPose);
-    enumerateConnectedCliques(g, opts, collector);
+    const truncated = enumerateConnectedCliques(g, opts, collector);
+    if (status) status.truncated = truncated;
     if (collector.bestSize < opts.minMatchedAtoms) return [];
 
     return collector.cliques.map(clique => cliqueToPairs(g, clique));
@@ -504,6 +514,8 @@ export interface LigandSuperposeResult {
     referenceElements: ElementIndex[];
     /** matched atoms in the target ligand as model ElementIndex, paired 1:1 with `referenceElements` */
     targetElements: ElementIndex[];
+    /** true if the MCCS search hit its time/iteration budget, so the result may not be the true maximum (always false for the atom-name fast path) */
+    truncated: boolean;
 }
 
 type MutablePositions = { x: Float64Array, y: Float64Array, z: Float64Array };
@@ -538,8 +550,7 @@ function pairsToElements(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number,
 export function superposeLigandsByMccs(
     reference: StructureElement.Loci,
     target: StructureElement.Loci,
-    options: Partial<LigandMccsOptions> = {},
-    ctx?: RuntimeContext
+    options: Partial<LigandMccsOptions> = {}
 ): LigandSuperposeResult | undefined {
     const opts: LigandMccsOptions = { ...DefaultLigandMccsOptions, ...options };
 
@@ -556,12 +567,13 @@ export function superposeLigandsByMccs(
         fillPairPositions(gA, gB, namePairs, posA, posB);
         const { bTransform, rmsd } = MinimizeRmsd.compute({ a: posA, b: posB, length: n });
         const { referenceElements, targetElements } = pairsToElements(gA, gB, namePairs);
-        return { method: 'atom-name', atomCount: n, rmsd, bTransform, referenceElements, targetElements };
+        return { method: 'atom-name', atomCount: n, rmsd, bTransform, referenceElements, targetElements, truncated: false };
     }
 
     // MCCS: superpose each maximum-size correspondence and keep the lowest-RMSD pose. Every clique
     // shares the maximum size, so one set of reused buffers (and a reused RMSD state) fits all of them.
-    const cliques = findMccsCliques(gA, gB, opts);
+    const status: LigandMccsStatus = { truncated: false };
+    const cliques = findMccsCliques(gA, gB, opts, status);
     if (cliques.length === 0) return;
 
     const n = cliques[0].length;
@@ -585,5 +597,5 @@ export function superposeLigandsByMccs(
     if (!bestPairs) return;
 
     const { referenceElements, targetElements } = pairsToElements(gA, gB, bestPairs);
-    return { method: 'mccs', atomCount: bestPairs.length, rmsd: bestRmsd, bTransform: bestTransform, referenceElements, targetElements };
+    return { method: 'mccs', atomCount: bestPairs.length, rmsd: bestRmsd, bTransform: bestTransform, referenceElements, targetElements, truncated: status.truncated };
 }

--- a/src/mol-model/structure/structure/util/superposition-ligand.ts
+++ b/src/mol-model/structure/structure/util/superposition-ligand.ts
@@ -1,0 +1,604 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
+ */
+
+import { OrderedSet, SortedArray } from '../../../../mol-data/int';
+import { ElementIndex } from '../../model';
+import { Mat4 } from '../../../../mol-math/linear-algebra';
+import { RuntimeContext } from '../../../../mol-task';
+import { Structure, StructureElement, StructureProperties, Unit } from '../../structure';
+import { superpose } from './superposition';
+import { UnitIndex } from '../element/util';
+
+/**
+ * Ligand MCCS utilities:
+ * - fast path: same compId -> match by atom name
+ * - MCCS search: connected common subgraph search with configurable vertex/edge matching lambdas
+ */
+export interface LigandGraphVertex {
+    readonly index: number;
+    readonly element: ElementIndex;
+    readonly atomName: string;
+    readonly elementSymbol: string;
+}
+
+export interface LigandGraphEdge {
+    readonly a: number;
+    readonly b: number;
+    readonly order: number;
+    readonly flags: number;
+    readonly key: number;
+}
+
+export interface LigandGraph {
+    readonly structure: Structure;
+    readonly unit: Unit.Atomic;
+    readonly compId: string;
+    readonly residueKey: number;
+    readonly vertices: readonly LigandGraphVertex[];
+    readonly adj: readonly Map<number, LigandGraphEdge>[];
+}
+
+export type LigandMccsVertexTest = (a: LigandGraphVertex, b: LigandGraphVertex) => boolean;
+export type LigandMccsEdgeTest = (a: LigandGraphEdge, b: LigandGraphEdge) => boolean;
+
+export interface LigandMccsOptions {
+    /** Whether atom i of A may be paired with atom j of B (default: same element symbol). */
+    readonly vertexTest: LigandMccsVertexTest;
+    /** Whether a bond in A may be paired with a bond in B (default: equal order, unknown = wildcard). */
+    readonly edgeTest: LigandMccsEdgeTest;
+    /** skip hydrogen/deuterium atoms */
+    readonly ignoreHydrogens: boolean;
+    /**
+     * Topological-distance tolerance for "d-edges" (pairs of atoms that are non-bonded in both
+     * ligands). These are required for the clique formulation to represent non-complete-graph
+     * substructures (e.g. rings), so the default is 1: two non-bonded atom pairs may be matched
+     * iff their shortest-path distances differ by at most this much. Higher values are more
+     * permissive about topological stretch; 0 disables d-edges entirely (only complete-subgraph
+     * matches survive, rarely useful).
+     */
+    readonly pathCutoff: number;
+    readonly maxTimeMs: number;
+    readonly minMatchedAtoms: number;
+    /** hard backstop on clique-search recursion steps */
+    readonly maxIterations: number;
+    /** number of equally-sized maximum cliques to retain and RMSD-rank when picking the pose */
+    readonly maxCliquesForPose: number;
+}
+
+export const DefaultLigandMccsOptions: LigandMccsOptions = {
+    vertexTest: (a, b) => a.elementSymbol === b.elementSymbol,
+    edgeTest: (a, b) => {
+        // unknown/0 bond orders are treated as compatible
+        const ao = a.order | 0, bo = b.order | 0;
+        if (ao > 0 && bo > 0) return ao === bo;
+        return true;
+    },
+    ignoreHydrogens: true,
+    pathCutoff: 1,
+    maxTimeMs: 400,
+    minMatchedAtoms: 3,
+    maxIterations: 10000000,
+    maxCliquesForPose: 64
+};
+
+function isAtomicUnit(u: Unit): u is Unit.Atomic {
+    return u.kind === Unit.Kind.Atomic;
+}
+
+/**
+ * Returns residueKey/compId iff:
+ * - loci is non-empty
+ * - all atoms are in the same residue (one ligand residue)
+ * - entity type is not polymer
+ */
+export function isSingleLigandLoci(loci: StructureElement.Loci): { residueKey: number, compId: string } | undefined {
+    if (StructureElement.Loci.isEmpty(loci)) return;
+
+    const loc = StructureElement.Location.create(loci.structure);
+    const first = StructureElement.Loci.getFirstLocation(loci, loc);
+    if (!first) return;
+
+    if (StructureProperties.entity.type(first) === 'polymer') return;
+
+    const firstResidueKey = StructureProperties.residue.key(first);
+    const firstCompId = StructureProperties.atom.label_comp_id(first);
+
+    let ok = true;
+    StructureElement.Loci.forEachLocation(loci, l => {
+        if (!ok) return;
+        if (StructureProperties.entity.type(l) === 'polymer') ok = false;
+        if (StructureProperties.residue.key(l) !== firstResidueKey) ok = false;
+    });
+
+    if (!ok) return;
+    return { residueKey: firstResidueKey, compId: firstCompId };
+}
+
+export function buildLigandGraphFromLoci(loci: StructureElement.Loci): LigandGraph | undefined {
+    const info = isSingleLigandLoci(loci);
+    if (!info) return;
+
+    if (loci.elements.length !== 1) return;
+    const e0 = loci.elements[0];
+    const unit = e0.unit;
+    if (!isAtomicUnit(unit)) return;
+
+    const { residueKey, compId } = info;
+
+    const indices: ElementIndex[] = [];
+    StructureElement.Loci.forEachLocation(loci, l => {
+        indices.push(l.element);
+    });
+    if (indices.length === 0) return;
+
+    const loc = StructureElement.Location.create(loci.structure, unit);
+    for (let i = 0; i < indices.length; i++) {
+        loc.element = indices[i];
+        if (StructureProperties.residue.key(loc) !== residueKey) return;
+    }
+
+    indices.sort((a, b) => a - b);
+    const vertices: LigandGraphVertex[] = indices.map((uIdx, i) => {
+        loc.element = uIdx;
+        return {
+            index: i,
+            element: uIdx,
+            atomName: StructureProperties.atom.label_atom_id(loc),
+            elementSymbol: StructureProperties.atom.type_symbol(loc)
+        };
+    });
+
+    const mapElToV = new Map<number, number>();
+    for (let i = 0; i < vertices.length; i++) mapElToV.set(vertices[i].element, i);
+
+    const adj: Map<number, LigandGraphEdge>[] = [];
+    for (let i = 0; i < vertices.length; i++) adj.push(new Map());
+
+    const { offset, b, edgeProps } = unit.bonds;
+    const { order, flags, key } = edgeProps;
+
+    for (let vi = 0; vi < vertices.length; vi++) {
+        const aEl = vertices[vi].element;
+        const start = offset[aEl];
+        const end = offset[aEl + 1];
+
+        for (let ei = start; ei < end; ei++) {
+            const bEl = b[ei];
+            const vj = mapElToV.get(bEl);
+            if (vj === void 0) continue;
+
+            const edge: LigandGraphEdge = {
+                a: vi,
+                b: vj,
+                order: order[ei],
+                flags: flags[ei],
+                key: key ? key[ei] : -1
+            };
+
+            if (!adj[vi].has(vj)) adj[vi].set(vj, edge);
+            if (!adj[vj].has(vi)) adj[vj].set(vi, { ...edge, a: vj, b: vi });
+        }
+    }
+
+    return { structure: loci.structure, unit, compId, residueKey, vertices, adj };
+}
+
+function lociFromVertexOrder(graph: LigandGraph, vertexOrder: readonly number[]): StructureElement.Loci {
+    // one element per atom so the A/B atom correspondence (and thus the RMSD pairing) is preserved
+    // in order; grouping all indices into a single OrderedSet would re-sort them and break it
+    const elements: StructureElement.Loci['elements'][0][] = [];
+    for (let i = 0; i < vertexOrder.length; i++) {
+        const v = graph.vertices[vertexOrder[i]];
+        const uIdx = SortedArray.indexOf(graph.unit.elements, v.element) as UnitIndex;
+        elements.push({ unit: graph.unit, indices: OrderedSet.ofSingleton(uIdx) });
+    }
+    return StructureElement.Loci(graph.structure, elements);
+}
+
+/** Fast path: same compId -> match by atom name (preferring same element symbol). */
+export function matchLigandsByAtomName(a: LigandGraph, b: LigandGraph): Array<[number, number]> | undefined {
+    if (!a.compId || !b.compId) return;
+    if (a.compId.toUpperCase() !== b.compId.toUpperCase()) return;
+
+    const byName = new Map<string, number[]>();
+    for (const v of b.vertices) {
+        const name = v.atomName || '';
+        if (!name) continue;
+        const arr = byName.get(name);
+        if (arr) arr.push(v.index);
+        else byName.set(name, [v.index]);
+    }
+
+    const usedB = new Uint8Array(b.vertices.length);
+    const pairs: Array<[number, number]> = [];
+
+    for (const va of a.vertices) {
+        const name = va.atomName || '';
+        if (!name) continue;
+
+        const cands = byName.get(name);
+        if (!cands) continue;
+
+        let chosen = -1;
+        for (let i = 0; i < cands.length; i++) {
+            const bi = cands[i];
+            if (usedB[bi]) continue;
+            if (b.vertices[bi].elementSymbol === va.elementSymbol) { chosen = bi; break; }
+        }
+        if (chosen < 0) {
+            for (let i = 0; i < cands.length; i++) {
+                const bi = cands[i];
+                if (!usedB[bi]) { chosen = bi; break; }
+            }
+        }
+        if (chosen < 0) continue;
+
+        usedB[chosen] = 1;
+        pairs.push([va.index, chosen]);
+    }
+
+    if (!pairs.length) return;
+    pairs.sort((p, q) => p[0] - q[0]);
+    return pairs;
+}
+
+/** Minimal fixed-size bit set backed by a Uint32Array, used by the clique search. */
+class BitSet {
+    readonly nbits: number;
+    readonly words: Uint32Array;
+
+    constructor(nbits: number) {
+        this.nbits = nbits;
+        this.words = new Uint32Array((nbits + 31) >>> 5);
+    }
+
+    static full(nbits: number): BitSet {
+        const b = new BitSet(nbits);
+        b.words.fill(0xffffffff);
+        const rem = nbits & 31;
+        if (rem !== 0) b.words[b.words.length - 1] = ~(0xffffffff << rem);
+        return b;
+    }
+
+    clone(): BitSet {
+        const b = new BitSet(this.nbits);
+        b.words.set(this.words);
+        return b;
+    }
+
+    set(i: number) { this.words[i >>> 5] |= (1 << (i & 31)); }
+    clear(i: number) { this.words[i >>> 5] &= ~(1 << (i & 31)); }
+    get(i: number): boolean { return (this.words[i >>> 5] & (1 << (i & 31))) !== 0; }
+
+    and(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] &= x[k]; }
+    andNot(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] &= ~x[k]; }
+    or(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] |= x[k]; }
+
+    isEmpty(): boolean {
+        const w = this.words;
+        for (let k = 0, n = w.length; k < n; k++) if (w[k] !== 0) return false;
+        return true;
+    }
+
+    cardinality(): number {
+        const w = this.words;
+        let c = 0;
+        for (let k = 0, n = w.length; k < n; k++) c += bitCount(w[k]);
+        return c;
+    }
+
+    nextSetBit(from: number): number {
+        if (from < 0) from = 0;
+        if (from >= this.nbits) return -1;
+        const w = this.words;
+        let wi = from >>> 5;
+        let word = w[wi] & (0xffffffff << (from & 31));
+        while (true) {
+            if (word !== 0) {
+                const bit = (wi << 5) + (31 - Math.clz32(word & -word));
+                return bit < this.nbits ? bit : -1;
+            }
+            if (++wi >= w.length) return -1;
+            word = w[wi];
+        }
+    }
+}
+
+function bitCount(n: number): number {
+    n = n - ((n >>> 1) & 0x55555555);
+    n = (n & 0x33333333) + ((n >>> 2) & 0x33333333);
+    return (((n + (n >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
+}
+
+/**
+ * Compatibility (modular product) graph. Vertices are atom pairs (pairA[k] in A, pairB[k] in B)
+ * that pass the vertex test. Two vertices are joined by a c-edge when their atoms are bonded in
+ * both ligands with compatible bonds, or by a d-edge when they are non-bonded in both with similar
+ * topological distance. A c-connected clique of this graph is a connected common substructure.
+ */
+interface CompatGraph {
+    readonly n: number;
+    readonly pairA: Int32Array;
+    readonly pairB: Int32Array;
+    readonly adj: BitSet[]; // c-edges and d-edges
+    readonly cadj: BitSet[]; // c-edges only
+}
+
+function isHydrogenVertex(v: LigandGraphVertex): boolean {
+    const s = v.elementSymbol.toUpperCase();
+    return s === 'H' || s === 'D';
+}
+
+/** BFS all-pairs shortest paths (edge count) within a ligand graph; -1 marks unreachable. */
+function ligandShortestPaths(g: LigandGraph): Int32Array[] {
+    const n = g.vertices.length;
+    const dist: Int32Array[] = new Array(n);
+    const queue = new Int32Array(n);
+    for (let s = 0; s < n; s++) {
+        const d = new Int32Array(n).fill(-1);
+        let head = 0, tail = 0;
+        queue[tail++] = s;
+        d[s] = 0;
+        while (head < tail) {
+            const u = queue[head++];
+            const du = d[u];
+            for (const w of g.adj[u].keys()) {
+                if (d[w] < 0) { d[w] = du + 1; queue[tail++] = w; }
+            }
+        }
+        dist[s] = d;
+    }
+    return dist;
+}
+
+function buildCompatGraph(a: LigandGraph, b: LigandGraph, opts: LigandMccsOptions): CompatGraph {
+    const nA = a.vertices.length, nB = b.vertices.length;
+    const ignoreH = opts.ignoreHydrogens;
+
+    const pa: number[] = [], pb: number[] = [];
+    for (let i = 0; i < nA; i++) {
+        if (ignoreH && isHydrogenVertex(a.vertices[i])) continue;
+        for (let j = 0; j < nB; j++) {
+            if (ignoreH && isHydrogenVertex(b.vertices[j])) continue;
+            if (opts.vertexTest(a.vertices[i], b.vertices[j])) { pa.push(i); pb.push(j); }
+        }
+    }
+
+    const n = pa.length;
+    const pairA = Int32Array.from(pa);
+    const pairB = Int32Array.from(pb);
+
+    const adj: BitSet[] = new Array(n);
+    const cadj: BitSet[] = new Array(n);
+    for (let i = 0; i < n; i++) { adj[i] = new BitSet(n); cadj[i] = new BitSet(n); }
+
+    const useD = opts.pathCutoff > 0;
+    const distA = useD ? ligandShortestPaths(a) : undefined;
+    const distB = useD ? ligandShortestPaths(b) : undefined;
+
+    for (let i = 0; i < n; i++) {
+        const ai = pairA[i], bi = pairB[i];
+        for (let j = i + 1; j < n; j++) {
+            const aj = pairA[j], bj = pairB[j];
+
+            // 1:1 constraint: a given atom may not be matched twice within one clique
+            if (ai === aj || bi === bj) continue;
+
+            const ea = a.adj[ai].get(aj);
+            const eb = b.adj[bi].get(bj);
+            const adjA = ea !== void 0;
+            const adjB = eb !== void 0;
+
+            let cEdge = false;
+            if (adjA && adjB) cEdge = opts.edgeTest(ea!, eb!);
+
+            let dEdge = false;
+            if (!cEdge && useD && !adjA && !adjB) {
+                const dA = distA![ai][aj];
+                const dB = distB![bi][bj];
+                if (dA >= 0 && dB >= 0 && Math.abs(dA - dB) <= opts.pathCutoff) dEdge = true;
+            }
+
+            if (cEdge || dEdge) {
+                adj[i].set(j); adj[j].set(i);
+                if (cEdge) { cadj[i].set(j); cadj[j].set(i); }
+            }
+        }
+    }
+
+    return { n, pairA, pairB, adj, cadj };
+}
+
+/** Retains every maximum-size clique encountered (up to a cap) for downstream RMSD pose selection. */
+class CliqueCollector {
+    bestSize = 0;
+    cliques: number[][] = [];
+    private readonly cap: number;
+    constructor(cap: number) { this.cap = Math.max(1, cap); }
+    offer(clique: number[]) {
+        const size = clique.length;
+        if (size < this.bestSize) return;
+        if (size > this.bestSize) { this.bestSize = size; this.cliques = [clique]; return; }
+        if (this.cliques.length < this.cap) this.cliques.push(clique);
+    }
+}
+
+/**
+ * Enumerate maximal c-connected cliques of the compatibility graph (Koch's connected-clique variant
+ * of Bron-Kerbosch). c-edges keep the match a single connected fragment; d-edges may appear inside a
+ * clique but never seed connectivity. Bounded by a wall-clock and a recursion-step budget.
+ */
+function enumerateConnectedCliques(g: CompatGraph, opts: LigandMccsOptions, collector: CliqueCollector) {
+    const n = g.n;
+    if (n === 0) return;
+
+    const minK = Math.max(1, opts.minMatchedAtoms);
+    const adj = g.adj, cadj = g.cadj;
+
+    const dAdj: BitSet[] = new Array(n);
+    for (let i = 0; i < n; i++) { const d = adj[i].clone(); d.andNot(cadj[i]); dAdj[i] = d; }
+
+    const all = BitSet.full(n);
+    const t = new BitSet(n); // already-processed seeds, so each maximal clique is found once
+
+    const deadline = Date.now() + opts.maxTimeMs;
+    const maxIter = opts.maxIterations;
+    let iters = 0;
+    let aborted = false;
+
+    const checkAbort = () => {
+        if (aborted) return true;
+        if ((maxIter > 0 && iters > maxIter) || Date.now() > deadline) { aborted = true; return true; }
+        return false;
+    };
+
+    const cClique = (R: BitSet, P: BitSet, Q: BitSet, X: BitSet, Y: BitSet) => {
+        if (checkAbort()) return;
+        iters++;
+
+        if (P.isEmpty() && X.isEmpty()) {
+            const size = R.cardinality();
+            if (size >= minK) {
+                const clique: number[] = new Array(size);
+                let idx = 0;
+                for (let v = R.nextSetBit(0); v >= 0; v = R.nextSetBit(v + 1)) clique[idx++] = v;
+                collector.offer(clique);
+            }
+            return;
+        }
+
+        const pIter = P.clone();
+        for (let ui = pIter.nextSetBit(0); ui >= 0; ui = pIter.nextSetBit(ui + 1)) {
+            P.clear(ui);
+
+            const dN = dAdj[ui], cN = cadj[ui], neigh = adj[ui];
+
+            const rNew = R.clone(); rNew.set(ui);
+            const qNew = Q.clone(); qNew.and(dN);
+            const pNew = P.clone(); pNew.and(neigh);
+            const qCapC = Q.clone(); qCapC.and(cN); pNew.or(qCapC);
+            const yNew = Y.clone(); yNew.and(dN);
+            const xNew = X.clone(); xNew.and(neigh);
+            const yCapC = Y.clone(); yCapC.and(cN); xNew.or(yCapC);
+
+            cClique(rNew, pNew, qNew, xNew, yNew);
+
+            X.set(ui);
+            if (checkAbort()) return;
+        }
+    };
+
+    for (let ui = 0; ui < n; ui++) {
+        const r = new BitSet(n); r.set(ui);
+        const dN = dAdj[ui], cN = cadj[ui];
+
+        const q = all.clone(); q.andNot(t); q.and(dN);
+        const p = all.clone(); p.andNot(t); p.and(cN);
+        const y = dN.clone(); y.and(t);
+        const x = cN.clone(); x.and(t);
+
+        cClique(r, p, q, x, y);
+
+        t.set(ui);
+        if (checkAbort()) break;
+    }
+}
+
+function cliqueToPairs(g: CompatGraph, clique: number[]): Array<[number, number]> {
+    const pairs: Array<[number, number]> = clique.map(ci => [g.pairA[ci], g.pairB[ci]] as [number, number]);
+    pairs.sort((p, q) => p[0] - q[0]);
+    return pairs;
+}
+
+/**
+ * Enumerate the maximum-size MCCS atom correspondences between two ligand graphs. Several equally
+ * sized candidates may be returned (symmetry-related mappings, e.g. ring flips) so the caller can
+ * pick the best pose by RMSD. Each correspondence is a list of [aVertexIndex, bVertexIndex] pairs.
+ */
+export function findMccsCliques(a: LigandGraph, b: LigandGraph, options: Partial<LigandMccsOptions> = {}): Array<Array<[number, number]>> {
+    const opts: LigandMccsOptions = { ...DefaultLigandMccsOptions, ...options };
+    const g = buildCompatGraph(a, b, opts);
+    if (g.n === 0) return [];
+
+    const collector = new CliqueCollector(opts.maxCliquesForPose);
+    enumerateConnectedCliques(g, opts, collector);
+    if (collector.bestSize < opts.minMatchedAtoms) return [];
+
+    return collector.cliques.map(clique => cliqueToPairs(g, clique));
+}
+
+/** Convenience wrapper returning a single (the first) maximum MCCS correspondence. */
+export function findMccsPairs(a: LigandGraph, b: LigandGraph, options: Partial<LigandMccsOptions> = {}): Array<[number, number]> | undefined {
+    const cliques = findMccsCliques(a, b, options);
+    return cliques.length ? cliques[0] : undefined;
+}
+
+export type LigandSuperposeMethod = 'atom-name' | 'mccs';
+
+export interface LigandSuperposeResult {
+    method: LigandSuperposeMethod;
+    atomCount: number;
+    rmsd: number;
+    bTransform: Mat4;
+}
+
+/** Superpose target onto reference using a fixed atom correspondence; returns the RMSD-minimizing transform. */
+function superposeFromPairs(gA: LigandGraph, gB: LigandGraph, pairs: Array<[number, number]>): { rmsd: number, bTransform: Mat4 } | undefined {
+    if (pairs.length === 0) return;
+
+    const aOrder: number[] = [];
+    const bOrder: number[] = [];
+    for (let i = 0; i < pairs.length; i++) {
+        aOrder.push(pairs[i][0]);
+        bOrder.push(pairs[i][1]);
+    }
+
+    const lociA = lociFromVertexOrder(gA, aOrder);
+    const lociB = lociFromVertexOrder(gB, bOrder);
+
+    const results = superpose([lociA, lociB]);
+    if (!results.length) return;
+    const { bTransform, rmsd } = results[0];
+    return { bTransform, rmsd };
+}
+
+/**
+ * Given two ligand loci (each one ligand residue), compute the bTransform that superposes the
+ * target onto the reference. Tries the atom-name fast path first (identical compId), then falls
+ * back to an MCCS search whose equally-sized maximum correspondences are each superposed so the
+ * lowest-RMSD pose wins (this resolves symmetry-related mappings the largest-clique alone cannot).
+ */
+export function superposeLigandsByMccs(
+    reference: StructureElement.Loci,
+    target: StructureElement.Loci,
+    options: Partial<LigandMccsOptions> = {},
+    ctx?: RuntimeContext
+): LigandSuperposeResult | undefined {
+    const opts: LigandMccsOptions = { ...DefaultLigandMccsOptions, ...options };
+
+    const gA = buildLigandGraphFromLoci(reference);
+    const gB = buildLigandGraphFromLoci(target);
+    if (!gA || !gB) return;
+
+    // fast path: identical compId -> match by atom name
+    const namePairs = matchLigandsByAtomName(gA, gB);
+    if (namePairs && namePairs.length >= opts.minMatchedAtoms) {
+        const res = superposeFromPairs(gA, gB, namePairs);
+        if (res) return { method: 'atom-name', atomCount: namePairs.length, rmsd: res.rmsd, bTransform: res.bTransform };
+    }
+
+    // MCCS: superpose each maximum-size correspondence and keep the lowest-RMSD pose
+    let best: LigandSuperposeResult | undefined;
+    for (const pairs of findMccsCliques(gA, gB, opts)) {
+        if (pairs.length < opts.minMatchedAtoms) continue;
+        const res = superposeFromPairs(gA, gB, pairs);
+        if (!res) continue;
+        if (!best || res.rmsd < best.rmsd) {
+            best = { method: 'mccs', atomCount: pairs.length, rmsd: res.rmsd, bTransform: res.bTransform };
+        }
+    }
+    return best;
+}

--- a/src/mol-plugin-ui/controls/icons.tsx
+++ b/src/mol-plugin-ui/controls/icons.tsx
@@ -204,9 +204,13 @@ export function LightModeSvg() { return _LightMode; }
 const _HeadsetVR = <svg width='16px' height='16px' viewBox='0 0 16 16'><path d='M8 1.248c1.857 0 3.526.641 4.65 1.794a5 5 0 0 1 2.518 1.09C13.907 1.482 11.295 0 8 0 4.75 0 2.12 1.48.844 4.122a5 5 0 0 1 2.289-1.047C4.236 1.872 5.974 1.248 8 1.248'/><path d='M12 12a4 4 0 0 1-2.786-1.13l-.002-.002a1.6 1.6 0 0 0-.276-.167A2.2 2.2 0 0 0 8 10.5c-.414 0-.729.103-.935.201a1.6 1.6 0 0 0-.277.167l-.002.002A4 4 0 1 1 4 4h8a4 4 0 0 1 0 8'/></svg>;
 export function HeadsetVRSvg() { return _HeadsetVR; }
 
+const _BenzeneRing = <svg width='24px' height='24px' viewBox='0 0 24 24'><path fillRule='evenodd' clipRule='evenodd' d='M12 2 L20.66 7 L20.66 17 L12 22 L3.34 17 L3.34 7 Z M12 4.5 L18.5 8.25 L18.5 15.75 L12 19.5 L5.5 15.75 L5.5 8.25 Z' /></svg>;
+export function BenzeneRingSvg() { return _BenzeneRing; }
+
 // Aliases
 
 export const SelectionModeSvg = CursorDefaultOutlineSvg;
 export const SuperposeAtomsSvg = ScatterPlotSvg;
 export const SuperposeChainsSvg = LinearScaleSvg;
+export const SuperposeLigandsSvg = BenzeneRingSvg;
 export const SuperpositionSvg = FlipToFrontSvg;

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -67,7 +67,14 @@ type SuperpositionControlsState = {
     isBusy: boolean,
     action?: 'byChains' | 'byAtoms' | 'byTMAlign' | 'byMccs' | 'options',
     canUseDb?: boolean,
+    canUseLigands?: boolean,
     options: StructureSuperpositionOptions
+}
+
+/** True iff the structure contains at least one ligand (the ligand query already excludes ions, water, lipids and saccharides). */
+function structureHasLigand(structure?: Structure): boolean {
+    if (!structure) return false;
+    return !StructureSelection.isEmpty(StructureSelectionQueries.ligand.query(new QueryContext(structure)));
 }
 
 export interface LociEntry {
@@ -88,6 +95,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
     state: SuperpositionControlsState = {
         isBusy: false,
         canUseDb: false,
+        canUseLigands: false,
         action: undefined,
         options: DefaultStructureSuperpositionOptions
     };
@@ -106,7 +114,11 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
         });
 
         this.subscribe(this.plugin.managers.structure.hierarchy.behaviors.selection, sel => {
-            this.setState({ canUseDb: sel.structures.every(s => !!s.cell.obj?.data && s.cell.obj.data.models.some(m => SIFTSMapping.Provider.isApplicable(m))) });
+            this.setState({
+                canUseDb: sel.structures.every(s => !!s.cell.obj?.data && s.cell.obj.data.models.some(m => SIFTSMapping.Provider.isApplicable(m))),
+                // need at least two ligand-bearing structures to superpose ligands
+                canUseLigands: sel.structures.filter(s => structureHasLigand(s.cell.obj?.data)).length >= 2
+            });
         });
     }
 
@@ -533,17 +545,19 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
     render() {
         return <>
             <div className='msp-flex-row'>
-                <ToggleButton icon={SuperposeChainsSvg} label='Chains' toggle={this.toggleByChains} isSelected={this.state.action === 'byChains'} disabled={this.state.isBusy} />
-                <ToggleButton icon={SuperposeAtomsSvg} label='Atoms' toggle={this.toggleByAtoms} isSelected={this.state.action === 'byAtoms'} disabled={this.state.isBusy} />
-                <ToggleButton icon={SuperposeChainsSvg} label='TM-align' toggle={this.toggleByTMAlign} isSelected={this.state.action === 'byTMAlign'} disabled={this.state.isBusy} />
+                <ToggleButton icon={SuperposeChainsSvg} label='Chains' title='Superpose selected polymer chains, optionally guided by a sequence alignment (see Options). Select one chain (or residues within it) per structure; 2+ structures.' toggle={this.toggleByChains} isSelected={this.state.action === 'byChains'} disabled={this.state.isBusy} />
+                <ToggleButton icon={SuperposeChainsSvg} label='TM-align' title='Sequence-independent structural alignment of polymer chains (TM-align) — best when sequence identity is low. Select one chain per structure; 2+ structures.' toggle={this.toggleByTMAlign} isSelected={this.state.action === 'byTMAlign'} disabled={this.state.isBusy} />
                 {this.state.canUseDb && this.superposeByDbMapping()}
-                <ToggleButton icon={SuperposeAtomsSvg} label='Ligands' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />
-                <ToggleButton icon={TuneSvg} label='' title='Options' toggle={this.toggleOptions} isSelected={this.state.action === 'options'} disabled={this.state.isBusy} style={{ flex: '0 0 40px', padding: 0 }} />
+                <ToggleButton icon={TuneSvg} label='' title='Options for chain- and UniProt-based superposition (sequence-guided alignment, trace/CA-only).' toggle={this.toggleOptions} isSelected={this.state.action === 'options'} disabled={this.state.isBusy} style={{ flex: '0 0 40px', padding: 0 }} />
+            </div>
+            <div className='msp-flex-row'>
+                {this.state.canUseLigands && <ToggleButton icon={SuperposeAtomsSvg} label='Ligands' title='Superpose ligands by atom-name match (identical compound) or maximum common substructure (MCCS) otherwise. Select one ligand residue per structure; 2+ structures.' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />}
+                <ToggleButton icon={SuperposeAtomsSvg} label='Atoms' title='Superpose by manually selected atoms, paired in selection order. Pick the same atoms, in the same order, in each structure (1+ per structure).' toggle={this.toggleByAtoms} isSelected={this.state.action === 'byAtoms'} disabled={this.state.isBusy} />
             </div>
             {this.state.action === 'byChains' && this.addByChains()}
             {this.state.action === 'byAtoms' && this.addByAtoms()}
             {this.state.action === 'byTMAlign' && this.addByTMAlign()}
-            {this.state.action === 'byMccs' && this.addByMccs()}
+            {this.state.action === 'byMccs' && this.state.canUseLigands && this.addByMccs()}
             {this.state.action === 'options' && <div className='msp-control-offset'>
                 <ParameterControls params={StructureSuperpositionParams} values={this.state.options} onChangeValues={this.setOptions} isDisabled={this.state.isBusy} />
             </div>}

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -224,6 +224,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
         const coordinateSystem = pivot?.transform?.cell.obj?.data.coordinateSystem;
 
         const mccsAlignTask = Task.create('Ligand Superposition', async ctx => {
+            let aligned = 0;
             for (let i = 1; i < entries.length; i++) {
                 if (ctx.shouldUpdate) await ctx.update(`Superposing ligand ${i} of ${entries.length - 1}...`);
 
@@ -238,13 +239,19 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 }
 
                 await this.transform(trgEntry.cell, result.bTransform, coordinateSystem);
+                aligned++;
 
                 const labelA = stripTags(refEntry.label);
                 const labelB = stripTags(trgEntry.label);
                 this.plugin.log.info(`Ligand superposed [${labelA}] and [${labelB}] via ${result.method} using ${result.atomCount} atoms (RMSD ${result.rmsd.toFixed(2)} Å).`);
             }
 
-            await this.cameraReset();
+            // focus the aligned ligands; the reference is the pivot, so every target now sits on it
+            if (aligned > 0 && !StructureElement.Loci.isEmpty(refLoci)) {
+                this.plugin.managers.camera.focusLoci(refLoci);
+            } else {
+                await this.cameraReset();
+            }
         });
 
         await this.plugin.runTask(mccsAlignTask, { useOverlay: true });

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -523,7 +523,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
 
     superposeByDbMapping() {
         return <>
-            <Button icon={SuperposeChainsSvg} title='Superpose structures using intersection of residues from SIFTS UNIPROT mapping.' className='msp-btn msp-btn-block' onClick={this.superposeDb} style={{ marginTop: '1px' }} disabled={this.state.isBusy}>
+            <Button icon={SuperposeChainsSvg} title='Superpose structures using intersection of residues from SIFTS UNIPROT mapping.' onClick={this.superposeDb} disabled={this.state.isBusy}>
                 UniProt
             </Button>
         </>;

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
- * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.org>
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
  * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -27,7 +27,7 @@ import { ParamDefinition as PD } from '../../mol-util/param-definition';
 import { stripTags } from '../../mol-util/string';
 import { CollapsableControls, PurePluginUIComponent } from '../base';
 import { Button, IconButton, ToggleButton } from '../controls/common';
-import { ArrowDownwardSvg, ArrowUpwardSvg, DeleteOutlinedSvg, HelpOutlineSvg, Icon, SuperposeAtomsSvg, SuperposeChainsSvg, SuperpositionSvg, TuneSvg } from '../controls/icons';
+import { ArrowDownwardSvg, ArrowUpwardSvg, DeleteOutlinedSvg, HelpOutlineSvg, Icon, SuperposeAtomsSvg, SuperposeChainsSvg, SuperposeLigandsSvg, SuperpositionSvg, TuneSvg } from '../controls/icons';
 import { ParameterControls } from '../controls/parameters';
 import { ToggleSelectionModeButton } from './selection';
 
@@ -558,7 +558,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 <ToggleButton icon={TuneSvg} label='' title='Options for chain- and UniProt-based superposition (sequence-guided alignment, trace/CA-only).' toggle={this.toggleOptions} isSelected={this.state.action === 'options'} disabled={this.state.isBusy} style={{ flex: '0 0 40px', padding: 0 }} />
             </div>
             <div className='msp-flex-row'>
-                {this.state.canUseLigands && <ToggleButton icon={SuperposeAtomsSvg} label='Ligands' title='Superpose ligands by atom-name match (identical compound) or maximum common connected subgraph (MCCS) otherwise. Select one ligand residue per structure; 2+ structures.' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />}
+                {this.state.canUseLigands && <ToggleButton icon={SuperposeLigandsSvg} label='Ligands' title='Superpose ligands by atom-name match (identical compound) or maximum common connected subgraph (MCCS) otherwise. Select one ligand residue per structure; 2+ structures.' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />}
                 <ToggleButton icon={SuperposeAtomsSvg} label='Atoms' title='Superpose by manually selected atoms, paired in selection order. Pick the same atoms, in the same order, in each structure (1+ per structure).' toggle={this.toggleByAtoms} isSelected={this.state.action === 'byAtoms'} disabled={this.state.isBusy} />
             </div>
             {this.state.action === 'byChains' && this.addByChains()}

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -232,7 +232,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 const trgSel = trgEntry.ligands[0];
                 const trgLoci = StructureElement.Loci.remap(trgSel.loci, this.getRootStructure(trgSel.loci.structure));
 
-                const result = superposeLigandsByMccs(refLoci, trgLoci, DefaultLigandMccsOptions, ctx);
+                const result = superposeLigandsByMccs(refLoci, trgLoci, DefaultLigandMccsOptions);
                 if (!result) {
                     this.plugin.log.warn(`Ligand superposition: insufficient overlap for ${stripTags(trgEntry.label)}.`);
                     continue;
@@ -244,6 +244,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 const labelA = stripTags(refEntry.label);
                 const labelB = stripTags(trgEntry.label);
                 this.plugin.log.info(`Ligand superposed [${labelA}] and [${labelB}] via ${result.method} using ${result.atomCount} atoms (RMSD ${result.rmsd.toFixed(2)} Å).`);
+                if (result.truncated) this.plugin.log.warn(`Ligand superposition: MCCS search for [${labelB}] hit its time budget; the alignment may not be optimal.`);
             }
 
             // focus the aligned ligands; the reference is the pivot, so every target now sits on it

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -524,7 +524,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
     superposeByDbMapping() {
         return <>
             <Button icon={SuperposeChainsSvg} title='Superpose structures using intersection of residues from SIFTS UNIPROT mapping.' className='msp-btn msp-btn-block' onClick={this.superposeDb} style={{ marginTop: '1px' }} disabled={this.state.isBusy}>
-                Uniprot
+                UniProt
             </Button>
         </>;
     }
@@ -539,7 +539,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 <div className='msp-help-description'><Icon svg={HelpOutlineSvg} inline />Add 1 selection{this.toggleHint()} per
                     structure (2+ structures total). Selections must be confined to a single ligand residue. Fast path matches atom names when compound name matches.</div>
             </div>}
-            {entries.length > 1 && <Button title='Superpose structures by selected ligands (atom-name fast path, then MCCS).' className='msp-btn-commit msp-btn-commit-on' onClick={this.superposeMccs} style={{ marginTop: '1px' }}>
+            {entries.length > 1 && <Button title='Superpose structures by selected ligands (atom-name fast path, then Maximum Common Connected Subgraph).' className='msp-btn-commit msp-btn-commit-on' onClick={this.superposeMccs} style={{ marginTop: '1px' }}>
                 Superpose
             </Button>}
         </>;
@@ -558,7 +558,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 <ToggleButton icon={TuneSvg} label='' title='Options for chain- and UniProt-based superposition (sequence-guided alignment, trace/CA-only).' toggle={this.toggleOptions} isSelected={this.state.action === 'options'} disabled={this.state.isBusy} style={{ flex: '0 0 40px', padding: 0 }} />
             </div>
             <div className='msp-flex-row'>
-                {this.state.canUseLigands && <ToggleButton icon={SuperposeAtomsSvg} label='Ligands' title='Superpose ligands by atom-name match (identical compound) or maximum common substructure (MCCS) otherwise. Select one ligand residue per structure; 2+ structures.' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />}
+                {this.state.canUseLigands && <ToggleButton icon={SuperposeAtomsSvg} label='Ligands' title='Superpose ligands by atom-name match (identical compound) or maximum common connected subgraph (MCCS) otherwise. Select one ligand residue per structure; 2+ structures.' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />}
                 <ToggleButton icon={SuperposeAtomsSvg} label='Atoms' title='Superpose by manually selected atoms, paired in selection order. Pick the same atoms, in the same order, in each structure (1+ per structure).' toggle={this.toggleByAtoms} isSelected={this.state.action === 'byAtoms'} disabled={this.state.isBusy} />
             </div>
             {this.state.action === 'byChains' && this.addByChains()}

--- a/src/mol-plugin-ui/structure/superposition.tsx
+++ b/src/mol-plugin-ui/structure/superposition.tsx
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2020-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
- * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.org>
  * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
@@ -13,6 +13,7 @@ import { QueryContext, Structure, StructureElement, StructureProperties, Structu
 import { alignAndSuperpose, superpose } from '../../mol-model/structure/structure/util/superposition';
 import { alignAndSuperposeWithSIFTSMapping } from '../../mol-model/structure/structure/util/superposition-sifts-mapping';
 import { tmAlign } from '../../mol-model/structure/structure/util/tm-align';
+import { isSingleLigandLoci, superposeLigandsByMccs, DefaultLigandMccsOptions } from '../../mol-model/structure/structure/util/superposition-ligand';
 import { StructureSelectionQueries } from '../../mol-plugin-state/helpers/structure-selection-query';
 import { StructureSelectionHistoryEntry } from '../../mol-plugin-state/manager/structure/selection';
 import { PluginStateObject } from '../../mol-plugin-state/objects';
@@ -64,7 +65,7 @@ const SuperpositionTag = 'SuperpositionTransform';
 
 type SuperpositionControlsState = {
     isBusy: boolean,
-    action?: 'byChains' | 'byAtoms' | 'byTMAlign' | 'options',
+    action?: 'byChains' | 'byAtoms' | 'byTMAlign' | 'byMccs' | 'options',
     canUseDb?: boolean,
     options: StructureSuperpositionOptions
 }
@@ -73,11 +74,15 @@ export interface LociEntry {
     loci: StructureElement.Loci,
     label: string,
     cell: StateObjectCell<PluginStateObject.Molecule.Structure>
-};
+}
 
 interface AtomsLociEntry extends LociEntry {
     atoms: StructureSelectionHistoryEntry[]
-};
+}
+
+interface LigandsLociEntry extends LociEntry {
+    ligands: StructureSelectionHistoryEntry[]
+}
 
 export class SuperpositionControls extends PurePluginUIComponent<{ }, SuperpositionControlsState> {
     state: SuperpositionControlsState = {
@@ -189,6 +194,50 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
         await this.cameraReset();
     };
 
+    superposeMccs = async () => {
+        const entries = this.ligandEntries;
+        if (entries.length < 2) return;
+
+        const bad = entries.filter(e => e.ligands.length !== 1);
+        if (bad.length) {
+            this.plugin.log.error('Ligand superposition: please select exactly 1 ligand per structure (remove extras in the history list).');
+            return;
+        }
+
+        const refEntry = entries[0];
+        const refSel = refEntry.ligands[0];
+        const refLoci = StructureElement.Loci.remap(refSel.loci, this.getRootStructure(refSel.loci.structure));
+
+        const pivot = this.plugin.managers.structure.hierarchy.findStructure(refLoci.structure);
+        const coordinateSystem = pivot?.transform?.cell.obj?.data.coordinateSystem;
+
+        const mccsAlignTask = Task.create('Ligand Superposition', async ctx => {
+            for (let i = 1; i < entries.length; i++) {
+                if (ctx.shouldUpdate) await ctx.update(`Superposing ligand ${i} of ${entries.length - 1}...`);
+
+                const trgEntry = entries[i];
+                const trgSel = trgEntry.ligands[0];
+                const trgLoci = StructureElement.Loci.remap(trgSel.loci, this.getRootStructure(trgSel.loci.structure));
+
+                const result = superposeLigandsByMccs(refLoci, trgLoci, DefaultLigandMccsOptions, ctx);
+                if (!result) {
+                    this.plugin.log.warn(`Ligand superposition: insufficient overlap for ${stripTags(trgEntry.label)}.`);
+                    continue;
+                }
+
+                await this.transform(trgEntry.cell, result.bTransform, coordinateSystem);
+
+                const labelA = stripTags(refEntry.label);
+                const labelB = stripTags(trgEntry.label);
+                this.plugin.log.info(`Ligand superposed [${labelA}] and [${labelB}] via ${result.method} using ${result.atomCount} atoms (RMSD ${result.rmsd.toFixed(2)} Å).`);
+            }
+
+            await this.cameraReset();
+        });
+
+        await this.plugin.runTask(mccsAlignTask, { useOverlay: true });
+    };
+
     superposeDb = async () => {
         const input = this.plugin.managers.structure.hierarchy.behaviors.selection.value.structures;
         const traceOnly = this.state.options.traceOnly;
@@ -264,6 +313,7 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
     toggleByChains = () => this.setState({ action: this.state.action === 'byChains' ? void 0 : 'byChains' });
     toggleByAtoms = () => this.setState({ action: this.state.action === 'byAtoms' ? void 0 : 'byAtoms' });
     toggleByTMAlign = () => this.setState({ action: this.state.action === 'byTMAlign' ? void 0 : 'byTMAlign' });
+    toggleByMccs = () => this.setState({ action: this.state.action === 'byMccs' ? void 0 : 'byMccs' });
     toggleOptions = () => this.setState({ action: this.state.action === 'options' ? void 0 : 'options' });
 
     highlight(loci: StructureElement.Loci) {
@@ -305,6 +355,17 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
             </div>
             <div className='msp-control-offset'>
                 {e.atoms.map((h, i) => this.historyEntry(h, i))}
+            </div>
+        </div>;
+    }
+
+    ligandsLociEntry(e: LigandsLociEntry, idx: number) {
+        return <div key={idx}>
+            <div className='msp-control-group-header'>
+                <div className='msp-no-overflow' title={e.label}>{e.label}</div>
+            </div>
+            <div className='msp-control-offset'>
+                {e.ligands.map((h, i) => this.historyEntry(h, i))}
             </div>
         </div>;
     }
@@ -357,6 +418,36 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
             const label = loci.structure.label.split(' | ')[0];
             entries.push({ loci, label, cell, atoms });
         });
+        return entries;
+    }
+
+    get ligandEntries() {
+        const structureEntries = new Map<Structure, StructureSelectionHistoryEntry[]>();
+        const history = this.plugin.managers.structure.selection.additionsHistory;
+
+        for (let i = 0, il = history.length; i < il; ++i) {
+            const e = history[i];
+            if (!isSingleLigandLoci(e.loci)) continue;
+
+            const k = e.loci.structure;
+            if (structureEntries.has(k)) structureEntries.get(k)!.push(e);
+            else structureEntries.set(k, [e]);
+        }
+
+        const entries: LigandsLociEntry[] = [];
+        structureEntries.forEach((ligands, structure) => {
+            const cell = this.plugin.helpers.substructureParent.get(structure)!;
+
+            const elements: StructureElement.Loci['elements'][0][] = [];
+            for (let i = 0, il = ligands.length; i < il; ++i) {
+                elements.push(ligands[i].loci.elements[0]);
+            }
+
+            const loci = StructureElement.Loci(ligands[0].loci.structure, elements);
+            const label = loci.structure.label.split(' | ')[0];
+            entries.push({ loci, label, cell, ligands });
+        });
+
         return entries;
     }
 
@@ -419,6 +510,22 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
         </>;
     }
 
+    addByMccs() {
+        const entries = this.ligandEntries;
+        return <>
+            {entries.length > 0 && <div className='msp-control-offset'>
+                {entries.map((e, i) => this.ligandsLociEntry(e, i))}
+            </div>}
+            {entries.length < 2 && <div className='msp-control-offset msp-help-text'>
+                <div className='msp-help-description'><Icon svg={HelpOutlineSvg} inline />Add 1 selection{this.toggleHint()} per
+                    structure (2+ structures total). Selections must be confined to a single ligand residue. Fast path matches atom names when compound name matches.</div>
+            </div>}
+            {entries.length > 1 && <Button title='Superpose structures by selected ligands (atom-name fast path, then MCCS).' className='msp-btn-commit msp-btn-commit-on' onClick={this.superposeMccs} style={{ marginTop: '1px' }}>
+                Superpose
+            </Button>}
+        </>;
+    }
+
     private setOptions = (values: StructureSuperpositionOptions) => {
         this.setState({ options: values });
     };
@@ -430,11 +537,13 @@ export class SuperpositionControls extends PurePluginUIComponent<{ }, Superposit
                 <ToggleButton icon={SuperposeAtomsSvg} label='Atoms' toggle={this.toggleByAtoms} isSelected={this.state.action === 'byAtoms'} disabled={this.state.isBusy} />
                 <ToggleButton icon={SuperposeChainsSvg} label='TM-align' toggle={this.toggleByTMAlign} isSelected={this.state.action === 'byTMAlign'} disabled={this.state.isBusy} />
                 {this.state.canUseDb && this.superposeByDbMapping()}
+                <ToggleButton icon={SuperposeAtomsSvg} label='Ligands' toggle={this.toggleByMccs} isSelected={this.state.action === 'byMccs'} disabled={this.state.isBusy} />
                 <ToggleButton icon={TuneSvg} label='' title='Options' toggle={this.toggleOptions} isSelected={this.state.action === 'options'} disabled={this.state.isBusy} style={{ flex: '0 0 40px', padding: 0 }} />
             </div>
             {this.state.action === 'byChains' && this.addByChains()}
             {this.state.action === 'byAtoms' && this.addByAtoms()}
             {this.state.action === 'byTMAlign' && this.addByTMAlign()}
+            {this.state.action === 'byMccs' && this.addByMccs()}
             {this.state.action === 'options' && <div className='msp-control-offset'>
                 <ParameterControls params={StructureSuperpositionParams} values={this.state.options} onChangeValues={this.setOptions} isDisabled={this.state.isBusy} />
             </div>}

--- a/src/mol-util/_spec/bit-set.spec.ts
+++ b/src/mol-util/_spec/bit-set.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
+ */
+
+import { BitSet } from '../bit-set';
+
+function setBits(b: BitSet): number[] {
+    const out: number[] = [];
+    for (let i = b.nextSetBit(0); i >= 0; i = b.nextSetBit(i + 1)) out.push(i);
+    return out;
+}
+
+describe('BitSet', () => {
+    it('set/get/clear including word boundaries and the sign bit', () => {
+        const b = new BitSet(70);
+        for (const i of [0, 31, 32, 63, 64, 69]) {
+            expect(b.get(i)).toBe(false);
+            b.set(i);
+            expect(b.get(i)).toBe(true);
+        }
+        b.clear(32);
+        expect(b.get(32)).toBe(false);
+        expect(b.get(31)).toBe(true); // neighbour untouched
+        expect(setBits(b)).toEqual([0, 31, 63, 64, 69]);
+    });
+
+    it('allocates ceil(nbits/32) words', () => {
+        expect(new BitSet(0).words.length).toBe(0);
+        expect(new BitSet(1).words.length).toBe(1);
+        expect(new BitSet(32).words.length).toBe(1);
+        expect(new BitSet(33).words.length).toBe(2);
+    });
+
+    it('cardinality / isEmpty', () => {
+        const b = new BitSet(40);
+        expect(b.isEmpty()).toBe(true);
+        expect(b.cardinality()).toBe(0);
+        b.set(5); b.set(39); b.set(5); // idempotent
+        expect(b.isEmpty()).toBe(false);
+        expect(b.cardinality()).toBe(2);
+        b.zero();
+        expect(b.isEmpty()).toBe(true);
+        expect(b.cardinality()).toBe(0);
+    });
+
+    it('full() sets exactly [0, nbits) even when not a multiple of 32', () => {
+        const b = new BitSet(40);
+        expect(b.cardinality()).toBe(0);
+        const f = BitSet.full(40);
+        expect(f.cardinality()).toBe(40);
+        expect(f.get(39)).toBe(true);
+        expect(f.get(40)).toBe(false); // beyond nbits, within the last word
+        expect(f.get(63)).toBe(false);
+        expect(setBits(f)).toEqual(Array.from({ length: 40 }, (_, i) => i));
+
+        const exact = BitSet.full(64);
+        expect(exact.cardinality()).toBe(64);
+    });
+
+    it('clone is an independent copy', () => {
+        const a = new BitSet(64);
+        a.set(1); a.set(40);
+        const c = a.clone();
+        c.set(2);
+        expect(setBits(a)).toEqual([1, 40]);
+        expect(setBits(c)).toEqual([1, 2, 40]);
+    });
+
+    it('in-place and / andNot / or', () => {
+        const mk = (...bits: number[]) => { const b = new BitSet(64); for (const i of bits) b.set(i); return b; };
+
+        const a1 = mk(1, 2, 3, 40);
+        a1.and(mk(2, 3, 4, 41));
+        expect(setBits(a1)).toEqual([2, 3]);
+
+        const a2 = mk(1, 2, 3, 40);
+        a2.andNot(mk(2, 40));
+        expect(setBits(a2)).toEqual([1, 3]);
+
+        const a3 = mk(1, 40);
+        a3.or(mk(2, 40, 63));
+        expect(setBits(a3)).toEqual([1, 2, 40, 63]);
+    });
+
+    it('nextSetBit crosses words, handles the high bit, and terminates', () => {
+        const b = new BitSet(100);
+        expect(b.nextSetBit(0)).toBe(-1); // empty
+        b.set(31); b.set(64); b.set(99);
+        expect(b.nextSetBit(0)).toBe(31);
+        expect(b.nextSetBit(31)).toBe(31);
+        expect(b.nextSetBit(32)).toBe(64); // skips the rest of word 0 and all of word 1
+        expect(b.nextSetBit(65)).toBe(99);
+        expect(b.nextSetBit(100)).toBe(-1); // at/after nbits
+        expect(b.nextSetBit(-5)).toBe(31); // negative clamps to 0
+    });
+});

--- a/src/mol-util/bit-set.ts
+++ b/src/mol-util/bit-set.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Sebastian Bittrich <sebastian.m.bittrich@gmail.com>
+ */
+
+/**
+ * A dense, fixed-size bit set backed by a Uint32Array. Bits are addressed 0..nbits-1.
+ *
+ * Intentionally minimal — extend as needed. The in-place set operations (and/andNot/or) assume the
+ * operand has the same capacity.
+ */
+export class BitSet {
+    readonly nbits: number;
+    readonly words: Uint32Array;
+
+    constructor(nbits: number) {
+        this.nbits = nbits;
+        this.words = new Uint32Array((nbits + 31) >>> 5);
+    }
+
+    /** A set with every bit in [0, nbits) set. */
+    static full(nbits: number): BitSet {
+        const b = new BitSet(nbits);
+        b.words.fill(0xffffffff);
+        const rem = nbits & 31;
+        if (rem !== 0) b.words[b.words.length - 1] = ~(0xffffffff << rem);
+        return b;
+    }
+
+    clone(): BitSet {
+        const b = new BitSet(this.nbits);
+        b.words.set(this.words);
+        return b;
+    }
+
+    /** Clear all bits. */
+    zero() { this.words.fill(0); }
+
+    set(i: number) { this.words[i >>> 5] |= (1 << (i & 31)); }
+    clear(i: number) { this.words[i >>> 5] &= ~(1 << (i & 31)); }
+    get(i: number): boolean { return (this.words[i >>> 5] & (1 << (i & 31))) !== 0; }
+
+    /** In-place intersection with `o` (same capacity). */
+    and(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] &= x[k]; }
+    /** In-place set difference with `o` (same capacity). */
+    andNot(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] &= ~x[k]; }
+    /** In-place union with `o` (same capacity). */
+    or(o: BitSet) { const w = this.words, x = o.words; for (let k = 0, n = w.length; k < n; k++) w[k] |= x[k]; }
+
+    isEmpty(): boolean {
+        const w = this.words;
+        for (let k = 0, n = w.length; k < n; k++) if (w[k] !== 0) return false;
+        return true;
+    }
+
+    /** Number of set bits. */
+    cardinality(): number {
+        const w = this.words;
+        let c = 0;
+        for (let k = 0, n = w.length; k < n; k++) c += bitCount(w[k]);
+        return c;
+    }
+
+    /** Index of the first set bit at or after `from`, or -1 if there is none. */
+    nextSetBit(from: number): number {
+        if (from < 0) from = 0;
+        if (from >= this.nbits) return -1;
+        const w = this.words;
+        let wi = from >>> 5;
+        let word = w[wi] & (0xffffffff << (from & 31));
+        while (true) {
+            if (word !== 0) {
+                const bit = (wi << 5) + (31 - Math.clz32(word & -word));
+                return bit < this.nbits ? bit : -1;
+            }
+            if (++wi >= w.length) return -1;
+            word = w[wi];
+        }
+    }
+}
+
+/** Population count (number of set bits) of a 32-bit word. */
+function bitCount(n: number): number {
+    n = n - ((n >>> 1) & 0x55555555);
+    n = (n & 0x33333333) + ((n >>> 2) & 0x33333333);
+    return (((n + (n >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
+}


### PR DESCRIPTION
# Description
- select one ligand each in 2 structures
- this will superimpose them by minimizing the RMSD, based on
  - atom names if the chemical component in both selections is identical
  - otherwise, the maximum common connected subgraph will establish correspondence between both sets of ligand atoms
- alignment options have been rearranged because that space is getting crowded
- some test cases
  - 1acj vs 5eie: THA vs TZ2
  - 9dsv vs 1kmm: ATP vs HAM
  - 1tqn vs 4hhb: HEM

<img width="1659" height="1293" alt="THA" src="https://github.com/user-attachments/assets/0fe21bdf-c186-4d9f-988f-d4b291216fc0" />

<img width="1659" height="1293" alt="ATP" src="https://github.com/user-attachments/assets/834a11f9-d643-4eb4-8db5-8794dc3fde56" />

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`