### PR TITLE
Bloom: occlude emissive glow behind foreground geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Note that since we don't clearly distinguish between a public and private interf
   - Tighten `isBackground` to handle packed transparent depth precisely
   - Enable bloom on transparent background
   - Background-aware blend: screen on transparent background, PMA over on opaque background, additive on geometry
+  - Occlude emissive bloom behind opaque foreground (e.g. opaque label backgrounds) by reusing the opaque depth (#1881)
+  - Dim emitters behind transparent foreground by its coverage
+  - Text label backgrounds occlude/dim emitters using their own opacity
 - Fix size-only representation theme updates in `updateRepresentationsTheme`.
 - Fix ASA coloring for hydrogens
 - Add `histogramPercentile`, `histogramRobustStats`, `downsampleHistogram` to `mol-math/histogram`

--- a/src/mol-canvas3d/passes/draw.ts
+++ b/src/mol-canvas3d/passes/draw.ts
@@ -175,6 +175,26 @@ export class DrawPass {
         this.dof.setSize(width, height);
     }
 
+    renderEmissiveBloom(renderer: Renderer, camera: ICamera, scene: Scene, transparency: boolean): void {
+        const bloom = this.postprocessing.bloom;
+        bloom.emissiveTarget.bind();
+        // (0,0,0,0) clear so the MAX blend in renderEmissiveTransparent isn't polluted by a white clear
+        renderer.clear(false, true, true);
+        // occlude emitters against real opaque depth so glow can't bleed through opaque foreground; packed depth builds its own
+        const occludeWithOpaqueDepth = !this.packedDepth;
+        if (occludeWithOpaqueDepth) {
+            this.depthTextureOpaque.attachFramebuffer(bloom.emissiveTarget.framebuffer, 'depth');
+        }
+        renderer.renderEmissiveOpaque(scene.primitives, camera, this.depthTextureTransparent, occludeWithOpaqueDepth);
+        if (transparency && scene.opacityAverage < 1) {
+            renderer.renderEmissiveTransparent(scene.primitives, camera, this.depthTextureTransparent);
+        }
+        if (occludeWithOpaqueDepth) {
+            this.depthTextureOpaque.detachFramebuffer(bloom.emissiveTarget.framebuffer, 'depth');
+            bloom.emissiveTarget.depthRenderbuffer?.attachFramebuffer(bloom.emissiveTarget.framebuffer);
+        }
+    }
+
     private _renderBloom(renderer: Renderer, camera: ICamera, scene: Scene, postprocessingProps: PostprocessingProps): boolean {
         if (!BloomPass.isEnabled(postprocessingProps) || postprocessingProps.bloom.name !== 'on') return false;
         const bloom = this.postprocessing.bloom;
@@ -183,13 +203,7 @@ export class DrawPass {
         if (emissiveBloom && scene.emissiveAverage === 0) return false;
 
         if (emissiveBloom) {
-            bloom.emissiveTarget.bind();
-            // (0,0,0,0) clear; default white clear would break the MAX blend in renderEmissiveTransparent.
-            renderer.clear(false, true, true);
-            renderer.renderEmissiveOpaque(scene.primitives, camera);
-            if (params.transparency && scene.opacityAverage < 1) {
-                renderer.renderEmissiveTransparent(scene.primitives, camera, this.depthTextureTransparent);
-            }
+            this.renderEmissiveBloom(renderer, camera, scene, params.transparency);
         }
 
         // Clear transparent buffers when opaque-only so luminosity doesn't sample stale halos.

--- a/src/mol-canvas3d/passes/illumination.ts
+++ b/src/mol-canvas3d/passes/illumination.ts
@@ -441,12 +441,7 @@ export class IlluminationPass {
 
             if (!skip) {
                 if (emissiveBloom) {
-                    bloom.emissiveTarget.bind();
-                    renderer.clear(false, true, true);
-                    renderer.renderEmissiveOpaque(scene.primitives, camera);
-                    if (params.transparency && scene.opacityAverage < 1) {
-                        renderer.renderEmissiveTransparent(scene.primitives, camera, this.drawPass.depthTextureTransparent);
-                    }
+                    this.drawPass.renderEmissiveBloom(renderer, camera, scene, params.transparency);
                 }
                 if (scene.opacityAverage >= 1) {
                     this.transparentTarget.bind();

--- a/src/mol-gl/renderer.ts
+++ b/src/mol-gl/renderer.ts
@@ -72,7 +72,7 @@ interface Renderer {
     renderDepthTransparent: (group: Scene.Group, camera: ICamera, depthTexture: Texture) => void
     renderMarkingDepth: (group: Scene.Group, camera: ICamera) => void
     renderMarkingMask: (group: Scene.Group, camera: ICamera, depthTexture: Texture | null) => void
-    renderEmissiveOpaque: (group: Scene.Group, camera: ICamera) => void
+    renderEmissiveOpaque: (group: Scene.Group, camera: ICamera, depthTexture: Texture, occludeWithOpaqueDepth: boolean) => void
     renderEmissiveTransparent: (group: Scene.Group, camera: ICamera, depthTexture: Texture) => void
     renderTracing: (group: Scene.Group, camera: ICamera) => void
     renderBlended: (group: Scene, camera: ICamera) => void
@@ -509,6 +509,10 @@ namespace Renderer {
             );
         };
 
+        const checkEmissive = function (r: GraphicsRenderable) {
+            return (r.values.emissiveAverage.ref.value + r.values.uEmissive.ref.value) > 0;
+        };
+
         const renderPick = (group: Scene.Group, camera: ICamera, variant: 'pick' | 'depth', pickType: PickType) => {
             if (isTimingMode) ctx.timer.mark('Renderer.renderPick');
             state.disable(gl.BLEND);
@@ -639,20 +643,33 @@ namespace Renderer {
             if (isTimingMode) ctx.timer.markEnd('Renderer.renderMarkingMask');
         };
 
-        const renderEmissiveOpaque = (group: Scene.Group, camera: ICamera) => {
+        const renderEmissiveOpaque = (group: Scene.Group, camera: ICamera, depthTexture: Texture, occludeWithOpaqueDepth: boolean) => {
             if (isTimingMode) ctx.timer.mark('Renderer.renderEmissiveOpaque');
             state.disable(gl.BLEND);
             state.enable(gl.DEPTH_TEST);
-            state.depthMask(true);
+            if (occludeWithOpaqueDepth) {
+                // test against caller-attached opaque depth, read-only + LEQUAL so an emitter at its own depth still passes
+                state.depthMask(false);
+                state.depthFunc(gl.LEQUAL);
+            } else {
+                // packed depth: build own occluding depth from all opaque geometry
+                state.depthMask(true);
+            }
 
-            updateInternal(group, camera, null, Mask.Opaque, false);
+            // tDepth = front transparent depth+alpha; emissive shader dims emitters behind it
+            updateInternal(group, camera, depthTexture, Mask.Opaque, false);
 
             const { renderables } = group;
             for (let i = 0, il = renderables.length; i < il; ++i) {
                 const r = renderables[i];
-                if (checkOpaque(r)) {
+                if (checkOpaque(r) && (!occludeWithOpaqueDepth || checkEmissive(r))) {
                     renderObject(r, 'emissive', Flag.None);
                 }
+            }
+
+            if (occludeWithOpaqueDepth) {
+                state.depthFunc(gl.LESS);
+                state.depthMask(true);
             }
             if (isTimingMode) ctx.timer.markEnd('Renderer.renderEmissiveOpaque');
         };
@@ -673,7 +690,7 @@ namespace Renderer {
             const { renderables } = group;
             for (let i = 0, il = renderables.length; i < il; ++i) {
                 const r = renderables[i];
-                if (checkTransparent(r) && r.values.dGeometryType.ref.value !== 'directVolume') {
+                if (checkTransparent(r) && r.values.dGeometryType.ref.value !== 'directVolume' && checkEmissive(r)) {
                     renderObject(r, 'emissive', Flag.None);
                 }
             }

--- a/src/mol-gl/shader/chunks/assign-material-color.glsl.ts
+++ b/src/mol-gl/shader/chunks/assign-material-color.glsl.ts
@@ -6,6 +6,11 @@ export const assign_material_color = `
     }
 #endif
 
+// optional per-fragment opacity multiplier; defaults to 1.0
+#ifndef dHasMaterialOpacity
+    float materialOpacity = 1.0;
+#endif
+
 #if defined(dRenderVariant_color) || defined(dRenderVariant_tracing)
     #if defined(dUsePalette)
         vec4 material = vec4(texture2D(tPalette, vec2(vPaletteV, 0.5)).rgb, uAlpha);
@@ -53,17 +58,17 @@ export const assign_material_color = `
                 if (vTransparency < 0.1) dta = 1.0; // hard cutoff to avoid artifacts
             #endif
 
-            if (uAlpha * dta < 1.0) {
+            if (uAlpha * materialOpacity * dta < 1.0) {
                 discard;
             }
         #else
-            if (uAlpha < 1.0) {
+            if (uAlpha * materialOpacity < 1.0) {
                 discard;
             }
         #endif
         material = packDepthToRGBA(fragmentDepth);
     } else if (uRenderMask == MaskTransparent) {
-        float alpha = uAlpha;
+        float alpha = uAlpha * materialOpacity;
         #if defined(dTransparency)
             float dta = 1.0 - vTransparency;
             alpha *= dta;

--- a/src/mol-gl/shader/text.frag.ts
+++ b/src/mol-gl/shader/text.frag.ts
@@ -32,8 +32,8 @@ void main(){
     // determine if this is a background or glyph fragment
     bool isBackground = vTexCoord.x > 1.0;
 
-    // discard background for non-visual variants (depth, pick, marking, emissive)
-    #if !defined(dRenderVariant_color) && !defined(dRenderVariant_tracing)
+    // discard background for pick/marking/emissive, but keep it in depth
+    #if !defined(dRenderVariant_color) && !defined(dRenderVariant_tracing) && !defined(dRenderVariant_depth)
         if (isBackground) discard;
     #endif
 
@@ -49,6 +49,9 @@ void main(){
         gl_FragDepthEXT = fragmentDepth;
     #endif
 
+    // background writes its own opacity into depth alpha; glyphs stay opaque
+    #define dHasMaterialOpacity
+    float materialOpacity = isBackground ? uBackgroundOpacity : 1.0;
     #include assign_material_color
 
     if (isBackground) {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Fixes #1881.

Emissive-bloom glow ignored what was in front of it: a backdrop emitter's glow bled through opaque label/image backgrounds, and emitters behind semi-transparent surfaces glowed at full brightness.
<img width="876" height="595" alt="image" src="https://github.com/user-attachments/assets/6210b108-94b3-41dd-b0db-3c9a0ec5fc49" />
<img width="568" height="339" alt="image" src="https://github.com/user-attachments/assets/62e79932-9cb8-4f5a-a081-d5b37d7eb8e8" />
<img width="485" height="478" alt="image" src="https://github.com/user-attachments/assets/87786b73-009d-4f3f-88a5-a14a9396c3ea" />


## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`