### PR TITLE
Surface representation fixes: traceOnly, floodfill, GPU/CPU handoff, blob wireframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
-- Fix the blob surface density blocking the main thread with no progress and no cancellation (the `RuntimeContext` was accepted by the task and then discarded)
-- Add `blob-surface-wireframe` and `structure-blob-surface-wireframe` visuals, so the blob surface can be drawn as a wireframe like the gaussian and molecular surfaces
-- Remove the `floodfill` param from the gaussian density volume representation, where it was exposed but had no meaning (DirectVolume has no scalar field to fill and no iso threshold to fill against)
-- Fix CPU surface/volume visuals rebuilding their geometry on every update when the GPU path is unavailable (`mustRecreate` did not mirror the conditions its dispatcher uses to pick between the GPU and CPU visual)
-- Fix `floodfill` having no effect on the gaussian surface wireframe (the param was exposed and forced a rebuild but was never applied)
-- Fix `traceOnly` being ignored by the molecular surface wireframe visuals (the option did not trigger a geometry rebuild, so the surface kept using every atom)
+- Fix the blob surface density blocking the main thread
+- Add `blob-surface-wireframe` and `structure-blob-surface-wireframe` visuals
+- Remove unused `floodfill` param from the gaussian density volume representation
+- Fix CPU surface/volume visuals rebuilding on every update if GPU path is unavailable
+- Fix `floodfill` not applied on the gaussian surface wireframe
+- Fix `traceOnly` update being ignored by the molecular surface wireframe visuals
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files
 - Added element symbol detection in lammps data file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix the blob surface density blocking the main thread with no progress and no cancellation (the `RuntimeContext` was accepted by the task and then discarded)
 - Add `blob-surface-wireframe` and `structure-blob-surface-wireframe` visuals, so the blob surface can be drawn as a wireframe like the gaussian and molecular surfaces
 - Remove the `floodfill` param from the gaussian density volume representation, where it was exposed but had no meaning (DirectVolume has no scalar field to fill and no iso threshold to fill against)
 - Fix CPU surface/volume visuals rebuilding their geometry on every update when the GPU path is unavailable (`mustRecreate` did not mirror the conditions its dispatcher uses to pick between the GPU and CPU visual)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix `floodfill` having no effect on the gaussian surface wireframe (the param was exposed and forced a rebuild but was never applied)
 - Fix `traceOnly` being ignored by the molecular surface wireframe visuals (the option did not trigger a geometry rebuild, so the surface kept using every atom)
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix CPU surface/volume visuals rebuilding their geometry on every update when the GPU path is unavailable (`mustRecreate` did not mirror the conditions its dispatcher uses to pick between the GPU and CPU visual)
 - Fix `floodfill` having no effect on the gaussian surface wireframe (the param was exposed and forced a rebuild but was never applied)
 - Fix `traceOnly` being ignored by the molecular surface wireframe visuals (the option did not trigger a geometry rebuild, so the surface kept using every atom)
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Remove the `floodfill` param from the gaussian density volume representation, where it was exposed but had no meaning (DirectVolume has no scalar field to fill and no iso threshold to fill against)
 - Fix CPU surface/volume visuals rebuilding their geometry on every update when the GPU path is unavailable (`mustRecreate` did not mirror the conditions its dispatcher uses to pick between the GPU and CPU visual)
 - Fix `floodfill` having no effect on the gaussian surface wireframe (the param was exposed and forced a rebuild but was never applied)
 - Fix `traceOnly` being ignored by the molecular surface wireframe visuals (the option did not trigger a geometry rebuild, so the surface kept using every atom)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Add `blob-surface-wireframe` and `structure-blob-surface-wireframe` visuals, so the blob surface can be drawn as a wireframe like the gaussian and molecular surfaces
 - Remove the `floodfill` param from the gaussian density volume representation, where it was exposed but had no meaning (DirectVolume has no scalar field to fill and no iso threshold to fill against)
 - Fix CPU surface/volume visuals rebuilding their geometry on every update when the GPU path is unavailable (`mustRecreate` did not mirror the conditions its dispatcher uses to pick between the GPU and CPU visual)
 - Fix `floodfill` having no effect on the gaussian surface wireframe (the param was exposed and forced a rebuild but was never applied)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix `traceOnly` being ignored by the molecular surface wireframe visuals (the option did not trigger a geometry rebuild, so the surface kept using every atom)
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files
 - Added element symbol detection in lammps data file

--- a/src/mol-math/geometry/blob-surface.ts
+++ b/src/mol-math/geometry/blob-surface.ts
@@ -5,6 +5,7 @@
  * @author Ludovic Autin <autin@scripps.edu>
  */
 
+import { RuntimeContext } from '../../mol-task';
 import { PositionData, DensityData, fillGridDim } from './common';
 import { Boundary, getFastBoundary } from './boundary';
 import { Box3D } from './primitives/box3d';
@@ -107,7 +108,7 @@ function groupAtomsByGrid(position: PositionData, boundary: Boundary, blobSize: 
  * empty-cluster remedy. Softens/avoids the grid method's atoms-near-a-bin-boundary-split
  * artifact, at the cost of `clusterIterations` extra O(atoms * k) passes.
  */
-function groupAtomsByClustering(position: PositionData, boundary: Boundary, blobSize: number, iterations: number): AtomGroup[] {
+async function groupAtomsByClustering(ctx: RuntimeContext, position: PositionData, boundary: Boundary, blobSize: number, iterations: number): Promise<AtomGroup[]> {
     const initialGroups = groupAtomsByGrid(position, boundary, blobSize);
     const k = initialGroups.length;
     if (k <= 1) return initialGroups;
@@ -140,6 +141,7 @@ function groupAtomsByClustering(position: PositionData, boundary: Boundary, blob
     const cellSize = Vec3.create(blobSize, blobSize, blobSize);
 
     for (let iter = 0; iter < iterations; ++iter) {
+        if (ctx.shouldUpdate) await ctx.update({ message: 'clustering atoms', current: iter, max: iterations });
         // console.time('k-means iteration');
         let changed = false;
 
@@ -329,16 +331,20 @@ function fitSHBlobFromGroup(position: PositionData, radius: (index: number) => n
  * each group's atoms are fit to either an ellipsoid (`shape: 'ellipsoid'`) or a
  * spherical-harmonics radial boundary (`shape: 'sh'`).
  */
-function fitBlobs(position: PositionData, boundary: Boundary, radius: (index: number) => number, props: BlobSurfaceProps): { blobs: Blob[], maxSemiAxis: number } {
+async function fitBlobs(ctx: RuntimeContext, position: PositionData, boundary: Boundary, radius: (index: number) => number, props: BlobSurfaceProps): Promise<{ blobs: Blob[], maxSemiAxis: number }> {
     const { blobSize, radiusOffset, method, clusterIterations, shape, shDegree, shRegularization } = props;
 
     const groups = method === 'clustering'
-        ? groupAtomsByClustering(position, boundary, blobSize, clusterIterations)
+        ? await groupAtomsByClustering(ctx, position, boundary, blobSize, clusterIterations)
         : groupAtomsByGrid(position, boundary, blobSize);
 
-    const blobs: Blob[] = shape === 'sh'
-        ? groups.map(group => fitSHBlobFromGroup(position, radius, radiusOffset, group, shDegree, shRegularization))
-        : groups.map(group => fitEllipsoidBlobFromGroup(position, radius, radiusOffset, group));
+    const blobs: Blob[] = [];
+    for (let i = 0, il = groups.length; i < il; ++i) {
+        blobs.push(shape === 'sh'
+            ? fitSHBlobFromGroup(position, radius, radiusOffset, groups[i], shDegree, shRegularization)
+            : fitEllipsoidBlobFromGroup(position, radius, radiusOffset, groups[i]));
+        if (ctx.shouldUpdate) await ctx.update({ message: 'fitting blobs', current: i, max: il });
+    }
 
     let maxSemiAxis = 0;
     for (const b of blobs) {
@@ -371,12 +377,12 @@ function ellipsoidWorldPad(out: Vec3, u0: Vec3, u1: Vec3, u2: Vec3, a0: number, 
  * high-resolution mesh over big blobs can still ask for one; keeping the box tight is what keeps
  * that affordable instead of also depending on a coarse resolution to avoid blowing up cell count.
  */
-export function computeBlobSurface(position: PositionData, boundary: Boundary, radius: (index: number) => number, props: BlobSurfaceProps): BlobSurfaceData {
+export async function computeBlobSurface(ctx: RuntimeContext, position: PositionData, boundary: Boundary, radius: (index: number) => number, props: BlobSurfaceProps): Promise<BlobSurfaceData> {
     const { resolution, smoothness, shDegree } = props;
     const alpha = smoothness;
     const scaleFactor = 1 / resolution;
 
-    const { blobs } = fitBlobs(position, boundary, radius, props);
+    const { blobs } = await fitBlobs(ctx, position, boundary, radius, props);
 
     const cutoff = 2; // matches the existing "2x radius" density cutoff convention
     const cutoffSq = cutoff * cutoff;
@@ -447,6 +453,8 @@ export function computeBlobSurface(position: PositionData, boundary: Boundary, r
     let shLUT: RadiusLUT | undefined;
 
     for (let bi = 0; bi < blobs.length; ++bi) {
+        if (ctx.shouldUpdate) await ctx.update({ message: 'filling density grid', current: bi, max: blobs.length });
+
         const blob = blobs[bi];
         const { center, atomId } = blob;
         const maxExtent = blobMaxExtent(blob);

--- a/src/mol-math/geometry/blob-surface.ts
+++ b/src/mol-math/geometry/blob-surface.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Ludovic Autin <autin@scripps.edu>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { RuntimeContext } from '../../mol-task';

--- a/src/mol-repr/structure/representation/blob-surface.ts
+++ b/src/mol-repr/structure/representation/blob-surface.ts
@@ -5,6 +5,7 @@
  */
 
 import { BlobSurfaceMeshParams, BlobSurfaceMeshVisual, StructureBlobSurfaceMeshParams, StructureBlobSurfaceMeshVisual } from '../visual/blob-surface-mesh';
+import { BlobSurfaceWireframeParams, BlobSurfaceWireframeVisual, StructureBlobSurfaceWireframeParams, StructureBlobSurfaceWireframeVisual } from '../visual/blob-surface-wireframe';
 import { UnitsRepresentation } from '../units-representation';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
 import { ComplexRepresentation, StructureRepresentation, StructureRepresentationProvider, StructureRepresentationStateBuilder } from '../representation';
@@ -15,10 +16,13 @@ import { Structure } from '../../../mol-model/structure';
 const BlobSurfaceVisuals = {
     'blob-surface-mesh': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, BlobSurfaceMeshParams>) => UnitsRepresentation('Blob surface mesh', ctx, getParams, BlobSurfaceMeshVisual),
     'structure-blob-surface-mesh': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureBlobSurfaceMeshParams>) => ComplexRepresentation('Structure Blob surface mesh', ctx, getParams, StructureBlobSurfaceMeshVisual),
+    'blob-surface-wireframe': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, BlobSurfaceWireframeParams>) => UnitsRepresentation('Blob surface wireframe', ctx, getParams, BlobSurfaceWireframeVisual),
+    'structure-blob-surface-wireframe': (ctx: RepresentationContext, getParams: RepresentationParamsGetter<Structure, StructureBlobSurfaceWireframeParams>) => ComplexRepresentation('Structure Blob surface wireframe', ctx, getParams, StructureBlobSurfaceWireframeVisual),
 };
 
 export const BlobSurfaceParams = {
     ...BlobSurfaceMeshParams,
+    ...BlobSurfaceWireframeParams,
     visuals: PD.MultiSelect(['blob-surface-mesh'], PD.objectToOptions(BlobSurfaceVisuals)),
 };
 export type BlobSurfaceParams = typeof BlobSurfaceParams

--- a/src/mol-repr/structure/representation/blob-surface.ts
+++ b/src/mol-repr/structure/representation/blob-surface.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { BlobSurfaceMeshParams, BlobSurfaceMeshVisual, StructureBlobSurfaceMeshParams, StructureBlobSurfaceMeshVisual } from '../visual/blob-surface-mesh';

--- a/src/mol-repr/structure/visual/blob-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/blob-surface-mesh.ts
@@ -14,7 +14,7 @@ import { Mesh } from '../../../mol-geo/geometry/mesh/mesh';
 import { computeMarchingCubesMesh } from '../../../mol-geo/util/marching-cubes/algorithm';
 import { ElementIterator, getElementLoci, eachElement, getSerialElementLoci, eachSerialElement } from './util/element';
 import { VisualUpdateState } from '../../util';
-import { BlobDensityParams, BlobDensityProps, computeUnitBlobSurface, computeStructureBlobSurface } from './util/blob-surface';
+import { BlobDensityParams, computeUnitBlobSurface, computeStructureBlobSurface, shouldUpdateBlobGeometry } from './util/blob-surface';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { ValueCell } from '../../../mol-util/value-cell';
 
@@ -29,27 +29,6 @@ export const StructureBlobSurfaceMeshParams = {
     ...BlobDensityParams,
 };
 export type StructureBlobSurfaceMeshParams = typeof StructureBlobSurfaceMeshParams
-
-function shouldUpdateGeometry(newProps: BlobDensityProps, currentProps: BlobDensityProps) {
-    return (
-        newProps.blobSize !== currentProps.blobSize ||
-        newProps.blobMethod.name !== currentProps.blobMethod.name ||
-        (newProps.blobMethod.name === 'clustering' && currentProps.blobMethod.name === 'clustering' &&
-            newProps.blobMethod.params.iterations !== currentProps.blobMethod.params.iterations) ||
-        newProps.blobShape.name !== currentProps.blobShape.name ||
-        (newProps.blobShape.name === 'sphericalHarmonics' && currentProps.blobShape.name === 'sphericalHarmonics' &&
-            (newProps.blobShape.params.degree !== currentProps.blobShape.params.degree ||
-                newProps.blobShape.params.regularization !== currentProps.blobShape.params.regularization)) ||
-        newProps.resolution !== currentProps.resolution ||
-        newProps.adjustResolution !== currentProps.adjustResolution ||
-        newProps.radiusOffset !== currentProps.radiusOffset ||
-        newProps.smoothness !== currentProps.smoothness ||
-        newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
-        newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
-        newProps.traceOnly !== currentProps.traceOnly ||
-        newProps.includeParent !== currentProps.includeParent
-    );
-}
 
 //
 
@@ -83,7 +62,7 @@ export function BlobSurfaceMeshVisual(materialId: number): UnitsVisual<BlobSurfa
         getLoci: getElementLoci,
         eachLocation: eachElement,
         setUpdateState: (state: VisualUpdateState, newProps: PD.Values<BlobSurfaceMeshParams>, currentProps: PD.Values<BlobSurfaceMeshParams>) => {
-            state.createGeometry = shouldUpdateGeometry(newProps, currentProps);
+            state.createGeometry = shouldUpdateBlobGeometry(newProps, currentProps);
         }
     }, materialId);
 }
@@ -120,7 +99,7 @@ export function StructureBlobSurfaceMeshVisual(materialId: number): ComplexVisua
         getLoci: getSerialElementLoci,
         eachLocation: eachSerialElement,
         setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureBlobSurfaceMeshParams>, currentProps: PD.Values<StructureBlobSurfaceMeshParams>) => {
-            state.createGeometry = shouldUpdateGeometry(newProps, currentProps);
+            state.createGeometry = shouldUpdateBlobGeometry(newProps, currentProps);
         }
     }, materialId);
 }

--- a/src/mol-repr/structure/visual/blob-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/blob-surface-mesh.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';

--- a/src/mol-repr/structure/visual/blob-surface-wireframe.ts
+++ b/src/mol-repr/structure/visual/blob-surface-wireframe.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
+ */
+
+import { ParamDefinition as PD } from '../../../mol-util/param-definition';
+import { VisualContext } from '../../visual';
+import { Unit, Structure } from '../../../mol-model/structure';
+import { Theme } from '../../../mol-theme/theme';
+import { Lines } from '../../../mol-geo/geometry/lines/lines';
+import { computeMarchingCubesLines } from '../../../mol-geo/util/marching-cubes/algorithm';
+import { UnitsLinesParams, UnitsVisual, UnitsLinesVisual } from '../units-visual';
+import { ComplexLinesParams, ComplexLinesVisual, ComplexVisual } from '../complex-visual';
+import { ElementIterator, getElementLoci, eachElement, getSerialElementLoci, eachSerialElement } from './util/element';
+import { VisualUpdateState } from '../../util';
+import { BlobDensityParams, computeUnitBlobSurface, computeStructureBlobSurface, shouldUpdateBlobGeometry } from './util/blob-surface';
+import { Sphere3D } from '../../../mol-math/geometry';
+
+const SharedParams = {
+    ...BlobDensityParams,
+    sizeFactor: PD.Numeric(3, { min: 0, max: 10, step: 0.1 }),
+};
+type SharedParams = typeof SharedParams
+
+export const BlobSurfaceWireframeParams = {
+    ...UnitsLinesParams,
+    ...SharedParams,
+};
+export type BlobSurfaceWireframeParams = typeof BlobSurfaceWireframeParams
+
+export const StructureBlobSurfaceWireframeParams = {
+    ...ComplexLinesParams,
+    ...SharedParams,
+};
+export type StructureBlobSurfaceWireframeParams = typeof StructureBlobSurfaceWireframeParams
+
+//
+
+async function createBlobSurfaceWireframe(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: PD.Values<BlobSurfaceWireframeParams>, lines?: Lines): Promise<Lines> {
+    const { smoothness, radiusOffset } = props;
+    const { transform, field, idField, radiusFactor, maxRadius } = await computeUnitBlobSurface(structure, unit, theme.size, props).runInContext(ctx.runtime);
+
+    const isoLevel = Math.exp(-smoothness) / radiusFactor;
+    const wireframe = await computeMarchingCubesLines({ isoLevel, scalarField: field, idField }, lines).runAsChild(ctx.runtime);
+
+    Lines.transform(wireframe, transform);
+
+    const extraRadius = radiusOffset * (1 + Math.exp(-smoothness));
+    const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, maxRadius + extraRadius);
+    wireframe.setBoundingSphere(sphere);
+
+    return wireframe;
+}
+
+export function BlobSurfaceWireframeVisual(materialId: number): UnitsVisual<BlobSurfaceWireframeParams> {
+    return UnitsLinesVisual<BlobSurfaceWireframeParams>({
+        defaultProps: PD.getDefaultValues(BlobSurfaceWireframeParams),
+        createGeometry: createBlobSurfaceWireframe,
+        createLocationIterator: ElementIterator.fromGroup,
+        getLoci: getElementLoci,
+        eachLocation: eachElement,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<BlobSurfaceWireframeParams>, currentProps: PD.Values<BlobSurfaceWireframeParams>) => {
+            state.createGeometry = shouldUpdateBlobGeometry(newProps, currentProps);
+        }
+    }, materialId);
+}
+
+//
+
+async function createStructureBlobSurfaceWireframe(ctx: VisualContext, structure: Structure, theme: Theme, props: PD.Values<StructureBlobSurfaceWireframeParams>, lines?: Lines): Promise<Lines> {
+    const { smoothness, radiusOffset } = props;
+    const { transform, field, idField, radiusFactor, maxRadius } = await computeStructureBlobSurface(structure, theme.size, props).runInContext(ctx.runtime);
+
+    const isoLevel = Math.exp(-smoothness) / radiusFactor;
+    const wireframe = await computeMarchingCubesLines({ isoLevel, scalarField: field, idField }, lines).runAsChild(ctx.runtime);
+
+    Lines.transform(wireframe, transform);
+
+    const extraRadius = radiusOffset * (1 + Math.exp(-smoothness));
+    const sphere = Sphere3D.expand(Sphere3D(), structure.boundary.sphere, maxRadius + extraRadius);
+    wireframe.setBoundingSphere(sphere);
+
+    return wireframe;
+}
+
+export function StructureBlobSurfaceWireframeVisual(materialId: number): ComplexVisual<StructureBlobSurfaceWireframeParams> {
+    return ComplexLinesVisual<StructureBlobSurfaceWireframeParams>({
+        defaultProps: PD.getDefaultValues(StructureBlobSurfaceWireframeParams),
+        createGeometry: createStructureBlobSurfaceWireframe,
+        createLocationIterator: ElementIterator.fromStructure,
+        getLoci: getSerialElementLoci,
+        eachLocation: eachSerialElement,
+        setUpdateState: (state: VisualUpdateState, newProps: PD.Values<StructureBlobSurfaceWireframeParams>, currentProps: PD.Values<StructureBlobSurfaceWireframeParams>) => {
+            state.createGeometry = shouldUpdateBlobGeometry(newProps, currentProps);
+        }
+    }, materialId);
+}

--- a/src/mol-repr/structure/visual/gaussian-density-volume.ts
+++ b/src/mol-repr/structure/visual/gaussian-density-volume.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>

--- a/src/mol-repr/structure/visual/gaussian-density-volume.ts
+++ b/src/mol-repr/structure/visual/gaussian-density-volume.ts
@@ -16,8 +16,9 @@ import { Mat4, Vec3 } from '../../../mol-math/linear-algebra';
 import { eachElement, eachSerialElement, ElementIterator, getElementLoci, getSerialElementLoci } from './util/element';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { UnitsDirectVolumeParams, UnitsVisual, UnitsDirectVolumeVisual } from '../units-visual';
+import { omitObjectKeys } from '../../../mol-util/object';
 
-function createGaussianDensityVolume(ctx: VisualContext, structure: Structure, theme: Theme, props: GaussianDensityProps, directVolume?: DirectVolume): DirectVolume {
+function createGaussianDensityVolume(ctx: VisualContext, structure: Structure, theme: Theme, props: Omit<GaussianDensityProps, 'floodfill'>, directVolume?: DirectVolume): DirectVolume {
     const { webgl } = ctx;
     if (!webgl) {
         // gpu gaussian density also needs blendMinMax but there is no fallback here so
@@ -54,7 +55,7 @@ function createGaussianDensityVolume(ctx: VisualContext, structure: Structure, t
 
 export const GaussianDensityVolumeParams = {
     ...ComplexDirectVolumeParams,
-    ...GaussianDensityParams,
+    ...omitObjectKeys(GaussianDensityParams, ['floodfill']),
     ignoreHydrogens: PD.Boolean(false),
     ignoreHydrogensVariant: PD.Select('all', PD.arrayToOptions(['all', 'non-polar'] as const)),
     includeParent: PD.Boolean(false, { isHidden: true }),
@@ -85,7 +86,7 @@ export function GaussianDensityVolumeVisual(materialId: number): ComplexVisual<G
 
 //
 
-function createUnitsGaussianDensityVolume(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: GaussianDensityProps, directVolume?: DirectVolume): DirectVolume {
+function createUnitsGaussianDensityVolume(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: Omit<GaussianDensityProps, 'floodfill'>, directVolume?: DirectVolume): DirectVolume {
     const { webgl } = ctx;
     if (!webgl) {
         // gpu gaussian density also needs blendMinMax but there is no fallback here so
@@ -121,7 +122,7 @@ function createUnitsGaussianDensityVolume(ctx: VisualContext, unit: Unit, struct
 
 export const UnitsGaussianDensityVolumeParams = {
     ...UnitsDirectVolumeParams,
-    ...GaussianDensityParams,
+    ...omitObjectKeys(GaussianDensityParams, ['floodfill']),
     ignoreHydrogens: PD.Boolean(false),
     ignoreHydrogensVariant: PD.Select('all', PD.arrayToOptions(['all', 'non-polar'] as const)),
     includeParent: PD.Boolean(false, { isHidden: true }),

--- a/src/mol-repr/structure/visual/gaussian-density-volume.ts
+++ b/src/mol-repr/structure/visual/gaussian-density-volume.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';

--- a/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
@@ -51,8 +51,8 @@ export const StructureGaussianSurfaceMeshParams = {
 };
 export type StructureGaussianSurfaceMeshParams = typeof StructureGaussianSurfaceMeshParams
 
-function gpuSupport(webgl: WebGLContext) {
-    return webgl.extensions.colorBufferFloat && webgl.extensions.textureFloat && webgl.extensions.textureFloatLinear && webgl.extensions.blendMinMax && webgl.extensions.drawBuffers;
+function gpuSupport(webgl: WebGLContext): boolean {
+    return !!(webgl.extensions.colorBufferFloat && webgl.extensions.textureFloat && webgl.extensions.textureFloatLinear && webgl.extensions.blendMinMax && webgl.extensions.drawBuffers);
 }
 
 function suitableForGpu(structure: Structure, props: PD.Values<SharedParams>, webgl: WebGLContext) {
@@ -147,7 +147,7 @@ export function GaussianSurfaceMeshVisual(materialId: number): UnitsVisual<Gauss
             }
         },
         mustRecreate: (structureGroup: StructureGroup, props: PD.Values<GaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.tryUseGpu && !!webgl && suitableForGpu(structureGroup.structure, props, webgl);
+            return !props.includeParent && props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(structureGroup.structure, props, webgl);
         },
         processValues: (values: MeshValues, geometry: Mesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;
@@ -225,7 +225,7 @@ export function StructureGaussianSurfaceMeshVisual(materialId: number): ComplexV
             }
         },
         mustRecreate: (structure: Structure, props: PD.Values<StructureGaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.tryUseGpu && !!webgl && suitableForGpu(structure, props, webgl);
+            return !props.includeParent && props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(structure, props, webgl);
         },
         processValues: (values: MeshValues, geometry: Mesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;
@@ -311,7 +311,7 @@ export function GaussianSurfaceTextureMeshVisual(materialId: number): UnitsVisua
             }
         },
         mustRecreate: (structureGroup: StructureGroup, props: PD.Values<GaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.includeParent || props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !suitableForGpu(structureGroup.structure, props, webgl);
+            return props.includeParent || props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(structureGroup.structure, props, webgl);
         },
         processValues: (values: TextureMeshValues, geometry: TextureMesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;
@@ -400,7 +400,7 @@ export function StructureGaussianSurfaceTextureMeshVisual(materialId: number): C
             }
         },
         mustRecreate: (structure: Structure, props: PD.Values<StructureGaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.includeParent || props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !suitableForGpu(structure, props, webgl);
+            return props.includeParent || props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(structure, props, webgl);
         },
         processValues: (values: TextureMeshValues, geometry: TextureMesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;

--- a/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';

--- a/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
+++ b/src/mol-repr/structure/visual/gaussian-surface-mesh.ts
@@ -66,15 +66,19 @@ function suitableForGpu(structure: Structure, props: PD.Values<SharedParams>, we
     return areaCells < maxAreaCells;
 }
 
+function useGpu(structure: Structure, props: PD.Values<SharedParams>, webgl?: WebGLContext): boolean {
+    return !props.includeParent && props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(structure, props, webgl);
+}
+
 export function GaussianSurfaceVisual(materialId: number, structure: Structure, props: PD.Values<GaussianSurfaceMeshParams>, webgl?: WebGLContext) {
-    if (!props.includeParent && props.floodfill === 'off' && props.tryUseGpu && webgl && gpuSupport(webgl) && suitableForGpu(structure, props, webgl)) {
+    if (useGpu(structure, props, webgl)) {
         return GaussianSurfaceTextureMeshVisual(materialId);
     }
     return GaussianSurfaceMeshVisual(materialId);
 }
 
 export function StructureGaussianSurfaceVisual(materialId: number, structure: Structure, props: PD.Values<StructureGaussianSurfaceMeshParams>, webgl?: WebGLContext) {
-    if (!props.includeParent && props.floodfill === 'off' && props.tryUseGpu && webgl && gpuSupport(webgl) && suitableForGpu(structure, props, webgl)) {
+    if (useGpu(structure, props, webgl)) {
         return StructureGaussianSurfaceTextureMeshVisual(materialId);
     }
     return StructureGaussianSurfaceMeshVisual(materialId);
@@ -147,7 +151,7 @@ export function GaussianSurfaceMeshVisual(materialId: number): UnitsVisual<Gauss
             }
         },
         mustRecreate: (structureGroup: StructureGroup, props: PD.Values<GaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return !props.includeParent && props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(structureGroup.structure, props, webgl);
+            return useGpu(structureGroup.structure, props, webgl);
         },
         processValues: (values: MeshValues, geometry: Mesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;
@@ -225,7 +229,7 @@ export function StructureGaussianSurfaceMeshVisual(materialId: number): ComplexV
             }
         },
         mustRecreate: (structure: Structure, props: PD.Values<StructureGaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return !props.includeParent && props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(structure, props, webgl);
+            return useGpu(structure, props, webgl);
         },
         processValues: (values: MeshValues, geometry: Mesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;
@@ -311,7 +315,7 @@ export function GaussianSurfaceTextureMeshVisual(materialId: number): UnitsVisua
             }
         },
         mustRecreate: (structureGroup: StructureGroup, props: PD.Values<GaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.includeParent || props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(structureGroup.structure, props, webgl);
+            return !useGpu(structureGroup.structure, props, webgl);
         },
         processValues: (values: TextureMeshValues, geometry: TextureMesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;
@@ -400,7 +404,7 @@ export function StructureGaussianSurfaceTextureMeshVisual(materialId: number): C
             }
         },
         mustRecreate: (structure: Structure, props: PD.Values<StructureGaussianSurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.includeParent || props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(structure, props, webgl);
+            return !useGpu(structure, props, webgl);
         },
         processValues: (values: TextureMeshValues, geometry: TextureMesh, props: PD.Values<GaussianSurfaceMeshParams>, theme: Theme, webgl?: WebGLContext) => {
             const { resolution, colorTexture } = geometry.meta as GaussianSurfaceMeta;

--- a/src/mol-repr/structure/visual/gaussian-surface-wireframe.ts
+++ b/src/mol-repr/structure/visual/gaussian-surface-wireframe.ts
@@ -22,7 +22,6 @@ import { Tensor } from '../../../mol-math/linear-algebra/tensor';
 const SharedParams = {
     ...GaussianDensityParams,
     sizeFactor: PD.Numeric(3, { min: 0, max: 10, step: 0.1 }),
-    lineSizeAttenuation: PD.Boolean(false),
 };
 type SharedParams = typeof SharedParams
 
@@ -39,10 +38,10 @@ export const StructureGaussianWireframeParams = {
 export type StructureGaussianWireframeParams = typeof StructureGaussianWireframeParams
 
 async function createGaussianWireframe(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: GaussianDensityProps, lines?: Lines): Promise<Lines> {
-    const { smoothness, floodfill } = props;
-    const { transform, field, idField, maxRadius } = await computeUnitGaussianDensity(structure, unit, theme.size, props).runInContext(ctx.runtime);
+    const { smoothness, floodfill, radiusOffset } = props;
+    const { transform, field, idField, maxRadius, radiusFactor } = await computeUnitGaussianDensity(structure, unit, theme.size, props).runInContext(ctx.runtime);
 
-    const isoLevel = Math.exp(-smoothness);
+    const isoLevel = Math.exp(-smoothness) / radiusFactor;
     const params = {
         isoLevel,
         scalarField: floodfill !== 'off' ? Tensor.createFloodfilled(field, isoLevel, floodfill) : field,
@@ -52,7 +51,8 @@ async function createGaussianWireframe(ctx: VisualContext, unit: Unit, structure
 
     Lines.transform(wireframe, transform);
 
-    const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, maxRadius);
+    const extraRadius = radiusOffset * (1 + Math.exp(-smoothness));
+    const sphere = Sphere3D.expand(Sphere3D(), unit.boundary.sphere, maxRadius + extraRadius);
     wireframe.setBoundingSphere(sphere);
 
     return wireframe;
@@ -84,10 +84,10 @@ export function GaussianWireframeVisual(materialId: number): UnitsVisual<Gaussia
 //
 
 async function createStructureGaussianWireframe(ctx: VisualContext, structure: Structure, theme: Theme, props: GaussianDensityProps, lines?: Lines): Promise<Lines> {
-    const { smoothness, floodfill } = props;
-    const { transform, field, idField, maxRadius } = await computeStructureGaussianDensity(structure, theme.size, props).runInContext(ctx.runtime);
+    const { smoothness, floodfill, radiusOffset } = props;
+    const { transform, field, idField, maxRadius, radiusFactor } = await computeStructureGaussianDensity(structure, theme.size, props).runInContext(ctx.runtime);
 
-    const isoLevel = Math.exp(-smoothness);
+    const isoLevel = Math.exp(-smoothness) / radiusFactor;
     const params = {
         isoLevel,
         scalarField: floodfill !== 'off' ? Tensor.createFloodfilled(field, isoLevel, floodfill) : field,
@@ -97,7 +97,8 @@ async function createStructureGaussianWireframe(ctx: VisualContext, structure: S
 
     Lines.transform(wireframe, transform);
 
-    const sphere = Sphere3D.expand(Sphere3D(), structure.boundary.sphere, maxRadius);
+    const extraRadius = radiusOffset * (1 + Math.exp(-smoothness));
+    const sphere = Sphere3D.expand(Sphere3D(), structure.boundary.sphere, maxRadius + extraRadius);
     wireframe.setBoundingSphere(sphere);
 
     return wireframe;

--- a/src/mol-repr/structure/visual/gaussian-surface-wireframe.ts
+++ b/src/mol-repr/structure/visual/gaussian-surface-wireframe.ts
@@ -17,6 +17,7 @@ import { ElementIterator, getElementLoci, eachElement, getSerialElementLoci, eac
 import { VisualUpdateState } from '../../util';
 import { Sphere3D } from '../../../mol-math/geometry';
 import { ComplexLinesParams, ComplexLinesVisual, ComplexVisual } from '../complex-visual';
+import { Tensor } from '../../../mol-math/linear-algebra/tensor';
 
 const SharedParams = {
     ...GaussianDensityParams,
@@ -38,12 +39,13 @@ export const StructureGaussianWireframeParams = {
 export type StructureGaussianWireframeParams = typeof StructureGaussianWireframeParams
 
 async function createGaussianWireframe(ctx: VisualContext, unit: Unit, structure: Structure, theme: Theme, props: GaussianDensityProps, lines?: Lines): Promise<Lines> {
-    const { smoothness } = props;
+    const { smoothness, floodfill } = props;
     const { transform, field, idField, maxRadius } = await computeUnitGaussianDensity(structure, unit, theme.size, props).runInContext(ctx.runtime);
 
+    const isoLevel = Math.exp(-smoothness);
     const params = {
-        isoLevel: Math.exp(-smoothness),
-        scalarField: field,
+        isoLevel,
+        scalarField: floodfill !== 'off' ? Tensor.createFloodfilled(field, isoLevel, floodfill) : field,
         idField
     };
     const wireframe = await computeMarchingCubesLines(params, lines).runAsChild(ctx.runtime);
@@ -82,12 +84,13 @@ export function GaussianWireframeVisual(materialId: number): UnitsVisual<Gaussia
 //
 
 async function createStructureGaussianWireframe(ctx: VisualContext, structure: Structure, theme: Theme, props: GaussianDensityProps, lines?: Lines): Promise<Lines> {
-    const { smoothness } = props;
+    const { smoothness, floodfill } = props;
     const { transform, field, idField, maxRadius } = await computeStructureGaussianDensity(structure, theme.size, props).runInContext(ctx.runtime);
 
+    const isoLevel = Math.exp(-smoothness);
     const params = {
-        isoLevel: Math.exp(-smoothness),
-        scalarField: field,
+        isoLevel,
+        scalarField: floodfill !== 'off' ? Tensor.createFloodfilled(field, isoLevel, floodfill) : field,
         idField
     };
     const wireframe = await computeMarchingCubesLines(params, lines).runAsChild(ctx.runtime);

--- a/src/mol-repr/structure/visual/molecular-surface-wireframe.ts
+++ b/src/mol-repr/structure/visual/molecular-surface-wireframe.ts
@@ -75,6 +75,7 @@ export function MolecularSurfaceWireframeVisual(materialId: number): UnitsVisual
                 newProps.probePositions !== currentProps.probePositions ||
                 newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
                 newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+                newProps.traceOnly !== currentProps.traceOnly ||
                 newProps.includeParent !== currentProps.includeParent ||
                 newProps.floodfill !== currentProps.floodfill
             );
@@ -116,6 +117,7 @@ export function StructureMolecularSurfaceWireframeVisual(materialId: number): Co
                 newProps.probePositions !== currentProps.probePositions ||
                 newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
                 newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+                newProps.traceOnly !== currentProps.traceOnly ||
                 newProps.includeParent !== currentProps.includeParent ||
                 newProps.floodfill !== currentProps.floodfill
             );

--- a/src/mol-repr/structure/visual/util/blob-surface.ts
+++ b/src/mol-repr/structure/visual/util/blob-surface.ts
@@ -40,6 +40,27 @@ export type BlobDensityProps = typeof DefaultBlobDensityProps
 
 export type BlobDensityData = BlobSurfaceData
 
+export function shouldUpdateBlobGeometry(newProps: BlobDensityProps, currentProps: BlobDensityProps) {
+    return (
+        newProps.blobSize !== currentProps.blobSize ||
+        newProps.blobMethod.name !== currentProps.blobMethod.name ||
+        (newProps.blobMethod.name === 'clustering' && currentProps.blobMethod.name === 'clustering' &&
+            newProps.blobMethod.params.iterations !== currentProps.blobMethod.params.iterations) ||
+        newProps.blobShape.name !== currentProps.blobShape.name ||
+        (newProps.blobShape.name === 'sphericalHarmonics' && currentProps.blobShape.name === 'sphericalHarmonics' &&
+            (newProps.blobShape.params.degree !== currentProps.blobShape.params.degree ||
+                newProps.blobShape.params.regularization !== currentProps.blobShape.params.regularization)) ||
+        newProps.resolution !== currentProps.resolution ||
+        newProps.adjustResolution !== currentProps.adjustResolution ||
+        newProps.radiusOffset !== currentProps.radiusOffset ||
+        newProps.smoothness !== currentProps.smoothness ||
+        newProps.ignoreHydrogens !== currentProps.ignoreHydrogens ||
+        newProps.ignoreHydrogensVariant !== currentProps.ignoreHydrogensVariant ||
+        newProps.traceOnly !== currentProps.traceOnly ||
+        newProps.includeParent !== currentProps.includeParent
+    );
+}
+
 /**
  * Reference feature radius (~vdW/atomic radius) that the incoming quality `resolution` is
  * calibrated to resolve (see `getQualityProps`).

--- a/src/mol-repr/structure/visual/util/blob-surface.ts
+++ b/src/mol-repr/structure/visual/util/blob-surface.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { Unit, Structure } from '../../../../mol-model/structure';

--- a/src/mol-repr/structure/visual/util/blob-surface.ts
+++ b/src/mol-repr/structure/visual/util/blob-surface.ts
@@ -5,7 +5,7 @@
  */
 
 import { Unit, Structure } from '../../../../mol-model/structure';
-import { Task } from '../../../../mol-task';
+import { RuntimeContext, Task } from '../../../../mol-task';
 import { ParamDefinition as PD } from '../../../../mol-util/param-definition';
 import { getUnitConformationAndRadius, getStructureConformationAndRadius, CommonSurfaceParams, ensureReasonableResolution } from './common';
 import { computeBlobSurface, BlobSurfaceData } from '../../../../mol-math/geometry/blob-surface';
@@ -83,7 +83,7 @@ const BlobResolutionScale = 0.5;
 /** Hard ceiling on the adjusted resolution (also re-guarded by box size in `ensureReasonableResolution`). */
 const BlobMaxResolution = 20;
 
-function getBlobDensityData(position: PositionData, boundary: Boundary, radius: (index: number) => number, props: BlobDensityProps): BlobDensityData {
+async function getBlobDensityData(ctx: RuntimeContext, position: PositionData, boundary: Boundary, radius: (index: number) => number, props: BlobDensityProps): Promise<BlobDensityData> {
     const { blobSize, blobMethod, blobShape, radiusOffset, smoothness, adjustResolution } = props;
     const p = ensureReasonableResolution(boundary.box, props);
 
@@ -111,7 +111,7 @@ function getBlobDensityData(position: PositionData, boundary: Boundary, radius: 
         resolution = Math.min(Math.max(p.resolution * (featureRadius / BlobReferenceRadius) * methodFactor * BlobResolutionScale, p.resolution), BlobMaxResolution);
     }
 
-    return computeBlobSurface(position, boundary, radius, {
+    return computeBlobSurface(ctx, position, boundary, radius, {
         blobSize,
         method: blobMethod.name,
         clusterIterations: blobMethod.name === 'clustering' ? blobMethod.params.iterations : 0,
@@ -126,14 +126,14 @@ function getBlobDensityData(position: PositionData, boundary: Boundary, radius: 
 
 export function computeUnitBlobSurface(structure: Structure, unit: Unit, sizeTheme: SizeTheme<any>, props: BlobDensityProps) {
     const { position, boundary, radius } = getUnitConformationAndRadius(structure, unit, sizeTheme, props);
-    return Task.create('Blob Surface', async () => {
-        return getBlobDensityData(position, boundary, radius, props);
+    return Task.create('Blob Surface', async ctx => {
+        return await getBlobDensityData(ctx, position, boundary, radius, props);
     });
 }
 
 export function computeStructureBlobSurface(structure: Structure, sizeTheme: SizeTheme<any>, props: BlobDensityProps) {
     const { position, boundary, radius } = getStructureConformationAndRadius(structure, sizeTheme, props);
-    return Task.create('Blob Surface', async () => {
-        return getBlobDensityData(position, boundary, radius, props);
+    return Task.create('Blob Surface', async ctx => {
+        return await getBlobDensityData(ctx, position, boundary, radius, props);
     });
 }

--- a/src/mol-repr/structure/visual/util/gaussian.ts
+++ b/src/mol-repr/structure/visual/util/gaussian.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>

--- a/src/mol-repr/structure/visual/util/gaussian.ts
+++ b/src/mol-repr/structure/visual/util/gaussian.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { Unit, Structure } from '../../../../mol-model/structure';

--- a/src/mol-repr/structure/visual/util/gaussian.ts
+++ b/src/mol-repr/structure/visual/util/gaussian.ts
@@ -42,7 +42,7 @@ export function computeUnitGaussianDensity(structure: Structure, unit: Unit, siz
     });
 }
 
-export function computeUnitGaussianDensityTexture(structure: Structure, unit: Unit, sizeTheme: SizeTheme<any>, props: GaussianDensityProps, webgl: WebGLContext, texture?: Texture) {
+export function computeUnitGaussianDensityTexture(structure: Structure, unit: Unit, sizeTheme: SizeTheme<any>, props: Omit<GaussianDensityProps, 'floodfill'>, webgl: WebGLContext, texture?: Texture) {
     const { position, boundary, radius } = getUnitConformationAndRadius(structure, unit, sizeTheme, props);
     const p = ensureReasonableResolution(boundary.box, props, getTextureMaxCells(webgl, structure));
     return GaussianDensityTexture(webgl, position, boundary.box, radius, p, texture);
@@ -64,7 +64,7 @@ export function computeStructureGaussianDensity(structure: Structure, sizeTheme:
     });
 }
 
-export function computeStructureGaussianDensityTexture(structure: Structure, sizeTheme: SizeTheme<any>, props: GaussianDensityProps, webgl: WebGLContext, texture?: Texture) {
+export function computeStructureGaussianDensityTexture(structure: Structure, sizeTheme: SizeTheme<any>, props: Omit<GaussianDensityProps, 'floodfill'>, webgl: WebGLContext, texture?: Texture) {
     const { position, boundary, radius } = getStructureConformationAndRadius(structure, sizeTheme, props);
     const p = ensureReasonableResolution(boundary.box, props);
     return GaussianDensityTexture(webgl, position, boundary.box, radius, p, texture);

--- a/src/mol-repr/volume/isosurface.ts
+++ b/src/mol-repr/volume/isosurface.ts
@@ -47,8 +47,8 @@ export const VolumeIsosurfaceTextureParams = {
 export type VolumeIsosurfaceTextureParams = typeof VolumeIsosurfaceTextureParams
 export type VolumeIsosurfaceTextureProps = PD.Values<VolumeIsosurfaceTextureParams>
 
-function gpuSupport(webgl: WebGLContext) {
-    return webgl.extensions.colorBufferFloat && webgl.extensions.textureFloat && webgl.extensions.drawBuffers;
+function gpuSupport(webgl: WebGLContext): boolean {
+    return !!(webgl.extensions.colorBufferFloat && webgl.extensions.textureFloat && webgl.extensions.drawBuffers);
 }
 
 function shouldWrap(volume: Volume, wrap: VolumeIsosurfaceProps['wrap']) {
@@ -166,7 +166,7 @@ export function IsosurfaceMeshVisual(materialId: number): VolumeVisual<Isosurfac
         },
         geometryUtils: Mesh.Utils,
         mustRecreate: (volumekey: VolumeKey, props: PD.Values<IsosurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.tryUseGpu && !!webgl && suitableForGpu(volumekey.volume, webgl);
+            return props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(volumekey.volume, webgl);
         }
     }, materialId);
 }
@@ -281,7 +281,7 @@ export function IsosurfaceTextureMeshVisual(materialId: number): VolumeVisual<Is
         },
         geometryUtils: TextureMesh.Utils,
         mustRecreate: (volumeKey: VolumeKey, props: PD.Values<IsosurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !suitableForGpu(volumeKey.volume, webgl);
+            return props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(volumeKey.volume, webgl);
         },
         dispose: (geometry: TextureMesh) => {
             geometry.vertexTexture.ref.value.destroy();

--- a/src/mol-repr/volume/isosurface.ts
+++ b/src/mol-repr/volume/isosurface.ts
@@ -69,8 +69,12 @@ function suitableForGpu(volume: Volume, webgl: WebGLContext) {
     return powerOfTwoSize <= webgl.maxTextureSize / 2;
 }
 
+function useGpu(volume: Volume, props: PD.Values<IsosurfaceMeshParams>, webgl?: WebGLContext): boolean {
+    return props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(volume, webgl);
+}
+
 export function IsosurfaceVisual(materialId: number, volume: Volume, key: number, props: PD.Values<IsosurfaceMeshParams>, webgl?: WebGLContext) {
-    if (props.floodfill === 'off' && props.tryUseGpu && webgl && gpuSupport(webgl) && suitableForGpu(volume, webgl)) {
+    if (useGpu(volume, props, webgl)) {
         return IsosurfaceTextureMeshVisual(materialId);
     }
     return IsosurfaceMeshVisual(materialId);
@@ -166,7 +170,7 @@ export function IsosurfaceMeshVisual(materialId: number): VolumeVisual<Isosurfac
         },
         geometryUtils: Mesh.Utils,
         mustRecreate: (volumekey: VolumeKey, props: PD.Values<IsosurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.floodfill === 'off' && props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(volumekey.volume, webgl);
+            return useGpu(volumekey.volume, props, webgl);
         }
     }, materialId);
 }
@@ -281,7 +285,7 @@ export function IsosurfaceTextureMeshVisual(materialId: number): VolumeVisual<Is
         },
         geometryUtils: TextureMesh.Utils,
         mustRecreate: (volumeKey: VolumeKey, props: PD.Values<IsosurfaceMeshParams>, webgl?: WebGLContext) => {
-            return props.floodfill !== 'off' || !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(volumeKey.volume, webgl);
+            return !useGpu(volumeKey.volume, props, webgl);
         },
         dispose: (geometry: TextureMesh) => {
             geometry.vertexTexture.ref.value.destroy();

--- a/src/mol-repr/volume/isosurface.ts
+++ b/src/mol-repr/volume/isosurface.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../../mol-util/param-definition';

--- a/src/mol-repr/volume/segment.ts
+++ b/src/mol-repr/volume/segment.ts
@@ -42,8 +42,8 @@ export const VolumeSegmentParams = {
 export type VolumeSegmentParams = typeof VolumeSegmentParams
 export type VolumeSegmentProps = PD.Values<VolumeSegmentParams>
 
-function gpuSupport(webgl: WebGLContext) {
-    return webgl.extensions.colorBufferFloat && webgl.extensions.textureFloat && webgl.extensions.drawBuffers;
+function gpuSupport(webgl: WebGLContext): boolean {
+    return !!(webgl.extensions.colorBufferFloat && webgl.extensions.textureFloat && webgl.extensions.drawBuffers);
 }
 
 const Padding = 1;
@@ -203,7 +203,7 @@ export function SegmentMeshVisual(materialId: number): VolumeVisual<SegmentMeshP
         },
         geometryUtils: Mesh.Utils,
         mustRecreate: (volumeKey: VolumeKey, props: PD.Values<SegmentMeshParams>, webgl?: WebGLContext) => {
-            return props.tryUseGpu && !!webgl && suitableForGpu(volumeKey.volume, webgl);
+            return props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(volumeKey.volume, webgl);
         }
     }, materialId);
 }
@@ -292,7 +292,7 @@ export function SegmentTextureMeshVisual(materialId: number): VolumeVisual<Segme
         },
         geometryUtils: TextureMesh.Utils,
         mustRecreate: (volumeKey: VolumeKey, props: PD.Values<SegmentMeshParams>, webgl?: WebGLContext) => {
-            return !props.tryUseGpu || !webgl || !suitableForGpu(volumeKey.volume, webgl);
+            return !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(volumeKey.volume, webgl);
         },
         dispose: (geometry: TextureMesh) => {
             geometry.vertexTexture.ref.value.destroy();

--- a/src/mol-repr/volume/segment.ts
+++ b/src/mol-repr/volume/segment.ts
@@ -65,8 +65,12 @@ function getSegmentTransform(grid: Grid, segmentBox: Box3D) {
     return Mat4.mul(Mat4(), transform, translate);
 }
 
+function useGpu(volume: Volume, props: PD.Values<SegmentMeshParams>, webgl?: WebGLContext): boolean {
+    return props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(volume, webgl);
+}
+
 export function SegmentVisual(materialId: number, volume: Volume, key: number, props: PD.Values<SegmentMeshParams>, webgl?: WebGLContext) {
-    if (props.tryUseGpu && webgl && gpuSupport(webgl) && suitableForGpu(volume, webgl)) {
+    if (useGpu(volume, props, webgl)) {
         return SegmentTextureMeshVisual(materialId);
     }
     return SegmentMeshVisual(materialId);
@@ -203,7 +207,7 @@ export function SegmentMeshVisual(materialId: number): VolumeVisual<SegmentMeshP
         },
         geometryUtils: Mesh.Utils,
         mustRecreate: (volumeKey: VolumeKey, props: PD.Values<SegmentMeshParams>, webgl?: WebGLContext) => {
-            return props.tryUseGpu && !!webgl && gpuSupport(webgl) && suitableForGpu(volumeKey.volume, webgl);
+            return useGpu(volumeKey.volume, props, webgl);
         }
     }, materialId);
 }
@@ -292,7 +296,7 @@ export function SegmentTextureMeshVisual(materialId: number): VolumeVisual<Segme
         },
         geometryUtils: TextureMesh.Utils,
         mustRecreate: (volumeKey: VolumeKey, props: PD.Values<SegmentMeshParams>, webgl?: WebGLContext) => {
-            return !props.tryUseGpu || !webgl || !gpuSupport(webgl) || !suitableForGpu(volumeKey.volume, webgl);
+            return !useGpu(volumeKey.volume, props, webgl);
         },
         dispose: (geometry: TextureMesh) => {
             geometry.vertexTexture.ref.value.destroy();

--- a/src/mol-repr/volume/segment.ts
+++ b/src/mol-repr/volume/segment.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2022-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Gianluca Tomasello <giagitom@gmail.com>
  */
 
 import { ParamDefinition as PD } from '../../mol-util/param-definition';


### PR DESCRIPTION
Eight fixes to the surface representations, found while tracking down a `traceOnly` bug in the molecular surface wireframe. Each commit stands alone.

**Bugs**

- `traceOnly` was ignored by both molecular surface **wireframe** visuals: it was missing from `setUpdateState`, so toggling it never invalidated the geometry and the surface kept using every atom. The mesh visuals and both gaussian wireframes already had the check.
- `floodfill` was exposed on the gaussian surface **wireframe**, and rebuilt the geometry when changed, but was never applied — the file did not even import `Tensor`.
- The CPU surface/volume visuals' `mustRecreate` checked fewer conditions than the dispatcher that selects between the GPU and CPU visual. Whenever a missing condition held, `mustRecreate` returned true, the visual was destroyed, and the dispatcher handed back the *same* CPU visual — a full re-march on every update, with the render object recreated and marker state lost. Reachable through `includeParent`, `floodfill`, or simply a context without `OES_texture_float_linear` (not core in WebGL2), where the default gaussian path was permanently in this state. `volume/segment.ts` was worst: every segment mesh re-marched together.
- The blob surface density never yielded — `Task.create` accepted a `RuntimeContext` and discarded it, so it blocked the main thread with no progress and could not be cancelled.

**Cleanups**

- `floodfill` removed from the gaussian density volume, where it was exposed but meaningless: that visual renders a `DirectVolume` from a GPU texture, so there is no scalar field to fill and no iso threshold to fill against.
- The GPU/CPU choice is now one `useGpu` predicate per file, used by the dispatcher and both `mustRecreate` bodies, replacing twelve hand-maintained copies. This is why the drift above was possible twice.

**Feature**

- `blob-surface-wireframe` / `structure-blob-surface-wireframe`, so the blob surface can be drawn as a wireframe like the other two. The blob density already produced everything `Lines` needs; the shared 13-field geometry predicate moved to `util/blob-surface.ts` rather than being duplicated.

Verified with `tsc --noEmit` and `eslint` clean at every commit.
