### PR TITLE
Fix stale marker data when a volume visual's group count changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Support non-default CRYSIN setting in MOL2 format (#338)
 - Fix `ssao-blur` background test: the RG-packed depth never equals `1.0`, so background samples were blurred into geometry and produced a bright rim at the far-clip cutoff
 - Fix picking/hover-highlight of the nucleic cartoon polymer-trace on reduced trace structures returning empty: `getResidueLoci` now accounts for whole residue, not limited to unit.
+- Fix stale marker data in `VolumeVisual` when a geometry update changes the group count (e.g. switching `slice` mode), which mismarked unrelated groups and disabled the marking pass scene-wide
 - Add Spherical Harmonics to mol-math
 - Add `blob-surface` structure representation
     - Bin atoms to grid or cluster

--- a/src/mol-repr/volume/visual.ts
+++ b/src/mol-repr/volume/visual.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
@@ -157,6 +158,7 @@ export function VolumeVisual<G extends Geometry, P extends VolumeParams & Geomet
         if (updateState.createGeometry) {
             updateState.updateColor = true;
             updateState.updateSize = true;
+            updateState.updateLocation = true;
         }
     }
 


### PR DESCRIPTION
# Description

This fixes an issue I encountered when using slice representation 

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`