### PR TITLE
MolQL selectors for MolViewSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Note that since we don't clearly distinguish between a public and private interf
 - Fix CPU surface/volume visuals rebuilding on every update if GPU path is unavailable
 - Fix `floodfill` not applied on the gaussian surface wireframe
 - Fix `traceOnly` update being ignored by the molecular surface wireframe visuals
-- Add MVS `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
 - Added support for molecular atom_style in lammps data files
 - Added element symbol detection in lammps data file
 - Fix inconsistent atomic weight for some elements in `ElementAtomWeights`
@@ -62,6 +61,8 @@ Note that since we don't clearly distinguish between a public and private interf
   - Added `transition` node with params `duration_ms`, `trajectory`, `easing`
   - Snapshot metadata: `linger_duration_ms` renamed to `duration_ms`, deprecated `transition_duration_ms`
   - MVS-related custom model properties (and custom structure properties) are hidden in UI (fixes override of default custom properties)
+  - Added `shape` node for rendering meshes from `vtp`, `ply` and `obj` resources
+  - Added support for MolQL selectors (e.g., select a residue + 5 ang surroundings)
 - Remove `new Function` usage for CSP / SOC2 compliance; server path templates use a whitelist of `${id...}` string methods
 
 ## [v5.11.0] - 2026-07-18

--- a/src/examples/mvs-stories/stories/index.ts
+++ b/src/examples/mvs-stories/stories/index.ts
@@ -9,6 +9,7 @@ import { buildStory as tbp } from './tbp';
 import { buildStory as animation } from './animation';
 import { buildStory as audio } from './audio';
 import { buildStory as motm1 } from './motm1';
+import { buildStory as molql } from './molql';
 
 export const Stories = [
     { id: 'kinase', name: 'BCR-ABL: A Kinase Out of Control', buildStory: kinase },
@@ -16,4 +17,5 @@ export const Stories = [
     { id: 'motm1', name: 'RCSB PDB Molecule of the Month #1', buildStory: motm1 },
     { id: 'animation-example', name: 'Molecular Animation Example', buildStory: animation },
     { id: 'audio-example', name: 'Audio Playback Example', buildStory: audio },
+    { id: 'molql', name: 'Experimental MolQL Selectors', buildStory: molql },
 ] as const;

--- a/src/examples/mvs-stories/stories/index.ts
+++ b/src/examples/mvs-stories/stories/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2025-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */

--- a/src/examples/mvs-stories/stories/molql.ts
+++ b/src/examples/mvs-stories/stories/molql.ts
@@ -85,7 +85,7 @@ Both are stored in MolViewSpec as JSON MolQL expression trees, not executable so
 function colorSnapshot() {
     const builder = createMVSBuilder();
     const structure = loadStructure(builder);
-    const representation = structure.component({ selector: 'all' })
+    const representation = structure.component({ selector: 'polymer' })
         .representation({ type: 'cartoon' });
 
     representation.color({ color: '#8AA6C1' });

--- a/src/examples/mvs-stories/stories/molql.ts
+++ b/src/examples/mvs-stories/stories/molql.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author David Sehnal
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { MVSData_States } from '../../../extensions/mvs/mvs-data';

--- a/src/examples/mvs-stories/stories/molql.ts
+++ b/src/examples/mvs-stories/stories/molql.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author David Sehnal
+ */
+
+import { MVSData_States } from '../../../extensions/mvs/mvs-data';
+import { createMVSBuilder } from '../../../extensions/mvs/tree/mvs/mvs-builder';
+import { MolScriptBuilder as MS } from '../../../mol-script/language/builder';
+import { parse } from '../../../mol-script/transpile';
+
+const imatinib = MS.struct.generator.atomGroups({
+    'chain-test': MS.core.rel.eq([
+        MS.struct.atomProperty.macromolecular.label_asym_id(),
+        'G',
+    ]),
+});
+
+const gatekeeper = MS.struct.generator.atomGroups({
+    'chain-test': MS.core.rel.eq([
+        MS.struct.atomProperty.macromolecular.auth_asym_id(),
+        'A',
+    ]),
+    'residue-test': MS.core.rel.eq([
+        MS.struct.atomProperty.macromolecular.auth_seq_id(),
+        315,
+    ]),
+});
+
+const imatinibN13 = MS.struct.generator.atomGroups({
+    'chain-test': MS.core.rel.eq([
+        MS.struct.atomProperty.macromolecular.label_asym_id(),
+        'G',
+    ]),
+    'atom-test': MS.core.rel.eq([
+        MS.struct.atomProperty.macromolecular.label_atom_id(),
+        'N13',
+    ]),
+});
+
+// Transpilers resolve their input syntax to the same JSON MolQL tree as the builder above.
+const bindingPocket = parse('pymol', 'byres polymer within 5 of resn STI');
+const thr315OG1 = parse('pymol', 'chain A and resi 315 and name OG1');
+
+export function buildStory(): MVSData_States {
+    return {
+        kind: 'multiple',
+        snapshots: [componentSnapshot(), colorSnapshot(), interactionSnapshot(), primitiveSnapshot()],
+        metadata: {
+            title: 'Experimental MolQL Selectors',
+            version: '1.0',
+            timestamp: new Date().toISOString(),
+        },
+    };
+}
+
+function componentSnapshot() {
+    const builder = createMVSBuilder();
+    const structure = loadStructure(builder);
+
+    structure.component({ selector: 'polymer' })
+        .representation({ type: 'cartoon' })
+        .color({ color: '#8AA6C1' });
+
+    structure.component({ selector: { expression: imatinib } })
+        .representation({ type: 'ball_and_stick' })
+        .color({ color: '#F08A4B' });
+
+    structure.component({ selector: { expression: bindingPocket } })
+        .representation({ type: 'ball_and_stick' })
+        .color({ color: '#B8497A' });
+
+    return builder.getSnapshot({
+        title: 'MolQL component selectors',
+        key: 'components',
+        description: `# MolQL component selectors
+
+Every non-static component selector is wrapped as \`{ expression: ... }\`. The orange imatinib selection is built with \`MolScriptBuilder\`; the pink binding pocket is compiled from the PyMOL expression \`byres polymer within 5 of resn STI\`.
+
+Both are stored in MolViewSpec as JSON MolQL expression trees, not executable source text.`,
+        description_format: 'markdown',
+    });
+}
+
+function colorSnapshot() {
+    const builder = createMVSBuilder();
+    const structure = loadStructure(builder);
+    const representation = structure.component({ selector: 'all' })
+        .representation({ type: 'cartoon' });
+
+    representation.color({ color: '#8AA6C1' });
+    representation.color({ selector: { expression: bindingPocket }, color: '#B8497A' });
+    representation.color({ selector: { expression: gatekeeper }, color: '#F08A4B' });
+
+    return builder.getSnapshot({
+        title: 'MolQL color selectors',
+        key: 'colors',
+        description: `# MolQL color selectors
+
+MolQL is also accepted by the \`selector\` on a \`color\` node. Here one broad cartoon representation is selectively recolored: the PyMOL-transpiled pocket is pink and the builder-generated gatekeeper residue Thr315 is orange.
+
+This demonstrates multilayer coloring without creating separate visual components for each selected region.`,
+        description_format: 'markdown',
+    });
+}
+
+function interactionSnapshot() {
+    const builder = createMVSBuilder();
+    const structure = loadStructure(builder);
+
+    structure.component({ selector: 'polymer' })
+        .representation({ type: 'cartoon' })
+        .color({ color: '#8AA6C1' });
+
+    structure.component({ selector: { expression: imatinib } })
+        .representation({ type: 'ball_and_stick' })
+        .color({ color: '#F08A4B' });
+
+    const pocket = structure.component({ selector: { expression: bindingPocket } });
+    pocket.representation({ type: 'ball_and_stick' }).color({ color: '#B8497A' });
+    pocket.label({ text: 'PyMOL binding-pocket selection' });
+    pocket.tooltip({ text: 'Polymer residues within 5 Å of imatinib (STI).' });
+
+    return builder.getSnapshot({
+        title: 'MolQL component interactions',
+        key: 'interactions',
+        description: `# Reusing a MolQL component
+
+Once a wrapped MolQL selector creates a component, its child labels and tooltips operate on that computed component as usual. Hover the pink pocket to see its tooltip.
+
+This keeps the query in the component node while labels, representations, and other component children reuse its result.`,
+        description_format: 'markdown',
+    });
+}
+
+function primitiveSnapshot() {
+    const builder = createMVSBuilder();
+    const structure = loadStructure(builder);
+
+    structure.component({ selector: 'polymer' })
+        .representation({ type: 'cartoon' })
+        .color({ color: '#8AA6C1' });
+    structure.component({ selector: { expression: imatinib } })
+        .representation({ type: 'ball_and_stick' })
+        .color({ color: '#F08A4B' });
+    structure.component({ selector: { expression: gatekeeper } })
+        .representation({ type: 'ball_and_stick' })
+        .color({ color: '#B8497A' });
+
+    const primitives = structure.primitives();
+    primitives.distance({
+        start: { expression: imatinibN13 },
+        end: { expression: thr315OG1 },
+        color: '#F08A4B',
+        radius: 0.12,
+        dash_length: 0.2,
+        label_template: 'Imatinib N13–Thr315 OG1: {{distance}}',
+        label_color: '#F08A4B',
+    });
+
+    return builder.getSnapshot({
+        title: 'MolQL primitive positions',
+        key: 'primitives',
+        description: `# MolQL primitive positions
+
+Primitive positions accept wrapped MolQL too. This dashed distance measurement connects imatinib atom N13, selected with \`MolScriptBuilder\`, to Thr315 atom OG1, selected from the PyMOL expression \`chain A and resi 315 and name OG1\`.
+
+Because both queries select one atom, their boundary-sphere centers are the exact atom coordinates. This makes the primitive a real measurement of a known imatinib–Thr315 hydrogen-bond contact.`,
+        description_format: 'markdown',
+    });
+}
+
+function loadStructure(builder: ReturnType<typeof createMVSBuilder>) {
+    return builder
+        .download({ url: 'https://www.ebi.ac.uk/pdbe/entry-files/download/1iep.bcif' })
+        .parse({ format: 'bcif' })
+        .assemblyStructure();
+}

--- a/src/examples/mvs-stories/stories/molql.ts
+++ b/src/examples/mvs-stories/stories/molql.ts
@@ -62,11 +62,11 @@ function componentSnapshot() {
         .representation({ type: 'cartoon' })
         .color({ color: '#8AA6C1' });
 
-    structure.component({ selector: { expression: imatinib } })
+    structure.component({ selector: { molql: imatinib } })
         .representation({ type: 'ball_and_stick' })
         .color({ color: '#F08A4B' });
 
-    structure.component({ selector: { expression: bindingPocket } })
+    structure.component({ selector: { molql: bindingPocket } })
         .representation({ type: 'ball_and_stick' })
         .color({ color: '#B8497A' });
 
@@ -75,7 +75,7 @@ function componentSnapshot() {
         key: 'components',
         description: `# MolQL component selectors
 
-Every non-static component selector is wrapped as \`{ expression: ... }\`. The orange imatinib selection is built with \`MolScriptBuilder\`; the pink binding pocket is compiled from the PyMOL expression \`byres polymer within 5 of resn STI\`.
+Every non-static component selector is wrapped as \`{ molql: ... }\`. The orange imatinib selection is built with \`MolScriptBuilder\`; the pink binding pocket is compiled from the PyMOL expression \`byres polymer within 5 of resn STI\`.
 
 Both are stored in MolViewSpec as JSON MolQL expression trees, not executable source text.`,
         description_format: 'markdown',
@@ -89,8 +89,8 @@ function colorSnapshot() {
         .representation({ type: 'cartoon' });
 
     representation.color({ color: '#8AA6C1' });
-    representation.color({ selector: { expression: bindingPocket }, color: '#B8497A' });
-    representation.color({ selector: { expression: gatekeeper }, color: '#F08A4B' });
+    representation.color({ selector: { molql: bindingPocket }, color: '#B8497A' });
+    representation.color({ selector: { molql: gatekeeper }, color: '#F08A4B' });
 
     return builder.getSnapshot({
         title: 'MolQL color selectors',
@@ -112,11 +112,11 @@ function interactionSnapshot() {
         .representation({ type: 'cartoon' })
         .color({ color: '#8AA6C1' });
 
-    structure.component({ selector: { expression: imatinib } })
+    structure.component({ selector: { molql: imatinib } })
         .representation({ type: 'ball_and_stick' })
         .color({ color: '#F08A4B' });
 
-    const pocket = structure.component({ selector: { expression: bindingPocket } });
+    const pocket = structure.component({ selector: { molql: bindingPocket } });
     pocket.representation({ type: 'ball_and_stick' }).color({ color: '#B8497A' });
     pocket.label({ text: 'PyMOL binding-pocket selection' });
     pocket.tooltip({ text: 'Polymer residues within 5 Å of imatinib (STI).' });
@@ -140,17 +140,17 @@ function primitiveSnapshot() {
     structure.component({ selector: 'polymer' })
         .representation({ type: 'cartoon' })
         .color({ color: '#8AA6C1' });
-    structure.component({ selector: { expression: imatinib } })
+    structure.component({ selector: { molql: imatinib } })
         .representation({ type: 'ball_and_stick' })
         .color({ color: '#F08A4B' });
-    structure.component({ selector: { expression: gatekeeper } })
+    structure.component({ selector: { molql: gatekeeper } })
         .representation({ type: 'ball_and_stick' })
         .color({ color: '#B8497A' });
 
     const primitives = structure.primitives();
     primitives.distance({
-        start: { expression: imatinibN13 },
-        end: { expression: thr315OG1 },
+        start: { molql: imatinibN13 },
+        end: { molql: thr315OG1 },
         color: '#F08A4B',
         radius: 0.12,
         dash_length: 0.2,

--- a/src/extensions/mvs/_spec/molql.spec.ts
+++ b/src/extensions/mvs/_spec/molql.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
- * @author mol* contributors
+ * @author David Sehnal <david.sehnal@gmail.com>
  */
 
 import { componentPropsFromSelector, prettyNameFromSelector } from '../load-helpers';

--- a/src/extensions/mvs/_spec/molql.spec.ts
+++ b/src/extensions/mvs/_spec/molql.spec.ts
@@ -16,9 +16,13 @@ import { parse } from '../../../mol-script/transpile';
 describe('MVS MolQL selectors', () => {
     const expression = { name: 'structure-query.generator.all' };
 
-    it('requires the expression wrapper while leaving its content opaque', () => {
+    it('requires a compilable expression wrapper', () => {
+        const malformed = { head: { name: 'not-implemented' } };
         expect(MolQLExpressionT.decode({ expression })._tag).toEqual('Right');
-        expect(MolQLExpressionT.decode({ expression: undefined })._tag).toEqual('Right');
+        expect(MolQLExpressionT.decode({ expression })._tag).toEqual('Right');
+        expect(MolQLExpressionT.decode({ expression: undefined })._tag).toEqual('Left');
+        expect(MolQLExpressionT.decode({ expression: malformed })._tag).toEqual('Left');
+        expect(MolQLExpressionT.decode({ expression: malformed })._tag).toEqual('Left');
         expect(MolQLExpressionT.decode({})._tag).toEqual('Left');
         expect(isMolQLExpression({ expression })).toEqual(true);
         expect(isMolQLExpression({})).toEqual(false);
@@ -30,7 +34,7 @@ describe('MVS MolQL selectors', () => {
         expect(PrimitiveMolQLExpressionT.decode(position)._tag).toEqual('Right');
         expect(PrimitiveMolQLExpressionT.decode({ expression, structure_ref: 1 })._tag).toEqual('Left');
         expect(isPrimitiveMolQLExpression(position)).toEqual(true);
-        // This remains a base MolQL wrapper, so primitive execution must reject its invalid ref before legacy row handling.
+        // The base wrapper has no structure_ref constraint; the primitive codec owns that validation.
         expect(isMolQLExpression({ expression, structure_ref: 1 })).toEqual(true);
         expect(isPrimitiveMolQLExpression({ expression, structure_ref: 1 })).toEqual(false);
     });
@@ -44,16 +48,21 @@ describe('MVS MolQL selectors', () => {
         expect(prettyNameFromSelector(wrapped)).toEqual('MolQL Selection');
     });
 
-    it('serializes wrapped expressions and defers malformed MolQL validation to execution', () => {
+    it('rejects malformed expressions and invalid primitive refs during MVS validation', () => {
         const builder = createMVSBuilder();
         const malformed = { head: { name: 'not-implemented' } };
         builder.download({ url: 'example.bcif' }).parse({ format: 'bcif' }).modelStructure()
             .component({ selector: { expression: malformed } });
         const state = builder.getState();
 
-        expect(MVSData.validationIssues(state)).toEqual(undefined);
+        expect(MVSData.validationIssues(state)?.join('\n')).toContain("Symbol 'not-implemented' is not implemented.");
         expect(MVSData.toMVSJ(state)).toContain('"expression":{"head":{"name":"not-implemented"}}');
         expect(() => compile(componentPropsFromSelector({ expression: malformed }).params as any)).toThrow("Symbol 'not-implemented' is not implemented.");
+
+        const primitiveBuilder = createMVSBuilder();
+        const structure = primitiveBuilder.download({ url: 'example.bcif' }).parse({ format: 'bcif' }).modelStructure();
+        structure.primitives().label({ position: { expression, structure_ref: 1 } as any, text: 'Invalid reference' });
+        expect(MVSData.validationIssues(primitiveBuilder.getState())?.join('\n')).toContain('Primitive MolQL structure_ref must be a string when provided');
     });
 
     it('builds a valid story from MolScriptBuilder and a PyMOL-transpiled expression', () => {

--- a/src/extensions/mvs/_spec/molql.spec.ts
+++ b/src/extensions/mvs/_spec/molql.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author mol* contributors
+ */
+
+import { componentPropsFromSelector, prettyNameFromSelector } from '../load-helpers';
+import { MVSData } from '../mvs-data';
+import { createMVSBuilder } from '../tree/mvs/mvs-builder';
+import { MolQLExpressionT, PrimitiveMolQLExpressionT, isMolQLExpression, isPrimitiveMolQLExpression } from '../tree/mvs/param-types';
+import { buildStory } from '../../../examples/mvs-stories/stories/molql';
+import { compile } from '../../../mol-script/runtime/query/base';
+import { MolScriptBuilder as MS } from '../../../mol-script/language/builder';
+import { parse } from '../../../mol-script/transpile';
+
+describe('MVS MolQL selectors', () => {
+    const expression = { name: 'structure-query.generator.all' };
+
+    it('requires the expression wrapper while leaving its content opaque', () => {
+        expect(MolQLExpressionT.decode({ expression })._tag).toEqual('Right');
+        expect(MolQLExpressionT.decode({ expression: undefined })._tag).toEqual('Right');
+        expect(MolQLExpressionT.decode({})._tag).toEqual('Left');
+        expect(isMolQLExpression({ expression })).toEqual(true);
+        expect(isMolQLExpression({})).toEqual(false);
+        expect(isMolQLExpression([])).toEqual(false);
+    });
+
+    it('allows primitive MolQL positions to reference another structure', () => {
+        const position = { expression, structure_ref: 'other-structure' };
+        expect(PrimitiveMolQLExpressionT.decode(position)._tag).toEqual('Right');
+        expect(PrimitiveMolQLExpressionT.decode({ expression, structure_ref: 1 })._tag).toEqual('Left');
+        expect(isPrimitiveMolQLExpression(position)).toEqual(true);
+        // This remains a base MolQL wrapper, so primitive execution must reject its invalid ref before legacy row handling.
+        expect(isMolQLExpression({ expression, structure_ref: 1 })).toEqual(true);
+        expect(isPrimitiveMolQLExpression({ expression, structure_ref: 1 })).toEqual(false);
+    });
+
+    it('passes wrapped expressions through unchanged and preserves legacy selectors', () => {
+        const wrapped = { expression };
+        expect(componentPropsFromSelector(wrapped)).toEqual({ name: 'expression', params: expression });
+        expect(componentPropsFromSelector('protein')).toEqual({ name: 'static', params: 'protein' });
+        expect(componentPropsFromSelector({ label_asym_id: 'A' })).toMatchObject({ name: 'expression' });
+        expect(componentPropsFromSelector([{ label_asym_id: 'A' }])).toMatchObject({ name: 'expression' });
+        expect(prettyNameFromSelector(wrapped)).toEqual('MolQL Selection');
+    });
+
+    it('serializes wrapped expressions and defers malformed MolQL validation to execution', () => {
+        const builder = createMVSBuilder();
+        const malformed = { head: { name: 'not-implemented' } };
+        builder.download({ url: 'example.bcif' }).parse({ format: 'bcif' }).modelStructure()
+            .component({ selector: { expression: malformed } });
+        const state = builder.getState();
+
+        expect(MVSData.validationIssues(state)).toEqual(undefined);
+        expect(MVSData.toMVSJ(state)).toContain('"expression":{"head":{"name":"not-implemented"}}');
+        expect(() => compile(componentPropsFromSelector({ expression: malformed }).params as any)).toThrow("Symbol 'not-implemented' is not implemented.");
+    });
+
+    it('builds a valid story from MolScriptBuilder and a PyMOL-transpiled expression', () => {
+        const story = buildStory();
+        expect(MVSData.validationIssues(story)).toEqual(undefined);
+        expect(story.snapshots).toHaveLength(4);
+        expect(findNodes(story, 'camera')).toHaveLength(0);
+
+        const componentSelectors = findNodes(story, 'component').map(node => node.params.selector);
+        expect(componentSelectors.some(selector => selector?.expression)).toEqual(true);
+
+        const colorSelectors = findNodes(story, 'color').map(node => node.params.selector);
+        expect(colorSelectors.filter(selector => selector?.expression)).toHaveLength(2);
+
+        const primitivePositions = findNodes(story, 'primitive').flatMap(node => [node.params.position, node.params.start, node.params.end]);
+        expect(primitivePositions.filter(position => position?.expression)).toHaveLength(2);
+
+        const serialized = MVSData.toMVSJ(story);
+        expect(serialized).toContain('"kind":"component"');
+        expect(serialized).toContain('"kind":"color"');
+        expect(serialized).toContain('"kind":"primitive"');
+        expect(serialized).toContain('"selector":{"expression"');
+        expect(() => compile(parse('pymol', 'byres polymer within 5 of resn STI'))).not.toThrow();
+        expect(() => compile(MS.struct.generator.atomGroups({
+            'chain-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.label_asym_id(), 'G']),
+            'atom-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.label_atom_id(), 'N13']),
+        }))).not.toThrow();
+        expect(() => compile(parse('pymol', 'chain A and resi 315 and name OG1'))).not.toThrow();
+    });
+});
+
+function findNodes(tree: any, kind: string): any[] {
+    const nodes: any[] = [];
+    const visit = (node: any) => {
+        if (node.kind === kind) nodes.push(node);
+        for (const child of node.children ?? []) visit(child);
+    };
+
+    for (const snapshot of tree.snapshots ?? []) visit(snapshot.root);
+    return nodes;
+}

--- a/src/extensions/mvs/_spec/molql.spec.ts
+++ b/src/extensions/mvs/_spec/molql.spec.ts
@@ -14,55 +14,59 @@ import { MolScriptBuilder as MS } from '../../../mol-script/language/builder';
 import { parse } from '../../../mol-script/transpile';
 
 describe('MVS MolQL selectors', () => {
-    const expression = { name: 'structure-query.generator.all' };
+    const molql = MS.struct.generator.atomGroups({});
 
-    it('requires a compilable expression wrapper', () => {
+    it('requires a compilable molql application wrapper', () => {
         const malformed = { head: { name: 'not-implemented' } };
-        expect(MolQLExpressionT.decode({ expression })._tag).toEqual('Right');
-        expect(MolQLExpressionT.decode({ expression })._tag).toEqual('Right');
-        expect(MolQLExpressionT.decode({ expression: undefined })._tag).toEqual('Left');
-        expect(MolQLExpressionT.decode({ expression: malformed })._tag).toEqual('Left');
-        expect(MolQLExpressionT.decode({ expression: malformed })._tag).toEqual('Left');
+        expect(MolQLExpressionT.decode({ molql })._tag).toEqual('Right');
+        expect(MolQLExpressionT.decode({ molql })._tag).toEqual('Right');
+        expect(MolQLExpressionT.decode({ molql: 'not-a-query' })._tag).toEqual('Left');
+        expect(MolQLExpressionT.decode({ molql: malformed })._tag).toEqual('Left');
+        expect(MolQLExpressionT.decode({ molql, label_seq_id: 1 })._tag).toEqual('Left');
         expect(MolQLExpressionT.decode({})._tag).toEqual('Left');
-        expect(isMolQLExpression({ expression })).toEqual(true);
+        expect(isMolQLExpression({ molql })).toEqual(true);
         expect(isMolQLExpression({})).toEqual(false);
         expect(isMolQLExpression([])).toEqual(false);
     });
 
     it('allows primitive MolQL positions to reference another structure', () => {
-        const position = { expression, structure_ref: 'other-structure' };
+        const position = { molql, structure_ref: 'other-structure' };
         expect(PrimitiveMolQLExpressionT.decode(position)._tag).toEqual('Right');
-        expect(PrimitiveMolQLExpressionT.decode({ expression, structure_ref: 1 })._tag).toEqual('Left');
+        expect(PrimitiveMolQLExpressionT.decode({ molql, structure_ref: 1 })._tag).toEqual('Left');
         expect(isPrimitiveMolQLExpression(position)).toEqual(true);
-        // The base wrapper has no structure_ref constraint; the primitive codec owns that validation.
-        expect(isMolQLExpression({ expression, structure_ref: 1 })).toEqual(true);
-        expect(isPrimitiveMolQLExpression({ expression, structure_ref: 1 })).toEqual(false);
+        expect(isMolQLExpression({ molql, structure_ref: 1 })).toEqual(false);
+        expect(isPrimitiveMolQLExpression({ molql, structure_ref: 1 })).toEqual(false);
     });
 
     it('passes wrapped expressions through unchanged and preserves legacy selectors', () => {
-        const wrapped = { expression };
-        expect(componentPropsFromSelector(wrapped)).toEqual({ name: 'expression', params: expression });
+        const wrapped = { molql };
+        expect(componentPropsFromSelector(wrapped)).toEqual({ name: 'expression', params: molql });
         expect(componentPropsFromSelector('protein')).toEqual({ name: 'static', params: 'protein' });
         expect(componentPropsFromSelector({ label_asym_id: 'A' })).toMatchObject({ name: 'expression' });
         expect(componentPropsFromSelector([{ label_asym_id: 'A' }])).toMatchObject({ name: 'expression' });
         expect(prettyNameFromSelector(wrapped)).toEqual('MolQL Selection');
     });
 
-    it('rejects malformed expressions and invalid primitive refs during MVS validation', () => {
+    it('rejects invalid selector and primitive addresses during MVS validation', () => {
         const builder = createMVSBuilder();
-        const malformed = { head: { name: 'not-implemented' } };
         builder.download({ url: 'example.bcif' }).parse({ format: 'bcif' }).modelStructure()
-            .component({ selector: { expression: malformed } });
-        const state = builder.getState();
+            .component({ selector: { molql: 'not-a-query' } as any });
+        expect(MVSData.validationIssues(builder.getState())?.join('\n')).toContain('MolQL expression must be a MolScript application');
 
-        expect(MVSData.validationIssues(state)?.join('\n')).toContain("Symbol 'not-implemented' is not implemented.");
-        expect(MVSData.toMVSJ(state)).toContain('"expression":{"head":{"name":"not-implemented"}}');
-        expect(() => compile(componentPropsFromSelector({ expression: malformed }).params as any)).toThrow("Symbol 'not-implemented' is not implemented.");
+        const mixedBuilder = createMVSBuilder();
+        mixedBuilder.download({ url: 'example.bcif' }).parse({ format: 'bcif' }).modelStructure()
+            .component({ selector: { molql, label_seq_id: 1 } as any });
+        expect(MVSData.validationIssues(mixedBuilder.getState())?.join('\n')).toContain('Expected an object with only a molql property');
 
         const primitiveBuilder = createMVSBuilder();
         const structure = primitiveBuilder.download({ url: 'example.bcif' }).parse({ format: 'bcif' }).modelStructure();
-        structure.primitives().label({ position: { expression, structure_ref: 1 } as any, text: 'Invalid reference' });
-        expect(MVSData.validationIssues(primitiveBuilder.getState())?.join('\n')).toContain('Primitive MolQL structure_ref must be a string when provided');
+        structure.primitives().label({ position: { molql, structure_ref: 1 } as any, text: 'Invalid reference' });
+        expect(MVSData.validationIssues(primitiveBuilder.getState())?.join('\n')).toContain('Expected an object with only molql and an optional string structure_ref');
+
+        const referencedBuilder = createMVSBuilder();
+        const referenced = referencedBuilder.download({ url: 'other.bcif' }).parse({ format: 'bcif' }).modelStructure({ ref: 'struct1' });
+        referenced.primitives().label({ position: { structure_ref: 'struct1', label_asym_id: 'A' }, text: 'Legacy reference' });
+        expect(MVSData.validationIssues(referencedBuilder.getState())).toEqual(undefined);
     });
 
     it('builds a valid story from MolScriptBuilder and a PyMOL-transpiled expression', () => {
@@ -72,19 +76,19 @@ describe('MVS MolQL selectors', () => {
         expect(findNodes(story, 'camera')).toHaveLength(0);
 
         const componentSelectors = findNodes(story, 'component').map(node => node.params.selector);
-        expect(componentSelectors.some(selector => selector?.expression)).toEqual(true);
+        expect(componentSelectors.some(selector => selector?.molql)).toEqual(true);
 
         const colorSelectors = findNodes(story, 'color').map(node => node.params.selector);
-        expect(colorSelectors.filter(selector => selector?.expression)).toHaveLength(2);
+        expect(colorSelectors.filter(selector => selector?.molql)).toHaveLength(2);
 
         const primitivePositions = findNodes(story, 'primitive').flatMap(node => [node.params.position, node.params.start, node.params.end]);
-        expect(primitivePositions.filter(position => position?.expression)).toHaveLength(2);
+        expect(primitivePositions.filter(position => position?.molql)).toHaveLength(2);
 
         const serialized = MVSData.toMVSJ(story);
         expect(serialized).toContain('"kind":"component"');
         expect(serialized).toContain('"kind":"color"');
         expect(serialized).toContain('"kind":"primitive"');
-        expect(serialized).toContain('"selector":{"expression"');
+        expect(serialized).toContain('"selector":{"molql"');
         expect(() => compile(parse('pymol', 'byres polymer within 5 of resn STI'))).not.toThrow();
         expect(() => compile(MS.struct.generator.atomGroups({
             'chain-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.label_asym_id(), 'G']),

--- a/src/extensions/mvs/components/multilayer-color-theme.ts
+++ b/src/extensions/mvs/components/multilayer-color-theme.ts
@@ -16,7 +16,7 @@ import { ColorNames } from '../../../mol-util/color/names';
 import { ParamDefinition as PD } from '../../../mol-util/param-definition';
 import { stringToWords } from '../../../mol-util/string';
 import { isMVSStructure } from './is-mvs-model-prop';
-import { ElementSet, SelectorParams, isSelectorAll, substructureFromSelector } from './selector';
+import { ElementSet, SelectorParams, isSelectorAll, substructureFromRootSelector } from './selector';
 
 
 /** Special value that can be used as color with null-like semantic (i.e. "no color provided").
@@ -165,7 +165,7 @@ function makeLayers(ctx: ThemeDataContext, props: MultilayerColorThemeProps, col
                     elementSet = undefined;
                     selectionGranularity = 'uniform';
                 } else {
-                    const substructure = substructureFromSelector(ctx.structure, layer.selection);
+                    const substructure = substructureFromRootSelector(ctx.structure, layer.selection);
                     elementSet = ElementSet.fromStructure(substructure);
                     selectionGranularity = getSubstructureGranularity(ctx.structure, substructure);
                 }

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -44,7 +44,7 @@ import { addParamDefaults } from '../tree/generic/params-schema';
 import { treeValidationIssues } from '../tree/generic/tree-validation';
 import { MolstarNode, MolstarNodeParams, MolstarSubtree } from '../tree/molstar/molstar-tree';
 import { MVSNode, MVSTreeSchema } from '../tree/mvs/mvs-tree';
-import { isComponentExpression, isPrimitiveComponentExpressions, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
+import { isComponentExpression, isMolQLExpression, isPrimitiveComponentExpressions, isPrimitiveMolQLExpression, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
 import { MVSTransform } from './annotation-structure-component';
 
 
@@ -487,7 +487,7 @@ function getPrimitives(primitives: MolstarSubtree<'primitives'>) {
 }
 
 function addRef(position: PrimitivePositionT, refs: Set<string>) {
-    if (isPrimitiveComponentExpressions(position) && position.structure_ref) {
+    if ((isPrimitiveComponentExpressions(position) || isPrimitiveMolQLExpression(position)) && position.structure_ref) {
         refs.add(position.structure_ref);
     }
 }
@@ -534,6 +534,12 @@ function resolvePosition(context: PrimitiveBuilderContext, position: PrimitivePo
     if (isPrimitiveComponentExpressions(position)) {
         // TODO: take schema into account for possible optimization
         expr = rowsToExpression(position.expressions!);
+        pivotRef = position.structure_ref;
+    } else if (isMolQLExpression(position)) {
+        if (!isPrimitiveMolQLExpression(position)) {
+            throw new Error('Invalid primitive MolQL position: structure_ref must be a string when provided.');
+        }
+        expr = position.expression as Expression;
         pivotRef = position.structure_ref;
     } else if (isComponentExpression(position)) {
         expr = rowToExpression(position);

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2024-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Adam Midlik <midlik@gmail.com>

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -44,7 +44,7 @@ import { addParamDefaults } from '../tree/generic/params-schema';
 import { treeValidationIssues } from '../tree/generic/tree-validation';
 import { MolstarNode, MolstarNodeParams, MolstarSubtree } from '../tree/molstar/molstar-tree';
 import { MVSNode, MVSTreeSchema } from '../tree/mvs/mvs-tree';
-import { isComponentExpression, isMolQLExpression, isPrimitiveComponentExpressions, isPrimitiveMolQLExpression, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
+import { isComponentExpression, isPrimitiveComponentExpressions, isPrimitiveMolQLExpression, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
 import { MVSTransform } from './annotation-structure-component';
 
 
@@ -535,10 +535,7 @@ function resolvePosition(context: PrimitiveBuilderContext, position: PrimitivePo
         // TODO: take schema into account for possible optimization
         expr = rowsToExpression(position.expressions!);
         pivotRef = position.structure_ref;
-    } else if (isMolQLExpression(position)) {
-        if (!isPrimitiveMolQLExpression(position)) {
-            throw new Error('Invalid primitive MolQL position: structure_ref must be a string when provided.');
-        }
+    } else if (isPrimitiveMolQLExpression(position)) {
         expr = position.expression as Expression;
         pivotRef = position.structure_ref;
     } else if (isComponentExpression(position)) {

--- a/src/extensions/mvs/components/primitives.ts
+++ b/src/extensions/mvs/components/primitives.ts
@@ -44,7 +44,7 @@ import { addParamDefaults } from '../tree/generic/params-schema';
 import { treeValidationIssues } from '../tree/generic/tree-validation';
 import { MolstarNode, MolstarNodeParams, MolstarSubtree } from '../tree/molstar/molstar-tree';
 import { MVSNode, MVSTreeSchema } from '../tree/mvs/mvs-tree';
-import { isComponentExpression, isPrimitiveComponentExpressions, isPrimitiveMolQLExpression, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
+import { isComponentExpression, isPrimitiveComponentExpression, isPrimitiveMolQLExpression, isVector3, PrimitivePositionT } from '../tree/mvs/param-types';
 import { MVSTransform } from './annotation-structure-component';
 
 
@@ -487,7 +487,7 @@ function getPrimitives(primitives: MolstarSubtree<'primitives'>) {
 }
 
 function addRef(position: PrimitivePositionT, refs: Set<string>) {
-    if ((isPrimitiveComponentExpressions(position) || isPrimitiveMolQLExpression(position)) && position.structure_ref) {
+    if ((isPrimitiveComponentExpression(position) || isPrimitiveMolQLExpression(position)) && position.structure_ref) {
         refs.add(position.structure_ref);
     }
 }
@@ -531,12 +531,12 @@ function resolvePosition(context: PrimitiveBuilderContext, position: PrimitivePo
         return true;
     }
 
-    if (isPrimitiveComponentExpressions(position)) {
+    if (isPrimitiveComponentExpression(position)) {
         // TODO: take schema into account for possible optimization
-        expr = rowsToExpression(position.expressions!);
+        expr = position.expressions ? rowsToExpression(position.expressions) : rowToExpression(position);
         pivotRef = position.structure_ref;
     } else if (isPrimitiveMolQLExpression(position)) {
-        expr = position.expression as Expression;
+        expr = position.molql as Expression;
         pivotRef = position.structure_ref;
     } else if (isComponentExpression(position)) {
         expr = rowToExpression(position);

--- a/src/extensions/mvs/components/selector.ts
+++ b/src/extensions/mvs/components/selector.ts
@@ -6,6 +6,7 @@
 
 import { SortedArray } from '../../../mol-data/int';
 import { ElementIndex, Structure, StructureElement } from '../../../mol-model/structure';
+import { structureIntersect } from '../../../mol-model/structure/query/utils/structure-set';
 import { StaticStructureComponentTypes, createStructureComponent } from '../../../mol-plugin-state/helpers/structure-component';
 import { PluginStateObject } from '../../../mol-plugin-state/objects';
 import { MolScriptBuilder } from '../../../mol-script/language/builder';
@@ -76,4 +77,9 @@ export function substructureFromSelector(structure: Structure, selector: Selecto
         createMVSAnnotationStructureComponent(structure, { ...selector.params, label: '', nullIfEmpty: false }, {})
         : createStructureComponent(structure, { type: selector, label: '', nullIfEmpty: false }, { source: structure });
     return PluginStateObject.Molecule.Structure.is(pso) ? pso.data : Structure.Empty;
+}
+
+/** Select against the root structure, then restrict the result to the supplied substructure. */
+export function substructureFromRootSelector(structure: Structure, selector: Selector): Structure {
+    return structureIntersect(structure, substructureFromSelector(structure.root, selector));
 }

--- a/src/extensions/mvs/load-helpers.ts
+++ b/src/extensions/mvs/load-helpers.ts
@@ -319,8 +319,7 @@ export function componentPropsFromSelector(selector?: MolstarNodeParams<'compone
     } else if (Array.isArray(selector)) {
         return { name: 'expression', params: rowsToExpression(selector) };
     } else if (isMolQLExpression(selector)) {
-        // MolQL is intentionally opaque to MVS. Mol* validates it when compiling the query.
-        return { name: 'expression', params: selector.expression as any };
+        return { name: 'expression', params: selector.molql as any };
     } else {
         return { name: 'expression', params: rowToExpression(selector) };
     }

--- a/src/extensions/mvs/load-helpers.ts
+++ b/src/extensions/mvs/load-helpers.ts
@@ -36,7 +36,7 @@ import { Subtree, getChildren } from './tree/generic/tree-schema';
 import { dfs, formatObject } from './tree/generic/tree-utils';
 import { MolstarKind, MolstarNode, MolstarNodeParams, MolstarSubtree, MolstarTree } from './tree/molstar/molstar-tree';
 import { DefaultColor } from './tree/mvs/mvs-tree';
-import { CategoricalPalette, CategoricalPaletteDefaults, ColorDictNameT, ColorListNameT, ContinuousPalette, ContinuousPaletteDefaults, DiscretePalette, DiscretePaletteDefaults } from './tree/mvs/param-types';
+import { CategoricalPalette, CategoricalPaletteDefaults, ColorDictNameT, ColorListNameT, ContinuousPalette, ContinuousPaletteDefaults, DiscretePalette, DiscretePaletteDefaults, isMolQLExpression } from './tree/mvs/param-types';
 
 
 export const AnnotationFromUriKinds = new Set(['color_from_uri', 'component_from_uri', 'label_from_uri', 'tooltip_from_uri'] satisfies MolstarKind[]);
@@ -318,6 +318,9 @@ export function componentPropsFromSelector(selector?: MolstarNodeParams<'compone
         return { name: 'static', params: selector };
     } else if (Array.isArray(selector)) {
         return { name: 'expression', params: rowsToExpression(selector) };
+    } else if (isMolQLExpression(selector)) {
+        // MolQL is intentionally opaque to MVS. Mol* validates it when compiling the query.
+        return { name: 'expression', params: selector.expression as any };
     } else {
         return { name: 'expression', params: rowToExpression(selector) };
     }
@@ -331,6 +334,8 @@ export function prettyNameFromSelector(selector?: MolstarNodeParams<'component'>
         return stringToWords(selector);
     } else if (Array.isArray(selector)) {
         return `Custom Selection: [${selector.map(formatObject).join(', ')}]`;
+    } else if (isMolQLExpression(selector)) {
+        return 'MolQL Selection';
     } else {
         return `Custom Selection: ${formatObject(selector)}`;
     }

--- a/src/extensions/mvs/tree/generic/field-schema.ts
+++ b/src/extensions/mvs/tree/generic/field-schema.ts
@@ -97,7 +97,7 @@ export function literal<V extends string | number | boolean>(...values: V[]) {
     return new iots.Type<V>(
         typeName,
         ((value: any) => valueSet.has(value)) as any,
-        (value, ctx) => valueSet.has(value as any) ? { _tag: 'Right', right: value as any } : { _tag: 'Left', left: [{ value: value, context: ctx, message: `"${value}" is not a valid value for literal type ${typeName}` }] },
+        (value, ctx) => valueSet.has(value as any) ? iots.success(value as V) : iots.failure(value, ctx, `"${value}" is not a valid value for literal type ${typeName}`),
         value => value
     );
 }

--- a/src/extensions/mvs/tree/mvs/mvs-tree.ts
+++ b/src/extensions/mvs/tree/mvs/mvs-tree.ts
@@ -10,10 +10,10 @@ import { SimpleParamsSchema } from '../generic/params-schema';
 import { NodeFor, ParamsOfKind, SubtreeOfKind, TreeFor, TreeSchema, TreeSchemaWithAllRequired } from '../generic/tree-schema';
 import { MVSPrimitiveParams } from './mvs-tree-primitives';
 import { MVSClipParams, MVSRepresentationParams, MVSVolumeRepresentationParams } from './mvs-tree-representations';
-import { CameraTransitionTrajectoryT, ColorT, ComponentExpressionT, ComponentSelectorT, EasingT, LabelAttachments, Matrix, Palette, ParseFormatT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
+import { CameraTransitionTrajectoryT, ColorT, ComponentExpressionT, ComponentSelectorT, EasingT, LabelAttachments, Matrix, MolQLExpressionT, Palette, ParseFormatT, SchemaFormatT, SchemaT, StrList, StructureTypeT, Vector3 } from './param-types';
 
 
-const SelectorT = union(ComponentSelectorT, ComponentExpressionT, list(ComponentExpressionT));
+const SelectorT = union(ComponentSelectorT, ComponentExpressionT, list(ComponentExpressionT), MolQLExpressionT);
 
 const _DataFromUriParams = {
     /** URL of the annotation resource. */

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2023-2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Adam Midlik <midlik@gmail.com>
  * @author David Sehnal <david.sehnal@gmail.com>

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -134,15 +134,15 @@ export interface ComponentExpressionT extends ValueFor<typeof _ComponentExpressi
 export const ComponentExpressionT = new iots.Type<ComponentExpressionT>(
     'ComponentExpression',
     isComponentExpression,
-    (value, context) => isMolQLExpression(value)
-        ? iots.failure(value, context, 'MolQL expression wrappers must contain a valid expression')
+    (value, context) => hasMolQLProperty(value) || hasStructureRefProperty(value)
+        ? iots.failure(value, context, 'MolQL wrappers and primitive structure_ref positions are not component expressions')
         : _ComponentExpressionT.validate(value, context),
     value => value,
 );
 
 /** A MolQL expression serialized as JSON. The expression is validated by the MolScript compiler. */
 export interface MolQLExpressionT {
-    expression: unknown
+    molql: unknown
 }
 export const MolQLExpressionT = new iots.Type<MolQLExpressionT>(
     'MolQLExpression',
@@ -186,13 +186,11 @@ const _PrimitiveComponentExpressionT = partial({
     expressions: list(ComponentExpressionT),
 });
 /** Primitives-related types */
-export interface PrimitiveComponentExpressionT extends ValueFor<typeof _PrimitiveComponentExpressionT> { }
+export interface PrimitiveComponentExpressionT extends ComponentExpressionT, ValueFor<typeof _PrimitiveComponentExpressionT> { }
 export const PrimitiveComponentExpressionT = new iots.Type<PrimitiveComponentExpressionT>(
     'PrimitiveComponentExpression',
-    isPrimitiveComponentExpressions,
-    (value, context) => isMolQLExpression(value)
-        ? iots.failure(value, context, 'MolQL expression wrappers must contain a valid expression')
-        : _PrimitiveComponentExpressionT.validate(value, context),
+    isPrimitiveComponentExpression,
+    (value, context) => validatePrimitiveComponentExpression(value, context),
     value => value,
 );
 
@@ -207,7 +205,7 @@ export const PrimitiveMolQLExpressionT = new iots.Type<PrimitiveMolQLExpressionT
     value => value,
 );
 
-export const PrimitivePositionT = union(Vector3, ComponentExpressionT, PrimitiveComponentExpressionT, PrimitiveMolQLExpressionT);
+export const PrimitivePositionT = union(Vector3, PrimitiveComponentExpressionT, ComponentExpressionT, PrimitiveMolQLExpressionT);
 export type PrimitivePositionT = ValueFor<typeof PrimitivePositionT>
 
 export const FloatList = list(float);
@@ -220,7 +218,7 @@ export type HexColorT = `#${string}`;
 export const HexColorT = new iots.Type<HexColorT>(
     'HexColor',
     ((value: any) => typeof value === 'string') as any,
-    (value, ctx) => isHexColorT(value) ? { _tag: 'Right', right: value } : { _tag: 'Left', left: [{ value: value, context: ctx, message: `"${value}" is not a valid hex color string` }] },
+    (value, ctx) => isHexColorT(value) ? iots.success(value) : iots.failure(value, ctx, `"${value}" is not a valid hex color string`),
     value => value
 );
 /** Regular expression matching a hexadecimal color string, e.g. '#FF1100' or '#f10' */
@@ -234,7 +232,7 @@ function isHexColorT(str: any): str is HexColorT {
 export const ColorNameT = new iots.Type<ColorNameT>(
     'ColorName',
     ((value: any) => typeof value === 'string') as any,
-    (value, ctx) => isColorNameT(value) ? { _tag: 'Right', right: value } : { _tag: 'Left', left: [{ value: value, context: ctx, message: `"${value}" is not a valid color name` }] },
+    (value, ctx) => isColorNameT(value) ? iots.success(value) : iots.failure(value, ctx, `"${value}" is not a valid color name`),
     value => value
 );
 export type ColorNameT =
@@ -274,53 +272,59 @@ export function isVector3(x: any): x is Vector3 {
     return !!x && Array.isArray(x) && x.length === 3 && typeof x[0] === 'number';
 }
 
+export function isPrimitiveComponentExpression(x: any): x is PrimitiveComponentExpressionT {
+    return !!x && typeof x === 'object' && !Array.isArray(x) && !hasMolQLProperty(x)
+        && (Array.isArray(x.expressions) || (Object.prototype.hasOwnProperty.call(x, 'structure_ref') && !x.expressions));
+}
+
 export function isPrimitiveComponentExpressions(x: any): x is PrimitiveComponentExpressionT {
-    return !!x && typeof x === 'object' && !isMolQLExpression(x) && Array.isArray(x.expressions);
+    return isPrimitiveComponentExpression(x) && Array.isArray(x.expressions);
 }
 
 export function isComponentExpression(x: any): x is ComponentExpressionT {
-    return !!x && typeof x === 'object' && !Array.isArray(x) && !isMolQLExpression(x) && !x.expressions;
+    return !!x && typeof x === 'object' && !Array.isArray(x) && !hasMolQLProperty(x) && !x.expressions && !Object.prototype.hasOwnProperty.call(x, 'structure_ref');
 }
 
 /** Decide if a selector is an MVS wrapper around a serialized MolQL expression. */
 export function isMolQLExpression(x: any): x is MolQLExpressionT {
-    return !!x && typeof x === 'object' && !Array.isArray(x) && Object.prototype.hasOwnProperty.call(x, 'expression');
+    return hasMolQLProperty(x) && Object.keys(x).length === 1;
 }
 
 /** Decide if a primitive position is a MolQL expression with an optional structure reference. */
 export function isPrimitiveMolQLExpression(x: any): x is PrimitiveMolQLExpressionT {
     const position = x as PrimitiveMolQLExpressionT;
-    return isMolQLExpression(x) && (position.structure_ref === undefined || typeof position.structure_ref === 'string');
+    return hasMolQLProperty(x) && Object.keys(x).every(key => key === 'molql' || key === 'structure_ref')
+        && (position.structure_ref === undefined || typeof position.structure_ref === 'string');
 }
 
 function validateMolQLExpression(value: unknown, context: iots.Context, primitive = false): iots.Validation<MolQLExpressionT | PrimitiveMolQLExpressionT> {
-    if (!isMolQLExpression(value)) {
-        return iots.failure(value, context, 'Expected an object with an expression property');
+    if (!(primitive ? isPrimitiveMolQLExpression(value) : isMolQLExpression(value))) {
+        return iots.failure(value, context, primitive
+            ? 'Expected an object with only molql and an optional string structure_ref'
+            : 'Expected an object with only a molql property');
     }
-    if (primitive && !isPrimitiveMolQLExpression(value)) {
-        return iots.failure(value, context, 'Primitive MolQL structure_ref must be a string when provided');
-    }
-    const validation = validateMolQLSyntax(value.expression);
+    const wrapper = value as MolQLExpressionT;
+    const validation = validateMolQLSyntax(wrapper.molql);
     return validation === true
-        ? iots.success(value)
+        ? iots.success(wrapper)
         : iots.failure(value, context, validation);
 }
 
 /** Cache MolQL validation by expression identity; io-ts failures are reconstructed with each decode context. */
 const MolQLValidationCache = new WeakMap<object, true | string>();
 
-function validateMolQLSyntax(expression: unknown): true | string {
-    const cacheKey = expression !== null && typeof expression === 'object' ? expression : undefined;
+function validateMolQLSyntax(molql: unknown): true | string {
+    const cacheKey = molql !== null && typeof molql === 'object' ? molql : undefined;
     const cached = cacheKey ? MolQLValidationCache.get(cacheKey) : undefined;
     if (cached !== undefined) return cached;
 
-    if (!Expression.is(expression)) {
-        const message = 'MolQL expression must be a MolScript symbol or application';
+    if (!Expression.is(molql) || !Expression.isApply(molql)) {
+        const message = 'MolQL expression must be a MolScript application';
         if (cacheKey) MolQLValidationCache.set(cacheKey, message);
         return message;
     }
     try {
-        compile(expression as Expression);
+        compile(molql);
     } catch (e) {
         const message = `Invalid MolQL expression: ${e instanceof Error ? e.message : String(e)}`;
         if (cacheKey) MolQLValidationCache.set(cacheKey, message);
@@ -328,6 +332,27 @@ function validateMolQLSyntax(expression: unknown): true | string {
     }
     if (cacheKey) MolQLValidationCache.set(cacheKey, true);
     return true;
+}
+
+function hasMolQLProperty(x: any): x is { molql: unknown } {
+    return !!x && typeof x === 'object' && !Array.isArray(x) && Object.prototype.hasOwnProperty.call(x, 'molql');
+}
+
+function hasStructureRefProperty(x: any): x is { structure_ref: unknown } {
+    return !!x && typeof x === 'object' && !Array.isArray(x) && Object.prototype.hasOwnProperty.call(x, 'structure_ref');
+}
+
+function validatePrimitiveComponentExpression(value: unknown, context: iots.Context): iots.Validation<PrimitiveComponentExpressionT> {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || hasMolQLProperty(value)) {
+        return iots.failure(value, context, 'Expected a legacy primitive position without molql');
+    }
+    const position = value as PrimitiveComponentExpressionT;
+    if (position.structure_ref !== undefined && typeof position.structure_ref !== 'string') {
+        return iots.failure(value, context, 'Primitive structure_ref must be a string when provided');
+    }
+    if (position.expressions !== undefined) return _PrimitiveComponentExpressionT.validate(value, context);
+    if (hasStructureRefProperty(position)) return _ComponentExpressionT.validate(value, context) as iots.Validation<PrimitiveComponentExpressionT>;
+    return iots.failure(value, context, 'Expected expressions or structure_ref for a primitive component expression');
 }
 
 

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -6,6 +6,8 @@
  */
 
 import * as iots from 'io-ts';
+import { Expression } from '../../../../mol-script/language/expression';
+import { compile } from '../../../../mol-script/runtime/query/base';
 import { ColorNames } from '../../../../mol-util/color/names';
 import { ValueFor, bool, dict, float, int, list, literal, nullable, object, partial, str, tuple, union } from '../generic/field-schema';
 
@@ -129,18 +131,23 @@ const _ComponentExpressionT = partial({
 });
 /** `selector` parameter values for `component` node in MVS tree */
 export interface ComponentExpressionT extends ValueFor<typeof _ComponentExpressionT> { }
-export const ComponentExpressionT: iots.Type<ComponentExpressionT> = _ComponentExpressionT;
+export const ComponentExpressionT = new iots.Type<ComponentExpressionT>(
+    'ComponentExpression',
+    isComponentExpression,
+    (value, context) => isMolQLExpression(value)
+        ? iots.failure(value, context, 'MolQL expression wrappers must contain a valid expression')
+        : _ComponentExpressionT.validate(value, context),
+    value => value,
+);
 
-/** A MolQL expression serialized as JSON. The expression itself is validated by Mol* when it is evaluated. */
+/** A MolQL expression serialized as JSON. The expression is validated by the MolScript compiler. */
 export interface MolQLExpressionT {
     expression: unknown
 }
 export const MolQLExpressionT = new iots.Type<MolQLExpressionT>(
     'MolQLExpression',
     isMolQLExpression,
-    (value, context) => isMolQLExpression(value)
-        ? iots.success(value)
-        : iots.failure(value, context, 'Expected an object with an expression property'),
+    (value, context) => validateMolQLExpression(value, context),
     value => value,
 );
 
@@ -180,7 +187,14 @@ const _PrimitiveComponentExpressionT = partial({
 });
 /** Primitives-related types */
 export interface PrimitiveComponentExpressionT extends ValueFor<typeof _PrimitiveComponentExpressionT> { }
-export const PrimitiveComponentExpressionT: iots.Type<PrimitiveComponentExpressionT> = _PrimitiveComponentExpressionT;
+export const PrimitiveComponentExpressionT = new iots.Type<PrimitiveComponentExpressionT>(
+    'PrimitiveComponentExpression',
+    isPrimitiveComponentExpressions,
+    (value, context) => isMolQLExpression(value)
+        ? iots.failure(value, context, 'MolQL expression wrappers must contain a valid expression')
+        : _PrimitiveComponentExpressionT.validate(value, context),
+    value => value,
+);
 
 /** A MolQL primitive position, optionally evaluated against a referenced structure. */
 export interface PrimitiveMolQLExpressionT extends MolQLExpressionT {
@@ -189,9 +203,7 @@ export interface PrimitiveMolQLExpressionT extends MolQLExpressionT {
 export const PrimitiveMolQLExpressionT = new iots.Type<PrimitiveMolQLExpressionT>(
     'PrimitiveMolQLExpression',
     isPrimitiveMolQLExpression,
-    (value, context) => isPrimitiveMolQLExpression(value)
-        ? iots.success(value)
-        : iots.failure(value, context, 'Expected an object with an expression property and an optional string structure_ref'),
+    (value, context) => validateMolQLExpression(value, context, true),
     value => value,
 );
 
@@ -263,11 +275,11 @@ export function isVector3(x: any): x is Vector3 {
 }
 
 export function isPrimitiveComponentExpressions(x: any): x is PrimitiveComponentExpressionT {
-    return !!x && Array.isArray(x.expressions);
+    return !!x && typeof x === 'object' && !isMolQLExpression(x) && Array.isArray(x.expressions);
 }
 
 export function isComponentExpression(x: any): x is ComponentExpressionT {
-    return !!x && typeof x === 'object' && !x.expressions;
+    return !!x && typeof x === 'object' && !Array.isArray(x) && !isMolQLExpression(x) && !x.expressions;
 }
 
 /** Decide if a selector is an MVS wrapper around a serialized MolQL expression. */
@@ -279,6 +291,43 @@ export function isMolQLExpression(x: any): x is MolQLExpressionT {
 export function isPrimitiveMolQLExpression(x: any): x is PrimitiveMolQLExpressionT {
     const position = x as PrimitiveMolQLExpressionT;
     return isMolQLExpression(x) && (position.structure_ref === undefined || typeof position.structure_ref === 'string');
+}
+
+function validateMolQLExpression(value: unknown, context: iots.Context, primitive = false): iots.Validation<MolQLExpressionT | PrimitiveMolQLExpressionT> {
+    if (!isMolQLExpression(value)) {
+        return iots.failure(value, context, 'Expected an object with an expression property');
+    }
+    if (primitive && !isPrimitiveMolQLExpression(value)) {
+        return iots.failure(value, context, 'Primitive MolQL structure_ref must be a string when provided');
+    }
+    const validation = validateMolQLSyntax(value.expression);
+    return validation === true
+        ? iots.success(value)
+        : iots.failure(value, context, validation);
+}
+
+/** Cache MolQL validation by expression identity; io-ts failures are reconstructed with each decode context. */
+const MolQLValidationCache = new WeakMap<object, true | string>();
+
+function validateMolQLSyntax(expression: unknown): true | string {
+    const cacheKey = expression !== null && typeof expression === 'object' ? expression : undefined;
+    const cached = cacheKey ? MolQLValidationCache.get(cacheKey) : undefined;
+    if (cached !== undefined) return cached;
+
+    if (!Expression.is(expression)) {
+        const message = 'MolQL expression must be a MolScript symbol or application';
+        if (cacheKey) MolQLValidationCache.set(cacheKey, message);
+        return message;
+    }
+    try {
+        compile(expression as Expression);
+    } catch (e) {
+        const message = `Invalid MolQL expression: ${e instanceof Error ? e.message : String(e)}`;
+        if (cacheKey) MolQLValidationCache.set(cacheKey, message);
+        return message;
+    }
+    if (cacheKey) MolQLValidationCache.set(cacheKey, true);
+    return true;
 }
 
 

--- a/src/extensions/mvs/tree/mvs/param-types.ts
+++ b/src/extensions/mvs/tree/mvs/param-types.ts
@@ -131,6 +131,19 @@ const _ComponentExpressionT = partial({
 export interface ComponentExpressionT extends ValueFor<typeof _ComponentExpressionT> { }
 export const ComponentExpressionT: iots.Type<ComponentExpressionT> = _ComponentExpressionT;
 
+/** A MolQL expression serialized as JSON. The expression itself is validated by Mol* when it is evaluated. */
+export interface MolQLExpressionT {
+    expression: unknown
+}
+export const MolQLExpressionT = new iots.Type<MolQLExpressionT>(
+    'MolQLExpression',
+    isMolQLExpression,
+    (value, context) => isMolQLExpression(value)
+        ? iots.success(value)
+        : iots.failure(value, context, 'Expected an object with an expression property'),
+    value => value,
+);
+
 
 /** `schema` parameter values for `*_from_uri` and `*_from_source` nodes in MVS tree */
 export type SchemaT = 'whole_structure' | 'entity' | 'chain' | 'auth_chain' | 'residue' | 'auth_residue' | 'residue_range' | 'auth_residue_range' | 'atom' | 'auth_atom' | 'all_atomic';
@@ -169,7 +182,20 @@ const _PrimitiveComponentExpressionT = partial({
 export interface PrimitiveComponentExpressionT extends ValueFor<typeof _PrimitiveComponentExpressionT> { }
 export const PrimitiveComponentExpressionT: iots.Type<PrimitiveComponentExpressionT> = _PrimitiveComponentExpressionT;
 
-export const PrimitivePositionT = union(Vector3, ComponentExpressionT, PrimitiveComponentExpressionT);
+/** A MolQL primitive position, optionally evaluated against a referenced structure. */
+export interface PrimitiveMolQLExpressionT extends MolQLExpressionT {
+    structure_ref?: string
+}
+export const PrimitiveMolQLExpressionT = new iots.Type<PrimitiveMolQLExpressionT>(
+    'PrimitiveMolQLExpression',
+    isPrimitiveMolQLExpression,
+    (value, context) => isPrimitiveMolQLExpression(value)
+        ? iots.success(value)
+        : iots.failure(value, context, 'Expected an object with an expression property and an optional string structure_ref'),
+    value => value,
+);
+
+export const PrimitivePositionT = union(Vector3, ComponentExpressionT, PrimitiveComponentExpressionT, PrimitiveMolQLExpressionT);
 export type PrimitivePositionT = ValueFor<typeof PrimitivePositionT>
 
 export const FloatList = list(float);
@@ -242,6 +268,17 @@ export function isPrimitiveComponentExpressions(x: any): x is PrimitiveComponent
 
 export function isComponentExpression(x: any): x is ComponentExpressionT {
     return !!x && typeof x === 'object' && !x.expressions;
+}
+
+/** Decide if a selector is an MVS wrapper around a serialized MolQL expression. */
+export function isMolQLExpression(x: any): x is MolQLExpressionT {
+    return !!x && typeof x === 'object' && !Array.isArray(x) && Object.prototype.hasOwnProperty.call(x, 'expression');
+}
+
+/** Decide if a primitive position is a MolQL expression with an optional structure reference. */
+export function isPrimitiveMolQLExpression(x: any): x is PrimitiveMolQLExpressionT {
+    const position = x as PrimitiveMolQLExpressionT;
+    return isMolQLExpression(x) && (position.structure_ref === undefined || typeof position.structure_ref === 'string');
 }
 
 

--- a/src/mol-script/language/_spec/expression.spec.ts
+++ b/src/mol-script/language/_spec/expression.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author David Sehnal <david.sehnal@gmail.com>
+ */
+
+import { Expression } from '../expression';
+
+describe('MolScript expression shape', () => {
+    it('accepts literals, symbols, and recursive applications', () => {
+        expect(Expression.is('text')).toEqual(true);
+        expect(Expression.is(42)).toEqual(true);
+        expect(Expression.is(false)).toEqual(true);
+        expect(Expression.is({ name: 'structure-query.generator.all' })).toEqual(true);
+        expect(Expression.is({
+            head: { name: 'core.rel.eq' },
+            args: [{ name: 'structure.atom-property.macromolecular.label_asym_id' }, 'A'],
+        })).toEqual(true);
+        expect(Expression.is({
+            head: { name: 'structure-query.generator.atom-groups' },
+            args: { 'chain-test': { head: { name: 'core.rel.eq' }, args: ['A', 'A'] } },
+        })).toEqual(true);
+    });
+
+    it('rejects malformed recursive shapes', () => {
+        expect(Expression.is(null)).toEqual(false);
+        expect(Expression.is([])).toEqual(false);
+        expect(Expression.is({})).toEqual(false);
+        expect(Expression.is({ head: null })).toEqual(false);
+        expect(Expression.is({ head: { name: 'core.rel.eq' }, args: [undefined] })).toEqual(false);
+        expect(Expression.is({ head: { name: 'core.rel.eq' }, args: 1 })).toEqual(false);
+        expect(Expression.is({ head: { malformed: true } })).toEqual(false);
+    });
+});

--- a/src/mol-script/language/expression.ts
+++ b/src/mol-script/language/expression.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * Copyright (c) 2018-2026 Mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  */
@@ -23,6 +23,18 @@ namespace Expression {
     export function isLiteral(e: Expression): e is Expression.Literal { return !isApply(e) && !isSymbol(e); }
     export function isApply(e: Expression): e is Expression.Apply { return !!e && !!(e as Expression.Apply).head && typeof e === 'object'; }
     export function isSymbol(e: Expression): e is Expression.Symbol { return !!e && typeof (e as any).name === 'string'; }
+
+    /** Decide if a value has the recursive JSON shape of a MolScript expression. */
+    export function is(value: unknown): value is Expression {
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return true;
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+        if (isSymbol(value as Expression)) return true;
+        const apply = value as Apply;
+        if (!Object.prototype.hasOwnProperty.call(apply, 'head') || !is(apply.head)) return false;
+        if (apply.args === undefined) return true;
+        if (Array.isArray(apply.args)) return apply.args.every(is);
+        return !!apply.args && typeof apply.args === 'object' && Object.values(apply.args).every(is);
+    }
 }
 
 export { Expression };


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

Adds experimental/proof-of-concept support for serialized MolQL expressions in MolViewSpec selectors.

Corresponding Python version https://github.com/molstar/mol-view-spec/pull/112

MolQL expressions use an explicit `molql` wrapper to distinguish them from existing named and schema-based selectors:

```json
{
  "molql": "<MolQL JSON expression>"
}
```

The wrapper shape and serialized expression tree are validated by MVS. The top-level value must be a MolScript application, and the expression is compiled before execution; validation results are cached by expression identity.

This PR adds support for wrapped MolQL expressions in:

- Component selectors.
- Selective color layers, including `color`, `color_from_uri`, and `color_from_source` selector parameters.
- Primitive positions, with optional `structure_ref` support.
- Component-derived labels and tooltips through the existing selector pipeline.

Color-layer selectors are evaluated against the root structure and then intersected with the represented component. This allows context-dependent queries, such as selecting polymer residues around a ligand, to work when the representation itself contains only the polymer subset.

Primitive positions also support direct schema-based addresses with `structure_ref`, alongside the existing explicit `expressions` list form. Existing named selectors, component-expression rows, and explicit row lists retain their current behavior.

A new four-step MVS story demonstrates:

1. Component selections created with `MolScriptBuilder` and the PyMOL transpiler.
2. MolQL selectors used for multilayer coloring on a polymer-only representation.
3. Reusing a MolQL component for representations, labels, and tooltips.
4. A primitive distance measurement between imatinib N13 and Thr315 OG1, with both endpoints selected using wrapped MolQL expressions.

The story loads the first biological assembly of PDB entry 1IEP and does not prescribe fixed camera positions.

## Testing

```bash
npm run dev -- -e mvs-stories
```

Open [the MolQL MVS story](http://localhost:1338/build/examples/mvs-stories/?story=molql).

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Contributor is already listed in `package.json`
- [ ] (Optional but encouraged) Improved documentation in `docs`
