### PR TITLE
Fix missing line in getElementSymbolFromMass

### DIFF
--- a/src/mol-model-formats/structure/common/element-mass.ts
+++ b/src/mol-model-formats/structure/common/element-mass.ts
@@ -14,6 +14,8 @@ for (const key in ElementAtomWeights) {
     }
 }
 
+ElementMassesByMass.sort((a, b) => a[1] - b[1]);
+
 /**
  * Resolve the closest matching element symbol for a given atomic mass.
  *

--- a/src/mol-model-formats/structure/common/element-mass.ts
+++ b/src/mol-model-formats/structure/common/element-mass.ts
@@ -6,6 +6,9 @@
 import { ElementAtomWeights } from '../../../mol-model/structure/model/properties/atomic/measures';
 import { ElementSymbol, getElementFromAtomicNumber } from '../../../mol-model/structure/model/types';
 
+/**
+ * Array of element symbols and their corresponding atomic masses, sorted by mass.
+ */
 const ElementMassesByMass: [ElementSymbol, number][] = [];
 for (const key in ElementAtomWeights) {
     const mass = ElementAtomWeights[Number(key)];
@@ -13,7 +16,6 @@ for (const key in ElementAtomWeights) {
         ElementMassesByMass.push([getElementFromAtomicNumber(Number(key)), mass]);
     }
 }
-
 ElementMassesByMass.sort((a, b) => a[1] - b[1]);
 
 /**


### PR DESCRIPTION
#1894 
While making changes I have omitted one line (ElementMassesByMass should be sorted for early break)


## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`