### PR TITLE
Add `variant` option (rectangle/circle) to the best-fit `Plane`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Add `variant` option (rectangle/circle) to the best-fit `Plane` (#358)
 - Add VTK PolyData `.vtp` file format support
 - Bloom on transparent and emissive geometry
   - Move bloom into the postprocessing/illumination pass (composited inline)

--- a/src/mol-repr/shape/loci/plane.ts
+++ b/src/mol-repr/shape/loci/plane.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2021-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -16,6 +16,7 @@ import { structureElementLociLabelMany } from '../../../mol-theme/label';
 import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
 import { MarkerActions } from '../../../mol-util/marker-action';
 import { Plane } from '../../../mol-geo/primitive/plane';
+import { Circle } from '../../../mol-geo/primitive/circle';
 import { StructureElement } from '../../../mol-model/structure';
 import { Axes3D } from '../../../mol-math/geometry';
 
@@ -27,6 +28,8 @@ const _PlaneParams = {
     ...Mesh.Params,
     color: PD.Color(ColorNames.orange),
     scaleFactor: PD.Numeric(1, { min: 0.1, max: 10, step: 0.1 }),
+    variant: PD.Select('rectangle', PD.arrayToOptions(['rectangle', 'circle'] as const), { label: 'Shape' }),
+    radialSegments: PD.Numeric(64, { min: 12, max: 256, step: 1 }, { hideIf: p => p.variant !== 'circle' }),
 };
 type _PlaneParams = typeof _PlaneParams
 
@@ -54,17 +57,34 @@ function buildPlaneMesh(data: PlaneData, props: PlaneProps, mesh?: Mesh): Mesh {
     const state = MeshBuilder.createState(256, 128, mesh);
     const principalAxes = StructureElement.Loci.getPrincipalAxesMany(data.locis);
     const axes = principalAxes.boxAxes;
-    const plane = Plane();
 
     Vec3.add(tmpV, axes.origin, axes.dirC);
     Mat4.targetTo(tmpMat, tmpV, axes.origin, axes.dirB);
-    Mat4.scale(tmpMat, tmpMat, Axes3D.size(tmpV, axes));
-    Mat4.scaleUniformly(tmpMat, tmpMat, props.scaleFactor);
-    Mat4.setTranslation(tmpMat, axes.origin);
 
     state.currentGroup = 0;
-    MeshBuilder.addPrimitive(state, tmpMat, plane);
-    MeshBuilder.addPrimitiveFlipped(state, tmpMat, plane);
+
+    if (props.variant === 'circle') {
+        // the Circle primitive lies in the xz-plane (y as normal), rotate it
+        // by 90 degrees around x so it aligns with the plane's local frame
+        // (z as normal), matching the orientation used for the rectangle
+        Mat4.mul(tmpMat, tmpMat, Mat4.rotX90);
+        Mat4.scaleUniformly(tmpMat, tmpMat, props.scaleFactor);
+        Mat4.setTranslation(tmpMat, axes.origin);
+
+        const radius = Math.max(Vec3.magnitude(axes.dirA), Vec3.magnitude(axes.dirB));
+        const circle = Circle({ radius, segments: props.radialSegments });
+        MeshBuilder.addPrimitive(state, tmpMat, circle);
+        MeshBuilder.addPrimitiveFlipped(state, tmpMat, circle);
+    } else {
+        const plane = Plane();
+        Mat4.scale(tmpMat, tmpMat, Axes3D.size(tmpV, axes));
+        Mat4.scaleUniformly(tmpMat, tmpMat, props.scaleFactor);
+        Mat4.setTranslation(tmpMat, axes.origin);
+
+        MeshBuilder.addPrimitive(state, tmpMat, plane);
+        MeshBuilder.addPrimitiveFlipped(state, tmpMat, plane);
+    }
+
     return MeshBuilder.getMesh(state);
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Add `variant` option (rectangle/circle) to the best-fit `Plane`. Closes #358.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`