### PR TITLE
Viewer app: keep track of viewer instances in global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
-- Viewer app: keep track of viewer instances in global
+- Viewer app: keep track of instances in static `Viewer.instances`
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files
 - Added element symbol detection in lammps data file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Viewer app: keep track of viewer instances in global
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files
 - Added element symbol detection in lammps data file

--- a/src/apps/viewer/app.ts
+++ b/src/apps/viewer/app.ts
@@ -32,16 +32,16 @@ export { consoleStats, isDebugMode, isProductionMode, isTimingMode, setDebugMode
 // TODO: consider removing these in v6.0
 export type { LoadStructureOptions, LoadTrajectoryParams, VolumeIsovalueInfo } from '../../extensions/plugin/loaders';
 
-export const viewerInstances: Viewer[] = [];
-
 export class Viewer {
     private _events = new PluginComponent();
     public readonly plugin: PluginUIContext;
 
     constructor(plugin: PluginUIContext) {
         this.plugin = plugin;
-        viewerInstances.push(this);
+        Viewer.instances.push(this);
     }
+
+    static readonly instances: Viewer[] = [];
 
     static async create(elementOrId: string | HTMLElement, options: Partial<ViewerOptions> = {}) {
         const spec = createViewerSpec(options);
@@ -221,6 +221,6 @@ export class Viewer {
     dispose() {
         this._events.dispose();
         this.plugin.dispose();
-        viewerInstances.splice(viewerInstances.indexOf(this), 1);
+        Viewer.instances.splice(Viewer.instances.indexOf(this), 1);
     }
 }

--- a/src/apps/viewer/app.ts
+++ b/src/apps/viewer/app.ts
@@ -32,12 +32,15 @@ export { consoleStats, isDebugMode, isProductionMode, isTimingMode, setDebugMode
 // TODO: consider removing these in v6.0
 export type { LoadStructureOptions, LoadTrajectoryParams, VolumeIsovalueInfo } from '../../extensions/plugin/loaders';
 
+export const viewerInstances: Viewer[] = [];
+
 export class Viewer {
     private _events = new PluginComponent();
     public readonly plugin: PluginUIContext;
 
     constructor(plugin: PluginUIContext) {
         this.plugin = plugin;
+        viewerInstances.push(this);
     }
 
     static async create(elementOrId: string | HTMLElement, options: Partial<ViewerOptions> = {}) {
@@ -218,5 +221,6 @@ export class Viewer {
     dispose() {
         this._events.dispose();
         this.plugin.dispose();
+        viewerInstances.splice(viewerInstances.indexOf(this), 1);
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Useful to have the viewer instances as a global sometimes

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`