### PR TITLE
MVS: custom props isHidden true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - MolViewSpec
   - Added `transition` node with params `duration_ms`, `trajectory`, `easing`
   - Snapshot metadata: `linger_duration_ms` renamed to `duration_ms`, deprecated `transition_duration_ms`
+  - MVS-related custom model properties (and custom structure properties) are hidden in UI (fixes override of default custom properties)
 
 ## [v5.11.0] - 2026-07-18
 - Fix LAMMPS unsorted-atom handling (trajectory frame ordering and data-file bonds)

--- a/src/extensions/mvs/behavior.ts
+++ b/src/extensions/mvs/behavior.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
  */
@@ -199,7 +199,7 @@ export const MolViewSpec = PluginBehavior.create<{ autoAttach: boolean }>({
         }
     },
     params: () => ({
-        autoAttach: PD.Boolean(false),
+        autoAttach: PD.Boolean(true),
     })
 });
 

--- a/src/extensions/mvs/behavior.ts
+++ b/src/extensions/mvs/behavior.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
  */

--- a/src/extensions/mvs/behavior.ts
+++ b/src/extensions/mvs/behavior.ts
@@ -199,7 +199,7 @@ export const MolViewSpec = PluginBehavior.create<{ autoAttach: boolean }>({
         }
     },
     params: () => ({
-        autoAttach: PD.Boolean(true),
+        autoAttach: PD.Boolean(false),
     })
 });
 

--- a/src/extensions/mvs/components/annotation-prop.ts
+++ b/src/extensions/mvs/components/annotation-prop.ts
@@ -90,7 +90,8 @@ export const MVSAnnotationsProvider: CustomModelProperty.Provider<MVSAnnotations
         const specs: MVSAnnotationSpec[] = props.annotations ?? [];
         const annots = await MVSAnnotations.fromSpecs(ctx, specs, data);
         return { value: annots } satisfies CustomProperty.Data<MVSAnnotations>;
-    }
+    },
+    isHidden: true,
 });
 
 

--- a/src/extensions/mvs/components/annotation-tooltips-prop.ts
+++ b/src/extensions/mvs/components/annotation-tooltips-prop.ts
@@ -47,6 +47,7 @@ export const MVSAnnotationTooltipsProvider: CustomStructureProperty.Provider<MVS
         const fullProps = { ...PD.getDefaultValues(MVSAnnotationTooltipsParams), ...props };
         return { value: fullProps } satisfies CustomProperty.Data<MVSAnnotationTooltipsProps>;
     },
+    isHidden: true,
 });
 
 

--- a/src/extensions/mvs/components/custom-tooltips-prop.ts
+++ b/src/extensions/mvs/components/custom-tooltips-prop.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
  */
@@ -52,6 +52,7 @@ export const CustomTooltipsProvider: CustomStructureProperty.Provider<CustomTool
         } satisfies CustomTooltipsData[number]));
         return { value: value } satisfies CustomProperty.Data<CustomTooltipsData>;
     },
+    isHidden: true,
 });
 
 

--- a/src/extensions/mvs/components/is-mvs-model-prop.ts
+++ b/src/extensions/mvs/components/is-mvs-model-prop.ts
@@ -31,6 +31,7 @@ export const IsMVSModelProvider: CustomModelProperty.Provider<IsMVSModelParams, 
     getParams: (data: Model) => IsMVSModelParams,
     isApplicable: (data: Model) => true,
     obtain: async (ctx: CustomProperty.Context, data: Model, props: Partial<IsMVSModelProps>) => ({ value: {} }),
+    isHidden: true,
 });
 
 /** Decide if the model is flagged as managed by MolViewSpec */

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -386,10 +386,6 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
                 [IsMVSModelProvider.descriptor.name]: { isMvs: true } satisfies IsMVSModelProps,
                 [MVSAnnotationsProvider.descriptor.name]: { annotations },
             },
-            autoAttach: [
-                IsMVSModelProvider.descriptor.name,
-                MVSAnnotationsProvider.descriptor.name,
-            ],
         });
         return model;
     },

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -401,10 +401,7 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
                 [MVSAnnotationTooltipsProvider.descriptor.name]: { tooltips: annotationTooltips },
                 [CustomTooltipsProvider.descriptor.name]: { tooltips: inlineTooltips },
             },
-            autoAttach: [
-                MVSAnnotationTooltipsProvider.descriptor.name,
-                CustomTooltipsProvider.descriptor.name,
-            ],
+            // autoAttach not needed for these properties because they have isHidden:true (explicit autoAttach here would override default autoAttach of other properties!)
         }); // CustomStructureProperties must be applied even when `annotationTooltips` and `inlineTooltips` are empty, otherwise tooltips would persists across MVS snapshots
         const inlineLabels = collectInlineLabels(node, context);
         if (inlineLabels.length > 0) {

--- a/src/extensions/mvs/load.ts
+++ b/src/extensions/mvs/load.ts
@@ -386,6 +386,7 @@ const MolstarLoadingActions: LoadingActions<MolstarTree, MolstarLoadingContext> 
                 [IsMVSModelProvider.descriptor.name]: { isMvs: true } satisfies IsMVSModelProps,
                 [MVSAnnotationsProvider.descriptor.name]: { annotations },
             },
+            // autoAttach not needed for these properties because they have isHidden:true (explicit autoAttach here would override default autoAttach of other properties!, e.g. sifts_sequence_mapping)
         });
         return model;
     },

--- a/src/mol-model-props/common/custom-model-property.ts
+++ b/src/mol-model-props/common/custom-model-property.ts
@@ -19,6 +19,7 @@ namespace CustomModelProperty {
     export interface ProviderBuilder<Params extends PD.Params, Value> {
         readonly label: string
         readonly descriptor: CustomPropertyDescriptor
+        /** Hides property in UI (in production) and always attaches */
         readonly isHidden?: boolean
         readonly defaultParams: Params
         readonly getParams: (data: Model) => Params

--- a/src/mol-model-props/common/custom-property.ts
+++ b/src/mol-model-props/common/custom-property.ts
@@ -1,16 +1,18 @@
 /**
- * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { RuntimeContext } from '../../mol-task';
-import { CustomPropertyDescriptor } from '../../mol-model/custom-property';
-import { ParamDefinition as PD } from '../../mol-util/param-definition';
-import { ValueBox } from '../../mol-util';
 import { OrderedMap } from 'immutable';
-import { AssetManager, Asset } from '../../mol-util/assets';
+import { CustomPropertyDescriptor } from '../../mol-model/custom-property';
+import { RuntimeContext } from '../../mol-task';
+import { ValueBox } from '../../mol-util';
+import { Asset, AssetManager } from '../../mol-util/assets';
+import { isProductionMode } from '../../mol-util/debug';
 import { ErrorContext } from '../../mol-util/error-context';
+import { ParamDefinition as PD } from '../../mol-util/param-definition';
 
 export { CustomProperty };
 
@@ -31,7 +33,7 @@ namespace CustomProperty {
     export interface Provider<Data, Params extends PD.Params, Value> {
         readonly label: string
         readonly descriptor: CustomPropertyDescriptor
-        /** hides property in ui and always attaches */
+        /** Hides property in UI (in production) and always attaches */
         readonly isHidden?: boolean
         readonly getParams: (data: Data) => Params
         readonly defaultParams: Params
@@ -70,7 +72,10 @@ namespace CustomProperty {
 
                     propertiesParams[provider.descriptor.name] = PD.Group({
                         ...provider.getParams(data)
-                    }, { label: provider.label, isHidden: provider.isHidden });
+                    }, {
+                        label: provider.isHidden ? `[Hidden] ${provider.label}` : provider.label,
+                        isHidden: provider.isHidden && isProductionMode,
+                    });
                 }
             }
             return {

--- a/src/mol-model-props/common/custom-structure-property.ts
+++ b/src/mol-model-props/common/custom-structure-property.ts
@@ -19,6 +19,7 @@ namespace CustomStructureProperty {
     export interface ProviderBuilder<Params extends PD.Params, Value> {
         readonly label: string
         readonly descriptor: CustomPropertyDescriptor
+        /** Hides property in UI (in production) and always attaches */
         readonly isHidden?: boolean
         readonly defaultParams: Params
         readonly getParams: (data: Structure) => Params


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This change prevents MolViewSpec from overriding Molstar's default list of autoAttached custom model properties and custom structure properties (e.g. SIFTS Mappings) and avoids breaking third-party functionality (e.g. PDBe Molstar's select by uniprot_residue_number) when the model is loaded from MVS.

MVS-related custom model properties and custom structure properties are hidden in UI (in production build).

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`