### PR TITLE
Element loci boundary improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Rework Superposition UI panel
 - Add Ligand alignments by maximum common connected subgraphs (MCCS)
 - Handle unobserved residues from `entity_poly_seq` (#965)
+- Refine step for coarse BoundaryHelper instances (#1455)
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add Ligand alignments by maximum common connected subgraphs (MCCS)
 - Handle unobserved residues from `entity_poly_seq` (#965)
 - Refine step for coarse BoundaryHelper instances (#1455)
+- Refactor `StructureElement.Loci.getBoundary`
+    - Add `.getBoundingSphere`, reuse whole structure/unit boundary
+    - [Breaking] remove transform argument
 
 ## [v5.10.0] - 2026-06-14
 - Fix exported image artifacts on transparent background with emissive, bloom, or antialiasing

--- a/src/extensions/debug-helpers/bounding-sphere-helper.ts
+++ b/src/extensions/debug-helpers/bounding-sphere-helper.ts
@@ -149,8 +149,9 @@ function createBoundingSphereMesh(boundingSphere: Sphere3D, mesh?: Mesh) {
     const builderState = MeshBuilder.createState(vertexCount, vertexCount / 2, mesh);
     if (boundingSphere.radius) {
         addSphere(builderState, boundingSphere.center, boundingSphere.radius, detail);
+        const er = boundingSphere.radius * 0.01;
         if (Sphere3D.hasExtrema(boundingSphere)) {
-            for (const e of boundingSphere.extrema) addSphere(builderState, e, 1.0, 0);
+            for (const e of boundingSphere.extrema) addSphere(builderState, e, er, 0);
         }
     }
     return MeshBuilder.getMesh(builderState);

--- a/src/extensions/interactions/visuals.ts
+++ b/src/extensions/interactions/visuals.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2025-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */
@@ -68,8 +68,8 @@ export function buildInteractionsShape(interactions: StructureInteractions, para
 
     const colors = new Map<number, Color>();
 
-    const bA = { sphere: Sphere3D.zero() };
-    const bB = { sphere: Sphere3D.zero() };
+    const sA = Sphere3D();
+    const sB = Sphere3D();
 
     const pA = Vec3();
     const pB = Vec3();
@@ -118,14 +118,14 @@ export function buildInteractionsShape(interactions: StructureInteractions, para
 
         colors.set(mesh.currentGroup, params.styles[interaction.info.kind].color);
 
-        StructureElement.Loci.getBoundary(interaction.a, undefined, bA);
-        StructureElement.Loci.getBoundary(interaction.b, undefined, bB);
+        StructureElement.Loci.getBoundingSphere(interaction.a, sA);
+        StructureElement.Loci.getBoundingSphere(interaction.b, sB);
 
-        Vec3.sub(dir, bB.sphere.center, bA.sphere.center);
+        Vec3.sub(dir, sB.center, sA.center);
         Vec3.normalize(dir, dir);
 
-        Vec3.copy(pA, bA.sphere.center);
-        Vec3.copy(pB, bB.sphere.center);
+        Vec3.copy(pA, sA.center);
+        Vec3.copy(pB, sB.center);
 
         if (interaction.info.kind === 'hydrogen-bond' || interaction.info.kind === 'weak-hydrogen-bond') {
             const hydrogenStyle = params.styles[interaction.info.kind];

--- a/src/mol-math/geometry/boundary-helper.ts
+++ b/src/mol-math/geometry/boundary-helper.ts
@@ -1,13 +1,14 @@
 /**
- * Copyright (c) 2020-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { Vec3 } from '../linear-algebra/3d/vec3';
+import { ReadonlyVec3, Vec3 } from '../linear-algebra/3d/vec3';
 import { CentroidHelper } from './centroid-helper';
 import { Sphere3D } from '../geometry/primitives/sphere3d';
 import { Box3D } from './primitives/box3d';
+import { memoize1 } from '../../mol-util/memoize';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const v3dot = Vec3.dot;
@@ -18,8 +19,8 @@ const v3scaleAndAdd = Vec3.scaleAndAdd;
 // implementing http://www.ep.liu.se/ecp/034/009/ecp083409.pdf
 
 export class BoundaryHelper {
-    private dir: Vec3[];
-    private dirLength: number;
+    private readonly dir: ReadonlyArray<Vec3>;
+    private readonly dirLength: number;
 
     private minDist: number[] = [];
     private maxDist: number[] = [];
@@ -76,10 +77,45 @@ export class BoundaryHelper {
     }
 
     finishedIncludeStep() {
+        if (this.dirLength < 49) {
+            this.refineExtrema();
+        }
+
         for (let i = 0; i < this.extrema.length; i++) {
             this.centroidHelper.includeStep(this.extrema[i]);
         }
         this.centroidHelper.finishedIncludeStep();
+    }
+
+    private refineExtrema() {
+        const dir98 = getEposDir('98');
+        const minDist: number[] = [];
+        const maxDist: number[] = [];
+        const extrema: Vec3[] = [];
+
+        for (let i = 0, il = dir98.length; i < il; ++i) {
+            minDist[i] = Infinity;
+            maxDist[i] = -Infinity;
+            extrema[i * 2] = Vec3();
+            extrema[i * 2 + 1] = Vec3();
+
+            const di = dir98[i];
+            for (let j = 0, jl = this.extrema.length; j < jl; ++j) {
+                const p = this.extrema[j];
+                const d = v3dot(di, p);
+
+                if (d < minDist[i]) {
+                    minDist[i] = d;
+                    v3copy(extrema[i * 2], p);
+                }
+                if (d > maxDist[i]) {
+                    maxDist[i] = d;
+                    v3copy(extrema[i * 2 + 1], p);
+                }
+            }
+        }
+
+        this.extrema = extrema;
     }
 
     radiusSphere(s: Sphere3D) {
@@ -109,6 +145,9 @@ export class BoundaryHelper {
     }
 
     reset() {
+        // discard any extrema added by a previous `refineExtrema` call
+        this.extrema.length = this.dirLength * 2;
+
         for (let i = 0; i < this.dirLength; ++i) {
             this.minDist[i] = Infinity;
             this.maxDist[i] = -Infinity;
@@ -127,7 +166,7 @@ export class BoundaryHelper {
 
 type EposQuality = '6' | '14' | '26' | '98'
 
-function getEposDir(quality: EposQuality) {
+const getEposDir = memoize1((quality: EposQuality): ReadonlyArray<ReadonlyVec3> => {
     let dir: number[][];
     switch (quality) {
         case '6': dir = [...Type001]; break;
@@ -139,7 +178,7 @@ function getEposDir(quality: EposQuality) {
         const v = Vec3.create(a[0], a[1], a[2]);
         return Vec3.normalize(v, v);
     });
-}
+});
 
 const Type001 = [
     [1, 0, 0], [0, 1, 0], [0, 0, 1]

--- a/src/mol-model/loci.ts
+++ b/src/mol-model/loci.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -157,7 +157,7 @@ namespace Loci {
         if (loci.kind === 'structure-loci') {
             return Sphere3D.copy(boundingSphere, loci.structure.boundary.sphere);
         } else if (loci.kind === 'element-loci') {
-            return Sphere3D.copy(boundingSphere, StructureElement.Loci.getBoundary(loci).sphere);
+            return StructureElement.Loci.getBoundingSphere(loci, boundingSphere);
         } else if (loci.kind === 'bond-loci') {
             return Bond.getBoundingSphere(loci, boundingSphere);
         } else if (loci.kind === 'shape-loci') {

--- a/src/mol-model/structure/structure/element/_spec/loci.spec.ts
+++ b/src/mol-model/structure/structure/element/_spec/loci.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { Column, Table } from '../../../../../mol-data/db';
+import { RuntimeContext } from '../../../../../mol-task';
+import { createModels } from '../../../../../mol-model-formats/structure/basic/parser';
+import { BasicSchema, createBasic } from '../../../../../mol-model-formats/structure/basic/schema';
+import { EntityBuilder } from '../../../../../mol-model-formats/structure/common/entity';
+import { ComponentBuilder } from '../../../../../mol-model-formats/structure/common/component';
+import { MoleculeType } from '../../../model/types';
+import { Box3D, Sphere3D } from '../../../../../mol-math/geometry';
+import { SymmetryOperator } from '../../../../../mol-math/geometry/symmetry-operator';
+import { Mat4, Vec3 } from '../../../../../mol-math/linear-algebra';
+import { OrderedSet } from '../../../../../mol-data/int';
+import { Structure } from '../../structure';
+import { Unit } from '../../unit';
+import { UnitIndex } from '../element';
+import { Loci } from '../loci';
+
+/** Helper: build a single-chain, 4-residue (one CA atom each) `BasicData` for `createModels`. */
+function buildSingleChainBasic() {
+    const coords: [number, number, number][] = [
+        [0, 0, 0],
+        [2, 0, 0],
+        [0, 2, 0],
+        [0, 0, 2],
+    ];
+    const count = coords.length;
+
+    const auth_asym_id = Column.ofConst('A', count, Column.Schema.str);
+    const auth_atom_id = Column.ofConst('CA', count, Column.Schema.str);
+    const auth_comp_id = Column.ofConst('ALA', count, Column.Schema.str);
+    const auth_seq_id = Column.ofIntArray(coords.map((_, i) => i + 1));
+    const type_symbol = Column.ofConst('C', count, Column.Schema.str);
+
+    const atom_site = Table.ofPartialColumns(BasicSchema.atom_site, {
+        auth_asym_id,
+        auth_atom_id,
+        auth_comp_id,
+        auth_seq_id,
+        Cartn_x: Column.ofFloatArray(Float32Array.from(coords.map(c => c[0]))),
+        Cartn_y: Column.ofFloatArray(Float32Array.from(coords.map(c => c[1]))),
+        Cartn_z: Column.ofFloatArray(Float32Array.from(coords.map(c => c[2]))),
+        id: Column.ofIntArray(coords.map((_, i) => i)),
+
+        label_asym_id: auth_asym_id,
+        label_atom_id: auth_atom_id,
+        label_comp_id: auth_comp_id,
+        label_seq_id: auth_seq_id,
+        label_entity_id: Column.ofConst('1', count, Column.Schema.str),
+
+        occupancy: Column.ofConst(1, count, Column.Schema.float),
+        type_symbol,
+
+        pdbx_PDB_model_num: Column.ofConst(1, count, Column.Schema.int),
+    }, count);
+
+    const entityBuilder = new EntityBuilder();
+    entityBuilder.getEntityId('ALA', MoleculeType.Protein, 'A');
+
+    const componentBuilder = new ComponentBuilder(auth_seq_id, auth_atom_id);
+    componentBuilder.add('ALA', 0);
+
+    return createBasic({
+        entity: entityBuilder.getEntityTable(),
+        chem_comp: componentBuilder.getChemCompTable(),
+        atom_site
+    });
+}
+
+async function buildSingleChainStructure(): Promise<Structure> {
+    const basic = buildSingleChainBasic();
+    const trajectory = await createModels(basic, { kind: 'test', name: 'synthetic-test', data: undefined }, RuntimeContext.Synchronous);
+    return Structure.ofModel(trajectory.representative);
+}
+
+function collectPositions(elements: ReadonlyArray<{ unit: Unit, indices: OrderedSet<UnitIndex> }>, transform?: Mat4): Vec3[] {
+    const positions: Vec3[] = [];
+    for (const { unit, indices } of elements) {
+        const { elements: unitElements, conformation } = unit;
+        for (let i = 0, _i = OrderedSet.size(indices); i < _i; i++) {
+            const eI = unitElements[OrderedSet.getAt(indices, i)];
+            const p = Vec3();
+            conformation.position(eI, p);
+            if (transform) Vec3.transformMat4(p, p, transform);
+            positions.push(p);
+        }
+    }
+    return positions;
+}
+
+function expectContains(boundary: { box: Box3D, sphere: Sphere3D }, positions: Vec3[], eps = 1e-4) {
+    for (const p of positions) {
+        expect(Vec3.distance(boundary.sphere.center, p)).toBeLessThanOrEqual(boundary.sphere.radius + eps);
+        expect(p[0]).toBeGreaterThanOrEqual(boundary.box.min[0] - eps);
+        expect(p[1]).toBeGreaterThanOrEqual(boundary.box.min[1] - eps);
+        expect(p[2]).toBeGreaterThanOrEqual(boundary.box.min[2] - eps);
+        expect(p[0]).toBeLessThanOrEqual(boundary.box.max[0] + eps);
+        expect(p[1]).toBeLessThanOrEqual(boundary.box.max[1] + eps);
+        expect(p[2]).toBeLessThanOrEqual(boundary.box.max[2] + eps);
+    }
+}
+
+function expectVec3Close(a: Vec3, b: Vec3, precision = 5) {
+    expect(a[0]).toBeCloseTo(b[0], precision);
+    expect(a[1]).toBeCloseTo(b[1], precision);
+    expect(a[2]).toBeCloseTo(b[2], precision);
+}
+
+/**
+ * The whole-unit/whole-structure fast paths reduce a cached sphere via its stored direction
+ * extrema (`BoundaryHelper.includeSphere`/`radiusSphere`), same as the pre-existing
+ * `computeStructureBoundary`. This reproduces the sphere center exactly, but can yield a
+ * slightly smaller radius than a naive point transform (the true farthest point of a bounded
+ * atom sphere isn't necessarily one of the fixed sample directions) - so radius comparisons use
+ * a relative tolerance instead of exact/close-to-N-decimals equality.
+ */
+function expectRadiusApprox(actual: number, expected: number, relTol = 0.05) {
+    expect(Math.abs(actual - expected) / expected).toBeLessThanOrEqual(relTol);
+}
+
+describe('StructureElement.Loci.getBoundary', () => {
+    let structure0: Structure;
+    let unit0: Unit;
+    let unit1: Unit;
+    let multiStructure: Structure;
+    let operator: SymmetryOperator;
+
+    let wholeIndices: OrderedSet<UnitIndex>;
+    let partialIndices: OrderedSet<UnitIndex>;
+
+    beforeAll(async () => {
+        structure0 = await buildSingleChainStructure();
+
+        // Guard: fixture is expected to parse into a single 4-atom unit.
+        expect(structure0.units.length).toBe(1);
+        unit0 = structure0.units[0];
+        expect(unit0.elements.length).toBe(4);
+
+        operator = SymmetryOperator.create('test-op', Mat4.fromTranslation(Mat4(), Vec3.create(10, 0, 0)));
+        unit1 = unit0.applyOperator(unit0.id + 1, operator, true);
+
+        multiStructure = Structure.create([unit0, unit1]);
+
+        wholeIndices = OrderedSet.ofBounds<UnitIndex>(0 as UnitIndex, 4 as UnitIndex);
+        partialIndices = OrderedSet.ofBounds<UnitIndex>(0 as UnitIndex, 2 as UnitIndex);
+    });
+
+    it('whole-structure loci reuses Structure.boundary exactly', () => {
+        const loci = Loci.all(structure0);
+        const b = Loci.getBoundary(loci);
+
+        expect(b.box.min).toEqual(structure0.boundary.box.min);
+        expect(b.box.max).toEqual(structure0.boundary.box.max);
+        expect(b.sphere.center).toEqual(structure0.boundary.sphere.center);
+        expect(b.sphere.radius).toBeCloseTo(structure0.boundary.sphere.radius, 6);
+    });
+
+    it('whole-unit loci (identity operator, not whole structure) matches unit.boundary and contains all atoms', () => {
+        const loci = Loci(multiStructure, [{ unit: unit0, indices: wholeIndices }]);
+        expect(Loci.isWholeStructure(loci)).toBe(false);
+
+        const b = Loci.getBoundary(loci);
+        expectVec3Close(b.sphere.center, unit0.boundary.sphere.center);
+        expectRadiusApprox(b.sphere.radius, unit0.boundary.sphere.radius);
+        expectContains(b, collectPositions([{ unit: unit0, indices: wholeIndices }]));
+    });
+
+    it('partial-unit loci falls back to the per-atom computation and only contains selected atoms', () => {
+        const loci = Loci(multiStructure, [{ unit: unit0, indices: partialIndices }]);
+        const b = Loci.getBoundary(loci);
+
+        expectContains(b, collectPositions([{ unit: unit0, indices: partialIndices }]));
+
+        const wholeUnitLoci = Loci(multiStructure, [{ unit: unit0, indices: wholeIndices }]);
+        const wholeUnitBoundary = Loci.getBoundary(wholeUnitLoci);
+        // partial selection's sphere should not be larger than the whole unit's
+        expect(b.sphere.radius).toBeLessThanOrEqual(wholeUnitBoundary.sphere.radius + 1e-6);
+    });
+
+    it('mixed loci (whole unit + partial unit) combines both fast and slow paths', () => {
+        const elements = [
+            { unit: unit0, indices: wholeIndices },
+            { unit: unit1, indices: partialIndices },
+        ];
+        const loci = Loci(multiStructure, elements);
+        const b = Loci.getBoundary(loci);
+
+        expectContains(b, collectPositions(elements));
+    });
+
+    it('whole-unit loci with a non-identity operator applies the operator matrix to the cached unit boundary', () => {
+        const loci = Loci(multiStructure, [{ unit: unit1, indices: wholeIndices }]);
+        const b = Loci.getBoundary(loci);
+
+        const expectedSphere = Sphere3D.transform(Sphere3D(), unit0.boundary.sphere, operator.matrix);
+        expectVec3Close(b.sphere.center, expectedSphere.center);
+        expectRadiusApprox(b.sphere.radius, expectedSphere.radius);
+
+        expectContains(b, collectPositions([{ unit: unit1, indices: wholeIndices }]));
+    });
+
+    it('boundary param is filled in place', () => {
+        const out = { box: Box3D(), sphere: Sphere3D() };
+        const loci = Loci.all(structure0);
+        const ret = Loci.getBoundary(loci, out);
+
+        expect(ret.box).toBe(out.box);
+        expect(ret.sphere).toBe(out.sphere);
+        expect(out.box.min).toEqual(structure0.boundary.box.min);
+        expect(out.sphere.center).toEqual(structure0.boundary.sphere.center);
+    });
+
+    it('does not alias the cached Structure.boundary object', () => {
+        const loci = Loci.all(structure0);
+        const originalMin = Vec3.clone(structure0.boundary.box.min);
+
+        const fresh = Loci.getBoundary(loci);
+        fresh.box.min[0] = 9999;
+
+        expect(structure0.boundary.box.min).toEqual(originalMin);
+    });
+});

--- a/src/mol-model/structure/structure/element/loci.ts
+++ b/src/mol-model/structure/structure/element/loci.ts
@@ -8,7 +8,7 @@
 
 import { UniqueArray } from '../../../../mol-data/generic';
 import { OrderedSet, SortedArray, Interval } from '../../../../mol-data/int';
-import { Mat4, Vec3 } from '../../../../mol-math/linear-algebra';
+import { Vec3 } from '../../../../mol-math/linear-algebra';
 import { MolScriptBuilder as MS } from '../../../../mol-script/language/builder';
 import { Structure } from '../structure';
 import { Unit } from '../unit';
@@ -612,38 +612,65 @@ export namespace Loci {
 
     const boundaryHelper = new BoundaryHelper('98');
     const tempPosBoundary = Vec3();
-    export function getBoundary(loci: Loci, transform?: Mat4, result?: { box?: Box3D, sphere?: Sphere3D }): Boundary {
+    const tempSphereBoundary = Sphere3D();
+
+    /**
+     * Get the boundary sphere of a whole unit (in the same frame as `Unit.conformation.position`),
+     * reusing the cached, invariant-frame `Unit.boundary` instead of visiting every element.
+     */
+    function getWholeUnitBoundarySphere(unit: Unit): Sphere3D {
+        const { isIdentity, matrix } = unit.conformation.operator;
+        const { sphere } = unit.boundary;
+        return isIdentity ? sphere : Sphere3D.transform(tempSphereBoundary, sphere, matrix);
+    }
+
+    export function getBoundingSphere(loci: Loci, boundingSphere?: Sphere3D): Sphere3D {
+        // reuse structure boundary if the loci covers the whole structure
+        if (isWholeStructure(loci)) {
+            return Sphere3D.copy(boundingSphere || Sphere3D(), loci.structure.boundary.sphere);
+        }
+
         boundaryHelper.reset();
 
         for (const e of loci.elements) {
+            // reuse unit boundary if the loci element covers the whole unit
+            if (isWholeUnit(e)) {
+                boundaryHelper.includeSphere(getWholeUnitBoundarySphere(e.unit));
+                continue;
+            }
+
             const { indices } = e;
             const { elements, conformation } = e.unit;
             for (let i = 0, _i = OrderedSet.size(indices); i < _i; i++) {
                 const eI = elements[OrderedSet.getAt(indices, i)];
                 conformation.position(eI, tempPosBoundary);
-                if (transform) Vec3.transformMat4(tempPosBoundary, tempPosBoundary, transform);
                 boundaryHelper.includePositionRadius(tempPosBoundary, conformation.r(eI));
             }
         }
         boundaryHelper.finishedIncludeStep();
         for (const e of loci.elements) {
+            // reuse unit boundary if the loci element covers the whole unit
+            if (isWholeUnit(e)) {
+                boundaryHelper.radiusSphere(getWholeUnitBoundarySphere(e.unit));
+                continue;
+            }
+
             const { indices } = e;
             const { elements, conformation } = e.unit;
             for (let i = 0, _i = OrderedSet.size(indices); i < _i; i++) {
                 const eI = elements[OrderedSet.getAt(indices, i)];
                 conformation.position(eI, tempPosBoundary);
-                if (transform) Vec3.transformMat4(tempPosBoundary, tempPosBoundary, transform);
                 boundaryHelper.radiusPositionRadius(tempPosBoundary, conformation.r(eI));
             }
         }
 
-        if (result) {
-            if (result.box) boundaryHelper.getBox(result.box);
-            if (result.sphere) boundaryHelper.getSphere(result.sphere);
-            return result as any;
-        }
+        return boundaryHelper.getSphere(boundingSphere);
+    }
 
-        return { box: boundaryHelper.getBox(), sphere: boundaryHelper.getSphere() };
+    export function getBoundary(loci: Loci, boundary?: Boundary): Boundary {
+        const sphere = getBoundingSphere(loci, boundary?.sphere);
+        const box = Box3D.fromSphere3D(boundary?.box || Box3D(), sphere);
+        return { sphere, box };
     }
 
     const tempPos = Vec3();

--- a/src/mol-plugin/behavior/dynamic/volume-streaming/behavior.ts
+++ b/src/mol-plugin/behavior/dynamic/volume-streaming/behavior.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -341,7 +341,10 @@ export namespace VolumeStreaming {
             if (transform) Mat4.invert(this._invTransform, transform);
 
             const extendedLoci = StructureElement.Loci.extendToWholeResidues(loci);
-            const box = StructureElement.Loci.getBoundary(extendedLoci, transform && !Number.isNaN(this._invTransform[0]) ? this._invTransform : void 0).box;
+            const box = StructureElement.Loci.getBoundary(extendedLoci).box;
+            if (transform && !Number.isNaN(this._invTransform[0])) {
+                Box3D.transform(box, box, this._invTransform);
+            }
 
             if (StructureElement.Loci.size(extendedLoci) === 1) {
                 Box3D.expand(box, box, Vec3.create(1, 1, 1));


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This improves Element Loci performance and produces more consistent bounding spheres among structures, element loci, and render-objects.

- Refine step for coarse BoundaryHelper instances
- Refactor `StructureElement.Loci.getBoundary`
    - Add `.getBoundingSphere`, reuse whole structure/unit boundary
    - [Breaking] remove transform argument

Closes #1455.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`