### PR TITLE
Altloc atomnames from pdb file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 Note that since we don't clearly distinguish between a public and private interfaces there will be changes in non-major versions that are potentially breaking. If we make breaking changes to less used interfaces we will highlight it in here.
 
 ## [Unreleased]
+- Fix altloc in PDB files receive different atom names (#156)
 - Optimize `GridLookup3D` building for sparse grids
 - Optimize `calcInstanceGrid` by reducing amount of data copied
 - Viewer app: keep track of instances in static `Viewer.instances`

--- a/src/mol-model-formats/structure/_spec/pdb.spec.ts
+++ b/src/mol-model-formats/structure/_spec/pdb.spec.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Ryan DiRisio <rjdiris@gmail.com>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { TokenBuilder, Tokenizer } from '../../../mol-io/reader/common/text/tokenizer';
@@ -240,5 +241,61 @@ describe('PDB SEQRES-to-label_seq_id alignment', () => {
         for (let i = 0; i < labelSeqId.rowCount; ++i) {
             expect(labelSeqId.int(i)).toBe(i + 1);
         }
+    });
+});
+
+describe('PDB label_atom_id unicity', () => {
+    it('preserves unique atom names within a residue', async () => {
+        const pdb = makePdb([
+            'ATOM   2161  CG2 MOL A 303      31.377  65.493  27.278  1.00 32.12           C  ',
+            'ATOM   2162  OG2 MOL A 303      31.727  64.432  26.692  1.00 30.76           O  ',
+            'ATOM   2163  OG3 MOL A 303      30.170  65.084  27.156  1.00 32.03           O  ',
+            'END                                                                             ',
+        ].join('\n'));
+
+        const cif = await pdbToMmCif(pdb);
+        const atomSite = cif.categories['atom_site'];
+        const labelAtomId = atomSite.getField('label_atom_id')!;
+
+        expect(labelAtomId.str(0)).toBe('CG2');
+        expect(labelAtomId.str(1)).toBe('OG2');
+        expect(labelAtomId.str(2)).toBe('OG3');
+    });
+
+    it('deduplicates repeated atom names within a residue', async () => {
+        const pdb = makePdb([
+            'ATOM   2161  C   MOL A 303      31.377  65.493  27.278  1.00 32.12           C  ',
+            'ATOM   2162  O   MOL A 303      31.727  64.432  26.692  1.00 30.76           O  ',
+            'ATOM   2163  O   MOL A 303      30.170  65.084  27.156  1.00 32.03           O  ',
+            'END                                                                             ',
+        ].join('\n'));
+
+        const cif = await pdbToMmCif(pdb);
+        const atomSite = cif.categories['atom_site'];
+        const labelAtomId = atomSite.getField('label_atom_id')!;
+
+        expect(labelAtomId.str(0)).toBe('C');
+        expect(labelAtomId.str(1)).toBe('O');
+        expect(labelAtomId.str(2)).toBe('O_1'); // deduplicated
+    });
+
+    it('No suffix added to same atom names for altlocs)', async () => {
+        const pdb = makePdb([
+            'HETATM 2161  CG2 SRY A 303      31.377  65.493  27.278  1.00 32.12           C  ',
+            'HETATM 2162  OG2ASRY A 303      31.727  64.432  26.692  0.50 30.76           O  ',
+            'HETATM 2163  OG2BSRY A 303      30.170  65.084  27.156  0.50 32.03           O  ',
+            'END                                                                             ',
+        ].join('\n'));
+
+        const cif = await pdbToMmCif(pdb);
+        const atomSite = cif.categories['atom_site'];
+        const labelAtomId = atomSite.getField('label_atom_id')!;
+        const labelAltId = atomSite.getField('label_alt_id')!;
+
+        expect(labelAtomId.str(0)).toBe('CG2');
+        expect(labelAtomId.str(1)).toBe('OG2');
+        expect(labelAtomId.str(2)).toBe('OG2');
+        expect(labelAltId.str(1)).toBe('A');
+        expect(labelAltId.str(2)).toBe('B');
     });
 });

--- a/src/mol-model-formats/structure/pdb/atom-site.ts
+++ b/src/mol-model-formats/structure/pdb/atom-site.ts
@@ -5,6 +5,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Kim Juho <juho_kim@outlook.com>
  * @author Ryan DiRisio <rjdiris@gmail.com>
+ * @author Paul Pillot <paul.pillot@tandemai.com>
  */
 
 import { CifField } from '../../../mol-io/reader/cif';
@@ -192,6 +193,7 @@ export function getAtomSite(sites: AtomSiteTemplate, labelAsymIdHelper: LabelAsy
     const auth_seq_id = CifField.ofTokens(sites.auth_seq_id);
     const pdbx_PDB_ins_code = CifField.ofTokens(sites.pdbx_PDB_ins_code);
     const auth_atom_id = CifField.ofTokens(sites.auth_atom_id);
+    const pdbx_PDB_alt_loc = CifField.ofTokens(sites.label_alt_id);
     const auth_comp_id = CifField.ofTokens(sites.auth_comp_id);
     const id = CifField.ofStrings(sites.id);
 
@@ -236,6 +238,7 @@ export function getAtomSite(sites: AtomSiteTemplate, labelAsymIdHelper: LabelAsy
         const seqId = auth_seq_id.int(i);
         const insCode = pdbx_PDB_ins_code.str(i);
         let atomId = auth_atom_id.str(i);
+        const altloc = pdbx_PDB_alt_loc.str(i);
 
         if (modelNum !== currModelNum) {
             asymIdCounts.clear();
@@ -273,7 +276,7 @@ export function getAtomSite(sites: AtomSiteTemplate, labelAsymIdHelper: LabelAsy
 
         labelAsymIds[i] = labelAsymIdHelper.get(i);
 
-        if (atomIdCounts.has(atomId)) {
+        if (atomIdCounts.has(atomId) && altloc === '') {
             const atomIdCount = atomIdCounts.get(atomId)! + 1;
             atomIdCounts.set(atomId, atomIdCount);
             atomId = `${atomId}_${atomIdCount}`;


### PR DESCRIPTION
<!-- Thank you for contributing to Mol* -->

# Description

This PR fixes an issue wrt atom names consistency when reading PDB files. This is due to PR #403 that handles gracefully duplicated atom names in PDB files by appending a suffix to duplicates. See Discussion #156 for the bug description.

This caused altloc to inherit suffixes as well, breaking atom names consistency for altlocs. This PR just skips adding a suffix when altlocs are present. It does not try to deduplicate atom names if altlocs themselves are duplicated: this issue has never presented itself previously.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`