### PR TITLE
Out of state tree format parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Artistic option fits spherical harmonics to bins
 - Fix camera reset handling for (temporary) empty scenes (#1903)
 - Remove `firstStepSize` tracing parameter, derive automatically
-
+- Add `.parseRaw` to `DataFormatProvider` for out of state tree parsing
 - Camera improvements
   - Support multiple camera transition shapes
   - Add `transitionTrajectory` and `transitionEasing` parameters to `PluginState.Snapshot` (MOLJ) and Plugin State > Save Options

--- a/src/extensions/kinemage/behavior.ts
+++ b/src/extensions/kinemage/behavior.ts
@@ -573,7 +573,7 @@ const KinemageDragAndDropHandler: DragAndDropHandler = {
     },
 };
 
-const KINFormatProvider: DataFormatProvider<{}, any, any> = DataFormatProvider({
+const KINFormatProvider: DataFormatProvider = DataFormatProvider({
     label: 'KIN',
     description: 'Kinemage',
     category: 'Miscellaneous',

--- a/src/mol-plugin-state/formats/provider.ts
+++ b/src/mol-plugin-state/formats/provider.ts
@@ -8,12 +8,12 @@
 import { binaryCifHasCategory, binaryCifHasColumn, getBinaryCifHeader } from '../../mol-io/common/binary-cif';
 import { StringLike } from '../../mol-io/common/string-like';
 import { PluginContext } from '../../mol-plugin/context';
-import { StateObjectRef } from '../../mol-state';
+import { StateObject, StateObjectRef, StateTransformer } from '../../mol-state';
+import { RuntimeContext, Task } from '../../mol-task';
 import { FileNameInfo } from '../../mol-util/file-info';
 import { PluginStateObject } from '../objects';
 
-
-export interface DataFormatProvider<P = any, R = any, V = any> {
+export interface DataFormatProvider<P = any, R = any, V = any, D = any> {
     label: string,
     description: string,
     category?: string,
@@ -29,10 +29,35 @@ export interface DataFormatProvider<P = any, R = any, V = any> {
     priority?: number,
     isApplicable?(info: FileNameInfo, data: StringLike | Uint8Array): boolean,
     parse(plugin: PluginContext, data: StateObjectRef<PluginStateObject.Data.Binary | PluginStateObject.Data.String>, params?: P): Promise<R>,
-    visuals?(plugin: PluginContext, data: R): Promise<V> | undefined
+    /**
+     * Parse the data into plain objects without creating state tree nodes. In contrast to `parse`
+     * this can be called from within a state update, e.g. from a transformer.
+     */
+    parseRaw?(plugin: PluginContext, ctx: RuntimeContext, data: StringLike | Uint8Array, params?: P): Promise<D>,
+    visuals?(plugin: PluginContext, data: R): Promise<V> | undefined,
+    defaultData?: D
 }
 
 export function DataFormatProvider<P extends DataFormatProvider>(provider: P): P { return provider; }
+
+export function rawDataObject(data: StringLike | Uint8Array) {
+    return data instanceof Uint8Array
+        ? new PluginStateObject.Data.Binary(data as Uint8Array<ArrayBuffer>)
+        : new PluginStateObject.Data.String(data);
+}
+
+/** Applies a transformer directly, without adding nodes to the state tree. */
+export function applyTransformerRaw<A extends StateObject, B extends StateObject, P extends {}>(plugin: PluginContext, ctx: RuntimeContext, transformer: StateTransformer<A, B, P>, a: A, params?: Partial<P>): Promise<B> | B {
+    const p = transformer.createDefaultParams(a, plugin);
+    if (params) {
+        for (const k of Object.keys(params) as (keyof P)[]) {
+            if (params[k] !== undefined) p[k] = params[k]!;
+        }
+    }
+    // no built-in transformer uses the spine, which is only available during a state update
+    const result = transformer.definition.apply({ a, params: p, cache: {}, spine: undefined as any }, plugin);
+    return Task.is(result) ? Task.resolveInContext(result, ctx) : result;
+}
 
 type CifVariants = 'dscif' | 'segcif' | 'sfcif' | 'coreCif' | -1
 export function guessCifVariant(info: FileNameInfo, data: Uint8Array | StringLike): CifVariants {

--- a/src/mol-plugin-state/formats/shape.ts
+++ b/src/mol-plugin-state/formats/shape.ts
@@ -6,7 +6,7 @@
  */
 
 import { StateTransforms } from '../transforms';
-import { DataFormatProvider } from './provider';
+import { applyTransformerRaw, DataFormatProvider, rawDataObject } from './provider';
 import { PluginContext } from '../../mol-plugin/context';
 import { StateObjectRef } from '../../mol-state';
 import { PluginStateObject } from '../objects';
@@ -29,6 +29,11 @@ export const PlyProvider = DataFormatProvider({
         await format.commit();
 
         return { format: format.selector, shape: shape.selector };
+    },
+    parseRaw: async (plugin, ctx, data) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParsePly, rawDataObject(data));
+        const shape = await applyTransformerRaw(plugin, ctx, StateTransforms.Shape.ShapeFromPly, format);
+        return { shape: shape.data };
     },
     visuals(plugin: PluginContext, data: { shape: StateObjectRef<PluginStateObject.Shape.Provider> }) {
         const repr = plugin.state.data.build()
@@ -54,6 +59,11 @@ export const ObjProvider = DataFormatProvider({
 
         return { format: format.selector, shape: shape.selector };
     },
+    parseRaw: async (plugin, ctx, data) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseObj, rawDataObject(data));
+        const shape = await applyTransformerRaw(plugin, ctx, StateTransforms.Shape.ShapeFromObj, format);
+        return { shape: shape.data };
+    },
     visuals(plugin: PluginContext, data: { shape: StateObjectRef<PluginStateObject.Shape.Provider> }) {
         const repr = plugin.state.data.build()
             .to(data.shape)
@@ -77,6 +87,11 @@ export const VtpProvider = DataFormatProvider({
         await format.commit();
 
         return { format: format.selector, shape: shape.selector };
+    },
+    parseRaw: async (plugin, ctx, data) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseVtp, rawDataObject(data));
+        const shape = await applyTransformerRaw(plugin, ctx, StateTransforms.Shape.ShapeFromVtp, format);
+        return { shape: shape.data };
     },
     visuals(plugin: PluginContext, data: { shape: StateObjectRef<PluginStateObject.Shape.Provider> }) {
         const repr = plugin.state.data.build()

--- a/src/mol-plugin-state/formats/trajectory.ts
+++ b/src/mol-plugin-state/formats/trajectory.ts
@@ -7,7 +7,7 @@
  */
 
 import { StateTransforms } from '../transforms';
-import { guessCifVariant, DataFormatProvider } from './provider';
+import { guessCifVariant, DataFormatProvider, applyTransformerRaw, rawDataObject } from './provider';
 import { StateTransformer, StateObjectRef } from '../../mol-state';
 import { PluginStateObject } from '../objects';
 import { PluginContext } from '../../mol-plugin/context';
@@ -48,6 +48,11 @@ export const MmcifProvider: TrajectoryFormatProvider = {
 
         return { trajectory };
     },
+    parseRaw: async (plugin, ctx, data) => {
+        const cif = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCif, rawDataObject(data));
+        const trajectory = await applyTransformerRaw(plugin, ctx, StateTransforms.Model.TrajectoryFromMmCif, cif);
+        return { trajectory: trajectory.data };
+    },
     visuals: defaultVisuals
 };
 
@@ -73,16 +78,27 @@ export const CifCoreProvider: TrajectoryFormatProvider = {
         }
         return { trajectory };
     },
+    parseRaw: async (plugin, ctx, data) => {
+        const cif = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCif, rawDataObject(data));
+        const trajectory = await applyTransformerRaw(plugin, ctx, StateTransforms.Model.TrajectoryFromCifCore, cif);
+        return { trajectory: trajectory.data };
+    },
     visuals: defaultVisuals
 };
 
-function directTrajectory<P extends {}>(transformer: StateTransformer<PluginStateObject.Data.String | PluginStateObject.Data.Binary, PluginStateObject.Molecule.Trajectory, P>, transformerParams?: P): TrajectoryFormatProvider['parse'] {
-    return async (plugin, data, params) => {
-        const state = plugin.state.data;
-        const trajectory = await state.build().to(data)
-            .apply(transformer, transformerParams, { tags: params?.trajectoryTags })
-            .commit({ revertOnError: true });
-        return { trajectory };
+function directTrajectory<P extends {}>(transformer: StateTransformer<PluginStateObject.Data.String | PluginStateObject.Data.Binary, PluginStateObject.Molecule.Trajectory, P>, transformerParams?: P): Pick<TrajectoryFormatProvider, 'parse' | 'parseRaw'> {
+    return {
+        parse: async (plugin, data, params) => {
+            const state = plugin.state.data;
+            const trajectory = await state.build().to(data)
+                .apply(transformer, transformerParams, { tags: params?.trajectoryTags })
+                .commit({ revertOnError: true });
+            return { trajectory };
+        },
+        parseRaw: async (plugin, ctx, data) => {
+            const trajectory = await applyTransformerRaw(plugin, ctx, transformer, rawDataObject(data), transformerParams);
+            return { trajectory: trajectory.data };
+        }
     };
 }
 
@@ -91,7 +107,7 @@ export const PdbProvider: TrajectoryFormatProvider = {
     description: 'PDB',
     category: TrajectoryFormatCategory,
     stringExtensions: ['pdb', 'ent'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromPDB),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromPDB),
     visuals: defaultVisuals
 };
 
@@ -100,7 +116,7 @@ export const PdbqtProvider: TrajectoryFormatProvider = {
     description: 'PDBQT',
     category: TrajectoryFormatCategory,
     stringExtensions: ['pdbqt'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromPDB, { variant: 'pdbqt' }),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromPDB, { variant: 'pdbqt' }),
     visuals: defaultVisuals
 };
 
@@ -109,7 +125,7 @@ export const PqrProvider: TrajectoryFormatProvider = {
     description: 'PQR',
     category: TrajectoryFormatCategory,
     stringExtensions: ['pqr'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromPDB, { variant: 'pqr' }),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromPDB, { variant: 'pqr' }),
     visuals: defaultVisuals
 };
 
@@ -118,7 +134,7 @@ export const XyzProvider: TrajectoryFormatProvider = {
     description: 'XYZ',
     category: TrajectoryFormatCategory,
     stringExtensions: ['xyz'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromXYZ),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromXYZ),
     visuals: defaultVisuals
 };
 
@@ -127,7 +143,7 @@ export const LammpsDataProvider: TrajectoryFormatProvider = {
     description: 'Lammps Data',
     category: TrajectoryFormatCategory,
     stringExtensions: ['data'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromLammpsData),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromLammpsData),
     visuals: defaultVisuals
 };
 
@@ -136,7 +152,7 @@ export const LammpsTrajectoryDataProvider: TrajectoryFormatProvider = {
     description: 'Lammps Trajectory Data',
     category: TrajectoryFormatCategory,
     stringExtensions: ['lammpstrj'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromLammpsTrajData),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromLammpsTrajData),
     visuals: defaultVisuals
 };
 
@@ -146,7 +162,7 @@ export const GroProvider: TrajectoryFormatProvider = {
     category: TrajectoryFormatCategory,
     stringExtensions: ['gro'],
     binaryExtensions: [],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromGRO),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromGRO),
     visuals: defaultVisuals
 };
 
@@ -155,7 +171,7 @@ export const MolProvider: TrajectoryFormatProvider = {
     description: 'MOL',
     category: TrajectoryFormatCategory,
     stringExtensions: ['mol'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromMOL),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromMOL),
     visuals: defaultVisuals
 };
 
@@ -164,7 +180,7 @@ export const SdfProvider: TrajectoryFormatProvider = {
     description: 'SDF',
     category: TrajectoryFormatCategory,
     stringExtensions: ['sdf', 'sd'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromSDF),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromSDF),
     visuals: defaultVisuals
 };
 
@@ -173,7 +189,7 @@ export const Mol2Provider: TrajectoryFormatProvider = {
     description: 'MOL2',
     category: TrajectoryFormatCategory,
     stringExtensions: ['mol2'],
-    parse: directTrajectory(StateTransforms.Model.TrajectoryFromMOL2),
+    ...directTrajectory(StateTransforms.Model.TrajectoryFromMOL2),
     visuals: defaultVisuals
 };
 

--- a/src/mol-plugin-state/formats/volume.ts
+++ b/src/mol-plugin-state/formats/volume.ts
@@ -7,7 +7,7 @@
  */
 
 import { StateTransforms } from '../transforms';
-import { DataFormatProvider, guessCifVariant } from './provider';
+import { applyTransformerRaw, DataFormatProvider, guessCifVariant, rawDataObject } from './provider';
 import { PluginContext } from '../../mol-plugin/context';
 import { StateObjectSelector } from '../../mol-state';
 import { PluginStateObject } from '../objects';
@@ -83,6 +83,11 @@ export const Ccp4Provider = DataFormatProvider({
 
         return { format: format.selector, volume: volume.selector };
     },
+    parseRaw: async (plugin, ctx, data, params?: Params) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCcp4, rawDataObject(data));
+        const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromCcp4, format, { entryId: params?.entryId });
+        return { volume: volume.data };
+    },
     visuals: defaultVisuals
 });
 
@@ -104,6 +109,11 @@ export const Dsn6Provider = DataFormatProvider({
         await tryObtainRecommendedIsoValue(plugin, volume.selector.data);
 
         return { format: format.selector, volume: volume.selector };
+    },
+    parseRaw: async (plugin, ctx, data, params?: Params) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseDsn6, rawDataObject(data));
+        const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromDsn6, format, { entryId: params?.entryId });
+        return { volume: volume.data };
     },
     visuals: defaultVisuals
 });
@@ -127,6 +137,11 @@ export const DxProvider = DataFormatProvider({
         await tryObtainRecommendedIsoValue(plugin, volume.selector.data);
 
         return { volume: volume.selector };
+    },
+    parseRaw: async (plugin, ctx, data, params?: Params) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseDx, rawDataObject(data));
+        const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromDx, format, { entryId: params?.entryId });
+        return { volume: volume.data };
     },
     visuals: defaultVisuals
 });
@@ -155,6 +170,11 @@ export const CubeProvider = DataFormatProvider({
         await tryObtainRecommendedIsoValue(plugin, volume.selector.data);
 
         return { format: format.selector, volume: volume.selector, structure: structure.selector };
+    },
+    parseRaw: async (plugin, ctx, data, params?: Params) => {
+        const format = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCube, rawDataObject(data));
+        const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromCube, format, { entryId: params?.entryId });
+        return { volume: volume.data };
     },
     visuals: async (plugin: PluginContext, data: { volume: VolumeData, structure: StateObjectSelector<PluginStateObject.Molecule.Structure> }) => {
         const surfaces = plugin.build();
@@ -236,6 +256,23 @@ export const DscifProvider = DataFormatProvider({
 
         return { volumes };
     },
+    parseRaw: async (plugin, ctx, data, params?: DsCifParams) => {
+        const cif = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCif, rawDataObject(data));
+        const blocks = cif.data.blocks;
+        if (blocks.length === 0) throw new Error('no data blocks');
+
+        const volumes: Volume[] = [];
+        for (const block of blocks) {
+            if (block.header.toUpperCase() === 'SERVER') continue;
+            if (!(block.categories['volume_data_3d_info']?.rowCount > 0)) continue;
+
+            const entryId = Array.isArray(params?.entryId) ? params?.entryId[volumes.length] : params?.entryId;
+            const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromDensityServerCif, cif, { blockHeader: block.header, entryId });
+            volumes.push(volume.data);
+        }
+
+        return { volumes };
+    },
     visuals: async (plugin, data: { volumes: StateObjectSelector<PluginStateObject.Volume.Data>[] }) => {
         const { volumes } = data;
         const tree = plugin.build();
@@ -293,6 +330,22 @@ export const SegcifProvider = DataFormatProvider({
         }
 
         await b.commit();
+
+        return { volumes };
+    },
+    parseRaw: async (plugin, ctx, data) => {
+        const cif = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCif, rawDataObject(data));
+        const blocks = cif.data.blocks;
+        if (blocks.length === 0) throw new Error('no data blocks');
+
+        const volumes: Volume[] = [];
+        for (const block of blocks) {
+            if (block.header.toUpperCase() === 'SERVER') continue;
+            if (!(block.categories['volume_data_3d_info']?.rowCount > 0)) continue;
+
+            const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromSegmentationCif, cif, { blockHeader: block.header });
+            volumes.push(volume.data);
+        }
 
         return { volumes };
     },
@@ -365,6 +418,30 @@ export const SfcifProvider = DataFormatProvider({
 
         return { volumes };
     },
+    parseRaw: async (plugin, ctx, data, params?: SfcifParams) => {
+        const cif = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseCif, rawDataObject(data));
+        const blocks = cif.data.blocks;
+        if (blocks.length === 0) throw new Error('no data blocks');
+
+        const twoFoFc: Volume[] = [];
+        const foFc: Volume[] = [];
+        for (const block of blocks) {
+            const reflnCat = block.categories['refln'];
+            if (!(reflnCat?.rowCount > 0)) continue;
+
+            if ((reflnCat.getField('pdbx_FWT')?.rowCount ?? 0) > 0 && (reflnCat.getField('pdbx_PHWT')?.rowCount ?? 0) > 0) {
+                const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromStructureFactorsCif, cif, { blockHeader: block.header, entryId: params?.entryId, mapType: '2fo-fc' });
+                twoFoFc.push(volume.data);
+            }
+
+            if ((reflnCat.getField('pdbx_DELFWT')?.rowCount ?? 0) > 0 && (reflnCat.getField('pdbx_DELPHWT')?.rowCount ?? 0) > 0) {
+                const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromStructureFactorsCif, cif, { blockHeader: block.header, entryId: params?.entryId, mapType: 'fo-fc' });
+                foFc.push(volume.data);
+            }
+        }
+
+        return { volumes: [...twoFoFc, ...foFc] };
+    },
     visuals: async (plugin, data: { volumes: { '2fofc': VolumeData[], 'fofc': VolumeData[] } }) => {
         const { volumes } = data;
         const tree = plugin.build();
@@ -426,6 +503,24 @@ export const MtzProvider = DataFormatProvider({
 
         await b.commit();
         return { volumes };
+    },
+    parseRaw: async (plugin, ctx, data, params?: MtzParams) => {
+        const mtz = await applyTransformerRaw(plugin, ctx, StateTransforms.Data.ParseMtz, rawDataObject(data));
+        const pairs = detectMtzColumnPairs(mtz.data.header);
+
+        if (pairs.length === 0) {
+            throw new Error('MTZ file does not contain any recognised amplitude+phase column pairs (FWT/PHWT, DELFWT/DELPHWT, 2FOFCWT/PH2FOFCWT, FOFCWT/PHFOFCWT).');
+        }
+
+        const twoFoFc: Volume[] = [];
+        const foFc: Volume[] = [];
+        for (const pair of pairs) {
+            const volume = await applyTransformerRaw(plugin, ctx, StateTransforms.Volume.VolumeFromMtz, mtz, { ampLabel: pair.ampLabel, phiLabel: pair.phiLabel, entryId: params?.entryId });
+            if (pair.label === '2fo-fc') twoFoFc.push(volume.data);
+            else foFc.push(volume.data);
+        }
+
+        return { volumes: [...twoFoFc, ...foFc] };
     },
     visuals: async (plugin, data: { volumes: { '2fofc': VolumeData[], 'fofc': VolumeData[] } }) => {
         const { volumes } = data;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Add `.parseRaw` to `DataFormatProvider` for out of state tree parsing.

Pulled out of #1904 to discuss. Used in https://github.com/molstar/molstar/blob/8584f6c95c55b2530f1a9fca99765faf84492607/src/mol-plugin-state/helpers/particle-targets.ts

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`