### PR TITLE
Carbohydrate rendering and coloring changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix camera reset handling for (temporary) empty scenes (#1903)
 - Remove `firstStepSize` tracing parameter, derive automatically
 - Add `.parseRaw` to `DataFormatProvider` for out of state tree parsing
+- Carbohydrate symbols
+  - All carbohydrate symbols are rendered with 2 groups (primary and secondary) and can be potentially colored in two colors
+  - CarbohydrateSymbolColorTheme decides which shape will be colored by one or two colors
+  - Changed side length ratio of FlatBox shape from 2:2:1 to 2:1:1
 - Camera improvements
   - Support multiple camera transition shapes
   - Add `transitionTrajectory` and `transitionEasing` parameters to `PluginState.Snapshot` (MOLJ) and Plugin State > Save Options

--- a/docs/docs/misc/interesting-pdb-entries.md
+++ b/docs/docs/misc/interesting-pdb-entries.md
@@ -64,4 +64,4 @@
     * FlatDiamond - no examples in PDB as it has no CCD codes mapped to it
     * 3k8d - FlatHexagon (KDO)
     * 8jq5 - Pentagon (PSV)
-    * 9k1g - no SNFG symbol assigned (X6Y)
+    * 9k1g - no SNFG symbol assigned -> white FlatHexagon (X6Y)

--- a/docs/docs/misc/interesting-pdb-entries.md
+++ b/docs/docs/misc/interesting-pdb-entries.md
@@ -52,3 +52,16 @@
 * Deuterium atoms
     * 3CWH (XUL with D and DOD)
     * 8TT8 (HOH and other with D)
+* Monosaccharides of all possible SNFG shapes
+    * 3d11 - FilledSphere (MAN, BMA), FilledCube (NAG)
+    * 5hwa - CrossedCube (GCS)
+    * 9k1g - FilledCone (FUC)
+    * 4y9v - DevidedCone (49T)
+    * 1mfd - FlatBox (ABE)
+    * 6rv7 - FilledStar (XYP)
+    * 9q5e - FilledDiamond (SIA)
+    * 1hv6 - DividedDiamond (GCU, MAV)
+    * FlatDiamond - no examples in PDB as it has no CCD codes mapped to it
+    * 3k8d - FlatHexagon (KDO)
+    * 8jq5 - Pentagon (PSV)
+    * 9k1g - no SNFG symbol assigned (X6Y)

--- a/src/mol-geo/geometry/mesh/builder/sphere.ts
+++ b/src/mol-geo/geometry/mesh/builder/sphere.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Vec3, Mat4 } from '../../../../mol-math/linear-algebra';
@@ -9,22 +10,23 @@ import { MeshBuilder } from '../mesh-builder';
 import { Primitive } from '../../../primitive/primitive';
 import { Sphere } from '../../../primitive/sphere';
 
-const sphereMap = new Map<number, Primitive>();
+const sphereCache = new Map<string, Primitive>();
 const tmpSphereMat = Mat4.identity();
 
 function setSphereMat(m: Mat4, center: Vec3, radius: number) {
     return Mat4.scaleUniformly(m, Mat4.fromTranslation(m, center), radius);
 }
 
-export function getSphere(detail: number) {
-    let sphere = sphereMap.get(detail);
+export function getSphere(detail: number, options?: { subset: 'ring' | 'caps' | undefined }) {
+    const cacheKey = `${detail}/${options?.subset ?? ''}`;
+    let sphere = sphereCache.get(cacheKey);
     if (sphere === undefined) {
-        sphere = Sphere(detail);
-        sphereMap.set(detail, sphere);
+        sphere = Sphere(detail, options);
+        sphereCache.set(cacheKey, sphere);
     }
     return sphere;
 }
 
-export function addSphere(state: MeshBuilder.State, center: Vec3, radius: number, detail: number) {
-    MeshBuilder.addPrimitive(state, setSphereMat(tmpSphereMat, center, radius), getSphere(detail));
+export function addSphere(state: MeshBuilder.State, center: Vec3, radius: number, detail: number, options?: { subset: 'ring' | 'caps' | undefined }) {
+    MeshBuilder.addPrimitive(state, setSphereMat(tmpSphereMat, center, radius), getSphere(detail, options));
 }

--- a/src/mol-geo/geometry/mesh/builder/sphere.ts
+++ b/src/mol-geo/geometry/mesh/builder/sphere.ts
@@ -5,28 +5,42 @@
  * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { Vec3, Mat4 } from '../../../../mol-math/linear-algebra';
-import { MeshBuilder } from '../mesh-builder';
+import { Mat4, Vec3 } from '../../../../mol-math/linear-algebra';
 import { Primitive } from '../../../primitive/primitive';
 import { Sphere } from '../../../primitive/sphere';
+import { MeshBuilder } from '../mesh-builder';
 
-const sphereCache = new Map<string, Primitive>();
+const sphereCache = new Map<number, Primitive>();
+const sphereSubsetCache = { ring: new Map<number, Primitive>(), caps: new Map<number, Primitive>() };
 const tmpSphereMat = Mat4.identity();
 
 function setSphereMat(m: Mat4, center: Vec3, radius: number) {
     return Mat4.scaleUniformly(m, Mat4.fromTranslation(m, center), radius);
 }
 
-export function getSphere(detail: number, options?: { subset: 'ring' | 'caps' | undefined }) {
-    const cacheKey = `${detail}/${options?.subset ?? ''}`;
-    let sphere = sphereCache.get(cacheKey);
+export function getSphere(detail: number) {
+    let sphere = sphereCache.get(detail);
     if (sphere === undefined) {
-        sphere = Sphere(detail, options);
-        sphereCache.set(cacheKey, sphere);
+        sphere = Sphere(detail);
+        sphereCache.set(detail, sphere);
     }
     return sphere;
 }
 
-export function addSphere(state: MeshBuilder.State, center: Vec3, radius: number, detail: number, options?: { subset: 'ring' | 'caps' | undefined }) {
-    MeshBuilder.addPrimitive(state, setSphereMat(tmpSphereMat, center, radius), getSphere(detail, options));
+export function getSphereSubset(detail: number, subset: 'ring' | 'caps') {
+    const cache = sphereSubsetCache[subset];
+    let sphere = cache.get(detail);
+    if (sphere === undefined) {
+        sphere = Sphere(detail, { subset });
+        cache.set(detail, sphere);
+    }
+    return sphere;
+}
+
+export function addSphere(state: MeshBuilder.State, center: Vec3, radius: number, detail: number) {
+    MeshBuilder.addPrimitive(state, setSphereMat(tmpSphereMat, center, radius), getSphere(detail));
+}
+
+export function addSphereSubset(state: MeshBuilder.State, center: Vec3, radius: number, detail: number, subset: 'ring' | 'caps') {
+    MeshBuilder.addPrimitive(state, setSphereMat(tmpSphereMat, center, radius), getSphereSubset(detail, subset));
 }

--- a/src/mol-geo/geometry/mesh/builder/sphere.ts
+++ b/src/mol-geo/geometry/mesh/builder/sphere.ts
@@ -10,8 +10,8 @@ import { Primitive } from '../../../primitive/primitive';
 import { Sphere } from '../../../primitive/sphere';
 import { MeshBuilder } from '../mesh-builder';
 
+/** Full sphere stored on key `detail`; sphere subsets (ring and caps) stored on keys `-2*detail - 1` and `-2*detail - 2` */
 const sphereCache = new Map<number, Primitive>();
-const sphereSubsetCache = { ring: new Map<number, Primitive>(), caps: new Map<number, Primitive>() };
 const tmpSphereMat = Mat4.identity();
 
 function setSphereMat(m: Mat4, center: Vec3, radius: number) {
@@ -28,11 +28,11 @@ export function getSphere(detail: number) {
 }
 
 export function getSphereSubset(detail: number, subset: 'ring' | 'caps') {
-    const cache = sphereSubsetCache[subset];
-    let sphere = cache.get(detail);
+    const cacheKey = -2 * detail + (subset === 'ring' ? -1 : -2);
+    let sphere = sphereCache.get(cacheKey);
     if (sphere === undefined) {
         sphere = Sphere(detail, { subset });
-        cache.set(detail, sphere);
+        sphereCache.set(cacheKey, sphere);
     }
     return sphere;
 }

--- a/src/mol-geo/primitive/box.ts
+++ b/src/mol-geo/primitive/box.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Vec3 } from '../../mol-math/linear-algebra';
@@ -28,7 +29,8 @@ function createBox(perforated: boolean): Primitive {
         Vec3.set(c, points[ni * 3], points[ni * 3 + 1], 0.5);
         Vec3.set(d, points[i * 3], points[i * 3 + 1], 0.5);
         if (perforated) {
-            builder.add(a, b, c);
+            if (i < 2) builder.add(a, c, d);
+            else builder.add(a, b, d);
         } else {
             builder.addQuad(a, b, c, d);
         }
@@ -49,7 +51,7 @@ function createBox(perforated: boolean): Primitive {
     Vec3.set(c, points[6], points[7], 0.5);
     Vec3.set(d, points[9], points[10], 0.5);
     if (perforated) {
-        builder.add(a, b, c);
+        builder.add(a, c, d);
     } else {
         builder.addQuad(a, b, c, d);
     }

--- a/src/mol-geo/primitive/icosahedron.ts
+++ b/src/mol-geo/primitive/icosahedron.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { createPrimitive, Primitive } from './primitive';
@@ -19,7 +20,17 @@ const icosahedronIndices: ReadonlyArray<number> = [
     0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11,
     1, 5, 9, 5, 11, 4, 11, 10, 2, 10, 7, 6, 7, 1, 8,
     3, 9, 4, 3, 4, 2, 3, 2, 6, 3, 6, 8, 3, 8, 9,
-    4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1
+    4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1,
+];
+/** Subset of `icosahedronIndices`, for 10 faces forming a ring around the icosahedron. */
+const icosahedronRingIndices: ReadonlyArray<number> = [
+    1, 5, 9, 5, 11, 4, 11, 10, 2, 10, 7, 6, 7, 1, 8,
+    4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7, 9, 8, 1,
+];
+/** Subset of `icosahedronIndices`, for 10 faces forming the caps of the icosahedron, complementary to `icosahedronRingIndices`. */
+const icosahedronCapsIndices: ReadonlyArray<number> = [
+    0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11,
+    3, 9, 4, 3, 4, 2, 3, 2, 6, 3, 6, 8, 3, 8, 9,
 ];
 
 const icosahedronEdges: ReadonlyArray<number> = [
@@ -29,9 +40,16 @@ const icosahedronEdges: ReadonlyArray<number> = [
 ];
 
 let icosahedron: Primitive;
-export function Icosahedron(): Primitive {
-    if (!icosahedron) icosahedron = createPrimitive(icosahedronVertices, icosahedronIndices);
-    return icosahedron;
+let icosahedronRing: Primitive;
+let icosahedronCaps: Primitive;
+export function Icosahedron(options?: { subset: 'ring' | 'caps' | undefined }): Primitive {
+    if (options?.subset === undefined) {
+        return icosahedron ??= createPrimitive(icosahedronVertices, icosahedronIndices);
+    } else if (options?.subset === 'ring') {
+        return icosahedronRing ??= createPrimitive(icosahedronVertices, icosahedronRingIndices);
+    } else {
+        return icosahedronCaps ??= createPrimitive(icosahedronVertices, icosahedronCapsIndices);
+    }
 }
 
 const icosahedronCage = createCage(icosahedronVertices, icosahedronEdges);

--- a/src/mol-geo/primitive/prism.ts
+++ b/src/mol-geo/primitive/prism.ts
@@ -1,13 +1,14 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Vec3 } from '../../mol-math/linear-algebra';
-import { Primitive, PrimitiveBuilder } from './primitive';
-import { polygon } from './polygon';
 import { Cage } from './cage';
+import { polygon } from './polygon';
+import { Primitive, PrimitiveBuilder } from './primitive';
 
 const on = Vec3(), op = Vec3();
 const a = Vec3(), b = Vec3(), c = Vec3(), d = Vec3();
@@ -16,6 +17,7 @@ export const DefaultPrismProps = {
     height: 1,
     topCap: true,
     bottomCap: true,
+    sides: true,
 };
 export type PrismProps = Partial<typeof DefaultPrismProps>
 
@@ -26,7 +28,7 @@ export function Prism(points: ArrayLike<number>, props?: PrismProps): Primitive 
     const sideCount = points.length / 3;
     if (sideCount < 3) throw new Error('need at least 3 points to build a prism');
 
-    const { height, topCap, bottomCap } = { ...DefaultPrismProps, ...props };
+    const { height, topCap, bottomCap, sides } = { ...DefaultPrismProps, ...props };
 
     let triangleCount = sideCount * 2;
     let vertexCount = sideCount * 4;
@@ -50,13 +52,15 @@ export function Prism(points: ArrayLike<number>, props?: PrismProps): Primitive 
     Vec3.set(op, 0, 0, halfHeight);
 
     // create sides
-    for (let i = 0; i < sideCount; ++i) {
-        const ni = (i + 1) % sideCount;
-        Vec3.set(a, points[i * 3], points[i * 3 + 1], -halfHeight);
-        Vec3.set(b, points[ni * 3], points[ni * 3 + 1], -halfHeight);
-        Vec3.set(c, points[ni * 3], points[ni * 3 + 1], halfHeight);
-        Vec3.set(d, points[i * 3], points[i * 3 + 1], halfHeight);
-        builder.addQuad(a, b, c, d);
+    if (sides) {
+        for (let i = 0; i < sideCount; ++i) {
+            const ni = (i + 1) % sideCount;
+            Vec3.set(a, points[i * 3], points[i * 3 + 1], -halfHeight);
+            Vec3.set(b, points[ni * 3], points[ni * 3 + 1], -halfHeight);
+            Vec3.set(c, points[ni * 3], points[ni * 3 + 1], halfHeight);
+            Vec3.set(d, points[i * 3], points[i * 3 + 1], halfHeight);
+            builder.addQuad(a, b, c, d);
+        }
     }
 
     // create bases
@@ -107,34 +111,12 @@ export function Prism(points: ArrayLike<number>, props?: PrismProps): Primitive 
     return builder.getPrimitive();
 }
 
-let diamond: Primitive;
-export function DiamondPrism() {
-    if (!diamond) diamond = Prism(polygon(4, false));
-    return diamond;
-}
+const prismCache: { [key: string]: Primitive } = {};
 
-let pentagonalPrism: Primitive;
-export function PentagonalPrism() {
-    if (!pentagonalPrism) pentagonalPrism = Prism(polygon(5, false));
-    return pentagonalPrism;
-}
-
-let hexagonalPrism: Primitive;
-export function HexagonalPrism() {
-    if (!hexagonalPrism) hexagonalPrism = Prism(polygon(6, false));
-    return hexagonalPrism;
-}
-
-let shiftedHexagonalPrism: Primitive;
-export function ShiftedHexagonalPrism() {
-    if (!shiftedHexagonalPrism) shiftedHexagonalPrism = Prism(polygon(6, true));
-    return shiftedHexagonalPrism;
-}
-
-let heptagonalPrism: Primitive;
-export function HeptagonalPrism() {
-    if (!heptagonalPrism) heptagonalPrism = Prism(polygon(7, false));
-    return heptagonalPrism;
+export function PolygonalPrism(n: number, options?: { shifted?: boolean, subset?: 'sides' | 'caps' }) {
+    const { shifted, subset } = options ?? {};
+    const cacheKey = `${n}/${shifted ? 'shifted' : ''}/${subset ?? ''}`;
+    return prismCache[cacheKey] ??= Prism(polygon(n, shifted ?? false), { topCap: subset !== 'sides', bottomCap: subset !== 'sides', sides: subset !== 'caps' });
 }
 
 //

--- a/src/mol-geo/primitive/pyramid.ts
+++ b/src/mol-geo/primitive/pyramid.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Vec3 } from '../../mol-math/linear-algebra';
@@ -83,8 +84,8 @@ export function PerforatedOctagonalPyramid() {
         vertices[8 * 3 + 4] = 0;
         vertices[8 * 3 + 5] = 0.5;
         const indices: ReadonlyArray<number> = [
-            0, 1, 8, 1, 2, 8, 4, 5, 8, 5, 6, 8,
-            2, 3, 9, 3, 4, 9, 6, 7, 9, 7, 0, 9
+            1, 0, 8, 2, 1, 8, 5, 4, 8, 6, 5, 8, // base
+            2, 3, 9, 3, 4, 9, 6, 7, 9, 7, 0, 9, // lateral surface
         ];
         perforatedOctagonalPyramid = createPrimitive(vertices, indices);
     }

--- a/src/mol-geo/primitive/sphere.ts
+++ b/src/mol-geo/primitive/sphere.ts
@@ -1,14 +1,13 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { Polyhedron } from './polyhedron';
 import { Icosahedron } from './icosahedron';
+import { Polyhedron } from './polyhedron';
 import { Primitive } from './primitive';
-
-const { vertices, indices } = Icosahedron();
 
 /** Calculate vertex count for subdived icosahedron */
 export function sphereVertexCount(detail: number) {
@@ -16,6 +15,11 @@ export function sphereVertexCount(detail: number) {
 }
 
 /** Create sphere by subdividing an icosahedron */
-export function Sphere(detail: number): Primitive {
-    return Polyhedron(vertices, indices, { detail, radius: 1 });
+export function Sphere(detail: number, options?: { subset: 'ring' | 'caps' | undefined }): Primitive {
+    const { vertices, indices } = Icosahedron({ subset: options?.subset });
+    const sphere = Polyhedron(vertices, indices, { detail, radius: 1 });
+    if (options?.subset !== undefined) {
+        sphere.normals = sphere.vertices; // prevent ugly surface of sphere subsets when merged into a full sphere
+    }
+    return sphere;
 }

--- a/src/mol-geo/primitive/star.ts
+++ b/src/mol-geo/primitive/star.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2018 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Vec3 } from '../../mol-math/linear-algebra';
@@ -11,7 +12,8 @@ export const DefaultStarProps = {
     pointCount: 5,
     outerRadius: 1,
     innerRadius: 0.5,
-    thickness: 0.3
+    thickness: 0.3,
+    perforated: false,
 };
 export type StarProps = Partial<typeof DefaultStarProps>
 
@@ -19,7 +21,7 @@ const op = Vec3.zero(), on = Vec3.zero();
 const a = Vec3.zero(), b = Vec3.zero(), c = Vec3.zero();
 
 export function Star(props?: StarProps): Primitive {
-    const { outerRadius, innerRadius, thickness, pointCount } = { ...DefaultStarProps, ...props };
+    const { outerRadius, innerRadius, thickness, pointCount, perforated } = { ...DefaultStarProps, ...props };
 
     const triangleCount = pointCount * 2 * 2;
     const builder = PrimitiveBuilder(triangleCount);
@@ -47,8 +49,10 @@ export function Star(props?: StarProps): Primitive {
 
         builder.add(op, a, b);
         builder.add(b, a, on);
-        builder.add(op, b, c);
-        builder.add(c, b, on);
+        if (!perforated) {
+            builder.add(op, b, c);
+            builder.add(c, b, on);
+        }
     }
 
     return builder.getPrimitive();

--- a/src/mol-model/structure/structure/carbohydrates/constants.ts
+++ b/src/mol-model/structure/structure/carbohydrates/constants.ts
@@ -1,8 +1,9 @@
 /**
- * Copyright (c) 2018-2025s mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
 import { Color, ColorMap } from '../../../../mol-util/color';
@@ -35,7 +36,12 @@ export const SaccharideColors = ColorMap({
 
 export enum SaccharideType {
     Hexose, HexNAc, Hexosamine, Hexuronate, Deoxyhexose, DeoxyhexNAc, DiDeoxyhexose,
-    Pentose, Deoxynonulosonate, DiDeoxynonulosonate, Unknown, Assigned
+    Pentose, Deoxynonulosonate, DiDeoxynonulosonate,
+    /** Flat Hexagon shape, but not unknown monosaccharide */
+    Other,
+    /** Unknown (not in the hardcoded list) */
+    Unknown,
+    Assigned,
 }
 
 const SaccharideTypeNameMap = {
@@ -49,6 +55,7 @@ const SaccharideTypeNameMap = {
     [SaccharideType.Pentose]: 'Pentose',
     [SaccharideType.Deoxynonulosonate]: 'Deoxynonulosonate',
     [SaccharideType.DiDeoxynonulosonate]: 'Di-deoxynonulosonate',
+    [SaccharideType.Other]: 'Other',
     [SaccharideType.Unknown]: 'Unknown',
     [SaccharideType.Assigned]: 'Assigned',
 };
@@ -68,9 +75,10 @@ const SaccharideTypeShapeMap = {
     [SaccharideType.Pentose]: SaccharideShape.FilledStar,
     [SaccharideType.Deoxynonulosonate]: SaccharideShape.FilledDiamond,
     [SaccharideType.DiDeoxynonulosonate]: SaccharideShape.FlatDiamond,
+    [SaccharideType.Other]: SaccharideShape.FlatHexagon,
     [SaccharideType.Unknown]: SaccharideShape.FlatHexagon,
     [SaccharideType.Assigned]: SaccharideShape.Pentagon,
-};
+} satisfies Record<SaccharideType, SaccharideShape>;
 
 export function getSaccharideShape(type: SaccharideType, ringMemberCount: number): SaccharideShape {
     if (type === SaccharideType.Unknown) {
@@ -82,6 +90,12 @@ export function getSaccharideShape(type: SaccharideType, ringMemberCount: number
     } else {
         return SaccharideTypeShapeMap[type];
     }
+}
+
+/** Decide whether a saccharide shape is divided into two colors. */
+export function isSaccharideShapeDivided(type: SaccharideType): boolean {
+    const shape = getSaccharideShape(type, 0);
+    return shape === SaccharideShape.CrossedCube || shape === SaccharideShape.DividedDiamond || shape === SaccharideShape.DevidedCone;
 }
 
 export type SaccharideComponent = {
@@ -176,16 +190,16 @@ const Monosaccharides: SaccharideComponent[] = [
     { abbr: 'Aci', name: 'Acinetaminic Acid', color: SaccharideColors.Pink, type: SaccharideType.DiDeoxynonulosonate },
     { abbr: '4eLeg', name: '4-Epilegionaminic Acid', color: SaccharideColors.LightBlue, type: SaccharideType.DiDeoxynonulosonate },
 
-    { abbr: 'Bac', name: 'Bacillosamine', color: SaccharideColors.Blue, type: SaccharideType.Unknown },
-    { abbr: 'LDmanHep', name: 'L-Glycero-D-Manno Heptose', color: SaccharideColors.Green, type: SaccharideType.Unknown },
-    { abbr: 'Kdo', name: 'Keto-Deoxy Octulonic Acid', color: SaccharideColors.Yellow, type: SaccharideType.Unknown },
-    { abbr: 'Dha', name: '3-Deoxy Lyxo-Heptulosaric Acid', color: SaccharideColors.Orange, type: SaccharideType.Unknown },
-    { abbr: 'DDmanHep', name: 'D-Glycero-D-Manno-Heptose', color: SaccharideColors.Pink, type: SaccharideType.Unknown },
-    { abbr: 'MurNAc', name: 'N-Acetyl Muramic Acid', color: SaccharideColors.Purple, type: SaccharideType.Unknown },
-    { abbr: 'MurNGc', name: 'N-Glycolyl Muramic Acid', color: SaccharideColors.LightBlue, type: SaccharideType.Unknown },
-    { abbr: 'Mur', name: 'Muramic Acid', color: SaccharideColors.Brown, type: SaccharideType.Unknown },
-    { abbr: 'K3O', name: 'D-glycero-a-D-talo-oct-2-Ulosonic Acid', color: SaccharideColors.Red, type: SaccharideType.Unknown }, // from GLYCAM
-    { abbr: 'dUA', name: '4-deoxy-4,5-didehydro iduronic acid', color: SaccharideColors.Secondary, type: SaccharideType.Unknown }, // from GLYCAM
+    { abbr: 'Bac', name: 'Bacillosamine', color: SaccharideColors.Blue, type: SaccharideType.Other },
+    { abbr: 'LDmanHep', name: 'L-Glycero-D-Manno Heptose', color: SaccharideColors.Green, type: SaccharideType.Other },
+    { abbr: 'Kdo', name: 'Keto-Deoxy Octulonic Acid', color: SaccharideColors.Yellow, type: SaccharideType.Other },
+    { abbr: 'Dha', name: '3-Deoxy Lyxo-Heptulosaric Acid', color: SaccharideColors.Orange, type: SaccharideType.Other },
+    { abbr: 'DDmanHep', name: 'D-Glycero-D-Manno-Heptose', color: SaccharideColors.Pink, type: SaccharideType.Other },
+    { abbr: 'MurNAc', name: 'N-Acetyl Muramic Acid', color: SaccharideColors.Purple, type: SaccharideType.Other },
+    { abbr: 'MurNGc', name: 'N-Glycolyl Muramic Acid', color: SaccharideColors.LightBlue, type: SaccharideType.Other },
+    { abbr: 'Mur', name: 'Muramic Acid', color: SaccharideColors.Brown, type: SaccharideType.Other },
+    { abbr: 'K3O', name: 'D-glycero-a-D-talo-oct-2-Ulosonic Acid', color: SaccharideColors.Red, type: SaccharideType.Other }, // from GLYCAM
+    { abbr: 'dUA', name: '4-deoxy-4,5-didehydro iduronic acid', color: SaccharideColors.Secondary, type: SaccharideType.Other }, // from GLYCAM
 
     { abbr: 'Api', name: 'Apicose', color: SaccharideColors.Green, type: SaccharideType.Assigned },
     { abbr: 'Fru', name: 'Fructose', color: SaccharideColors.Green, type: SaccharideType.Assigned },

--- a/src/mol-model/structure/structure/carbohydrates/constants.ts
+++ b/src/mol-model/structure/structure/carbohydrates/constants.ts
@@ -37,9 +37,7 @@ export const SaccharideColors = ColorMap({
 export enum SaccharideType {
     Hexose, HexNAc, Hexosamine, Hexuronate, Deoxyhexose, DeoxyhexNAc, DiDeoxyhexose,
     Pentose, Deoxynonulosonate, DiDeoxynonulosonate,
-    /** Flat Hexagon shape, but not unknown monosaccharide */
-    Other,
-    /** Unknown (not in the hardcoded list) */
+    /** This includes known monosaccharides with FlatHexagon shape and unknown monosaccharides (i.e. not in the hardcoded list) */
     Unknown,
     Assigned,
 }
@@ -55,7 +53,6 @@ const SaccharideTypeNameMap = {
     [SaccharideType.Pentose]: 'Pentose',
     [SaccharideType.Deoxynonulosonate]: 'Deoxynonulosonate',
     [SaccharideType.DiDeoxynonulosonate]: 'Di-deoxynonulosonate',
-    [SaccharideType.Other]: 'Other',
     [SaccharideType.Unknown]: 'Unknown',
     [SaccharideType.Assigned]: 'Assigned',
 };
@@ -75,26 +72,17 @@ const SaccharideTypeShapeMap = {
     [SaccharideType.Pentose]: SaccharideShape.FilledStar,
     [SaccharideType.Deoxynonulosonate]: SaccharideShape.FilledDiamond,
     [SaccharideType.DiDeoxynonulosonate]: SaccharideShape.FlatDiamond,
-    [SaccharideType.Other]: SaccharideShape.FlatHexagon,
     [SaccharideType.Unknown]: SaccharideShape.FlatHexagon,
     [SaccharideType.Assigned]: SaccharideShape.Pentagon,
 } satisfies Record<SaccharideType, SaccharideShape>;
 
-export function getSaccharideShape(type: SaccharideType, ringMemberCount: number): SaccharideShape {
-    if (type === SaccharideType.Unknown) {
-        if (ringMemberCount === 4) return SaccharideShape.DiamondPrism;
-        else if (ringMemberCount === 5) return SaccharideShape.PentagonalPrism;
-        else if (ringMemberCount === 6) return SaccharideShape.HexagonalPrism;
-        else if (ringMemberCount === 7) return SaccharideShape.HeptagonalPrism;
-        else return SaccharideShape.FlatHexagon;
-    } else {
-        return SaccharideTypeShapeMap[type];
-    }
+export function getSaccharideShape(type: SaccharideType): SaccharideShape {
+    return SaccharideTypeShapeMap[type] ?? SaccharideShape.FlatHexagon;
 }
 
 /** Decide whether a saccharide shape is divided into two colors. */
 export function isSaccharideShapeDivided(type: SaccharideType): boolean {
-    const shape = getSaccharideShape(type, 0);
+    const shape = getSaccharideShape(type);
     return shape === SaccharideShape.CrossedCube || shape === SaccharideShape.DividedDiamond || shape === SaccharideShape.DevidedCone;
 }
 
@@ -190,16 +178,16 @@ const Monosaccharides: SaccharideComponent[] = [
     { abbr: 'Aci', name: 'Acinetaminic Acid', color: SaccharideColors.Pink, type: SaccharideType.DiDeoxynonulosonate },
     { abbr: '4eLeg', name: '4-Epilegionaminic Acid', color: SaccharideColors.LightBlue, type: SaccharideType.DiDeoxynonulosonate },
 
-    { abbr: 'Bac', name: 'Bacillosamine', color: SaccharideColors.Blue, type: SaccharideType.Other },
-    { abbr: 'LDmanHep', name: 'L-Glycero-D-Manno Heptose', color: SaccharideColors.Green, type: SaccharideType.Other },
-    { abbr: 'Kdo', name: 'Keto-Deoxy Octulonic Acid', color: SaccharideColors.Yellow, type: SaccharideType.Other },
-    { abbr: 'Dha', name: '3-Deoxy Lyxo-Heptulosaric Acid', color: SaccharideColors.Orange, type: SaccharideType.Other },
-    { abbr: 'DDmanHep', name: 'D-Glycero-D-Manno-Heptose', color: SaccharideColors.Pink, type: SaccharideType.Other },
-    { abbr: 'MurNAc', name: 'N-Acetyl Muramic Acid', color: SaccharideColors.Purple, type: SaccharideType.Other },
-    { abbr: 'MurNGc', name: 'N-Glycolyl Muramic Acid', color: SaccharideColors.LightBlue, type: SaccharideType.Other },
-    { abbr: 'Mur', name: 'Muramic Acid', color: SaccharideColors.Brown, type: SaccharideType.Other },
-    { abbr: 'K3O', name: 'D-glycero-a-D-talo-oct-2-Ulosonic Acid', color: SaccharideColors.Red, type: SaccharideType.Other }, // from GLYCAM
-    { abbr: 'dUA', name: '4-deoxy-4,5-didehydro iduronic acid', color: SaccharideColors.Secondary, type: SaccharideType.Other }, // from GLYCAM
+    { abbr: 'Bac', name: 'Bacillosamine', color: SaccharideColors.Blue, type: SaccharideType.Unknown },
+    { abbr: 'LDmanHep', name: 'L-Glycero-D-Manno Heptose', color: SaccharideColors.Green, type: SaccharideType.Unknown },
+    { abbr: 'Kdo', name: 'Keto-Deoxy Octulonic Acid', color: SaccharideColors.Yellow, type: SaccharideType.Unknown },
+    { abbr: 'Dha', name: '3-Deoxy Lyxo-Heptulosaric Acid', color: SaccharideColors.Orange, type: SaccharideType.Unknown },
+    { abbr: 'DDmanHep', name: 'D-Glycero-D-Manno-Heptose', color: SaccharideColors.Pink, type: SaccharideType.Unknown },
+    { abbr: 'MurNAc', name: 'N-Acetyl Muramic Acid', color: SaccharideColors.Purple, type: SaccharideType.Unknown },
+    { abbr: 'MurNGc', name: 'N-Glycolyl Muramic Acid', color: SaccharideColors.LightBlue, type: SaccharideType.Unknown },
+    { abbr: 'Mur', name: 'Muramic Acid', color: SaccharideColors.Brown, type: SaccharideType.Unknown },
+    { abbr: 'K3O', name: 'D-glycero-a-D-talo-oct-2-Ulosonic Acid', color: SaccharideColors.Red, type: SaccharideType.Unknown }, // from GLYCAM
+    { abbr: 'dUA', name: '4-deoxy-4,5-didehydro iduronic acid', color: SaccharideColors.Secondary, type: SaccharideType.Unknown }, // from GLYCAM
 
     { abbr: 'Api', name: 'Apicose', color: SaccharideColors.Green, type: SaccharideType.Assigned },
     { abbr: 'Fru', name: 'Fructose', color: SaccharideColors.Green, type: SaccharideType.Assigned },

--- a/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
+++ b/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
@@ -1,32 +1,34 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
-import { Box, PerforatedBox } from '../../../mol-geo/primitive/box';
-import { OctagonalPyramid, PerforatedOctagonalPyramid } from '../../../mol-geo/primitive/pyramid';
-import { Star } from '../../../mol-geo/primitive/star';
-import { Octahedron, PerforatedOctahedron } from '../../../mol-geo/primitive/octahedron';
-import { DiamondPrism, PentagonalPrism, ShiftedHexagonalPrism, HexagonalPrism, HeptagonalPrism } from '../../../mol-geo/primitive/prism';
-import { Structure, StructureElement, Unit } from '../../../mol-model/structure';
+import { Interval, OrderedSet } from '../../../mol-data/int';
+import { BaseGeometry } from '../../../mol-geo/geometry/base';
+import { addSphere } from '../../../mol-geo/geometry/mesh/builder/sphere';
 import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
-import { getSaccharideShape, SaccharideShape } from '../../../mol-model/structure/structure/carbohydrates/constants';
-import { addSphere } from '../../../mol-geo/geometry/mesh/builder/sphere';
-import { ComplexMeshParams, ComplexMeshVisual } from '../complex-visual';
-import { ParamDefinition as PD } from '../../../mol-util/param-definition';
-import { ComplexVisual } from '../representation';
-import { VisualUpdateState } from '../../util';
-import { LocationIterator } from '../../../mol-geo/util/location-iterator';
 import { PickingId } from '../../../mol-geo/geometry/picking';
-import { OrderedSet, Interval } from '../../../mol-data/int';
+import { PerforatedBox } from '../../../mol-geo/primitive/box';
+import { PerforatedOctahedron } from '../../../mol-geo/primitive/octahedron';
+import { PolygonalPrism, } from '../../../mol-geo/primitive/prism';
+import { PerforatedOctagonalPyramid } from '../../../mol-geo/primitive/pyramid';
+import { Star } from '../../../mol-geo/primitive/star';
+import { LocationIterator } from '../../../mol-geo/util/location-iterator';
+import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
 import { EmptyLoci, Loci } from '../../../mol-model/loci';
+import { Structure, StructureElement, Unit } from '../../../mol-model/structure';
+import { getSaccharideShape, SaccharideShape } from '../../../mol-model/structure/structure/carbohydrates/constants';
 import { VisualContext } from '../../../mol-repr/visual';
 import { Theme } from '../../../mol-theme/theme';
+import { ParamDefinition as PD } from '../../../mol-util/param-definition';
+import { VisualUpdateState } from '../../util';
+import { ComplexMeshParams, ComplexMeshVisual } from '../complex-visual';
+import { ComplexVisual } from '../representation';
 import { getAltResidueLociFromId } from './util/common';
-import { BaseGeometry } from '../../../mol-geo/geometry/base';
+
 
 const t = Mat4.identity();
 const sVec = Vec3();
@@ -34,18 +36,30 @@ const pd = Vec3();
 
 const SideFactor = 2 * 0.806; // 0.806 == Math.cos(Math.PI / 4)
 
-const box = Box();
 const perforatedBox = PerforatedBox();
-const octagonalPyramid = OctagonalPyramid();
 const perforatedOctagonalPyramid = PerforatedOctagonalPyramid();
-const star = Star({ outerRadius: 1, innerRadius: 0.5, thickness: 0.5, pointCount: 5 });
-const octahedron = Octahedron();
+const perforatedStar = Star({ outerRadius: 1, innerRadius: 0.5, thickness: 0.5, pointCount: 5, perforated: true });
 const perforatedOctahedron = PerforatedOctahedron();
-const diamondPrism = DiamondPrism();
-const pentagonalPrism = PentagonalPrism();
-const hexagonalPrism = HexagonalPrism();
-const shiftedHexagonalPrism = ShiftedHexagonalPrism();
-const heptagonalPrism = HeptagonalPrism();
+const diamondPrism = {
+    caps: PolygonalPrism(4, { subset: 'caps' }),
+    sides: PolygonalPrism(4, { subset: 'sides' }),
+};
+const pentagonalPrism = {
+    caps: PolygonalPrism(5, { subset: 'caps' }),
+    sides: PolygonalPrism(5, { subset: 'sides' }),
+};
+const hexagonalPrism = {
+    caps: PolygonalPrism(6, { subset: 'caps' }),
+    sides: PolygonalPrism(6, { subset: 'sides' }),
+};
+const shiftedHexagonalPrism = {
+    caps: PolygonalPrism(6, { shifted: true, subset: 'caps' }),
+    sides: PolygonalPrism(6, { shifted: true, subset: 'sides' }),
+};
+const heptagonalPrism = {
+    caps: PolygonalPrism(7, { subset: 'caps' }),
+    sides: PolygonalPrism(7, { subset: 'sides' }),
+};
 
 function createCarbohydrateSymbolMesh(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<CarbohydrateSymbolParams>, mesh?: Mesh) {
     const builderState = MeshBuilder.createState(256, 128, mesh);
@@ -75,47 +89,45 @@ function createCarbohydrateSymbolMesh(ctx: VisualContext, structure: Structure, 
         builderState.currentGroup = i * 2;
 
         switch (shapeType) {
-            case SaccharideShape.FilledSphere:
-                addSphere(builderState, center, radius, detail);
+            case SaccharideShape.FilledSphere: // e.g. 3d11
+                addSphere(builderState, center, radius, detail, { subset: 'ring' });
+                builderState.currentGroup += 1;
+                addSphere(builderState, center, radius, detail, { subset: 'caps' });
                 break;
-            case SaccharideShape.FilledCube:
-                Mat4.scaleUniformly(t, t, side);
-                MeshBuilder.addPrimitive(builderState, t, box);
-                break;
-            case SaccharideShape.CrossedCube:
+            case SaccharideShape.FilledCube: // e.g. 3d11
+            case SaccharideShape.CrossedCube: // e.g. 5hwa
                 Mat4.scaleUniformly(t, t, side);
                 MeshBuilder.addPrimitive(builderState, t, perforatedBox);
-                Mat4.mul(t, t, Mat4.rotZ90X180);
+                Mat4.mul(t, t, Mat4.rotY90Z180);
                 builderState.currentGroup += 1;
                 MeshBuilder.addPrimitive(builderState, t, perforatedBox);
                 break;
-            case SaccharideShape.FilledCone:
-                Mat4.scaleUniformly(t, t, side * 1.2);
-                MeshBuilder.addPrimitive(builderState, t, octagonalPyramid);
-                break;
-            case SaccharideShape.DevidedCone:
+            case SaccharideShape.FilledCone: // e.g. 9k1g
+            case SaccharideShape.DevidedCone: // e.g. 4y9v
                 Mat4.scaleUniformly(t, t, side * 1.2);
                 MeshBuilder.addPrimitive(builderState, t, perforatedOctagonalPyramid);
                 Mat4.mul(t, t, Mat4.rotZ90);
                 builderState.currentGroup += 1;
                 MeshBuilder.addPrimitive(builderState, t, perforatedOctagonalPyramid);
                 break;
-            case SaccharideShape.FlatBox:
+            case SaccharideShape.FlatBox: // e.g. 1mfd
                 Mat4.mul(t, t, Mat4.rotZY90);
-                Mat4.scale(t, t, Vec3.set(sVec, side, side, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, box);
+                Mat4.scale(t, t, Vec3.set(sVec, side * 1.2, side * 0.6, side * 0.6));
+                MeshBuilder.addPrimitive(builderState, t, perforatedBox);
+                Mat4.mul(t, t, Mat4.rotY90Z180);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, perforatedBox);
                 break;
-            case SaccharideShape.FilledStar:
+            case SaccharideShape.FilledStar: // e.g. 6rv7
                 Mat4.scaleUniformly(t, t, side);
                 Mat4.mul(t, t, Mat4.rotZY90);
-                MeshBuilder.addPrimitive(builderState, t, star);
+                MeshBuilder.addPrimitive(builderState, t, perforatedStar);
+                Mat4.mul(t, t, Mat4.rotX180);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, perforatedStar);
                 break;
-            case SaccharideShape.FilledDiamond:
-                Mat4.mul(t, t, Mat4.rotZY90);
-                Mat4.scale(t, t, Vec3.set(sVec, side * 1.4, side * 1.4, side * 1.4));
-                MeshBuilder.addPrimitive(builderState, t, octahedron);
-                break;
-            case SaccharideShape.DividedDiamond:
+            case SaccharideShape.FilledDiamond: // e.g. 9q5e
+            case SaccharideShape.DividedDiamond: // e.g. 1hv6
                 Mat4.mul(t, t, Mat4.rotZY90);
                 Mat4.scale(t, t, Vec3.set(sVec, side * 1.4, side * 1.4, side * 1.4));
                 MeshBuilder.addPrimitive(builderState, t, perforatedOctahedron);
@@ -123,37 +135,49 @@ function createCarbohydrateSymbolMesh(ctx: VisualContext, structure: Structure, 
                 builderState.currentGroup += 1;
                 MeshBuilder.addPrimitive(builderState, t, perforatedOctahedron);
                 break;
-            case SaccharideShape.FlatDiamond:
+            case SaccharideShape.FlatDiamond: // no CCD codes mapped
                 Mat4.mul(t, t, Mat4.rotZY90);
                 Mat4.scale(t, t, Vec3.set(sVec, side, side / 2, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, diamondPrism);
+                MeshBuilder.addPrimitive(builderState, t, diamondPrism.caps);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, diamondPrism.sides);
                 break;
             case SaccharideShape.DiamondPrism:
                 Mat4.mul(t, t, Mat4.rotZY90);
                 Mat4.scale(t, t, Vec3.set(sVec, side, side, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, diamondPrism);
+                MeshBuilder.addPrimitive(builderState, t, diamondPrism.caps);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, diamondPrism.sides);
                 break;
             case SaccharideShape.PentagonalPrism:
-            case SaccharideShape.Pentagon:
+            case SaccharideShape.Pentagon: // e.g. 8jq5
                 Mat4.mul(t, t, Mat4.rotZY90);
                 Mat4.scale(t, t, Vec3.set(sVec, side, side, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, pentagonalPrism);
+                MeshBuilder.addPrimitive(builderState, t, pentagonalPrism.caps);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, pentagonalPrism.sides);
                 break;
-            case SaccharideShape.HexagonalPrism:
+            case SaccharideShape.HexagonalPrism: // e.g. 9k1g
                 Mat4.mul(t, t, Mat4.rotZY90);
                 Mat4.scale(t, t, Vec3.set(sVec, side, side, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, hexagonalPrism);
+                MeshBuilder.addPrimitive(builderState, t, hexagonalPrism.caps);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, hexagonalPrism.sides);
                 break;
             case SaccharideShape.HeptagonalPrism:
                 Mat4.mul(t, t, Mat4.rotZY90);
                 Mat4.scale(t, t, Vec3.set(sVec, side, side, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, heptagonalPrism);
+                MeshBuilder.addPrimitive(builderState, t, heptagonalPrism.caps);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, heptagonalPrism.sides);
                 break;
-            case SaccharideShape.FlatHexagon:
+            case SaccharideShape.FlatHexagon: // e.g. 3k8d
             default:
                 Mat4.mul(t, t, Mat4.rotZYZ90);
                 Mat4.scale(t, t, Vec3.set(sVec, side / 1.5, side, side / 2));
-                MeshBuilder.addPrimitive(builderState, t, shiftedHexagonalPrism);
+                MeshBuilder.addPrimitive(builderState, t, shiftedHexagonalPrism.caps);
+                builderState.currentGroup += 1;
+                MeshBuilder.addPrimitive(builderState, t, shiftedHexagonalPrism.sides);
                 break;
         }
     }
@@ -234,7 +258,9 @@ function eachCarbohydrate(loci: Loci, structure: Structure, apply: (interval: In
             for (let i = 0, il = elementIndices.length; i < il; ++i) {
                 if (!__elementIndicesSet.has(elementIndices[i])) {
                     __elementIndicesSet.add(elementIndices[i]);
-                    if (apply(Interval.ofSingleton(elementIndices[i] * 2))) changed = true;
+                    const firstGroup = elementIndices[i] * 2;
+                    const groupInterval = Interval.ofRange(firstGroup, firstGroup + 1); // each residue has up to 2 groups
+                    if (apply(groupInterval)) changed = true;
                 }
             }
         });

--- a/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
+++ b/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
@@ -73,7 +73,7 @@ function createCarbohydrateSymbolMesh(ctx: VisualContext, structure: Structure, 
     for (let i = 0; i < n; ++i) {
         const c = carbohydrates.elements[i];
         const ring = c.unit.rings.all[c.ringIndex];
-        const shapeType = getSaccharideShape(c.component.type, ring.length);
+        const shapeType = getSaccharideShape(c.component.type);
 
         l.unit = c.unit;
         l.element = c.unit.elements[ring[0]];

--- a/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
+++ b/src/mol-repr/structure/visual/carbohydrate-symbol-mesh.ts
@@ -7,7 +7,7 @@
 
 import { Interval, OrderedSet } from '../../../mol-data/int';
 import { BaseGeometry } from '../../../mol-geo/geometry/base';
-import { addSphere } from '../../../mol-geo/geometry/mesh/builder/sphere';
+import { addSphereSubset } from '../../../mol-geo/geometry/mesh/builder/sphere';
 import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { MeshBuilder } from '../../../mol-geo/geometry/mesh/mesh-builder';
 import { PickingId } from '../../../mol-geo/geometry/picking';
@@ -90,9 +90,9 @@ function createCarbohydrateSymbolMesh(ctx: VisualContext, structure: Structure, 
 
         switch (shapeType) {
             case SaccharideShape.FilledSphere: // e.g. 3d11
-                addSphere(builderState, center, radius, detail, { subset: 'ring' });
+                addSphereSubset(builderState, center, radius, detail, 'ring');
                 builderState.currentGroup += 1;
-                addSphere(builderState, center, radius, detail, { subset: 'caps' });
+                addSphereSubset(builderState, center, radius, detail, 'caps');
                 break;
             case SaccharideShape.FilledCube: // e.g. 3d11
             case SaccharideShape.CrossedCube: // e.g. 5hwa

--- a/src/mol-theme/color/carbohydrate-symbol.ts
+++ b/src/mol-theme/color/carbohydrate-symbol.ts
@@ -1,23 +1,25 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Adam Midlik <midlik@gmail.com>
  */
 
-import { StructureElement, Bond, ElementIndex, Unit, Model } from '../../mol-model/structure';
-import { SaccharideColors, MonosaccharidesColorTable } from '../../mol-model/structure/structure/carbohydrates/constants';
 import { Location } from '../../mol-model/location';
-import type { ColorTheme, LocationColor } from '../color';
+import { Bond, ElementIndex, Model, StructureElement, Unit } from '../../mol-model/structure';
+import { MonosaccharidesColorTable, SaccharideColors, isSaccharideShapeDivided } from '../../mol-model/structure/structure/carbohydrates/constants';
 import { Color } from '../../mol-util/color';
-import { ParamDefinition as PD } from '../../mol-util/param-definition';
-import { ThemeDataContext } from '../theme';
 import { TableLegend } from '../../mol-util/legend';
+import { ParamDefinition as PD } from '../../mol-util/param-definition';
+import type { ColorTheme, LocationColor } from '../color';
+import { ThemeDataContext } from '../theme';
 import { ColorThemeCategory } from './categories';
+
 
 const DefaultColor = Color(0xCCCCCC);
 const Description = 'Assigns colors according to the Symbol Nomenclature for Glycans (SNFG).';
 
-export const CarbohydrateSymbolColorThemeParams = { };
+export const CarbohydrateSymbolColorThemeParams = {};
 export type CarbohydrateSymbolColorThemeParams = typeof CarbohydrateSymbolColorThemeParams
 export function getCarbohydrateSymbolColorThemeParams(ctx: ThemeDataContext) {
     return CarbohydrateSymbolColorThemeParams; // TODO return copy
@@ -29,21 +31,23 @@ export function CarbohydrateSymbolColorTheme(ctx: ThemeDataContext, props: PD.Va
     if (ctx.structure) {
         const { elements, getElementIndices } = ctx.structure.carbohydrates;
 
-        const getColor = (unit: Unit, index: ElementIndex) => {
+        const getColor = (unit: Unit, index: ElementIndex, isSecondary: boolean) => {
             if (!Unit.isAtomic(unit)) return DefaultColor;
             const carbs = getElementIndices(unit, index);
-            return carbs.length > 0 ? elements[carbs[0]].component.color : DefaultColor;
+            if (carbs.length === 0) return DefaultColor;
+            const component = elements[carbs[0]].component;
+            if (isSecondary && isSaccharideShapeDivided(component.type)) {
+                return SaccharideColors.Secondary;
+            } else {
+                return component.color;
+            }
         };
 
         color = (location: Location, isSecondary: boolean) => {
-            if (isSecondary) {
-                return SaccharideColors.Secondary;
-            } else {
-                if (StructureElement.Location.is(location)) {
-                    return getColor(location.unit, location.element);
-                } else if (Bond.isLocation(location)) {
-                    return getColor(location.aUnit, location.aUnit.elements[location.aIndex]);
-                }
+            if (StructureElement.Location.is(location)) {
+                return getColor(location.unit, location.element, isSecondary);
+            } else if (Bond.isLocation(location)) {
+                return getColor(location.aUnit, location.aUnit.elements[location.aIndex], isSecondary);
             }
             return DefaultColor;
         };


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

A few changes in carbohydrate symbol rendering and coloring (this is preparation for MVS split coloring https://github.com/molstar/molstar/pull/1912):

- All carbohydrate symbols are rendered with 2 groups (primary and secondary) and can be potentially colored in two colors
  <img width="2800" height="1600" alt="all-shapes" src="https://github.com/user-attachments/assets/701eb33b-59af-4551-8c24-eeaa3eb74e20" />

- `CarbohydrateSymbolColorTheme` decides which shape will be colored by one or two colors

- Changed side length ratio of FlatBox shape from 2:2:1 to 2:1:1 (in accordance with https://pmc.ncbi.nlm.nih.gov/articles/PMC5018049/#cww076C8), please check if this is correct
  <img width="1418" height="793" alt="Flatbox-side-ratio-change-1MFD" src="https://github.com/user-attachments/assets/e3051dc0-129d-40ac-8825-c788d2af88a4" />

- Fixed DividedCone shape (had inverted base), e.g. 49T in 4y9v
  <img width="1390" height="793" alt="DividedCone-change-4Y9V" src="https://github.com/user-attachments/assets/ad202b01-5b06-40b5-8d44-68ab264b3bdb" />

- Fixed shape of known monosaccharides which are in "Unknown" category here (https://en.wikipedia.org/wiki/Symbol_Nomenclature_For_Glycans#/media/File:SNFG.tif)
  - Original plan: Move these monosaccharides to a new category "Other" (FlatHexagon) to distinguish from truly unknown monosaccharides (shape depending on ring count)
  - After discussion: We decided to keep them in "Unknown" category and render all "Unknown" as FlatHexagon (including truly unknown)
  - e.g. KDO in 3k8d (yellow FlatHexagon in SNFG)
  - e.g. X6Y in 9k1g (no SNFG symbol assigned -> render white FlatHexagon)
  <img width="1418" height="793" alt="FlatHexagon-fix-3K8D" src="https://github.com/user-attachments/assets/cb387fca-b601-4d9e-8fc6-43cd086d4f86" />

- Fixed highlighting of two-color carbohydrate symbols (used to highlight only first group), e.g. GCS in 5hwa
  <img width="1414" height="672" alt="Highlight-fix-5HWA" src="https://github.com/user-attachments/assets/71d91227-4907-42c1-8286-d1304383e15b" />

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`