### PR TITLE
Illumination fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix camera reset handling for (temporary) empty scenes (#1903)
 - Remove `firstStepSize` tracing parameter, derive automatically
 - Fix illumination `auto` thickness mode never being applied
+- Fix illumination ray marching stepping over occluders when the acceptance window is narrower than the current step
 
 - Camera improvements
   - Support multiple camera transition shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Note that since we don't clearly distinguish between a public and private interf
     - Artistic option fits spherical harmonics to bins
 - Fix camera reset handling for (temporary) empty scenes (#1903)
 - Remove `firstStepSize` tracing parameter, derive automatically
+- Fix illumination `auto` thickness mode never being applied
 
 - Camera improvements
   - Support multiple camera transition shapes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Note that since we don't clearly distinguish between a public and private interf
 - Remove `firstStepSize` tracing parameter, derive automatically
 - Fix illumination `auto` thickness mode never being applied
 - Fix illumination ray marching stepping over occluders when the acceptance window is narrower than the current step
+- Evaluate illumination `auto` thickness at the surface being tested instead of latching it from the shaded pixel
 
 - Camera improvements
   - Support multiple camera transition shapes

--- a/src/mol-canvas3d/passes/tracing.ts
+++ b/src/mol-canvas3d/passes/tracing.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2024-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2024-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { QuadSchema, QuadValues } from '../../mol-gl/compute/util';

--- a/src/mol-canvas3d/passes/tracing.ts
+++ b/src/mol-canvas3d/passes/tracing.ts
@@ -54,7 +54,7 @@ export const TracingParams = {
     glow: PD.Boolean(true, { description: 'Bounced rays always get the full light. This produces a slight glowing effect.' }),
     shadowEnable: PD.Boolean(false),
     shadowSoftness: PD.Numeric(0.1, { min: 0.01, max: 1.0, step: 0.01 }),
-    shadowThickness: PD.Numeric(0.5, { min: 0.1, max: 32, step: 0.1 }),
+    shadowThickness: PD.Numeric(0.5, { min: 0.0, max: 32, step: 0.1 }, { description: 'Thickness of the shadow casting geometry. Set to 0.0 for automatic estimation.' }),
 };
 export type TracingProps = PD.Values<typeof TracingParams>
 

--- a/src/mol-canvas3d/passes/tracing.ts
+++ b/src/mol-canvas3d/passes/tracing.ts
@@ -151,8 +151,10 @@ export class TracingPass {
         if (props.thicknessMode === 'auto') {
             this.thicknessTarget.bind();
             state.clearColor(0, 0, 0, 0);
+            state.clearDepth(0);
             gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
             renderer.renderDepthOpaqueBack(scene.primitives, camera);
+            state.clearDepth(1);
         }
         if (isTimingMode) this.webgl.timer.markEnd('TracePass.renderInput');
     }

--- a/src/mol-gl/renderer.ts
+++ b/src/mol-gl/renderer.ts
@@ -167,6 +167,7 @@ namespace Renderer {
         None = 0,
         BlendedFront = 1,
         BlendedBack = 2,
+        DepthBack = 3,
     }
 
     const enum Mask {
@@ -366,6 +367,8 @@ namespace Renderer {
                     state.frontFace(gl.CCW);
                     state.cullFace(gl.BACK);
                 }
+            } else if (flag === Flag.DepthBack) {
+                state.disable(gl.CULL_FACE);
             } else if (flag === Flag.BlendedBack) {
                 state.enable(gl.CULL_FACE);
                 if (r.values.dFlipSided?.ref.value) {
@@ -577,7 +580,7 @@ namespace Renderer {
             for (let i = 0, il = renderables.length; i < il; ++i) {
                 const r = renderables[i];
                 if (checkOpaque(r)) {
-                    renderObject(r, 'depth', Flag.BlendedBack);
+                    renderObject(r, 'depth', Flag.DepthBack);
                 }
             }
             state.depthFunc(gl.LESS);

--- a/src/mol-gl/shader/illumination/trace.frag.ts
+++ b/src/mol-gl/shader/illumination/trace.frag.ts
@@ -193,19 +193,22 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
         float z = getViewZ(depth);
         rayHitDepthDifference = z - hitPos.z;
 
-        if (thickness == 0.0) {
-            #ifdef dThicknessMode_auto
-                thickness = max(uMinThickness, (z - getViewZ(getThickness(coords))) * uThicknessFactor * texture2D(tColor, coords).a);
-            #else
-                thickness = uThickness;
-            #endif
-        }
+        if (rayHitDepthDifference >= 0.0) {
+            float t = thickness;
+            if (t == 0.0) {
+                #ifdef dThicknessMode_auto
+                    t = max(uMinThickness, (z - getViewZ(getThickness(coords))) * uThicknessFactor * texture2D(tColor, coords).a);
+                #else
+                    t = uThickness;
+                #endif
+            }
 
-        if (rayHitDepthDifference >= 0.0 && rayHitDepthDifference < max(thickness, stepZ)) {
-            if (dRefineSteps == 0) {
-                return coords;
-            } else {
-                return binarySearch(dir, hitPos);
+            if (rayHitDepthDifference < max(t, stepZ)) {
+                if (dRefineSteps == 0) {
+                    return coords;
+                } else {
+                    return binarySearch(dir, hitPos);
+                }
             }
         }
     }

--- a/src/mol-gl/shader/illumination/trace.frag.ts
+++ b/src/mol-gl/shader/illumination/trace.frag.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2024-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 export const trace_frag = `

--- a/src/mol-gl/shader/illumination/trace.frag.ts
+++ b/src/mol-gl/shader/illumination/trace.frag.ts
@@ -194,7 +194,7 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
 
         if (thickness == 0.0) {
             #ifdef dThicknessMode_auto
-                thickness = max(uMinThickness, (getViewZ(getThickness(coords)) - z) * uThicknessFactor * texture2D(tColor, coords).a);
+                thickness = max(uMinThickness, (z - getViewZ(getThickness(coords))) * uThicknessFactor * texture2D(tColor, coords).a);
             #else
                 thickness = uThickness;
             #endif

--- a/src/mol-gl/shader/illumination/trace.frag.ts
+++ b/src/mol-gl/shader/illumination/trace.frag.ts
@@ -185,6 +185,7 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
 
     for (int i = 1; i < dSteps; i++) {
         hitPos += dir;
+        float stepZ = abs(dir.z);
         dir *= gf;
 
         coords = viewSpaceToScreenSpace(hitPos);
@@ -200,7 +201,7 @@ vec2 rayMarch(in vec3 dir, in float thickness, inout vec3 hitPos, out bool misse
             #endif
         }
 
-        if (rayHitDepthDifference >= 0.0 && rayHitDepthDifference < thickness) {
+        if (rayHitDepthDifference >= 0.0 && rayHitDepthDifference < max(thickness, stepZ)) {
             if (dRefineSteps == 0) {
                 return coords;
             } else {


### PR DESCRIPTION
# Description

- Fix illumination `auto` thickness mode never being applied
- Fix illumination ray marching stepping over occluders when the acceptance window is narrower than the current step
- Evaluate illumination `auto` thickness at the surface being tested instead of latching it from the shaded pixel

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`