### PR TITLE
Fix missing reset time for `Canvas3dInteractionHelper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix missing reset time for `Canvas3dInteractionHelper`
 - Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files
 - Added element symbol detection in lammps data file

--- a/src/mol-canvas3d/canvas3d.ts
+++ b/src/mol-canvas3d/canvas3d.ts
@@ -819,11 +819,14 @@ namespace Canvas3D {
         function resetTime(t: now.Timestamp) {
             startTime = t;
             controls.start(t);
+            interactionHelper.resetTime(t);
         }
 
         function animate() {
             drawPaused = false;
-            controls.start(now());
+            const t = now();
+            controls.start(t);
+            interactionHelper.resetTime(t);
             if (animationFrameHandle === 0) _animate(0);
         }
 

--- a/src/mol-canvas3d/helper/interaction-events.ts
+++ b/src/mol-canvas3d/helper/interaction-events.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -209,6 +209,10 @@ export class Canvas3dInteractionHelper {
             }
         }
         return { repr, loci };
+    }
+
+    resetTime(t: number) {
+        this.prevT = t;
     }
 
     dispose() {


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Without a time reset the Canvas3dInteractionHelper can break when pause/resume animation - never handle drag/move

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`