### PR TITLE
Fix nucleic cartoon trace picking returning empty loci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Move base functionality from `SpacegroupCell` to `Cell`
 - Support non-default CRYSIN setting in MOL2 format (#338)
 - Fix `ssao-blur` background test: the RG-packed depth never equals `1.0`, so background samples were blurred into geometry and produced a bright rim at the far-clip cutoff
+- Fix picking/hover-highlight of the nucleic cartoon polymer-trace on reduced trace structures returning empty: `getResidueLoci` now resolves the residue from the representative element even when the model trace atom (nucleic `O3'`) is not present in the unit (e.g. a `{CA, P}` trace selection keeps only `P`)
 
 ## [v5.11.0] - 2026-07-18
 - Fix LAMMPS unsorted-atom handling (trajectory frame ordering and data-file bonds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Move base functionality from `SpacegroupCell` to `Cell`
 - Support non-default CRYSIN setting in MOL2 format (#338)
 - Fix `ssao-blur` background test: the RG-packed depth never equals `1.0`, so background samples were blurred into geometry and produced a bright rim at the far-clip cutoff
-- Fix picking/hover-highlight of the nucleic cartoon polymer-trace on reduced trace structures returning empty: `getResidueLoci` now resolves the residue from the representative element even when the model trace atom (nucleic `O3'`) is not present in the unit (e.g. a `{CA, P}` trace selection keeps only `P`)
+- Fix picking/hover-highlight of the nucleic cartoon polymer-trace on reduced trace structures returning empty: `getResidueLoci` now accounts for whole residue, not limited to unit.
 
 ## [v5.11.0] - 2026-07-18
 - Fix LAMMPS unsorted-atom handling (trajectory frame ordering and data-file bonds)

--- a/src/mol-data/int/_spec/sorted-array.spec.ts
+++ b/src/mol-data/int/_spec/sorted-array.spec.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2017-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import { Interval } from '../interval';
@@ -58,6 +59,17 @@ describe('sortedArray', () => {
     test('predIndexDuplBig', SortedArray.findPredecessorIndex(aDuplBig, 3), 334);
 
     testI('findRange', SortedArray.findRange(a2468, 2, 4), Interval.ofRange(0, 1));
+
+    test('hasRange-within', SortedArray.hasRange(a2468, 2, 4), true);
+    test('hasRange-partial-overlap-start', SortedArray.hasRange(a2468, 0, 2), true);
+    test('hasRange-partial-overlap-end', SortedArray.hasRange(a2468, 8, 10), true);
+    test('hasRange-gap', SortedArray.hasRange(a2468, 3, 3), false);
+    test('hasRange-below', SortedArray.hasRange(a2468, -2, 1), false);
+    test('hasRange-above', SortedArray.hasRange(a2468, 9, 20), false);
+    test('hasRange-covers-all', SortedArray.hasRange(a2468, 0, 100), true);
+    test('hasRange-single-match', SortedArray.hasRange(a2468, 6, 6), true);
+    test('hasRange-inverted', SortedArray.hasRange(a2468, 5, 2), false);
+    test('hasRange-empty', SortedArray.hasRange(SortedArray.Empty, 0, 10), false);
 
     it('deduplicate', () => {
         compareArrays(SortedArray.deduplicate(SortedArray.ofSortedArray([1, 1, 1, 1])), [1]);

--- a/src/mol-data/int/impl/sorted-array.ts
+++ b/src/mol-data/int/impl/sorted-array.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2017-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Adam Midlik <midlik@gmail.com>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import { createRangeArray } from '../../util/array';
@@ -92,6 +93,14 @@ export function findPredecessorIndexInInterval(xs: Nums, query: number, bounds: 
 
 export function findRange(xs: Nums, min: number, max: number) {
     return Interval.ofBounds(findPredecessorIndex(xs, min), findPredecessorIndex(xs, max + 1));
+}
+
+/** Returns true if `xs` contains any value within `[min, max]` (inclusive). */
+export function hasRange(xs: Nums, min: number, max: number) {
+    const l = xs.length;
+    if (l === 0 || max < min || max < xs[0] || min > xs[l - 1]) return false;
+    const idx = findPredecessorIndex(xs, min);
+    return idx < l && xs[idx] <= max;
 }
 
 function binarySearchRange(xs: Nums, value: number, start: number, end: number) {

--- a/src/mol-data/int/sorted-array.ts
+++ b/src/mol-data/int/sorted-array.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2017-2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import * as Impl from './impl/sorted-array';
@@ -47,6 +48,8 @@ namespace SortedArray {
     export const findPredecessorIndexInInterval: <T extends number = number>(array: SortedArray<T>, x: T, bounds: Interval) => number = Impl.findPredecessorIndexInInterval as any;
     export const findRange: <T extends number = number>(array: SortedArray<T>, min: T, max: T) => Interval = Impl.findRange as any;
     export const intersectionSize: <T extends number = number>(a: SortedArray<T>, b: SortedArray<T>) => number = Impl.intersectionSize as any;
+    /** Returns true if `array` contains any value within `[min, max]` (inclusive), without allocating an `Interval`. */
+    export const hasRange: <T extends number = number>(array: SortedArray<T>, min: T, max: T) => boolean = Impl.hasRange as any;
 
     export const deduplicate: <T extends number = number>(array: SortedArray<T>) => SortedArray<T> = Impl.deduplicate as any;
     /** Returns indices of xs in the array. E.g. indicesOf([10, 11, 12], [10, 12]) ==> [0, 2] */

--- a/src/mol-model/structure/structure/unit.ts
+++ b/src/mol-model/structure/structure/unit.ts
@@ -375,6 +375,14 @@ namespace Unit {
             return this.residueIndex[this.elements[elementIndex]];
         }
 
+        /** Check if any element of the unit belongs to the given residue. */
+        hasResidueIndex(residueIndex: ResidueIndex) {
+            const { offsets } = this.model.atomicHierarchy.residueAtomSegments;
+            const start = offsets[residueIndex];
+            const end = offsets[residueIndex + 1];
+            return SortedArray.hasRange(this.elements, start, end - 1);
+        }
+
         constructor(id: number, invariantId: number, chainGroupId: number, traits: Traits, model: Model, elements: StructureElement.Set, conformation: SymmetryOperator.ArrayMapping<ElementIndex>, props: AtomicProperties) {
             this.id = id;
             this.invariantId = invariantId;

--- a/src/mol-repr/structure/visual/util/common.ts
+++ b/src/mol-repr/structure/visual/util/common.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { Unit, Structure, ElementIndex, StructureElement, ResidueIndex } from '../../../../mol-model/structure';
@@ -72,18 +73,21 @@ export function checkCylinderImpostorSupport(webgl?: WebGLContext) {
 /** Return a Loci for the elements of a whole residue the elementIndex belongs to. */
 export function getResidueLoci(structure: Structure, unit: Unit.Atomic, elementIndex: ElementIndex): Loci {
     const { elements, model } = unit;
-    if (OrderedSet.indexOf(elements, elementIndex) !== -1) {
-        const { index, offsets } = model.atomicHierarchy.residueAtomSegments;
-        const rI = index[elementIndex];
-        const _indices: number[] = [];
-        for (let i = offsets[rI], il = offsets[rI + 1]; i < il; ++i) {
-            const unitIndex = OrderedSet.indexOf(elements, i);
-            if (unitIndex !== -1) _indices.push(unitIndex);
-        }
-        const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_indices));
-        return StructureElement.Loci(structure, [{ unit, indices }]);
+    const { index, offsets } = model.atomicHierarchy.residueAtomSegments;
+    // Resolve the residue directly from the (model-level) representative element rather than
+    // requiring that element to be a member of the unit. A reduced unit — e.g. a {CA,P} trace
+    // selection — keeps only a subset of each residue's atoms, and for nucleic residues the
+    // representative trace atom (O3', from traceElementIndex) is not among them (only P is). We
+    // still want to mark/pick the residue, so gather whatever of its atoms ARE present in the unit.
+    const rI = index[elementIndex];
+    const _indices: number[] = [];
+    for (let i = offsets[rI], il = offsets[rI + 1]; i < il; ++i) {
+        const unitIndex = OrderedSet.indexOf(elements, i as ElementIndex);
+        if (unitIndex !== -1) _indices.push(unitIndex);
     }
-    return EmptyLoci;
+    if (_indices.length === 0) return EmptyLoci;
+    const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_indices));
+    return StructureElement.Loci(structure, [{ unit, indices }]);
 }
 
 /**

--- a/src/mol-repr/structure/visual/util/common.ts
+++ b/src/mol-repr/structure/visual/util/common.ts
@@ -70,19 +70,21 @@ export function checkCylinderImpostorSupport(webgl?: WebGLContext) {
 
 //
 
-/** Return a Loci for the elements of a whole residue the elementIndex belongs to. */
+/**
+ * Return a Loci for the elements of a whole residue the elementIndex
+ * belongs to. Accounts for whole the residue, not limited to the unit.
+ */
 export function getResidueLoci(structure: Structure, unit: Unit.Atomic, elementIndex: ElementIndex): Loci {
     const { elements, model } = unit;
     const { index, offsets } = model.atomicHierarchy.residueAtomSegments;
-    // Resolve the residue directly from the (model-level) representative element rather than
-    // requiring that element to be a member of the unit. A reduced unit — e.g. a {CA,P} trace
-    // selection — keeps only a subset of each residue's atoms, and for nucleic residues the
-    // representative trace atom (O3', from traceElementIndex) is not among them (only P is). We
-    // still want to mark/pick the residue, so gather whatever of its atoms ARE present in the unit.
     const rI = index[elementIndex];
+    const start = offsets[rI];
+    const end = offsets[rI + 1];
+    if (SortedArray.hasRange(elements, start, end - 1)) return EmptyLoci;
+
     const _indices: number[] = [];
-    for (let i = offsets[rI], il = offsets[rI + 1]; i < il; ++i) {
-        const unitIndex = OrderedSet.indexOf(elements, i as ElementIndex);
+    for (let i = start, il = end; i < il; ++i) {
+        const unitIndex = OrderedSet.indexOf(elements, i);
         if (unitIndex !== -1) _indices.push(unitIndex);
     }
     if (_indices.length === 0) return EmptyLoci;

--- a/src/mol-repr/structure/visual/util/common.ts
+++ b/src/mol-repr/structure/visual/util/common.ts
@@ -80,14 +80,13 @@ export function getResidueLoci(structure: Structure, unit: Unit.Atomic, elementI
     const rI = index[elementIndex];
     const start = offsets[rI];
     const end = offsets[rI + 1];
-    if (SortedArray.hasRange(elements, start, end - 1)) return EmptyLoci;
+    if (!SortedArray.hasRange(elements, start, end - 1)) return EmptyLoci;
 
     const _indices: number[] = [];
     for (let i = start, il = end; i < il; ++i) {
         const unitIndex = OrderedSet.indexOf(elements, i);
         if (unitIndex !== -1) _indices.push(unitIndex);
     }
-    if (_indices.length === 0) return EmptyLoci;
     const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_indices));
     return StructureElement.Loci(structure, [{ unit, indices }]);
 }


### PR DESCRIPTION
# Description

On reduced trace structures (atoms limited to {CA, P}) hovering the nucleic cartoon polymer-trace resolved no loci, so it could not be highlighted. The model trace atom for nucleic residues is O3' (traceElementIndex), which is absent from a P-only unit, and getResidueLoci required that exact element to be present. It now resolves the residue from the representative element and gathers whatever of its atoms are in the unit. Protein was unaffected because its trace atom (CA) is kept by such selections.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`