### PR TITLE
Illumination: automatically derive firstStepSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Fast option fits ellipsoids to bins
     - Artistic option fits spherical harmonics to bins
 - Fix camera reset handling for (temporary) empty scenes (#1903)
+- Remove `firstStepSize` tracing parameter, derive automatically
 
 - Camera improvements
   - Support multiple camera transition shapes

--- a/src/apps/mesoscale-explorer/ui/states.tsx
+++ b/src/apps/mesoscale-explorer/ui/states.tsx
@@ -106,7 +106,6 @@ function adjustPluginProps(ctx: PluginContext) {
         },
         illumination: {
             enabled: customState.illumination,
-            firstStepSize: 0.1,
             rayDistance: 1024,
         },
     });

--- a/src/mol-canvas3d/passes/tracing.ts
+++ b/src/mol-canvas3d/passes/tracing.ts
@@ -43,7 +43,6 @@ export const TracingParams = {
     rendersPerFrame: PD.Interval([1, 16], { min: 1, max: 64, step: 1 }, { description: 'Number of rays per pixel each frame. May be adjusted to reach targetFps but will stay within given interval.' }),
     targetFps: PD.Numeric(30, { min: 0, max: 120, step: 0.1 }, { description: 'Target FPS per frame. If observed FPS is lower or higher, some parameters may get adjusted.' }),
     steps: PD.Numeric(32, { min: 1, max: 1024, step: 1 }),
-    firstStepSize: PD.Numeric(0.01, { min: 0.001, max: 1, step: 0.001 }),
     refineSteps: PD.Numeric(4, { min: 0, max: 8, step: 1 }, { description: 'Number of refine steps per ray hit. May be lower to reach targetFps.' }),
     rayDistance: PD.Numeric(256, { min: 1, max: 8192, step: 1 }, { description: 'Maximum distance a ray can travel (in world units).' }),
     thicknessMode: PD.Select('auto', PD.arrayToOptions(['auto', 'fixed'] as const)),
@@ -371,10 +370,6 @@ export class TracingPass {
             ValueCell.update(this.traceRenderable.values.dSteps, steps);
             needsUpdateTrace = true;
         }
-        if (this.traceRenderable.values.dFirstStepSize.ref.value !== props.firstStepSize) {
-            ValueCell.update(this.traceRenderable.values.dFirstStepSize, props.firstStepSize);
-            needsUpdateTrace = true;
-        }
         if (this.traceRenderable.values.dRefineSteps.ref.value !== refineSteps) {
             ValueCell.update(this.traceRenderable.values.dRefineSteps, refineSteps);
             needsUpdateTrace = true;
@@ -440,7 +435,6 @@ const TraceSchema = {
     dGlow: DefineSpec('boolean'),
     dBounces: DefineSpec('number'),
     dSteps: DefineSpec('number'),
-    dFirstStepSize: DefineSpec('number'),
     dRefineSteps: DefineSpec('number'),
     uRayDistance: UniformSpec('f'),
 
@@ -490,7 +484,6 @@ function getTraceRenderable(ctx: WebGLContext, colorTexture: Texture, normalText
         dGlow: ValueCell.create(true),
         dBounces: ValueCell.create(4),
         dSteps: ValueCell.create(32),
-        dFirstStepSize: ValueCell.create(0.01),
         dRefineSteps: ValueCell.create(4),
         uRayDistance: ValueCell.create(256),
 

--- a/src/mol-gl/shader/illumination/trace.frag.ts
+++ b/src/mol-gl/shader/illumination/trace.frag.ts
@@ -52,6 +52,10 @@ uniform mat4 uInvProjection;
 
 //
 
+// after a hit, it moves the ray this far along the normal away from a surface.
+// Helps prevent incorrect intersections when rays bounce off of objects.
+#define RayPosNormalNudge 0.0001
+
 #if __VERSION__ == 100
     #define StateType float
 
@@ -137,7 +141,7 @@ float getRayOffset(const vec3 position) {
     projectedCoord.xyz = projectedCoord.xyz * 0.5 + 0.5;
     float viewportWidth = uTexSize.x * (uBounds.z - uBounds.x);
     vec3 adjacentPosition = screenSpaceToViewSpace(vec3(projectedCoord.xy + vec2(1.0 / viewportWidth, 0.0), projectedCoord.z), uInvProjection);
-    return max(distance(position, adjacentPosition) * 0.1, 0.0001);
+    return max(distance(position, adjacentPosition) * 0.1, 0.001);
 }
 
 vec2 binarySearch(inout vec3 dir, inout vec3 hitPos) {
@@ -181,6 +185,7 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
 
     for (int i = 1; i < dSteps; i++) {
         hitPos += dir;
+        dir *= gf;
 
         coords = viewSpaceToScreenSpace(hitPos);
         float depth = getDepth(coords);
@@ -202,8 +207,6 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
                 return binarySearch(dir, hitPos);
             }
         }
-
-        dir *= gf;
     }
 
     missed = true;
@@ -264,7 +267,7 @@ vec3 colorForRay(in vec3 startRayPos, in vec3 startRayDir, inout StateType rngSt
                     vec3 hitPos;
                     for (int i = 0; i < dLightCount; ++i) {
                         missed = false;
-                        hitPos = viewPos + hitInfo.normal * getRayOffset(viewPos);
+                        hitPos = viewPos + hitInfo.normal * RayPosNormalNudge;
                         hitPos += -uLightDirection[i] * (randomFloat(rngState));
                         rayMarch(-uLightDirection[i] + randomUnitVector(rngState) * uShadowSoftness, uShadowThickness, hitPos, missed);
                         if (missed) directLight += uLightColor[i];
@@ -313,7 +316,7 @@ vec3 colorForRay(in vec3 startRayPos, in vec3 startRayDir, inout StateType rngSt
         ret += hitInfo.emissive * throughput;
 
         // update the ray position
-        rayPos = hitInfo.position + hitInfo.normal * getRayOffset(hitInfo.position);
+        rayPos = hitInfo.position + hitInfo.normal * RayPosNormalNudge;
 
         // new ray direction from normal oriented cosine weighted hemisphere sample
         rayDir = normalize(hitInfo.normal + randomUnitVector(rngState));

--- a/src/mol-gl/shader/illumination/trace.frag.ts
+++ b/src/mol-gl/shader/illumination/trace.frag.ts
@@ -52,10 +52,6 @@ uniform mat4 uInvProjection;
 
 //
 
-// after a hit, it moves the ray this far along the normal away from a surface.
-// Helps prevent incorrect intersections when rays bounce off of objects.
-#define RayPosNormalNudge 0.0001
-
 #if __VERSION__ == 100
     #define StateType float
 
@@ -135,6 +131,15 @@ vec2 viewSpaceToScreenSpace(const vec3 position) {
     return projectedCoord.xy;
 }
 
+float getRayOffset(const vec3 position) {
+    vec4 projectedCoord = uProjection * vec4(position, 1.0);
+    projectedCoord.xyz /= projectedCoord.w;
+    projectedCoord.xyz = projectedCoord.xyz * 0.5 + 0.5;
+    float viewportWidth = uTexSize.x * (uBounds.z - uBounds.x);
+    vec3 adjacentPosition = screenSpaceToViewSpace(vec3(projectedCoord.xy + vec2(1.0 / viewportWidth, 0.0), projectedCoord.z), uInvProjection);
+    return max(distance(position, adjacentPosition) * 0.1, 0.0001);
+}
+
 vec2 binarySearch(inout vec3 dir, inout vec3 hitPos) {
     float rayHitDepthDifference;
     vec2 coords;
@@ -169,14 +174,13 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
     float rayHitDepthDifference;
     vec2 coords;
 
-    float begin = float(dFirstStepSize);
+    float begin = getRayOffset(hitPos);
     dir *= begin;
     missed = false;
     float gf = calculateGrowthFactor(begin, uRayDistance, float(dSteps));
 
     for (int i = 1; i < dSteps; i++) {
         hitPos += dir;
-        dir *= gf;
 
         coords = viewSpaceToScreenSpace(hitPos);
         float depth = getDepth(coords);
@@ -198,6 +202,8 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
                 return binarySearch(dir, hitPos);
             }
         }
+
+        dir *= gf;
     }
 
     missed = true;
@@ -258,7 +264,7 @@ vec3 colorForRay(in vec3 startRayPos, in vec3 startRayDir, inout StateType rngSt
                     vec3 hitPos;
                     for (int i = 0; i < dLightCount; ++i) {
                         missed = false;
-                        hitPos = viewPos + hitInfo.normal * RayPosNormalNudge;
+                        hitPos = viewPos + hitInfo.normal * getRayOffset(viewPos);
                         hitPos += -uLightDirection[i] * (randomFloat(rngState));
                         rayMarch(-uLightDirection[i] + randomUnitVector(rngState) * uShadowSoftness, uShadowThickness, hitPos, missed);
                         if (missed) directLight += uLightColor[i];
@@ -307,7 +313,7 @@ vec3 colorForRay(in vec3 startRayPos, in vec3 startRayDir, inout StateType rngSt
         ret += hitInfo.emissive * throughput;
 
         // update the ray position
-        rayPos = hitInfo.position + hitInfo.normal * RayPosNormalNudge;
+        rayPos = hitInfo.position + hitInfo.normal * getRayOffset(hitInfo.position);
 
         // new ray direction from normal oriented cosine weighted hemisphere sample
         rayDir = normalize(hitInfo.normal + randomUnitVector(rngState));


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Remove `firstStepSize` tracing parameter, derive automatically

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`