### PR TITLE
Cell & symmetry improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Note that since we don't clearly distinguish between a public and private interf
     - Generate operators from Hall symbols
     - Introduce change-of-basis settings
     - Move base functionality from `SpacegroupCell` to `Cell`
+- Improve `Cell` handling
+    - Fix volume calculation for non-orthogonal cells
+    - Use as base for `Unitcell` shape
+    - Add `order` property (for AU volume estimation)
+- Add per-format cache for `FormatProperty`
+    - Use for `ModelSymmetry` and `ComponentBond`
+- `ModelSymmetry` improvements
+    - Fix property not beeing dynamic
+    - Defer Symmetry calculation in ModelSymmetry.fromData
 - Support non-default CRYSIN setting in MOL2 format (#338)
 - Fix `ssao-blur` background test: the RG-packed depth never equals `1.0`, so background samples were blurred into geometry and produced a bright rim at the far-clip cutoff
 - Fix picking/hover-highlight of the nucleic cartoon polymer-trace on reduced trace structures returning empty: `getResidueLoci` now accounts for whole residue, not limited to unit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Add per-format cache for `FormatProperty`
     - Use for `ModelSymmetry` and `ComponentBond`
 - `ModelSymmetry` improvements
-    - Fix property not beeing dynamic
+    - Fix property not being dynamic
     - Defer Symmetry calculation in ModelSymmetry.fromData
 - Support non-default CRYSIN setting in MOL2 format (#338)
 - Fix `ssao-blur` background test: the RG-packed depth never equals `1.0`, so background samples were blurred into geometry and produced a bright rim at the far-clip cutoff

--- a/src/mol-math/geometry/_spec/spacegroup.spec.ts
+++ b/src/mol-math/geometry/_spec/spacegroup.spec.ts
@@ -5,6 +5,8 @@
  */
 
 import { Spacegroup, SpacegroupCell } from '../spacegroup/construction';
+import { Cell } from '../spacegroup/cell';
+import { operatorsForEntry, orderForEntry, SpacegroupData } from '../spacegroup/tables';
 import { Vec3 } from '../../linear-algebra';
 
 function getSpacegroup(name: string) {
@@ -34,5 +36,30 @@ describe('Spacegroup', () => {
         checkOperatorsXyz('P 41', ['X,Y,Z', '-X,-Y,1/2+Z', '-Y,X,1/4+Z', 'Y,-X,3/4+Z']);
         checkOperatorsXyz('P 41 21 2', ['X,Y,Z', '-X,-Y,1/2+Z', '1/2-Y,1/2+X,1/4+Z', '1/2+Y,1/2-X,3/4+Z', '1/2-X,1/2+Y,1/4-Z', '1/2+X,1/2-Y,3/4-Z', 'Y,X,-Z', '-Y,-X,1/2-Z']);
         checkOperatorsXyz('P 3', ['X,Y,Z', '-Y,X-Y,Z', 'Y-X,-X,Z']);
+    });
+
+    it('orderForEntry matches the generated operator count', () => {
+        for (const entry of SpacegroupData) {
+            expect([entry.names[0], orderForEntry(entry)]).toEqual([entry.names[0], operatorsForEntry(entry).length]);
+        }
+    });
+});
+
+describe('Cell', () => {
+    const angles90 = Vec3.create(Math.PI / 2, Math.PI / 2, Math.PI / 2);
+
+    it('volume', () => {
+        expect(Cell.create(Vec3.create(2, 3, 4), angles90).volume).toBeCloseTo(24, 6);
+        // triclinic, all angles 60 degrees
+        const angles60 = Vec3.create(Math.PI / 3, Math.PI / 3, Math.PI / 3);
+        expect(Cell.create(Vec3.create(10, 10, 10), angles60).volume).toBeCloseTo(707.10678, 4);
+        expect(Cell.empty().volume).toBe(0);
+    });
+
+    it('order', () => {
+        expect(Cell.create(Vec3.create(1, 1, 1), angles90).order).toBe(1);
+        expect(SpacegroupCell.create('P 1', Vec3.create(10, 10, 10), angles90).order).toBe(1);
+        expect(SpacegroupCell.create('P 21 21 21', Vec3.create(10, 10, 10), angles90).order).toBe(4);
+        expect(SpacegroupCell.create('P 41 21 2', Vec3.create(10, 10, 10), angles90).order).toBe(8);
     });
 });

--- a/src/mol-math/geometry/spacegroup/cell.ts
+++ b/src/mol-math/geometry/spacegroup/cell.ts
@@ -5,6 +5,7 @@
  */
 
 import { Mat4, Vec3 } from '../../linear-algebra';
+import { radToDeg } from '../../misc';
 
 export { Cell };
 
@@ -70,5 +71,21 @@ namespace Cell {
         } else {
             return create(Vec3.create(a, b, c), Vec3.create(alpha, beta, gamma));
         }
+    }
+
+    /** Human readable dimensions and angles, prefixed by `title` */
+    export function getLabel(cell: Cell, title = 'Unit Cell') {
+        const { size, anglesInRadians } = cell;
+        const a = size[0].toFixed(2);
+        const b = size[1].toFixed(2);
+        const c = size[2].toFixed(2);
+        const alpha = radToDeg(anglesInRadians[0]).toFixed(2);
+        const beta = radToDeg(anglesInRadians[1]).toFixed(2);
+        const gamma = radToDeg(anglesInRadians[2]).toFixed(2);
+        return [
+            title,
+            `${a}\u00D7${b}\u00D7${c} \u212B`,
+            `\u03b1=${alpha}\u00B0 \u03b2=${beta}\u00B0 \u03b3=${gamma}\u00B0`
+        ].join(' | ');
     }
 }

--- a/src/mol-math/geometry/spacegroup/cell.ts
+++ b/src/mol-math/geometry/spacegroup/cell.ts
@@ -24,20 +24,21 @@ function Cell() {
 
 namespace Cell {
     export function create(size: Vec3, anglesInRadians: Vec3): Cell {
-        const volume = size[0] * size[1] * size[2];
-
         const alpha = anglesInRadians[0];
         const beta = anglesInRadians[1];
         const gamma = anglesInRadians[2];
 
+        const ca = Math.cos(alpha), cb = Math.cos(beta), cg = Math.cos(gamma);
+        const volume = size[0] * size[1] * size[2] * Math.sqrt(1.0 - ca * ca - cb * cb - cg * cg + 2.0 * ca * cb * cg);
+
         const xScale = size[0], yScale = size[1], zScale = size[2];
 
-        const z1 = Math.cos(beta);
-        const z2 = (Math.cos(alpha) - Math.cos(beta) * Math.cos(gamma)) / Math.sin(gamma);
+        const z1 = cb;
+        const z2 = (ca - cb * cg) / Math.sin(gamma);
         const z3 = Math.sqrt(1.0 - z1 * z1 - z2 * z2);
 
         const x = [xScale, 0.0, 0.0];
-        const y = [Math.cos(gamma) * yScale, Math.sin(gamma) * yScale, 0.0];
+        const y = [cg * yScale, Math.sin(gamma) * yScale, 0.0];
         const z = [z1 * zScale, z2 * zScale, z3 * zScale];
 
         const fromFractional = Mat4.ofRows([

--- a/src/mol-math/geometry/spacegroup/cell.ts
+++ b/src/mol-math/geometry/spacegroup/cell.ts
@@ -13,6 +13,8 @@ interface Cell {
     readonly size: Vec3
     readonly anglesInRadians: Vec3
     readonly volume: number,
+    /** Number of symmetry operators of the spacegroup the cell belongs to, 1 for a plain box */
+    readonly order: number,
     /** Transfrom cartesian -> fractional coordinates within the cell */
     readonly toFractional: Mat4,
     /** Transfrom fractional coordinates within the cell -> cartesian */
@@ -24,7 +26,7 @@ function Cell() {
 }
 
 namespace Cell {
-    export function create(size: Vec3, anglesInRadians: Vec3): Cell {
+    export function create(size: Vec3, anglesInRadians: Vec3, order = 1): Cell {
         const alpha = anglesInRadians[0];
         const beta = anglesInRadians[1];
         const gamma = anglesInRadians[2];
@@ -50,7 +52,7 @@ namespace Cell {
         ]);
         const toFractional = Mat4.invert(Mat4.zero(), fromFractional);
 
-        return { size, anglesInRadians, volume, toFractional, fromFractional };
+        return { size, anglesInRadians, volume, order, toFractional, fromFractional };
     }
 
     export function empty(): Cell {

--- a/src/mol-math/geometry/spacegroup/construction.ts
+++ b/src/mol-math/geometry/spacegroup/construction.ts
@@ -42,6 +42,11 @@ namespace SpacegroupCell {
     /** Create a 'P 1' with cellsize [1, 1, 1] */
     export const Zero: SpacegroupCell = create('P 1', Vec3.create(1, 1, 1), Vec3.create(Math.PI / 2, Math.PI / 2, Math.PI / 2));
 
+    /** True if the cell belongs to a known spacegroup */
+    export function is(cell: Cell): cell is SpacegroupCell {
+        return typeof (cell as SpacegroupCell).name === 'string';
+    }
+
     /** True if 'P 1' with cellsize [1, 1, 1] */
     export function isZero(cell?: SpacegroupCell) {
         if (!cell) return true;
@@ -59,6 +64,10 @@ namespace SpacegroupCell {
         const cell = Cell.create(size, anglesInRadians);
 
         return { ...cell, name: entry.names[0] };
+    }
+
+    export function getLabel(cell: SpacegroupCell) {
+        return Cell.getLabel(cell, `Unit Cell <b>${cell.name}</b> #${getSpacegroupNumber(cell.name)}`);
     }
 }
 

--- a/src/mol-math/geometry/spacegroup/construction.ts
+++ b/src/mol-math/geometry/spacegroup/construction.ts
@@ -6,7 +6,7 @@
  */
 
 import { Vec3, Mat4 } from '../../linear-algebra';
-import { findSpacegroupEntry, operatorsForEntry } from './tables';
+import { findSpacegroupEntry, getSpacegroupNumber, operatorsForEntry, orderForEntry } from './tables';
 import { SymmetryOperator } from '../../geometry/symmetry-operator';
 import { Cell } from './cell';
 
@@ -61,7 +61,7 @@ namespace SpacegroupCell {
             return Zero;
         }
 
-        const cell = Cell.create(size, anglesInRadians);
+        const cell = Cell.create(size, anglesInRadians, orderForEntry(entry));
 
         return { ...cell, name: entry.names[0] };
     }
@@ -97,7 +97,7 @@ namespace Spacegroup {
     export function createWithSetting(cell: SpacegroupCell, name: string, basisop: string, operators: ReadonlyArray<Mat4>): Spacegroup {
         const entry = findSpacegroupEntry(cell.name);
         const num = entry ? (entry.ccp4Number !== 0 ? entry.ccp4Number : entry.itaNumber) : -1;
-        return { name, num, cell, basisop, operators };
+        return { name, num, cell: { ...cell, order: operators.length }, basisop, operators };
     }
 
     const _ijkVec = Vec3();

--- a/src/mol-math/geometry/spacegroup/construction.ts
+++ b/src/mol-math/geometry/spacegroup/construction.ts
@@ -42,7 +42,7 @@ namespace SpacegroupCell {
     /** Create a 'P 1' with cellsize [1, 1, 1] */
     export const Zero: SpacegroupCell = create('P 1', Vec3.create(1, 1, 1), Vec3.create(Math.PI / 2, Math.PI / 2, Math.PI / 2));
 
-    /** True if the cell belongs to a known spacegroup */
+    /** True if the cell is a `SpacegroupCell` */
     export function is(cell: Cell): cell is SpacegroupCell {
         return typeof (cell as SpacegroupCell).name === 'string';
     }

--- a/src/mol-math/geometry/spacegroup/tables.ts
+++ b/src/mol-math/geometry/spacegroup/tables.ts
@@ -7,7 +7,7 @@
 
 import { Mat4 } from '../../linear-algebra';
 import { coordinateExpressionToOperator, transformOperators } from './common';
-import { hasLongFormChangeOfBasis, operatorsFromHall } from './notation';
+import { centringVectors, hasLongFormChangeOfBasis, operatorsFromHall } from './notation';
 import { RawSpacegroupData } from './syminfo';
 
 /**
@@ -134,6 +134,50 @@ export function getSpacegroupNumber(nameOrNumber: number | string): number {
  */
 export function getHallSymbol(spacegroupNumber: number): string | undefined {
     return SpacegroupEntryByNumber.get(spacegroupNumber)?.hall;
+}
+
+/**
+ * `[first ITA number, point group order]` pairs, ascending - each pair covers
+ * the ITA numbers up to (excluding) the next pair's first number.
+ */
+const PointGroupOrderRanges: readonly (readonly [number, number])[] = [
+    [1, 1], [2, 2], [10, 4], [47, 8], // triclinic, monoclinic, orthorhombic
+    [75, 4], [83, 8], [123, 16], // tetragonal
+    [143, 3], [147, 6], [162, 12], // trigonal
+    [168, 6], [175, 12], [191, 24], // hexagonal
+    [195, 12], [200, 24], [221, 48], // cubic
+];
+
+const PointGroupOrderByItaNumber = (function () {
+    const orders = new Uint8Array(231);
+    for (let i = 0; i < PointGroupOrderRanges.length; i++) {
+        const [start, order] = PointGroupOrderRanges[i];
+        const end = i + 1 < PointGroupOrderRanges.length ? PointGroupOrderRanges[i + 1][0] : orders.length;
+        for (let n = start; n < end; n++) orders[n] = order;
+    }
+    return orders;
+}());
+
+/**
+ * Order of the point group (crystal class) an ITA spacegroup number belongs
+ * to, i.e. the number of distinct rotation parts among its operators.
+ */
+export function pointGroupOrder(itaNumber: number): number {
+    return PointGroupOrderByItaNumber[itaNumber] ?? 0;
+}
+
+/**
+ * Number of symmetry operators of an entry (the multiplicity of the general
+ * position) - its point group order times its lattice centering count. Both
+ * are table lookups, so unlike `operatorsForEntry(entry).length` this builds
+ * no matrices.
+ */
+export function orderForEntry(entry: SpacegroupEntry): number {
+    // the Hall symbol's lattice letter, unlike the Hermann-Mauguin name's, is
+    // 'P' for a rhombohedral-axes description of an R spacegroup
+    const hall = entry.hall.trim();
+    const latticeLetter = hall[0] === '-' ? hall.slice(1).trim()[0] : hall[0];
+    return pointGroupOrder(entry.itaNumber) * centringVectors(latticeLetter).length;
 }
 
 const OperatorsByEntryCache = new Map<SpacegroupEntry, ReadonlyArray<Mat4>>();

--- a/src/mol-model-formats/structure/common/property.ts
+++ b/src/mol-model-formats/structure/common/property.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2022 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2020-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
@@ -46,9 +46,24 @@ interface FormatPropertyProvider<T> {
 }
 
 namespace FormatPropertyProvider {
-    export function create<T>(descriptor: CustomPropertyDescriptor, options?: { asDynamic?: boolean }): FormatPropertyProvider<T> {
+    /** Values obtained from the format registry, keyed by source data and property name */
+    const FormatCache = new WeakMap<ModelFormat, { [name: string]: any }>();
+
+    export function create<T>(descriptor: CustomPropertyDescriptor, options?: { asDynamic?: boolean, cachePerFormat?: boolean }): FormatPropertyProvider<T> {
         const { name } = descriptor;
         const formatRegistry = new FormatRegistry<T>();
+
+        function obtainValue(model: Model, obtain: (model: Model) => T | undefined) {
+            if (!options?.cachePerFormat) return obtain(model);
+
+            let cache = FormatCache.get(model.sourceData);
+            if (!cache) {
+                cache = Object.create(null) as { [name: string]: any };
+                FormatCache.set(model.sourceData, cache);
+            }
+            if (!(name in cache)) cache[name] = obtain(model);
+            return cache[name] as T | undefined;
+        }
 
         return {
             descriptor,
@@ -65,7 +80,7 @@ namespace FormatPropertyProvider {
                 const obtain = formatRegistry.get(model.sourceData.kind);
                 if (!obtain) return;
 
-                store[name] = obtain(model);
+                store[name] = obtainValue(model, obtain);
                 model.customProperties.add(descriptor);
                 return store[name];
             },

--- a/src/mol-model-formats/structure/common/property.ts
+++ b/src/mol-model-formats/structure/common/property.ts
@@ -46,23 +46,16 @@ interface FormatPropertyProvider<T> {
 }
 
 namespace FormatPropertyProvider {
-    /** Values obtained from the format registry, keyed by source data and property name */
-    const FormatCache = new WeakMap<ModelFormat, { [name: string]: any }>();
-
     export function create<T>(descriptor: CustomPropertyDescriptor, options?: { asDynamic?: boolean, cachePerFormat?: boolean }): FormatPropertyProvider<T> {
         const { name } = descriptor;
         const formatRegistry = new FormatRegistry<T>();
+        const formatCache = new WeakMap<ModelFormat, T | undefined>();
 
         function obtainValue(model: Model, obtain: (model: Model) => T | undefined) {
             if (!options?.cachePerFormat) return obtain(model);
 
-            let cache = FormatCache.get(model.sourceData);
-            if (!cache) {
-                cache = Object.create(null) as { [name: string]: any };
-                FormatCache.set(model.sourceData, cache);
-            }
-            if (!(name in cache)) cache[name] = obtain(model);
-            return cache[name] as T | undefined;
+            if (!formatCache.has(model.sourceData)) formatCache.set(model.sourceData, obtain(model));
+            return formatCache.get(model.sourceData);
         }
 
         return {

--- a/src/mol-model-formats/structure/property/bonds/chem_comp.ts
+++ b/src/mol-model-formats/structure/property/bonds/chem_comp.ts
@@ -44,7 +44,7 @@ export namespace ComponentBond {
         }
     };
 
-    export const Provider = FormatPropertyProvider.create<ComponentBond>(Descriptor);
+    export const Provider = FormatPropertyProvider.create<ComponentBond>(Descriptor, { cachePerFormat: true });
 
     export function chemCompBondFromTable(model: Model, table: Table<mmCIF_Schema['chem_comp_bond']>): Table<mmCIF_Schema['chem_comp_bond']> {
         return Table.pick(table, mmCIF_Schema.chem_comp_bond, (i: number) => {

--- a/src/mol-model-formats/structure/property/symmetry.ts
+++ b/src/mol-model-formats/structure/property/symmetry.ts
@@ -21,7 +21,7 @@ namespace ModelSymmetry {
         name: 'model_symmetry',
     };
 
-    export const Provider = FormatPropertyProvider.create<Symmetry>(Descriptor, { cachePerFormat: true });
+    export const Provider = FormatPropertyProvider.create<Symmetry>(Descriptor, { asDynamic: true, cachePerFormat: true });
 
     type Data = {
         symmetry: Table<mmCIF_Schema['symmetry']>

--- a/src/mol-model-formats/structure/property/symmetry.ts
+++ b/src/mol-model-formats/structure/property/symmetry.ts
@@ -8,7 +8,7 @@
 import { mmCIF_Schema } from '../../../mol-io/reader/cif/schema/mmcif';
 import { Spacegroup, SpacegroupCell, SymmetryOperator } from '../../../mol-math/geometry';
 import { Tensor, Vec3, Mat3 } from '../../../mol-math/linear-algebra';
-import { Symmetry } from '../../../mol-model/structure/model/properties/symmetry';
+import { Symmetry, Assembly } from '../../../mol-model/structure/model/properties/symmetry';
 import { createAssemblies } from './assembly';
 import { CustomPropertyDescriptor } from '../../../mol-model/custom-property';
 import { FormatPropertyProvider } from '../common/property';
@@ -34,10 +34,35 @@ namespace ModelSymmetry {
     }
 
     export function fromData(data: Data): Symmetry {
-        const assemblies = createAssemblies(data.pdbx_struct_assembly, data.pdbx_struct_assembly_gen, data.pdbx_struct_oper_list);
-        const spacegroup = getSpacegroup(data.symmetry, data.cell);
-        const isNonStandardCrystalFrame = checkNonStandardCrystalFrame(data.atom_sites, spacegroup);
-        return { assemblies, spacegroup, isNonStandardCrystalFrame, ncsOperators: getNcsOperators(data.struct_ncs_oper) };
+        let assemblies: ReadonlyArray<Assembly> | undefined;
+        let spacegroup: Spacegroup | undefined;
+        let ncsOperators: ReadonlyArray<SymmetryOperator> | undefined;
+        let hasNcsOperators = false;
+
+        const _getSpacegroup = () => {
+            if (!spacegroup) spacegroup = getSpacegroup(data.symmetry, data.cell);
+            return spacegroup;
+        };
+
+        return {
+            get assemblies() {
+                if (!assemblies) assemblies = createAssemblies(data.pdbx_struct_assembly, data.pdbx_struct_assembly_gen, data.pdbx_struct_oper_list);
+                return assemblies;
+            },
+            get spacegroup() {
+                return _getSpacegroup();
+            },
+            get isNonStandardCrystalFrame() {
+                return checkNonStandardCrystalFrame(data.atom_sites, _getSpacegroup());
+            },
+            get ncsOperators() {
+                if (!hasNcsOperators) {
+                    ncsOperators = getNcsOperators(data.struct_ncs_oper);
+                    hasNcsOperators = true;
+                }
+                return ncsOperators;
+            },
+        };
     }
 
     export function fromCell(size: Vec3, anglesInRadians: Vec3): Symmetry {

--- a/src/mol-model-formats/structure/property/symmetry.ts
+++ b/src/mol-model-formats/structure/property/symmetry.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -21,7 +21,7 @@ namespace ModelSymmetry {
         name: 'model_symmetry',
     };
 
-    export const Provider = FormatPropertyProvider.create<Symmetry>(Descriptor);
+    export const Provider = FormatPropertyProvider.create<Symmetry>(Descriptor, { cachePerFormat: true });
 
     type Data = {
         symmetry: Table<mmCIF_Schema['symmetry']>

--- a/src/mol-model/structure/model/model.ts
+++ b/src/mol-model/structure/model/model.ts
@@ -108,6 +108,8 @@ export namespace Model {
         const srcIndexArray = getSourceIndexArray(model);
         const coarseGrained = isCoarseGrained(model);
         const elementCount = model.atomicHierarchy.atoms._rowCount;
+        // fall back to the symmetry of the model if a frame has no cell
+        const symmetry = ModelSymmetry.Provider.get(model);
 
         for (let i = 0, il = frames.length; i < il; ++i) {
             const f = frames[i];
@@ -125,7 +127,8 @@ export namespace Model {
             };
 
             if (f.cell) {
-                const symmetry = ModelSymmetry.fromCell(f.cell.size, f.cell.anglesInRadians);
+                ModelSymmetry.Provider.set(m, ModelSymmetry.fromCell(f.cell.size, f.cell.anglesInRadians));
+            } else if (symmetry) {
                 ModelSymmetry.Provider.set(m, symmetry);
             }
 

--- a/src/mol-model/structure/model/properties/symmetry.ts
+++ b/src/mol-model/structure/model/properties/symmetry.ts
@@ -11,7 +11,6 @@ import { Model } from '../../model';
 import { Spacegroup } from '../../../../mol-math/geometry';
 import { Vec3 } from '../../../../mol-math/linear-algebra';
 import { ModelSymmetry } from '../../../../mol-model-formats/structure/property/symmetry';
-import { radToDeg } from '../../../../mol-math/misc';
 
 /** Determine an atom set and a list of operators that should be applied to that set  */
 export interface OperatorGroup {
@@ -68,25 +67,6 @@ namespace Symmetry {
         const _id = id.toLocaleLowerCase();
         const symmetry = ModelSymmetry.Provider.get(model);
         return symmetry ? arrayFind(symmetry.assemblies, a => a.id.toLowerCase() === _id) : undefined;
-    }
-
-    export function getUnitcellLabel(symmetry: Symmetry) {
-        const { cell, name, num } = symmetry.spacegroup;
-        const { size, anglesInRadians } = cell;
-        const a = size[0].toFixed(2);
-        const b = size[1].toFixed(2);
-        const c = size[2].toFixed(2);
-        const alpha = radToDeg(anglesInRadians[0]).toFixed(2);
-        const beta = radToDeg(anglesInRadians[1]).toFixed(2);
-        const gamma = radToDeg(anglesInRadians[2]).toFixed(2);
-        const label: string[] = [];
-        // name
-        label.push(`Unit Cell <b>${name}</b> #${num}`);
-        // sizes
-        label.push(`${a}\u00D7${b}\u00D7${c} \u212B`);
-        // angles
-        label.push(`\u03b1=${alpha}\u00B0 \u03b2=${beta}\u00B0 \u03b3=${gamma}\u00B0`);
-        return label.join(' | ');
     }
 }
 

--- a/src/mol-plugin-state/transforms/representation.ts
+++ b/src/mol-plugin-state/transforms/representation.ts
@@ -1220,7 +1220,7 @@ const ModelUnitcell3D = PluginStateTransform.BuiltIn({
         return Task.create('Model Unit Cell', async ctx => {
             const symmetry = ModelSymmetry.Provider.get(a.data);
             if (!symmetry) return StateObject.Null;
-            const data = getUnitcellData(a.data, symmetry, params);
+            const data = getUnitcellData(a.data, symmetry.spacegroup.cell, params);
             const repr = UnitcellRepresentation({ webgl: plugin.canvas3d?.webgl, ...plugin.representation.structure.themes }, () => UnitcellParams);
             await repr.createOrUpdate(params, data).runInContext(ctx);
             return new SO.Shape.Representation3D({ repr, sourceData: data }, { label: `Unit Cell`, description: symmetry.spacegroup.name });
@@ -1231,7 +1231,7 @@ const ModelUnitcell3D = PluginStateTransform.BuiltIn({
             const symmetry = ModelSymmetry.Provider.get(a.data);
             if (!symmetry) return StateTransformer.UpdateResult.Null;
             const props = { ...b.data.repr.props, ...newParams };
-            const data = getUnitcellData(a.data, symmetry, props);
+            const data = getUnitcellData(a.data, symmetry.spacegroup.cell, props);
             await b.data.repr.createOrUpdate(props, data).runInContext(ctx);
             b.data.sourceData = data;
             return StateTransformer.UpdateResult.Updated;

--- a/src/mol-repr/shape/model/unitcell.ts
+++ b/src/mol-repr/shape/model/unitcell.ts
@@ -1,10 +1,10 @@
 /**
- * Copyright (c) 2019-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2019-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
-import { Model, Symmetry } from '../../../mol-model/structure';
+import { Model } from '../../../mol-model/structure';
 import { ShapeRepresentation } from '../representation';
 import { Shape } from '../../../mol-model/shape';
 import { ColorNames } from '../../../mol-util/color/names';
@@ -16,6 +16,8 @@ import { BoxCage } from '../../../mol-geo/primitive/box';
 import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
 import { transformCage, cloneCage } from '../../../mol-geo/primitive/cage';
 import { Sphere3D } from '../../../mol-math/geometry';
+import { Cell } from '../../../mol-math/geometry/spacegroup/cell';
+import { SpacegroupCell } from '../../../mol-math/geometry/spacegroup/construction';
 import { RepresentationParamsGetter, Representation, RepresentationContext } from '../../representation';
 
 const translate05 = Mat4.fromTranslation(Mat4(), Vec3.create(0.5, 0.5, 0.5));
@@ -25,7 +27,7 @@ const tmpRef = Vec3();
 const tmpTranslate = Mat4();
 
 interface UnitcellData {
-    symmetry: Symmetry
+    cell: Cell
     ref: Vec3
 }
 
@@ -61,7 +63,7 @@ export type UnitcellProps = PD.Values<UnitcellParams>
 function getUnitcellMesh(data: UnitcellData, props: UnitcellProps, mesh?: Mesh) {
     const state = MeshBuilder.createState(256, 128, mesh);
 
-    const { fromFractional } = data.symmetry.spacegroup.cell;
+    const { fromFractional } = data.cell;
 
     Vec3.copy(tmpRef, data.ref);
     if (props.attachment === 'center') {
@@ -73,7 +75,7 @@ function getUnitcellMesh(data: UnitcellData, props: UnitcellProps, mesh?: Mesh) 
     Mat4.fromTranslation(tmpTranslate, tmpRef);
     const cellCage = transformCage(cloneCage(unitCage), tmpTranslate);
 
-    const radius = (Math.cbrt(data.symmetry.spacegroup.cell.volume) / 300) * props.cellScale;
+    const radius = (Math.cbrt(data.cell.volume) / 300) * props.cellScale;
     state.currentGroup = 1;
     MeshBuilder.addCage(state, fromFractional, cellCage, radius, 2, 20);
 
@@ -87,20 +89,24 @@ function getUnitcellMesh(data: UnitcellData, props: UnitcellProps, mesh?: Mesh) 
     return m;
 }
 
+export function getUnitcellLabel(cell: Cell) {
+    return SpacegroupCell.is(cell) ? SpacegroupCell.getLabel(cell) : Cell.getLabel(cell);
+}
+
 function getUnitcellShape(ctx: RuntimeContext, data: UnitcellData, props: UnitcellProps, shape?: Shape<Mesh>) {
     const geo = getUnitcellMesh(data, props, shape && shape.geometry);
-    const label = Symmetry.getUnitcellLabel(data.symmetry);
+    const label = getUnitcellLabel(data.cell);
     return Shape.create(label, data, geo, () => props.cellColor, () => 1, () => label);
 }
 
 //
 
-export function getUnitcellData(model: Model, symmetry: Symmetry, props: UnitcellProps) {
+export function getUnitcellData(model: Model, cell: Cell, props: UnitcellProps) {
     const ref = Vec3();
     if (props.ref === 'model') {
-        Vec3.transformMat4(ref, Model.getCenter(model), symmetry.spacegroup.cell.toFractional);
+        Vec3.transformMat4(ref, Model.getCenter(model), cell.toFractional);
     }
-    return { symmetry, ref };
+    return { cell, ref };
 }
 
 export type UnitcellRepresentation = Representation<UnitcellData, UnitcellParams>

--- a/src/mol-repr/util.ts
+++ b/src/mol-repr/util.ts
@@ -7,7 +7,7 @@
 import { defaults } from '../mol-util';
 import { Structure } from '../mol-model/structure';
 import { VisualQuality } from '../mol-geo/geometry/base';
-import { Box3D, SpacegroupCell } from '../mol-math/geometry';
+import { Box3D } from '../mol-math/geometry';
 import { ModelSymmetry } from '../mol-model-formats/structure/property/symmetry';
 import { Volume } from '../mol-model/volume';
 import { Location } from '../mol-model/location';
@@ -122,15 +122,14 @@ export function getStructureQuality(structure: Structure, tresholds: Partial<Qua
 }
 
 /**
- * Uses cell volume to avoid costly boundary calculation if
- * - single model
- * - non-empty 'P 1' spacegroup
+ * Uses cell volume divided by the number of symmetry operators to avoid
+ * costly boundary calculation if a single model with a non-empty cell.
  */
 function getRootVolume(structure: Structure) {
     if (structure.root.models.length === 1) {
-        const sym = ModelSymmetry.Provider.get(structure.root.model);
-        if (sym && sym.spacegroup.name === 'P 1' && !SpacegroupCell.isZero(sym.spacegroup.cell)) {
-            return sym.spacegroup.cell.volume;
+        const cell = ModelSymmetry.Provider.get(structure.root.model)?.spacegroup.cell;
+        if (cell && cell.volume > 0) {
+            return cell.volume / cell.order;
         }
     }
     return Box3D.volume(structure.root.boundary.box);


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- Improve `Cell` handling
    - Fix volume calculation for non-orthogonal cells
    - Use as base for `Unitcell` shape
    - Add `order` property (for AU volume estimation)
- Add per-format cache for `FormatProperty`
    - Use for `ModelSymmetry` and `ComponentBond`
- `ModelSymmetry` improvements
    - Fix property not beeing dynamic
    - Defer Symmetry calculation in ModelSymmetry.fromData

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`