### PR TITLE
Optimize instance-grid & lookup3d grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Optimize `GridLookup3D` building for sparse grids
 - Viewer app: keep track of instances in static `Viewer.instances`
 - Fix missing reset time for `Canvas3dInteractionHelper`
 - Fix the blob surface density blocking the main thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note that since we don't clearly distinguish between a public and private interf
 
 ## [Unreleased]
 - Optimize `GridLookup3D` building for sparse grids
+- Optimize `calcInstanceGrid` by reducing amount of data copied
 - Viewer app: keep track of instances in static `Viewer.instances`
 - Fix missing reset time for `Canvas3dInteractionHelper`
 - Fix the blob surface density blocking the main thread

--- a/src/mol-data/util/_spec/sort.spec.ts
+++ b/src/mol-data/util/_spec/sort.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { radixSort } from '../sort';
+
+function randomUints(n: number, max: number) {
+    const data = new Uint32Array(n);
+    for (let i = 0; i < n; i++) data[i] = Math.floor(Math.random() * max);
+    return data;
+}
+
+function expectSorted(data: ArrayLike<number>, reference: number[]) {
+    expect(Array.from(data)).toEqual(reference.slice().sort((a, b) => a - b));
+}
+
+describe('radixSortUint', () => {
+    it('sorts random values like a comparison sort', () => {
+        const data = randomUints(1000, 2 ** 24);
+        const reference = Array.from(data);
+        expect(radixSort(data)).toBe(data);
+        expectSorted(data, reference);
+    });
+
+    it('handles empty and single-element arrays', () => {
+        expect(Array.from(radixSort(new Int32Array(0)))).toEqual([]);
+        expect(Array.from(radixSort(Int32Array.of(42)))).toEqual([42]);
+    });
+
+    it('handles duplicates and zeros', () => {
+        const data = Int32Array.of(5, 0, 3, 5, 0, 3, 3, 0);
+        radixSort(data);
+        expect(Array.from(data)).toEqual([0, 0, 0, 3, 3, 3, 5, 5]);
+    });
+
+    it('handles already sorted and reversed input', () => {
+        const asc = Int32Array.of(1, 2, 3, 4, 5);
+        expect(Array.from(radixSort(asc))).toEqual([1, 2, 3, 4, 5]);
+        const desc = Int32Array.of(5, 4, 3, 2, 1);
+        expect(Array.from(radixSort(desc))).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('supports the full Uint32Array range', () => {
+        const data = Uint32Array.of(4294967295, 0, 2147483648, 1, 2147483647);
+        radixSort(data);
+        expect(Array.from(data)).toEqual([0, 1, 2147483647, 2147483648, 4294967295]);
+    });
+
+    it('respects an explicit maxValue', () => {
+        const data = randomUints(500, 255);
+        const reference = Array.from(data);
+        radixSort(data, 255);
+        expectSorted(data, reference);
+    });
+
+    it('sorts only the given subarray view', () => {
+        const data = Int32Array.of(9, 8, 3, 1, 2, 7, 6);
+        radixSort(data.subarray(2, 5));
+        expect(Array.from(data)).toEqual([9, 8, 1, 2, 3, 7, 6]);
+    });
+
+    it('works with an even and odd number of passes', () => {
+        // 1 pass (max < 2^8), 2 passes (< 2^16), 3 passes (< 2^24), 4 passes (< 2^32)
+        for (const max of [2 ** 8, 2 ** 16, 2 ** 24, 2 ** 32]) {
+            const data = randomUints(300, max);
+            const reference = Array.from(data);
+            radixSort(data);
+            expectSorted(data, reference);
+        }
+    });
+});

--- a/src/mol-data/util/sort.ts
+++ b/src/mol-data/util/sort.ts
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2017 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2017-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 export type Comparer<T = any> = (data: T, i: number, j: number) => number
@@ -155,5 +156,42 @@ export function sortArrayRange(data: ArrayLike<number>, start: number, end: numb
 export function sort<T>(data: T, start: number, end: number, cmp: Comparer<T>, swap: Swapper<T>): T {
     const ctx: Ctx = { data, cmp, swap, parts: [0, 0] };
     quickSort(ctx, start, end - 1);
+    return data;
+}
+
+const _radixCounts = new Uint32Array(257);
+
+/**
+ * In-place LSD radix sort (8-bit digits) for non-negative integers, ascending.
+ * `maxValue` is an inclusive upper bound of the values and determines the number
+ * of passes; it is computed from the data when omitted.
+ *
+ * Typically outperforms comparison sorts, at the cost of a scratch
+ * array allocation of the same size as the input.
+ */
+export function radixSort<T extends Int32Array | Uint32Array>(data: T, maxValue?: number): T {
+    const n = data.length;
+    if (n < 2) return data;
+
+    let max = maxValue;
+    if (max === undefined) {
+        max = 0;
+        for (let i = 0; i < n; i++) {
+            if (data[i] > max) max = data[i];
+        }
+    }
+
+    const counts = _radixCounts;
+    let a: Int32Array | Uint32Array = data;
+    let b: Int32Array | Uint32Array = new (data.constructor as new (n: number) => T)(n);
+    for (let shift = 0; shift < 32 && (max >>> shift) > 0; shift += 8) {
+        counts.fill(0);
+        for (let i = 0; i < n; i++) counts[((a[i] >>> shift) & 0xff) + 1]++;
+        for (let i = 0; i < 256; i++) counts[i + 1] += counts[i];
+        for (let i = 0; i < n; i++) b[counts[(a[i] >>> shift) & 0xff]++] = a[i];
+        const t = a; a = b; b = t;
+    }
+    // odd number of passes ends in the scratch array
+    if (a !== data) data.set(a);
     return data;
 }

--- a/src/mol-math/geometry/_spec/instance-grid.spec.ts
+++ b/src/mol-math/geometry/_spec/instance-grid.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import { Mat4 } from '../../linear-algebra/3d/mat4';
+import { Vec3 } from '../../linear-algebra/3d/vec3';
+import { Sphere3D } from '../primitives/sphere3d';
+import { calcInstanceGrid, createEmptyInstanceGrid, InstanceData, InstanceGrid } from '../instance-grid';
+import { fillSerial } from '../../../mol-util/array';
+
+function createInstanceData(positions: Vec3[], radius = 1): InstanceData {
+    const instanceCount = positions.length;
+    const transform = new Float32Array(instanceCount * 16);
+    const m = Mat4();
+    for (let i = 0; i < instanceCount; ++i) {
+        Mat4.fromTranslation(m, positions[i]);
+        transform.set(m, i * 16);
+    }
+    return {
+        instanceCount,
+        instance: fillSerial(new Float32Array(instanceCount)),
+        transform,
+        invariantBoundingSphere: Sphere3D.create(Vec3.create(0, 0, 0), radius),
+    };
+}
+
+function checkInvariants(grid: InstanceGrid, data: InstanceData) {
+    const { instanceCount, transform } = data;
+
+    // offsets are monotonic and cover all instances
+    expect(grid.cellOffsets.length).toBe(grid.cellCount + 1);
+    expect(grid.cellOffsets[0]).toBe(0);
+    for (let i = 0; i < grid.cellCount; ++i) {
+        expect(grid.cellOffsets[i + 1]).toBeGreaterThan(grid.cellOffsets[i]);
+    }
+    expect(grid.cellOffsets[grid.cellCount]).toBe(instanceCount);
+
+    // every instance appears exactly once
+    const seen = new Set<number>();
+    for (let i = 0; i < instanceCount; ++i) seen.add(grid.cellInstance[i]);
+    expect(seen.size).toBe(instanceCount);
+
+    // cellTransform is the original transform of each instance, in cell order
+    for (let i = 0; i < instanceCount; ++i) {
+        const id = grid.cellInstance[i];
+        for (let k = 0; k < 16; ++k) {
+            expect(grid.cellTransform[i * 16 + k]).toBe(transform[id * 16 + k]);
+        }
+    }
+
+    // every instance center is contained in the sphere of its cell
+    const { center, radius } = data.invariantBoundingSphere;
+    const p = Vec3();
+    for (let c = 0; c < grid.cellCount; ++c) {
+        for (let i = grid.cellOffsets[c], il = grid.cellOffsets[c + 1]; i < il; ++i) {
+            Vec3.transformMat4Offset(p, center, grid.cellTransform as unknown as number[], 0, 0, i * 16);
+            const dx = p[0] - grid.cellSpheres[c * 4];
+            const dy = p[1] - grid.cellSpheres[c * 4 + 1];
+            const dz = p[2] - grid.cellSpheres[c * 4 + 2];
+            const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            expect(dist).toBeLessThanOrEqual(grid.cellSpheres[c * 4 + 3] + 1e-4);
+        }
+    }
+
+    // batches partition the cells; after reorder batchCell is serial
+    expect(grid.batchOffsets.length).toBe(grid.batchCount + 1);
+    expect(grid.batchOffsets[0]).toBe(0);
+    expect(grid.batchOffsets[grid.batchCount]).toBe(grid.cellCount);
+    expect(Array.from(grid.batchCell)).toEqual(Array.from(fillSerial(new Uint32Array(grid.cellCount))));
+
+    // every cell sphere is contained in the sphere of its batch
+    for (let b = 0; b < grid.batchCount; ++b) {
+        for (let c = grid.batchOffsets[b], cl = grid.batchOffsets[b + 1]; c < cl; ++c) {
+            const dx = grid.cellSpheres[c * 4] - grid.batchSpheres[b * 4];
+            const dy = grid.cellSpheres[c * 4 + 1] - grid.batchSpheres[b * 4 + 1];
+            const dz = grid.cellSpheres[c * 4 + 2] - grid.batchSpheres[b * 4 + 2];
+            const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+            expect(dist).toBeLessThanOrEqual(grid.batchSpheres[b * 4 + 3] + 1e-4);
+        }
+    }
+
+    // radius must be accounted for in cell spheres
+    for (let c = 0; c < grid.cellCount; ++c) {
+        expect(grid.cellSpheres[c * 4 + 3]).toBeGreaterThanOrEqual(radius - 1e-4);
+    }
+}
+
+describe('instance-grid', () => {
+    it('createEmptyInstanceGrid', () => {
+        const grid = createEmptyInstanceGrid();
+        expect(grid.cellCount).toBe(0);
+        expect(grid.batchCount).toBe(0);
+        expect(grid.cellOffsets.length).toBe(0);
+    });
+
+    it('single instance', () => {
+        const data = createInstanceData([Vec3.create(1, 2, 3)]);
+        const grid = calcInstanceGrid(data, 10, 100);
+
+        expect(grid.cellCount).toBe(1);
+        expect(grid.batchCount).toBe(1);
+        checkInvariants(grid, data);
+
+        // the cell sphere is the transformed invariant sphere
+        expect(grid.cellSpheres[0]).toBeCloseTo(1);
+        expect(grid.cellSpheres[1]).toBeCloseTo(2);
+        expect(grid.cellSpheres[2]).toBeCloseTo(3);
+        expect(grid.cellSpheres[3]).toBeCloseTo(1);
+    });
+
+    it('two clusters far apart get separate cells', () => {
+        const data = createInstanceData([
+            Vec3.create(0, 0, 0), Vec3.create(1, 0, 0),
+            Vec3.create(100, 0, 0), Vec3.create(101, 0, 0),
+        ]);
+        const grid = calcInstanceGrid(data, 10, 1000);
+
+        expect(grid.cellCount).toBeGreaterThanOrEqual(2);
+        checkInvariants(grid, data);
+
+        // instances of the same cluster share a cell
+        const cellOf = new Map<number, number>();
+        for (let c = 0; c < grid.cellCount; ++c) {
+            for (let i = grid.cellOffsets[c], il = grid.cellOffsets[c + 1]; i < il; ++i) {
+                cellOf.set(grid.cellInstance[i], c);
+            }
+        }
+        expect(cellOf.get(0)).toBe(cellOf.get(1));
+        expect(cellOf.get(2)).toBe(cellOf.get(3));
+        expect(cellOf.get(0)).not.toBe(cellOf.get(2));
+    });
+
+    it('many random instances keep invariants', () => {
+        // deterministic LCG so the test is reproducible
+        let seed = 7;
+        const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+
+        const positions: Vec3[] = [];
+        for (let i = 0; i < 500; ++i) {
+            positions.push(Vec3.create(rand() * 200, rand() * 200, rand() * 200));
+        }
+        const data = createInstanceData(positions, 2);
+        const grid = calcInstanceGrid(data, 25, 100);
+
+        expect(grid.cellCount).toBeGreaterThan(1);
+        expect(grid.batchCount).toBeGreaterThan(1);
+        checkInvariants(grid, data);
+    });
+});

--- a/src/mol-math/geometry/_spec/lookup3d.spec.ts
+++ b/src/mol-math/geometry/_spec/lookup3d.spec.ts
@@ -1,13 +1,15 @@
 /**
- * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
 
 import { GridLookup3D } from '../../geometry';
 import { sortArray } from '../../../mol-data/util/sort';
 import { OrderedSet } from '../../../mol-data/int/ordered-set';
+import { Vec3 } from '../../linear-algebra/3d/vec3';
 import { getBoundary } from '../boundary';
 
 const xs = [0, 0, 1];
@@ -78,5 +80,113 @@ describe('GridLookup3d', () => {
         r = grid.nearest(0, 0, 0, 3);
         expect(r.count).toBe(1);
         expect(sortArray(r.indices)).toEqual([0]);
+    });
+
+    it('sorted-array indices', () => {
+        const position = { x: xs, y: ys, z: zs, indices: OrderedSet.ofSortedArray([0, 2]), radius: rs };
+        const boundary = getBoundary(position);
+        const grid = GridLookup3D(position, boundary);
+
+        let r = grid.find(0, 0, 0, 0);
+        expect(r.count).toBe(1);
+        expect(r.indices[0]).toBe(0);
+
+        // element 1 (y = 1) is excluded, so within radius 1 only elements 0 and 2 are found
+        r = grid.find(0, 0, 0, 1);
+        expect(r.count).toBe(2);
+        expect(sortArray(r.indices)).toEqual([0, 1]);
+
+        r = grid.nearest(0, 0, 0, 2);
+        expect(r.count).toBe(2);
+        expect(sortArray(r.indices)).toEqual([0, 1]);
+    });
+
+    it('check', () => {
+        const position = { x: xs, y: ys, z: zs, indices: OrderedSet.ofBounds(0, 3) };
+        const boundary = getBoundary(position);
+        const grid = GridLookup3D(position, boundary);
+
+        expect(grid.check(0, 0, 0, 0.5)).toBe(true);
+        expect(grid.check(5, 5, 5, 0.5)).toBe(false);
+    });
+
+    it('approxNearest', () => {
+        const position = { x: xs, y: ys, z: zs, indices: OrderedSet.ofBounds(0, 3) };
+        const boundary = getBoundary(position);
+        const grid = GridLookup3D(position, boundary);
+
+        let r = grid.approxNearest(0, 0, 0, 0.5);
+        expect(r.count).toBe(1);
+        expect(r.indices[0]).toBe(0);
+
+        r = grid.approxNearest(5, 5, 5, 0.5);
+        expect(r.count).toBe(0);
+    });
+
+    it('empty', () => {
+        const position = { x: [] as number[], y: [] as number[], z: [] as number[], indices: OrderedSet.ofBounds(0, 0) };
+        const boundary = getBoundary(position);
+        const grid = GridLookup3D(position, boundary);
+
+        expect(grid.find(0, 0, 0, 1).count).toBe(0);
+        expect(grid.nearest(0, 0, 0, 1).count).toBe(0);
+        expect(grid.check(0, 0, 0, 1)).toBe(false);
+    });
+
+    it('nearest from outside the boundary', () => {
+        const position = { x: xs, y: ys, z: zs, indices: OrderedSet.ofBounds(0, 3) };
+        const boundary = getBoundary(position);
+        const grid = GridLookup3D(position, boundary);
+
+        const r = grid.nearest(50, 50, 50, 1);
+        expect(r.count).toBe(1);
+        // element 1 (0,1,0) and element 2 (1,0,0) are equidistant candidates; (0,1,0) wins on distance ties by heap order
+        expect(r.squaredDistances[0]).toBeCloseTo(Math.min(
+            (50 - 0) ** 2 + (50 - 1) ** 2 + 50 ** 2,
+            (50 - 1) ** 2 + 50 ** 2 + 50 ** 2,
+        ));
+    });
+
+    it('nearest with stopIf', () => {
+        const position = { x: xs, y: ys, z: zs, indices: OrderedSet.ofBounds(0, 3) };
+        const boundary = getBoundary(position);
+        const grid = GridLookup3D(position, boundary);
+
+        const r = grid.nearest(0, 0, 0, 3, () => true);
+        expect(r.count).toBeGreaterThanOrEqual(1);
+        expect(r.count).toBeLessThanOrEqual(3);
+    });
+
+    it('many points with fixed cell size match brute force', () => {
+        // deterministic LCG so the test is reproducible
+        let seed = 42;
+        const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+
+        const count = 1000;
+        const px = new Float32Array(count);
+        const py = new Float32Array(count);
+        const pz = new Float32Array(count);
+        for (let i = 0; i < count; ++i) {
+            px[i] = rand() * 100;
+            py[i] = rand() * 100;
+            pz[i] = rand() * 100;
+        }
+
+        const position = { x: px, y: py, z: pz, indices: OrderedSet.ofBounds(0, count) };
+        const boundary = getBoundary(position);
+        // sparse fixed-size cells exercise the occupied-cell compaction path
+        const grid = GridLookup3D(position, boundary, Vec3.create(3, 3, 3));
+
+        const queries: [number, number, number, number][] = [[50, 50, 50, 10], [0, 0, 0, 25], [100, 100, 100, 15], [50, 0, 100, 5]];
+        for (const [qx, qy, qz, qr] of queries) {
+            const expected: number[] = [];
+            for (let i = 0; i < count; ++i) {
+                const dx = px[i] - qx, dy = py[i] - qy, dz = pz[i] - qz;
+                if (dx * dx + dy * dy + dz * dz <= qr * qr) expected.push(i);
+            }
+            const r = grid.find(qx, qy, qz, qr);
+            expect(sortArray(r.indices.slice(0, r.count))).toEqual(expected);
+            expect(grid.check(qx, qy, qz, qr)).toBe(expected.length > 0);
+        }
     });
 });

--- a/src/mol-math/geometry/instance-grid.ts
+++ b/src/mol-math/geometry/instance-grid.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2022-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  */
@@ -72,6 +72,14 @@ export function calcInstanceGrid(instanceData: InstanceData, cellSize: number, b
     const cellSpheres = new Float32Array(bottomGrid.cellSpheres.length);
     const cellInstance = new Float32Array(bottomGrid.cellInstance.length);
 
+    // gather transforms as float64 pairs when 8-byte aligned to halve the copy work;
+    // bit-exact unless a float32 pair aliases a double NaN, which requires Inf/NaN input
+    const { transform } = instanceData;
+    const { cellTransform } = bottomGrid;
+    const use64 = transform.byteOffset % 8 === 0 && cellTransform.byteOffset % 8 === 0;
+    const src64 = use64 ? new Float64Array(transform.buffer, transform.byteOffset, transform.length >> 1) : undefined;
+    const dst64 = use64 ? new Float64Array(cellTransform.buffer, cellTransform.byteOffset, cellTransform.length >> 1) : undefined;
+
     let offset = 0;
     for (let i = 0, il = topGrid.batchCell.length; i < il; ++i) {
         const cellIdx = topGrid.batchCell[i];
@@ -86,10 +94,18 @@ export function calcInstanceGrid(instanceData: InstanceData, cellSize: number, b
 
         for (let j = 0; j < count; ++j) {
             const idx = start + j;
-            const id = bottomGrid.cellInstance[idx];
-            for (let k = 0; k < 16; ++k) {
-                // assumes instanceData.instance is strictly serially ordered
-                bottomGrid.cellTransform[offset * 16 + k] = instanceData.transform[id * 16 + k];
+            // assumes instanceData.instance is strictly serially ordered
+            const id = bottomGrid.cellInstance[idx] | 0;
+            if (src64 && dst64) {
+                const so = id * 8, dof = offset * 8;
+                for (let k = 0; k < 8; ++k) {
+                    dst64[dof + k] = src64[so + k];
+                }
+            } else {
+                const so = id * 16, dof = offset * 16;
+                for (let k = 0; k < 16; ++k) {
+                    cellTransform[dof + k] = transform[so + k];
+                }
             }
             cellInstance[offset] = id;
             offset += 1;
@@ -149,6 +165,7 @@ function calcBottomGrid(instanceData: InstanceData, cellSize: number): BottomGri
     const cellCount = offset.length;
     const cellOffsets = new Uint32Array(cellCount + 1);
     const cellSpheres = new Float32Array(cellCount * 4);
+    // only allocated here; fully populated by the reorder in calcInstanceGrid
     const cellTransform = new Float32Array(instanceCount * 16);
     const cellInstance = new Float32Array(instanceCount);
 
@@ -160,24 +177,22 @@ function calcBottomGrid(instanceData: InstanceData, cellSize: number): BottomGri
         const start = offset[i];
         const size = count[i];
         cellOffsets[i] = start;
-        const kStart = k;
         for (let j = start, jl = start + size; j < jl; ++j) {
-            const idx = array[j];
-            cellInstance[k] = instance[idx];
-            for (let l = 0; l < 16; ++l) {
-                cellTransform[k * 16 + l] = transform[idx * 16 + l];
-            }
+            cellInstance[k] = instance[array[j]];
             k += 1;
         }
 
         if (size === 1) {
-            v3transformMat4Offset(cellSpheres, center, cellTransform, i * 4, 0, kStart * 16);
+            const idx = array[start];
+            cellSpheres[i * 4] = x[idx];
+            cellSpheres[i * 4 + 1] = y[idx];
+            cellSpheres[i * 4 + 2] = z[idx];
             cellSpheres[i * 4 + 3] = radius;
         } else {
             Box3D.setEmpty(b);
-            const o = kStart * 16;
-            for (let l = 0; l < size; ++l) {
-                v3transformMat4Offset(v, center, cellTransform, 0, 0, l * 16 + o);
+            for (let j = start, jl = start + size; j < jl; ++j) {
+                const idx = array[j];
+                Vec3.set(v, x[idx], y[idx], z[idx]);
                 b3add(b, v);
             }
             Box3D.expand(b, b, rv);

--- a/src/mol-math/geometry/lookup3d/grid.ts
+++ b/src/mol-math/geometry/lookup3d/grid.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
@@ -11,11 +11,12 @@ import { Box3D } from '../primitives/box3d';
 import { Sphere3D } from '../primitives/sphere3d';
 import { PositionData } from '../common';
 import { Vec3 } from '../../linear-algebra';
-import { OrderedSet } from '../../../mol-data/int';
+import { Interval, OrderedSet, SortedArray } from '../../../mol-data/int';
 import { Boundary } from '../boundary';
 import { FibonacciHeap } from '../../../mol-util/fibonacci-heap';
 import { memoize1 } from '../../../mol-util/memoize';
 import { Ray3D } from '../primitives/ray3d';
+import { radixSort } from '../../../mol-data/util/sort';
 
 interface GridLookup3D<T = number> extends Lookup3D<T> {
     readonly buckets: { readonly offset: ArrayLike<number>, readonly count: ArrayLike<number>, readonly array: ArrayLike<number> }
@@ -127,37 +128,56 @@ function _build(state: BuildState): Grid3D {
     const n = sX * sY * sZ;
     const { min: [minX, minY, minZ] } = expandedBox;
 
+    // resolve the OrderedSet union once instead of per-element getAt dispatch in the hot loops
+    let sortedIndices: SortedArray | undefined;
+    let startIdx = 0;
+    if (Interval.is(indices)) startIdx = Interval.start(indices);
+    else sortedIndices = indices;
+
+    // multiply by reciprocals instead of dividing in the hot loop
+    const invDX = 1 / delta[0], invDY = 1 / delta[1], invDZ = 1 / delta[2];
+
     let maxRadius = 0;
     let bucketCount = 0;
     const grid = new Uint32Array(n);
     const bucketIndex = new Int32Array(elementCount);
+    // occupied cell ids, so compaction does not need to scan all n grid cells
+    const occupied = new Uint32Array(Math.min(n, elementCount));
     for (let t = 0; t < elementCount; t++) {
-        const i = OrderedSet.getAt(indices, t);
-        const x = Math.floor((px[i] - minX) / delta[0]);
-        const y = Math.floor((py[i] - minY) / delta[1]);
-        const z = Math.floor((pz[i] - minZ) / delta[2]);
+        const i = sortedIndices ? sortedIndices[t] : startIdx + t;
+        const x = Math.floor((px[i] - minX) * invDX);
+        const y = Math.floor((py[i] - minY) * invDY);
+        const z = Math.floor((pz[i] - minZ) * invDZ);
         const idx = (((x * sY) + y) * sZ) + z;
 
         if ((grid[idx] += 1) === 1) {
+            occupied[bucketCount] = idx;
             bucketCount += 1;
         }
         bucketIndex[t] = idx;
+
+        if (radius && radius[i] > maxRadius) maxRadius = radius[i];
     }
 
-    if (radius) {
-        for (let t = 0; t < elementCount; t++) {
-            const i = OrderedSet.getAt(indices, t);
-            if (radius[i] > maxRadius) maxRadius = radius[i];
-        }
-    }
-
+    // both branches number buckets in ascending cell-id order
     const bucketCounts = new Int32Array(bucketCount);
-    for (let i = 0, j = 0; i < n; i++) {
-        const c = grid[i];
-        if (c > 0) {
+    if (bucketCount <= n >>> 2) {
+        // sparse grid: radix-sorting the occupied cell ids beats scanning all n cells
+        const occupiedSorted = radixSort(occupied.subarray(0, bucketCount), n - 1);
+        for (let j = 0; j < bucketCount; j++) {
+            const i = occupiedSorted[j];
+            bucketCounts[j] = grid[i];
             grid[i] = j + 1;
-            bucketCounts[j] = c;
-            j += 1;
+        }
+    } else {
+        // dense grid (> ~25% cells occupied): linear scan beats the radix sort
+        for (let i = 0, j = 0; i < n; i++) {
+            const c = grid[i];
+            if (c > 0) {
+                grid[i] = j + 1;
+                bucketCounts[j] = c;
+                j += 1;
+            }
         }
     }
 
@@ -169,12 +189,9 @@ function _build(state: BuildState): Grid3D {
     const bucketFill = new Int32Array(bucketCount);
     const bucketArray = new Int32Array(elementCount);
     for (let i = 0; i < elementCount; i++) {
-        const bucketIdx = grid[bucketIndex[i]];
-        if (bucketIdx > 0) {
-            const k = bucketIdx - 1;
-            bucketArray[bucketOffset[k] + bucketFill[k]] = i;
-            bucketFill[k] += 1;
-        }
+        const k = grid[bucketIndex[i]] - 1;
+        bucketArray[bucketOffset[k] + bucketFill[k]] = i;
+        bucketFill[k] += 1;
     }
 
     return {

--- a/src/perf-tests/grid.ts
+++ b/src/perf-tests/grid.ts
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ */
+
+import * as B from 'benchmark';
+import { radixSort, sortArray } from '../mol-data/util/sort';
+
+/**
+ * Benchmarks the two grid-bucket compaction strategies used by `_build` in
+ * src/mol-math/geometry/lookup3d/grid.ts, isolated from coordinate handling
+ * (elements are given directly as precomputed cell ids):
+ *
+ * - scanAll: count elements per cell, then scan ALL n grid cells to assign
+ *   bucket ids. Cost: O(elementCount + n).
+ * - sortOccupied: additionally track occupied cell ids during the fill, then sort
+ *   them and only touch occupied cells. Cost: O(elementCount + b log b) with
+ *   b = number of occupied cells.
+ *
+ * Expectation: `sortOccupied` wins for sparse grids (b << n, e.g. large boxes hitting
+ * the MaxVolume cap), `scanAll` wins for dense grids where b approaches n and
+ * the O(b log b) sort exceeds the O(n) linear scan.
+ *
+ * `hybridStrategy` picks a sort path only for sparse grids and the scan path otherwise.
+ * With radix sort the measured crossover is at ~25-30% occupancy => b <= n / 4.
+ */
+
+function genCellIds(n: number, elementCount: number, occupiedTarget: number) {
+    const used = new Set<number>();
+    while (used.size < occupiedTarget) used.add((Math.random() * n) | 0);
+    const cells = new Int32Array(used.size);
+    let i = 0;
+    used.forEach(c => { cells[i++] = c; });
+
+    const cellIds = new Int32Array(elementCount);
+    // ensure every picked cell is occupied at least once
+    for (let t = 0; t < cells.length; t++) cellIds[t] = cells[t];
+    for (let t = cells.length; t < elementCount; t++) {
+        cellIds[t] = cells[(Math.random() * cells.length) | 0];
+    }
+    return cellIds;
+}
+
+function scanAll(cellIds: Int32Array, n: number) {
+    const elementCount = cellIds.length;
+    let bucketCount = 0;
+    const grid = new Uint32Array(n);
+    for (let t = 0; t < elementCount; t++) {
+        const idx = cellIds[t];
+        if ((grid[idx] += 1) === 1) bucketCount += 1;
+    }
+
+    const bucketCounts = new Int32Array(bucketCount);
+    for (let i = 0, j = 0; i < n; i++) {
+        const c = grid[i];
+        if (c > 0) {
+            grid[i] = j + 1;
+            bucketCounts[j] = c;
+            j += 1;
+        }
+    }
+    return { grid, bucketCounts };
+}
+
+type Sorter = (occupied: Uint32Array, bucketCount: number, n: number) => ArrayLike<number>
+
+const sortNative: Sorter = (occupied, bucketCount) => occupied.subarray(0, bucketCount).sort();
+
+const sortQuick: Sorter = (occupied, bucketCount) => sortArray(occupied.subarray(0, bucketCount));
+
+const sortRadix: Sorter = (occupied, bucketCount, n) => radixSort(occupied.subarray(0, bucketCount), n - 1);
+
+function sortOccupied(cellIds: Int32Array, n: number, sorter: Sorter = sortNative) {
+    const elementCount = cellIds.length;
+    let bucketCount = 0;
+    const grid = new Uint32Array(n);
+    const occupied = new Uint32Array(Math.min(n, elementCount));
+    for (let t = 0; t < elementCount; t++) {
+        const idx = cellIds[t];
+        if ((grid[idx] += 1) === 1) {
+            occupied[bucketCount] = idx;
+            bucketCount += 1;
+        }
+    }
+
+    const occupiedSorted = sorter(occupied, bucketCount, n);
+    const bucketCounts = new Int32Array(bucketCount);
+    for (let j = 0; j < bucketCount; j++) {
+        const i = occupiedSorted[j];
+        bucketCounts[j] = grid[i];
+        grid[i] = j + 1;
+    }
+    return { grid, bucketCounts };
+}
+
+function hybridStrategy(cellIds: Int32Array, n: number) {
+    const elementCount = cellIds.length;
+    let bucketCount = 0;
+    const grid = new Uint32Array(n);
+    const occupied = new Uint32Array(Math.min(n, elementCount));
+    for (let t = 0; t < elementCount; t++) {
+        const idx = cellIds[t];
+        if ((grid[idx] += 1) === 1) {
+            occupied[bucketCount] = idx;
+            bucketCount += 1;
+        }
+    }
+
+    const bucketCounts = new Int32Array(bucketCount);
+    if (bucketCount <= n >>> 2) {
+        const occupiedSorted = sortRadix(occupied, bucketCount, n);
+        for (let j = 0; j < bucketCount; j++) {
+            const i = occupiedSorted[j];
+            bucketCounts[j] = grid[i];
+            grid[i] = j + 1;
+        }
+    } else {
+        for (let i = 0, j = 0; i < n; i++) {
+            const c = grid[i];
+            if (c > 0) {
+                grid[i] = j + 1;
+                bucketCounts[j] = c;
+                j += 1;
+            }
+        }
+    }
+    return { grid, bucketCounts };
+}
+
+function verify(cellIds: Int32Array, n: number) {
+    const a = scanAll(cellIds, n);
+    const others = [
+        sortOccupied(cellIds, n, sortNative),
+        sortOccupied(cellIds, n, sortQuick),
+        sortOccupied(cellIds, n, sortRadix),
+        hybridStrategy(cellIds, n),
+    ];
+    for (const other of others) {
+        if (a.bucketCounts.length !== other.bucketCounts.length) throw new Error('bucketCount mismatch');
+        for (let i = 0; i < a.bucketCounts.length; i++) {
+            if (a.bucketCounts[i] !== other.bucketCounts[i]) throw new Error(`bucketCounts mismatch at ${i}`);
+        }
+        for (let i = 0; i < n; i++) {
+            if (a.grid[i] !== other.grid[i]) throw new Error(`grid mismatch at ${i}`);
+        }
+    }
+}
+
+function runTest(n: number, elementCount: number, occupiedTarget: number) {
+    const cellIds = genCellIds(n, elementCount, occupiedTarget);
+    verify(cellIds, n);
+
+    const label = `n=${n} elements=${elementCount} occupied=${occupiedTarget} (${(100 * occupiedTarget / n).toFixed(2)}%)`;
+    console.log(label);
+
+    const suite = new B.Suite();
+    suite
+        .add('scan all cells', () => scanAll(cellIds, n))
+        .add('sortOccupied (native .sort)', () => sortOccupied(cellIds, n, sortNative))
+        .add('sortOccupied (sortArray quicksort)', () => sortOccupied(cellIds, n, sortQuick))
+        .add('sortOccupied (radix sort)', () => sortOccupied(cellIds, n, sortRadix))
+        .add('hybrid (radix if b <= n / 4)', () => hybridStrategy(cellIds, n))
+        .on('cycle', (e: any) => console.log(`  ${String(e.target)}`))
+        .on('complete', function (this: any) {
+            const sorted = [this[0], this[1], this[2], this[3], this[4]].sort((a, b) => b.hz - a.hz);
+            console.log(`  => fastest: ${sorted[0].name} (${(sorted[0].hz / sorted[1].hz).toFixed(2)}x over ${sorted[1].name})`);
+        })
+        .run();
+    console.log('---------------------');
+}
+
+// sparse: large grid capped at MaxVolume, ~32 elements per occupied cell
+// (typical big-structure case) => sortOccupied expected to win
+runTest(2 ** 24, 100000, Math.floor(100000 / 32));
+runTest(2 ** 24, 1000000, Math.floor(1000000 / 32));
+
+// near the crossover (~1.5-2% occupancy)
+runTest(2 ** 22, 200000, Math.floor(2 ** 22 * 0.015));
+
+// dense: nearly every cell occupied, sort dominates => scanAll expected to win
+runTest(2 ** 20, 1000000, Math.floor(2 ** 20 * 0.6));
+runTest(2 ** 18, 500000, Math.floor(2 ** 18 * 0.9));
+
+// tiny default grid (32^3): compaction negligible vs fill => roughly equal
+runTest(32 ** 3, 100000, 32 ** 3 / 2);
+
+// n=16777216 elements=100000 occupied=3125 (0.02%)
+//   scan all cells x 28.40 ops/sec ±5.38% (49 runs sampled)
+//   sortOccupied (native .sort) x 257 ops/sec ±1.53% (81 runs sampled)
+//   sortOccupied (sortArray quicksort) x 270 ops/sec ±1.26% (86 runs sampled)
+//   sortOccupied (radix sort) x 275 ops/sec ±1.24% (85 runs sampled)
+//   hybrid (radix if b <= n / 4) x 261 ops/sec ±1.37% (82 runs sampled)
+//   => fastest: sortOccupied (radix sort) (1.02x over sortOccupied (sortArray quicksort))
+// ---------------------
+// n=16777216 elements=1000000 occupied=31250 (0.19%)
+//   scan all cells x 33.80 ops/sec ±0.95% (59 runs sampled)
+//   sortOccupied (native .sort) x 52.17 ops/sec ±1.92% (65 runs sampled)
+//   sortOccupied (sortArray quicksort) x 50.51 ops/sec ±1.76% (64 runs sampled)
+//   sortOccupied (radix sort) x 53.30 ops/sec ±1.87% (55 runs sampled)
+//   hybrid (radix if b <= n / 4) x 53.88 ops/sec ±2.35% (61 runs sampled)
+//   => fastest: hybrid (radix if b <= n / 4) (1.01x over sortOccupied (radix sort))
+// ---------------------
+// n=4194304 elements=200000 occupied=62914 (1.50%)
+//   scan all cells x 125 ops/sec ±0.76% (81 runs sampled)
+//   sortOccupied (native .sort) x 122 ops/sec ±1.07% (80 runs sampled)
+//   sortOccupied (sortArray quicksort) x 116 ops/sec ±0.72% (75 runs sampled)
+//   sortOccupied (radix sort) x 171 ops/sec ±1.05% (80 runs sampled)
+//   hybrid (radix if b <= n / 4) x 163 ops/sec ±1.26% (80 runs sampled)
+//   => fastest: sortOccupied (radix sort) (1.04x over hybrid (radix if b <= n / 4))
+// ---------------------
+// n=1048576 elements=1000000 occupied=629145 (60.00%)
+//   scan all cells x 127 ops/sec ±0.44% (82 runs sampled)
+//   sortOccupied (native .sort) x 26.55 ops/sec ±0.47% (48 runs sampled)
+//   sortOccupied (sortArray quicksort) x 23.39 ops/sec ±0.34% (43 runs sampled)
+//   sortOccupied (radix sort) x 91.07 ops/sec ±0.78% (79 runs sampled)
+//   hybrid (radix if b <= n / 4) x 109 ops/sec ±1.12% (81 runs sampled)
+//   => fastest: scan all cells (1.17x over hybrid (radix if b <= n / 4))
+// ---------------------
+// n=262144 elements=500000 occupied=235929 (90.00%)
+//   scan all cells x 516 ops/sec ±0.56% (92 runs sampled)
+//   sortOccupied (native .sort) x 77.55 ops/sec ±0.35% (81 runs sampled)
+//   sortOccupied (sortArray quicksort) x 67.41 ops/sec ±0.31% (71 runs sampled)
+//   sortOccupied (radix sort) x 294 ops/sec ±0.45% (89 runs sampled)
+//   hybrid (radix if b <= n / 4) x 472 ops/sec ±0.47% (90 runs sampled)
+//   => fastest: scan all cells (1.09x over hybrid (radix if b <= n / 4))
+// ---------------------
+// n=32768 elements=100000 occupied=16384 (50.00%)
+//   scan all cells x 4,837 ops/sec ±2.11% (82 runs sampled)
+//   sortOccupied (native .sort) x 1,308 ops/sec ±1.05% (94 runs sampled)
+//   sortOccupied (sortArray quicksort) x 1,150 ops/sec ±0.71% (97 runs sampled)
+//   sortOccupied (radix sort) x 4,148 ops/sec ±2.18% (90 runs sampled)
+//   hybrid (radix if b <= n / 4) x 5,230 ops/sec ±1.75% (91 runs sampled)
+//   => fastest: hybrid (radix if b <= n / 4) (1.08x over scan all cells)
+// ---------------------


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

- Optimize `GridLookup3D` building for sparse grids
- Optimize `calcInstanceGrid` by reducing amount of data copied

Important for data with many instances, e.g., large particle systems (https://github.com/molstar/molstar/pull/1904)

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [ ] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`