### PR TITLE
Fix lammps trajectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
-- Fix LAMMPS trajectory atom ordering
+- Fix LAMMPS unsorted-atom handling (trajectory frame ordering and data-file bonds)
 - Add VTK PolyData `.vtp` file format support
 - Bloom on transparent and emissive geometry
   - Move bloom into the postprocessing/illumination pass (composited inline)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix LAMMPS trajectory frames atom-`id` order 
 - Add VTK PolyData `.vtp` file format support
 - Bloom on transparent and emissive geometry
   - Move bloom into the postprocessing/illumination pass (composited inline)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
-- Fix LAMMPS trajectory frames atom-`id` order 
+- Fix LAMMPS trajectory atom ordering
 - Add VTK PolyData `.vtp` file format support
 - Bloom on transparent and emissive geometry
   - Move bloom into the postprocessing/illumination pass (composited inline)

--- a/src/mol-model-formats/structure/_spec/lammps-trajectory.spec.ts
+++ b/src/mol-model-formats/structure/_spec/lammps-trajectory.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Ludovic Autin <autin@scripps.edu>
+ */
+
+import { Column } from '../../../mol-data/db';
+import { getCanonicalOrder } from '../lammps-trajectory';
+
+function frame(atomIds: number[]) {
+    return { count: atomIds.length, atomId: Column.ofIntArray(atomIds) };
+}
+
+describe('lammps-trajectory getCanonicalOrder', () => {
+    it('returns undefined when rows are already in id order (identity fast-path)', () => {
+        expect(getCanonicalOrder(frame([1, 2, 3, 4]))).toBeUndefined();
+        expect(getCanonicalOrder(frame([1]))).toBeUndefined();
+        expect(getCanonicalOrder(frame([]))).toBeUndefined(); // empty frame
+    });
+
+    it('maps each row to the 0-based slot id - 1', () => {
+        // row 0 -> id 3 -> slot 2, row 1 -> id 1 -> slot 0, row 2 -> id 2 -> slot 1
+        expect(getCanonicalOrder(frame([3, 1, 2]))).toEqual(new Int32Array([2, 0, 1]));
+        // out of order from the first row
+        expect(getCanonicalOrder(frame([2, 1]))).toEqual(new Int32Array([1, 0]));
+    });
+
+    it('preserves the leading identity prefix before the first out-of-order row', () => {
+        // rows 0,1 already in order, row 2/3 swapped
+        expect(getCanonicalOrder(frame([1, 2, 4, 3]))).toEqual(new Int32Array([0, 1, 3, 2]));
+    });
+
+    it('returns undefined for a duplicate id landing in the already-filled prefix (dst < j)', () => {
+        // identity prefix [1,2], then id 1 points back into it
+        expect(getCanonicalOrder(frame([1, 2, 1]))).toBeUndefined();
+    });
+
+    it('returns undefined for a duplicate id after the permutation is allocated (seen[dst])', () => {
+        // first row already out of order (allocates), then a repeated id
+        expect(getCanonicalOrder(frame([2, 1, 1]))).toBeUndefined();
+    });
+
+    it('returns undefined for out-of-range ids', () => {
+        expect(getCanonicalOrder(frame([0, 1, 2]))).toBeUndefined(); // id 0 -> slot -1
+        expect(getCanonicalOrder(frame([1, 2, 4]))).toBeUndefined(); // id 4 -> slot 3 >= count
+    });
+});

--- a/src/mol-model-formats/structure/lammps-data.ts
+++ b/src/mol-model-formats/structure/lammps-data.ts
@@ -28,7 +28,6 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
     const count = atoms.count;
     const scale = lammpsUnitStyles[unitsStyle].scale;
     const type_symbols = new Array<string>(count);
-    const id = new Int32Array(count);
     const cx = new Float32Array(count);
     const cy = new Float32Array(count);
     const cz = new Float32Array(count);
@@ -45,11 +44,10 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
         cx[j] = atoms.x.value(j) * scale;
         cy[j] = atoms.y.value(j) * scale;
         cz[j] = atoms.z.value(j) * scale;
-        id[j] = atomId;
         if (atomId > maxId) maxId = atomId;
     }
     const rowOfId = new Int32Array(maxId + 1).fill(-1);
-    for (let j = 0; j < count; j++) rowOfId[id[j]] = j;
+    for (let j = 0; j < count; j++) rowOfId[atoms.atomId.value(j)] = j;
 
     const MOL = Column.ofConst('MOL', count, Column.Schema.str);
     const asym_id = Column.ofLambda({
@@ -69,7 +67,7 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
         Cartn_x: Column.ofFloatArray(cx),
         Cartn_y: Column.ofFloatArray(cy),
         Cartn_z: Column.ofFloatArray(cz),
-        id: Column.ofIntArray(id),
+        id: atoms.atomId,
 
         label_asym_id: asym_id,
         label_atom_id: type_symbol,

--- a/src/mol-model-formats/structure/lammps-data.ts
+++ b/src/mol-model-formats/structure/lammps-data.ts
@@ -34,15 +34,19 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
     const cz = new Float32Array(count);
     const model_num = new Int32Array(count);
 
-    let offset = 0;
+    // A LAMMPS `.data` file may list atoms in any order (rows are not necessarily sorted by atom id),
+    // while the Bonds section references atoms by id. Map each id to its row so bonds connect the
+    // correct atoms (handles any unique-id scheme, not just contiguous 1..count).
+    const rowOfId = new Map<number, number>();
     for (let j = 0; j < count; j++) {
-        type_symbols[offset] = atoms.atomType.value(j).toString();
-        cx[offset] = atoms.x.value(j) * scale;
-        cy[offset] = atoms.y.value(j) * scale;
-        cz[offset] = atoms.z.value(j) * scale;
-        id[offset] = atoms.atomId.value(j) - 1;
-        model_num[offset] = 0;
-        offset++;
+        const atomId = atoms.atomId.value(j);
+        type_symbols[j] = atoms.atomType.value(j).toString();
+        cx[j] = atoms.x.value(j) * scale;
+        cy[j] = atoms.y.value(j) * scale;
+        cz[j] = atoms.z.value(j) * scale;
+        id[j] = atomId - 1;
+        model_num[j] = 0;
+        rowOfId.set(atomId, j);
     }
 
     const MOL = Column.ofConst('MOL', count, Column.Schema.str);
@@ -94,11 +98,20 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
     if (_models.frameCount > 0) {
         const first = _models.representative;
         if (bonds.count !== 0) {
-            const indexA = Column.ofIntArray(Column.mapToArray(bonds.atomIdA, x => x - 1, Int32Array));
-            const indexB = Column.ofIntArray(Column.mapToArray(bonds.atomIdB, x => x - 1, Int32Array));
-            const key = bonds.bondId;
-            const order = Column.ofConst(1, bonds.count, Column.Schema.int);
-            const flag = Column.ofConst(BondType.Flag.Covalent, bonds.count, Column.Schema.int);
+            // resolve bond atom ids to atom rows via `rowOfId`; drop a bond that references an
+            // unknown atom id rather than silently pointing it at row 0
+            const ia: number[] = [], ib: number[] = [], keys: number[] = [];
+            for (let i = 0; i < bonds.count; i++) {
+                const a = rowOfId.get(bonds.atomIdA.value(i));
+                const b = rowOfId.get(bonds.atomIdB.value(i));
+                if (a === undefined || b === undefined) continue;
+                ia.push(a); ib.push(b); keys.push(bonds.bondId.value(i));
+            }
+            const indexA = Column.ofIntArray(new Int32Array(ia));
+            const indexB = Column.ofIntArray(new Int32Array(ib));
+            const key = Column.ofIntArray(new Int32Array(keys));
+            const order = Column.ofConst(1, ia.length, Column.Schema.int);
+            const flag = Column.ofConst(BondType.Flag.Covalent, ia.length, Column.Schema.int);
             const pairBonds = IndexPairBonds.fromData(
                 { pairs: { key, indexA, indexB, order, flag }, count: atoms.count },
                 { maxDistance: Infinity }

--- a/src/mol-model-formats/structure/lammps-data.ts
+++ b/src/mol-model-formats/structure/lammps-data.ts
@@ -32,22 +32,24 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
     const cx = new Float32Array(count);
     const cy = new Float32Array(count);
     const cz = new Float32Array(count);
-    const model_num = new Int32Array(count);
 
-    // A LAMMPS `.data` file may list atoms in any order (rows are not necessarily sorted by atom id),
-    // while the Bonds section references atoms by id. Map each id to its row so bonds connect the
-    // correct atoms (handles any unique-id scheme, not just contiguous 1..count).
-    const rowOfId = new Map<number, number>();
+    // A LAMMPS `.data` file may list atoms in any order (rows are not necessarily sorted by atom
+    // id), while the Bonds section references atoms by id. Record each id's row so bonds connect
+    // the correct atoms. Atom ids are positive and, for a data file, on the order of 1..count, so
+    // an array indexed by id (with a -1 sentinel for holes) is smaller and faster than a Map; this
+    // deliberately assumes `maxId` stays close to `count` (true for a real data file).
+    let maxId = 0;
     for (let j = 0; j < count; j++) {
         const atomId = atoms.atomId.value(j);
         type_symbols[j] = atoms.atomType.value(j).toString();
         cx[j] = atoms.x.value(j) * scale;
         cy[j] = atoms.y.value(j) * scale;
         cz[j] = atoms.z.value(j) * scale;
-        id[j] = atomId - 1;
-        model_num[j] = 0;
-        rowOfId.set(atomId, j);
+        id[j] = atomId;
+        if (atomId > maxId) maxId = atomId;
     }
+    const rowOfId = new Int32Array(maxId + 1).fill(-1);
+    for (let j = 0; j < count; j++) rowOfId[id[j]] = j;
 
     const MOL = Column.ofConst('MOL', count, Column.Schema.str);
     const asym_id = Column.ofLambda({
@@ -78,7 +80,7 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
         occupancy: Column.ofConst(1, count, Column.Schema.float),
         type_symbol,
 
-        pdbx_PDB_model_num: Column.ofIntArray(model_num),
+        pdbx_PDB_model_num: Column.ofConst(0, count, Column.Schema.int),
     }, count);
 
     const entityBuilder = new EntityBuilder();
@@ -98,13 +100,15 @@ async function getModels(mol: LammpsDataFile, ctx: RuntimeContext, unitsStyle: U
     if (_models.frameCount > 0) {
         const first = _models.representative;
         if (bonds.count !== 0) {
-            // resolve bond atom ids to atom rows via `rowOfId`; drop a bond that references an
-            // unknown atom id rather than silently pointing it at row 0
+            // resolve bond atom ids to atom rows via `rowOfId`, dropping a bond that references an
+            // unknown atom id (past the table, or a -1 hole in the id range) rather than silently
+            // pointing it at row 0
             const ia: number[] = [], ib: number[] = [], keys: number[] = [];
             for (let i = 0; i < bonds.count; i++) {
-                const a = rowOfId.get(bonds.atomIdA.value(i));
-                const b = rowOfId.get(bonds.atomIdB.value(i));
-                if (a === undefined || b === undefined) continue;
+                const idA = bonds.atomIdA.value(i), idB = bonds.atomIdB.value(i);
+                if (idA > maxId || idB > maxId) continue;
+                const a = rowOfId[idA], b = rowOfId[idB];
+                if (a < 0 || b < 0) continue;
                 ia.push(a); ib.push(b); keys.push(bonds.bondId.value(i));
             }
             const indexA = Column.ofIntArray(new Int32Array(ia));

--- a/src/mol-model-formats/structure/lammps-trajectory.ts
+++ b/src/mol-model-formats/structure/lammps-trajectory.ts
@@ -29,17 +29,29 @@ import { ModelSymmetry } from './property/symmetry';
  * (destination index = id - 1) to keep all frames consistent with each other and
  * with the topology. Without this, coordinates land on the wrong atoms.
  *
- * Returns the source-row -> canonical-index permutation, or `undefined` when the
- * ids are not a contiguous 1..count set (in which case callers keep file order).
+ * Returns the source-row -> canonical-index permutation, or `undefined` when no
+ * reordering is needed (rows already in id order) or the ids are not a contiguous
+ * 1..count set - in both cases callers keep file order. Allocates the permutation
+ * only once a row is found out of order, in a single pass (`atomId.value` parses a
+ * token, so it is read exactly once per row).
  */
 function getCanonicalOrder(frame: LammpsFrame): Int32Array | undefined {
     const { count, atomId } = frame;
-    const order = new Int32Array(count);
-    const seen = new Uint8Array(count);
+    let order: Int32Array | undefined;
+    let seen: Uint8Array | undefined;
     for (let j = 0; j < count; j++) {
         const dst = atomId.value(j) - 1;
-        if (dst < 0 || dst >= count || seen[dst]) return undefined;
-        seen[dst] = 1;
+        if (dst < 0 || dst >= count) return undefined;
+        if (!order) {
+            // still in the leading identity run - nothing to permute yet
+            if (dst === j) continue;
+            // first out-of-order row: allocate and backfill the identity prefix [0, j)
+            order = new Int32Array(count);
+            seen = new Uint8Array(count);
+            for (let k = 0; k < j; k++) { order[k] = k; seen[k] = 1; }
+        }
+        if (seen![dst]) return undefined; // seen is set with order
+        seen![dst] = 1;
         order[j] = dst;
     }
     return order;

--- a/src/mol-model-formats/structure/lammps-trajectory.ts
+++ b/src/mol-model-formats/structure/lammps-trajectory.ts
@@ -22,12 +22,17 @@ import { ModelFormat } from '../format';
 import { ModelSymmetry } from './property/symmetry';
 
 /**
- * A LAMMPS dump may list atoms in a different order in every frame (atoms are
- * reordered as they migrate between MPI domains), and that order generally does
- * not match a separately-loaded topology (e.g. a sorted `.data` file). Each atom
- * row carries its `id`, so we scatter every frame into canonical id order
- * (destination index = id - 1) to keep all frames consistent with each other and
- * with the topology. Without this, coordinates land on the wrong atoms.
+ * A LAMMPS dump may list atoms in a different order in every frame: LAMMPS splits
+ * the simulation box across processors (spatial domain decomposition) and writes
+ * each processor's atoms as they arrive, so the per-frame order follows how atoms
+ * are distributed and migrate between domains rather than their id. That order also
+ * generally does not match a separately-loaded topology (e.g. a sorted `.data`
+ * file). Each atom row carries its `id`, so we scatter every frame into canonical
+ * id order (row for `id` lands at 0-based array slot `id - 1`) to keep all frames
+ * consistent with each other and with the topology. Without this, coordinates land
+ * on the wrong atoms.
+ * (Dumps written with `dump_modify sort id` are already ordered and hit the
+ * identity fast-path below.)
  *
  * Returns the source-row -> canonical-index permutation, or `undefined` when no
  * reordering is needed (rows already in id order) or the ids are not a contiguous
@@ -35,7 +40,7 @@ import { ModelSymmetry } from './property/symmetry';
  * only once a row is found out of order, in a single pass (`atomId.value` parses a
  * token, so it is read exactly once per row).
  */
-function getCanonicalOrder(frame: LammpsFrame): Int32Array | undefined {
+export function getCanonicalOrder(frame: Pick<LammpsFrame, 'count' | 'atomId'>): Int32Array | undefined {
     const { count, atomId } = frame;
     let order: Int32Array | undefined;
     let seen: Uint8Array | undefined;
@@ -127,12 +132,11 @@ async function getModels(mol: LammpsTrajectoryFile, ctx: RuntimeContext, unitsSt
         offset_pos.z = box.lower[2];
     }
     const type_symbols = new Array<string>(count);
+    const asym_ids = new Array<string>(count);
     const id = new Int32Array(count);
     const cx = new Float32Array(count);
     const cy = new Float32Array(count);
     const cz = new Float32Array(count);
-    const model_num = new Int32Array(count);
-    const molecule_ids = new Int32Array(count);
 
     // fold the loop-invariant `* scale` into the scale/offset factors
     const sx = offset_scale.x * scale, sy = offset_scale.y * scale, sz = offset_scale.z * scale;
@@ -144,20 +148,15 @@ async function getModels(mol: LammpsTrajectoryFile, ctx: RuntimeContext, unitsSt
     for (let j = 0; j < count; j++) {
         const dst = order ? order[j] : j;
         type_symbols[dst] = atoms.atomType.value(j).toString();
+        asym_ids[dst] = atoms.moleculeId.value(j).toString();
         cx[dst] = atoms.x.value(j) * sx + ox;
         cy[dst] = atoms.y.value(j) * sy + oy;
         cz[dst] = atoms.z.value(j) * sz + oz;
         id[dst] = atoms.atomId.value(j);
-        molecule_ids[dst] = atoms.moleculeId.value(j);
-        model_num[dst] = 0;
     }
 
     const MOL = Column.ofConst('MOL', count, Column.Schema.str);
-    const asym_id = Column.ofLambda({
-        value: (row: number) => molecule_ids[row].toString(),
-        rowCount: count,
-        schema: Column.Schema.str,
-    });
+    const asym_id = Column.ofStringArray(asym_ids);
     const seq_id = Column.ofConst(1, count, Column.Schema.int);
 
     const type_symbol = Column.ofStringArray(type_symbols);
@@ -181,7 +180,7 @@ async function getModels(mol: LammpsTrajectoryFile, ctx: RuntimeContext, unitsSt
         occupancy: Column.ofConst(1, count, Column.Schema.float),
         type_symbol,
 
-        pdbx_PDB_model_num: Column.ofIntArray(model_num),
+        pdbx_PDB_model_num: Column.ofConst(0, count, Column.Schema.int),
     }, count);
 
     const entityBuilder = new EntityBuilder();

--- a/src/mol-model-formats/structure/lammps-trajectory.ts
+++ b/src/mol-model-formats/structure/lammps-trajectory.ts
@@ -7,7 +7,7 @@
  */
 
 import { Coordinates, Frame, Time } from '../../mol-model/structure/coordinates';
-import { LammpsTrajectoryFile, lammpsUnitStyles, UnitStyle } from '../../mol-io/reader/lammps/schema';
+import { LammpsFrame, LammpsTrajectoryFile, lammpsUnitStyles, UnitStyle } from '../../mol-io/reader/lammps/schema';
 import { Model } from '../../mol-model/structure/model';
 import { RuntimeContext, Task } from '../../mol-task';
 import { Column, Table } from '../../mol-data/db';
@@ -20,6 +20,30 @@ import { createModels } from './basic/parser';
 import { MoleculeType } from '../../mol-model/structure/model/types';
 import { ModelFormat } from '../format';
 import { ModelSymmetry } from './property/symmetry';
+
+/**
+ * A LAMMPS dump may list atoms in a different order in every frame (atoms are
+ * reordered as they migrate between MPI domains), and that order generally does
+ * not match a separately-loaded topology (e.g. a sorted `.data` file). Each atom
+ * row carries its `id`, so we scatter every frame into canonical id order
+ * (destination index = id - 1) to keep all frames consistent with each other and
+ * with the topology. Without this, coordinates land on the wrong atoms.
+ *
+ * Returns the source-row -> canonical-index permutation, or `undefined` when the
+ * ids are not a contiguous 1..count set (in which case callers keep file order).
+ */
+function getCanonicalOrder(frame: LammpsFrame): Int32Array | undefined {
+    const { count, atomId } = frame;
+    const order = new Int32Array(count);
+    const seen = new Uint8Array(count);
+    for (let j = 0; j < count; j++) {
+        const dst = atomId.value(j) - 1;
+        if (dst < 0 || dst >= count || seen[dst]) return undefined;
+        seen[dst] = 1;
+        order[j] = dst;
+    }
+    return order;
+}
 
 export function coordinatesFromLammpsTrajectory(file: LammpsTrajectoryFile, unitsStyle: UnitStyle = 'real'): Task<Coordinates> {
     return Task.create('Parse Lammps Trajectory', async ctx => {
@@ -42,19 +66,23 @@ export function coordinatesFromLammpsTrajectory(file: LammpsTrajectoryFile, unit
                 offset_pos.y = box.lower[1];
                 offset_pos.z = box.lower[2];
             }
-            const count = file.frames[i].count;
+            const frame = file.frames[i];
+            const count = frame.count;
+            const order = getCanonicalOrder(frame);
             const cx = new Float32Array(count);
             const cy = new Float32Array(count);
             const cz = new Float32Array(count);
-            let offset = 0;
+            // fold the loop-invariant `* scale` into the per-frame scale/offset factors
+            const sx = offset_scale.x * scale, sy = offset_scale.y * scale, sz = offset_scale.z * scale;
+            const ox = offset_pos.x * scale, oy = offset_pos.y * scale, oz = offset_pos.z * scale;
             for (let j = 0; j < count; j++) {
-                cx[offset] = (file.frames[i].x.value(j) * offset_scale.x + offset_pos.x) * scale;
-                cy[offset] = (file.frames[i].y.value(j) * offset_scale.y + offset_pos.y) * scale;
-                cz[offset] = (file.frames[i].z.value(j) * offset_scale.z + offset_pos.z) * scale;
-                offset++;
+                const dst = order ? order[j] : j;
+                cx[dst] = frame.x.value(j) * sx + ox;
+                cy[dst] = frame.y.value(j) * sy + oy;
+                cz[dst] = frame.z.value(j) * sz + oz;
             }
             frames.push({
-                elementCount: file.frames[i].count,
+                elementCount: count,
                 x: cx,
                 y: cy,
                 z: cz,
@@ -90,21 +118,29 @@ async function getModels(mol: LammpsTrajectoryFile, ctx: RuntimeContext, unitsSt
     const cy = new Float32Array(count);
     const cz = new Float32Array(count);
     const model_num = new Int32Array(count);
+    const molecule_ids = new Int32Array(count);
 
-    let offset = 0;
+    // fold the loop-invariant `* scale` into the scale/offset factors
+    const sx = offset_scale.x * scale, sy = offset_scale.y * scale, sz = offset_scale.z * scale;
+    const ox = offset_pos.x * scale, oy = offset_pos.y * scale, oz = offset_pos.z * scale;
+
+    // Build the topology in canonical id order so it stays aligned with the
+    // per-frame coordinates produced by coordinatesFromLammpsTrajectory.
+    const order = getCanonicalOrder(atoms);
     for (let j = 0; j < count; j++) {
-        type_symbols[offset] = atoms.atomType.value(j).toString();
-        cx[offset] = (atoms.x.value(j) * offset_scale.x + offset_pos.x) * scale;
-        cy[offset] = (atoms.y.value(j) * offset_scale.y + offset_pos.y) * scale;
-        cz[offset] = (atoms.z.value(j) * offset_scale.z + offset_pos.z) * scale;
-        id[offset] = atoms.atomId.value(j);
-        model_num[offset] = 0;
-        offset++;
+        const dst = order ? order[j] : j;
+        type_symbols[dst] = atoms.atomType.value(j).toString();
+        cx[dst] = atoms.x.value(j) * sx + ox;
+        cy[dst] = atoms.y.value(j) * sy + oy;
+        cz[dst] = atoms.z.value(j) * sz + oz;
+        id[dst] = atoms.atomId.value(j);
+        molecule_ids[dst] = atoms.moleculeId.value(j);
+        model_num[dst] = 0;
     }
 
     const MOL = Column.ofConst('MOL', count, Column.Schema.str);
     const asym_id = Column.ofLambda({
-        value: (row: number) => atoms.moleculeId.value(row).toString(),
+        value: (row: number) => molecule_ids[row].toString(),
         rowCount: count,
         schema: Column.Schema.str,
     });

--- a/src/mol-model-formats/structure/lammps-trajectory.ts
+++ b/src/mol-model-formats/structure/lammps-trajectory.ts
@@ -43,8 +43,10 @@ function getCanonicalOrder(frame: LammpsFrame): Int32Array | undefined {
         const dst = atomId.value(j) - 1;
         if (dst < 0 || dst >= count) return undefined;
         if (!order) {
-            // still in the leading identity run - nothing to permute yet
+            // in order so far (id === row + 1): nothing to permute yet
             if (dst === j) continue;
+            // out of order, but dst falls in the already-filled prefix [0, j): duplicate id, reject
+            if (dst < j) return undefined;
             // first out-of-order row: allocate and backfill the identity prefix [0, j)
             order = new Int32Array(count);
             seen = new Uint8Array(count);

--- a/src/mol-repr/structure/representation/ball-and-stick.ts
+++ b/src/mol-repr/structure/representation/ball-and-stick.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */

--- a/src/mol-repr/structure/representation/ball-and-stick.ts
+++ b/src/mol-repr/structure/representation/ball-and-stick.ts
@@ -45,7 +45,7 @@ export function getBallAndStickParams(ctx: ThemeRegistryContext, structure: Stru
     if (size >= Structure.Size.Huge) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['element-sphere', 'intra-bond'];
-    } else if (structure.unitSymmetryGroups.length > 1000) {
+    } else if (structure.unitSymmetryGroups.length > 500) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-sphere', 'structure-intra-bond'];
     }

--- a/src/mol-repr/structure/representation/ball-and-stick.ts
+++ b/src/mol-repr/structure/representation/ball-and-stick.ts
@@ -45,7 +45,7 @@ export function getBallAndStickParams(ctx: ThemeRegistryContext, structure: Stru
     if (size >= Structure.Size.Huge) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['element-sphere', 'intra-bond'];
-    } else if (structure.unitSymmetryGroups.length > 5000) {
+    } else if (structure.unitSymmetryGroups.length > 1000) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-sphere', 'structure-intra-bond'];
     }

--- a/src/mol-repr/structure/representation/ellipsoid.ts
+++ b/src/mol-repr/structure/representation/ellipsoid.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */

--- a/src/mol-repr/structure/representation/ellipsoid.ts
+++ b/src/mol-repr/structure/representation/ellipsoid.ts
@@ -44,7 +44,7 @@ export function getEllipsoidParams(ctx: ThemeRegistryContext, structure: Structu
     if (size >= Structure.Size.Huge) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['ellipsoid-mesh', 'intra-bond'];
-    } else if (structure.unitSymmetryGroups.length > 1000) {
+    } else if (structure.unitSymmetryGroups.length > 500) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-ellipsoid-mesh', 'structure-intra-bond'];
     }

--- a/src/mol-repr/structure/representation/ellipsoid.ts
+++ b/src/mol-repr/structure/representation/ellipsoid.ts
@@ -44,7 +44,7 @@ export function getEllipsoidParams(ctx: ThemeRegistryContext, structure: Structu
     if (size >= Structure.Size.Huge) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['ellipsoid-mesh', 'intra-bond'];
-    } else if (structure.unitSymmetryGroups.length > 5000) {
+    } else if (structure.unitSymmetryGroups.length > 1000) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-ellipsoid-mesh', 'structure-intra-bond'];
     }

--- a/src/mol-repr/structure/representation/line.ts
+++ b/src/mol-repr/structure/representation/line.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */

--- a/src/mol-repr/structure/representation/line.ts
+++ b/src/mol-repr/structure/representation/line.ts
@@ -49,7 +49,7 @@ export function getLineParams(ctx: ThemeRegistryContext, structure: Structure) {
     if (size >= Structure.Size.Huge) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['intra-bond', 'element-point', 'element-cross'];
-    } else if (structure.unitSymmetryGroups.length > 5000) {
+    } else if (structure.unitSymmetryGroups.length > 1000) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-intra-bond', 'structure-element-point', 'structure-element-cross'];
     }

--- a/src/mol-repr/structure/representation/line.ts
+++ b/src/mol-repr/structure/representation/line.ts
@@ -49,7 +49,7 @@ export function getLineParams(ctx: ThemeRegistryContext, structure: Structure) {
     if (size >= Structure.Size.Huge) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['intra-bond', 'element-point', 'element-cross'];
-    } else if (structure.unitSymmetryGroups.length > 1000) {
+    } else if (structure.unitSymmetryGroups.length > 500) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-intra-bond', 'structure-element-point', 'structure-element-cross'];
     }

--- a/src/mol-repr/structure/representation/point.ts
+++ b/src/mol-repr/structure/representation/point.ts
@@ -26,7 +26,7 @@ export const PointParams = {
 export type PointParams = typeof PointParams
 export function getPointParams(ctx: ThemeRegistryContext, structure: Structure) {
     let params = PointParams;
-    if (structure.unitSymmetryGroups.length > 1000) {
+    if (structure.unitSymmetryGroups.length > 500) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-point'];
     }

--- a/src/mol-repr/structure/representation/point.ts
+++ b/src/mol-repr/structure/representation/point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */

--- a/src/mol-repr/structure/representation/point.ts
+++ b/src/mol-repr/structure/representation/point.ts
@@ -26,7 +26,7 @@ export const PointParams = {
 export type PointParams = typeof PointParams
 export function getPointParams(ctx: ThemeRegistryContext, structure: Structure) {
     let params = PointParams;
-    if (structure.unitSymmetryGroups.length > 5000) {
+    if (structure.unitSymmetryGroups.length > 1000) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-point'];
     }

--- a/src/mol-repr/structure/representation/spacefill.ts
+++ b/src/mol-repr/structure/representation/spacefill.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */

--- a/src/mol-repr/structure/representation/spacefill.ts
+++ b/src/mol-repr/structure/representation/spacefill.ts
@@ -36,7 +36,7 @@ export function getSpacefillParams(ctx: ThemeRegistryContext, structure: Structu
         }
         params = CoarseGrainedSpacefillParams;
     }
-    if (structure.unitSymmetryGroups.length > 1000) {
+    if (structure.unitSymmetryGroups.length > 500) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-sphere'];
     }

--- a/src/mol-repr/structure/representation/spacefill.ts
+++ b/src/mol-repr/structure/representation/spacefill.ts
@@ -36,7 +36,7 @@ export function getSpacefillParams(ctx: ThemeRegistryContext, structure: Structu
         }
         params = CoarseGrainedSpacefillParams;
     }
-    if (structure.unitSymmetryGroups.length > 5000) {
+    if (structure.unitSymmetryGroups.length > 1000) {
         params = PD.clone(params);
         params.visuals.defaultValue = ['structure-element-sphere'];
     }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description
LAMMPS dumps can list atoms in a different order each frame, so coordinates were landing on the wrong atoms (frames out of sync with each other and with the topology). Each frame is now scattered into canonical atom-id order (index = id − 1); falls back to file order if ids aren't a contiguous 1..N set. Applied to both the per-frame coordinates and the .lammpstrj topology in src/mol-model-formats/structure/lammps-trajectory.ts.

See issue #1872.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`