### PR TITLE
chore: general performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@ Note that since we don't clearly distinguish between a public and private interf
     - Formats: ariatomi-em, cryoet-ndjson, dynamo-tbl, relion-star, simularium, cellpack & petworld mmcif
     - Properties: position, orientation, radius, entity, compartment, custom attributes, fibers
     - Particles can be decorated with structure, volume, and shape visuals
+- Improve WebGL rendering performance
+    - Skip redundant uniform uploads when values have not changed
+    - Batch shared uniforms and textures once per program switch instead of per render object
+    - Cache active texture units and bound textures to avoid redundant GL calls
+    - Reuse cull results within a frame when grid/LOD versions are unchanged
+    - Reuse light-direction buffer allocation; fix render-item buffer upload size
 
 ## [v5.11.0] - 2026-07-18
 - Fix LAMMPS unsorted-atom handling (trajectory frame ordering and data-file bonds)

--- a/src/mol-canvas3d/canvas3d.ts
+++ b/src/mol-canvas3d/canvas3d.ts
@@ -6,6 +6,7 @@
  * @author Gianluca Tomasello <giagitom@gmail.com>
  * @author Herman Bergwerf <post@hbergwerf.nl>
  * @author Adam Midlik <midlik@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { BehaviorSubject, Subject, Subscription, debounceTime, merge } from 'rxjs';
@@ -610,7 +611,7 @@ namespace Canvas3D {
 
                 loci = helper.handle.getLoci(pickingId);
 
-                reprRenderObjects.forEach((_, _repr) => {
+                for (const [_repr] of reprRenderObjects) {
                     const _loci = _repr.getLoci(pickingId);
                     if (!isEmptyLoci(_loci)) {
                         if (!isEmptyLoci(loci)) {
@@ -618,13 +619,14 @@ namespace Canvas3D {
                         }
                         loci = _loci;
                         repr = _repr;
+                        break;
                     }
-                });
+                }
             }
             return { loci, repr };
         }
 
-        let markBuffer: [reprLoci: Representation.Loci, action: MarkerAction][] = [];
+        const markBuffer: [reprLoci: Representation.Loci, action: MarkerAction][] = [];
 
         function mark(reprLoci: Representation.Loci, action: MarkerAction) {
             // NOTE: might try to optimize a case with opposite actions for the
@@ -638,7 +640,7 @@ namespace Canvas3D {
             for (const [r, l] of markBuffer) {
                 changed = applyMark(r, l) || changed;
             }
-            markBuffer = [];
+            markBuffer.length = 0;
             if (changed) {
                 scene.update(void 0, true);
                 helper.handle.scene.update(void 0, true);
@@ -971,7 +973,7 @@ namespace Canvas3D {
                 camera.setState({ radiusMax: getSceneRadius() }, 0);
             }
             reprCount.next(reprRenderObjects.size);
-            if (isDebugMode) consoleStats();
+            if (isDebugMode || isTimingMode) consoleStats();
 
             return true;
         }
@@ -1017,6 +1019,12 @@ namespace Canvas3D {
 
             if (isTimingMode) {
                 console.log(JSON.stringify(webgl.timer.formatedStats(), undefined, 4));
+                console.log(JSON.stringify({
+                    uniforms: webgl.stats.uniforms,
+                    cull: webgl.stats.cull,
+                    calls: webgl.stats.calls,
+                    culled: webgl.stats.culled,
+                }, undefined, 4));
             }
 
             console.groupEnd();
@@ -1041,7 +1049,7 @@ namespace Canvas3D {
 
             scene.update(repr.renderObjects, false);
             forceDrawAfterAllCommited = true;
-            if (isDebugMode) consoleStats();
+            if (isDebugMode || isTimingMode) consoleStats();
         }
 
         function remove(repr: Representation.Any) {
@@ -1052,7 +1060,7 @@ namespace Canvas3D {
                 renderObjects.forEach(o => scene.remove(o));
                 reprRenderObjects.delete(repr);
                 forceDrawAfterAllCommited = true;
-                if (isDebugMode) consoleStats();
+                if (isDebugMode || isTimingMode) consoleStats();
             }
         }
 
@@ -1448,7 +1456,7 @@ namespace Canvas3D {
                 cancelAnimationFrame(animationFrameHandle);
                 animationFrameCB = undefined;
 
-                markBuffer = [];
+                markBuffer.length = 0;
 
                 scene.clear();
                 helper.debug.clear();

--- a/src/mol-canvas3d/passes/draw.ts
+++ b/src/mol-canvas3d/passes/draw.ts
@@ -4,6 +4,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Áron Samuel Kovács <aron.kovacs@mail.muni.cz>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { WebGLContext } from '../../mol-gl/webgl/context';
@@ -547,12 +548,15 @@ export class DrawPass {
             }
         }
 
-        this.webgl.gl.flush();
+        if (toDrawingBuffer) {
+            this.webgl.gl.flush();
+        }
     }
 
     render(ctx: RenderContext, props: Props, toDrawingBuffer: boolean) {
         if (isTimingMode) this.webgl.timer.mark('DrawPass.render');
         const { renderer, camera, scene, helper } = ctx;
+        renderer.beginFrame();
 
         this.postprocessing.setTransparentBackground(props.transparentBackground);
         const pp = props.postprocessing;

--- a/src/mol-canvas3d/passes/shadow.ts
+++ b/src/mol-canvas3d/passes/shadow.ts
@@ -5,6 +5,7 @@
  * @author Áron Samuel Kovács <aron.kovacs@mail.muni.cz>
  * @author Ludovic Autin <ludovic.autin@gmail.com>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { QuadSchema, QuadValues } from '../../mol-gl/compute/util';
@@ -96,7 +97,7 @@ export class ShadowPass {
 
         const hasHeadRotation = !Mat4.isZero(camera.headRotation);
         if (hasHeadRotation) {
-            ValueCell.update(this.renderable.values.uLightDirection, getTransformedLightDirection(light, Mat4.invert(this.invHeadRotation, camera.headRotation)));
+            ValueCell.update(this.renderable.values.uLightDirection, getTransformedLightDirection(light, Mat4.invert(this.invHeadRotation, camera.headRotation), this.renderable.values.uLightDirection.ref.value));
         } else {
             ValueCell.update(this.renderable.values.uLightDirection, light.direction);
         }

--- a/src/mol-gl/cull-frame.ts
+++ b/src/mol-gl/cull-frame.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * 
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
+ */
+
+import { WebGLStats } from './webgl/context';
+
+let cullFrameId = 0;
+
+export function beginCullFrame(stats?: WebGLStats) {
+    cullFrameId++;
+    if (stats) {
+        stats.cull.cached = 0;
+        stats.cull.computed = 0;
+        stats.uniforms.uploaded = 0;
+        stats.uniforms.skipped = 0;
+    }
+}
+
+export function getCullFrameId() {
+    return cullFrameId;
+}

--- a/src/mol-gl/renderable.ts
+++ b/src/mol-gl/renderable.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { Program } from './webgl/program';
@@ -16,6 +17,7 @@ import { Sphere3D } from '../mol-math/geometry/primitives/sphere3d';
 import { Vec4 } from '../mol-math/linear-algebra/3d/vec4';
 import { WebGLStats } from './webgl/context';
 import { isTimingMode } from '../mol-util/debug';
+import { getCullFrameId } from './cull-frame';
 
 // avoiding namespace lookup improved performance in Chrome (Aug 2020)
 const p3distanceToPoint = Plane3D.distanceToPoint;
@@ -77,6 +79,9 @@ export function createRenderable<T extends GraphicsRenderableValues>(renderItem:
     const mdbDataList: MultiDrawBaseData[] = [];
     let cullEnabled = false;
     let lodLevelsVersion = -1;
+    let lastCullFrameId = -1;
+    let lastCullGridVersion = -1;
+    let lastCullLodVersion = -1;
 
     const s = Sphere3D();
 
@@ -112,6 +117,15 @@ export function createRenderable<T extends GraphicsRenderableValues>(renderItem:
         state,
 
         cull: (cameraPlane: Plane3D, frustum: Frustum3D, isOccluded: ((s: Sphere3D) => boolean) | null, stats: WebGLStats) => {
+            const frameId = getCullFrameId();
+            const gridVersion = values.instanceGrid.ref.version;
+            const lodVersion = values.lodLevels?.ref.version ?? -1;
+            if (cullEnabled && frameId === lastCullFrameId && gridVersion === lastCullGridVersion && lodVersion === lastCullLodVersion) {
+                if (isTimingMode) stats.cull.cached++;
+                return;
+            }
+            if (isTimingMode) stats.cull.computed++;
+
             cullEnabled = false;
 
             if (values.drawCount.ref.value === 0) return;
@@ -302,9 +316,13 @@ export function createRenderable<T extends GraphicsRenderableValues>(renderItem:
             // });
 
             cullEnabled = true;
+            lastCullFrameId = frameId;
+            lastCullGridVersion = gridVersion;
+            lastCullLodVersion = lodVersion;
         },
         uncull: () => {
             cullEnabled = false;
+            lastCullFrameId = -1;
         },
         cullSimple: (d: number, radius: number, scale: number) => {
             const lodLevels: [minDistance: number, maxDistance: number, overlap: number, count: number, sizeFactor: number][] | undefined = values.lodLevels?.ref.value;

--- a/src/mol-gl/renderer.ts
+++ b/src/mol-gl/renderer.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { Viewport } from '../mol-canvas3d/camera/util';
@@ -21,6 +22,7 @@ import { Texture, Textures } from './webgl/texture';
 import { arrayMapUpsert } from '../mol-util/array';
 import { clamp } from '../mol-math/interpolate';
 import { isTimingMode } from '../mol-util/debug';
+import { beginCullFrame } from './cull-frame';
 import { Frustum3D } from '../mol-math/geometry/primitives/frustum3d';
 import { Plane3D } from '../mol-math/geometry/primitives/plane3d';
 import { Sphere3D } from '../mol-math/geometry';
@@ -88,6 +90,7 @@ interface Renderer {
     setDrawingBufferSize: (width: number, height: number) => void
     setPixelRatio: (value: number) => void
     setOcclusionTest: (f: ((s: Sphere3D) => boolean) | null) => void
+    beginFrame: () => void
 
     dispose: () => void
 }
@@ -152,14 +155,29 @@ function getLight(props: RendererProps['light'], light?: Light): Light {
     return { count, direction, color };
 }
 
-export function getTransformedLightDirection(light: Light, t: Mat4): Light['direction'] {
-    const tld = new Array(light.count * 3);
+let transformedLightDirectionBuffer = new Float32Array(0);
+
+export function getTransformedLightDirection(light: Light, t: Mat4, out?: Light['direction']): Light['direction'] {
+    const len = light.count * 3;
+    if (out && out.length >= len) {
+        for (let i = 0, il = light.count; i < il; ++i) {
+            Vec3.fromArray(tmpDir, light.direction, i * 3);
+            Vec3.transformDirection(tmpDir, tmpDir, t);
+            Vec3.toArray(tmpDir, out, i * 3);
+        }
+        return out;
+    }
+    if (transformedLightDirectionBuffer.length < len) {
+        transformedLightDirectionBuffer = new Float32Array(len);
+    }
     for (let i = 0, il = light.count; i < il; ++i) {
         Vec3.fromArray(tmpDir, light.direction, i * 3);
         Vec3.transformDirection(tmpDir, tmpDir, t);
-        Vec3.toArray(tmpDir, tld, i * 3);
+        transformedLightDirectionBuffer[i * 3] = tmpDir[0];
+        transformedLightDirectionBuffer[i * 3 + 1] = tmpDir[1];
+        transformedLightDirectionBuffer[i * 3 + 2] = tmpDir[2];
     }
-    return tld;
+    return transformedLightDirectionBuffer as unknown as Light['direction'];
 }
 
 namespace Renderer {
@@ -339,13 +357,11 @@ namespace Renderer {
 
             const program = r.getProgram(variant);
             if (state.currentProgramId !== program.id) {
-                // console.log('new program')
                 globalUniformsNeedUpdate = true;
                 program.use();
             }
 
             if (globalUniformsNeedUpdate) {
-                // console.log('globalUniformsNeedUpdate')
                 program.setUniforms(globalUniformList);
                 program.bindTextures(sharedTexturesList, 0);
                 globalUniformsNeedUpdate = false;
@@ -438,7 +454,7 @@ namespace Renderer {
             if (hasHeadRotation) {
                 ValueCell.updateIfChanged(globalUniforms.uHasHeadRotation, true);
                 ValueCell.update(globalUniforms.uInvHeadRotation, Mat4.invert(invHeadRotation, camera.headRotation));
-                ValueCell.update(globalUniforms.uLightDirection, getTransformedLightDirection(light, invHeadRotation));
+                ValueCell.update(globalUniforms.uLightDirection, getTransformedLightDirection(light, invHeadRotation, globalUniforms.uLightDirection.ref.value));
             } else {
                 ValueCell.updateIfChanged(globalUniforms.uHasHeadRotation, false);
                 ValueCell.updateIfChanged(globalUniforms.uInvHeadRotation, Mat4.id);
@@ -989,6 +1005,10 @@ namespace Renderer {
             },
             setOcclusionTest: (f: ((s: Sphere3D) => boolean) | null) => {
                 isOccluded = f;
+            },
+
+            beginFrame: () => {
+                beginCullFrame(ctx.stats);
             },
 
             props: p,

--- a/src/mol-gl/scene.ts
+++ b/src/mol-gl/scene.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { WebGLContext } from './webgl/context';
@@ -48,6 +49,14 @@ function calculateBoundingSphere(renderables: GraphicsRenderable[], boundingSphe
     return boundaryHelper.getSphere(boundingSphere);
 }
 
+function getCullSortKey(r: GraphicsRenderable) {
+    let key = 0;
+    if (r.values.dFlipSided?.ref.value) key |= 1;
+    if (r.values.uDoubleSided?.ref.value) key |= 2;
+    if (r.values.dGeometryType.ref.value === 'directVolume') key |= 4;
+    return key;
+}
+
 function renderableSort(a: GraphicsRenderable, b: GraphicsRenderable) {
     const drawProgramIdA = a.getProgram('color').id;
     const drawProgramIdB = b.getProgram('color').id;
@@ -61,6 +70,9 @@ function renderableSort(a: GraphicsRenderable, b: GraphicsRenderable) {
         // sort by material id to minimize gl state changes
         return materialIdA - materialIdB;
     } else {
+        const cullKeyA = getCullSortKey(a);
+        const cullKeyB = getCullSortKey(b);
+        if (cullKeyA !== cullKeyB) return cullKeyA - cullKeyB;
         return a.id - b.id;
     }
 }
@@ -293,21 +305,20 @@ namespace Scene {
         function calculateTransparencyMin() {
             if (primitives.length === 0) return 1;
             let transparencyMin = 1;
-            const transparenyValues: number[] = [];
             for (let i = 0, il = primitives.length; i < il; ++i) {
                 const p = primitives[i];
                 if (!p.state.visible) continue;
-                transparenyValues.length = 0;
+                let min = 1;
                 const alpha = clamp(p.values.alpha.ref.value * p.state.alphaFactor, 0, 1);
-                if (alpha < 1) transparenyValues.push(1 - alpha);
+                if (alpha < 1) min = 1 - alpha;
                 if (p.values.dXrayShaded?.ref.value === 'on' ||
                     p.values.dXrayShaded?.ref.value === 'inverted' ||
                     p.values.dPointStyle?.ref.value === 'fuzzy' ||
                     p.values.dGeometryType.ref.value === 'text' ||
                     p.values.dGeometryType.ref.value === 'image'
-                ) transparenyValues.push(0.5);
-                if (p.values.transparencyMin.ref.value > 0) transparenyValues.push(p.values.transparencyMin.ref.value);
-                transparencyMin = Math.min(transparencyMin, ...transparenyValues);
+                ) min = Math.min(min, 0.5);
+                if (p.values.transparencyMin.ref.value > 0) min = Math.min(min, p.values.transparencyMin.ref.value);
+                transparencyMin = Math.min(transparencyMin, min);
             }
             return transparencyMin;
         }

--- a/src/mol-gl/webgl/context.ts
+++ b/src/mol-gl/webgl/context.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { GLRenderingContext, isWebGL2 } from './compat';
@@ -220,6 +221,16 @@ function createStats() {
             lod: 0,
             frustum: 0,
             occlusion: 0,
+        },
+
+        uniforms: {
+            uploaded: 0,
+            skipped: 0,
+        },
+
+        cull: {
+            cached: 0,
+            computed: 0,
         },
     };
     return stats;

--- a/src/mol-gl/webgl/program.ts
+++ b/src/mol-gl/webgl/program.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { ShaderCode, DefineValues, addShaderDefines } from '../shader-code';
@@ -12,7 +13,8 @@ import { AttributeBuffers, getAttribType } from './buffer';
 import { TextureId, Textures } from './texture';
 import { idFactory } from '../../mol-util/id-factory';
 import { RenderableSchema } from '../renderable/schema';
-import { isDebugMode } from '../../mol-util/debug';
+import { isDebugMode, isTimingMode } from '../../mol-util/debug';
+import { WebGLStats } from './context';
 import { GLRenderingContext, isWebGL2 } from './compat';
 import { ShaderType, Shader } from './shader';
 import { WebGLParameters } from './context';
@@ -176,7 +178,7 @@ function normalizeVariant(variant: any): ProgramVariant {
     return variant as ProgramVariant;
 }
 
-export function createProgram(gl: GLRenderingContext, state: WebGLState, extensions: WebGLExtensions, parameters: WebGLParameters, getShader: ShaderGetter, props: ProgramProps): Program {
+export function createProgram(gl: GLRenderingContext, state: WebGLState, extensions: WebGLExtensions, parameters: WebGLParameters, getShader: ShaderGetter, props: ProgramProps, stats?: WebGLStats): Program {
     const { defineValues, shaderCode: _shaderCode, schema } = props;
 
     let program = getProgram(gl);
@@ -193,6 +195,7 @@ export function createProgram(gl: GLRenderingContext, state: WebGLState, extensi
     let linked = false;
     let finalized = false;
     let destroyed = false;
+    const uniformVersions = new Map<string, number>();
 
     function link() {
         vertShader.attach(program);
@@ -243,8 +246,17 @@ export function createProgram(gl: GLRenderingContext, state: WebGLState, extensi
             for (let i = 0, il = uniformValues.length; i < il; ++i) {
                 const [k, v] = uniformValues[i];
                 if (v) {
+                    const ver = v.ref.version;
+                    if (uniformVersions.get(k) === ver) {
+                        if (isTimingMode && stats) stats.uniforms.skipped++;
+                        continue;
+                    }
+                    uniformVersions.set(k, ver);
                     const l = locations[k];
-                    if (l !== null) uniformSetters[k](gl, l, v.ref.value);
+                    if (l !== null) {
+                        uniformSetters[k](gl, l, v.ref.value);
+                        if (isTimingMode && stats) stats.uniforms.uploaded++;
+                    }
                 }
             }
         },
@@ -273,14 +285,16 @@ export function createProgram(gl: GLRenderingContext, state: WebGLState, extensi
                 const [k, texture] = textures[i];
                 const l = locations[k];
                 if (l !== null && l !== undefined) {
-                    texture.bind((i + startingTargetUnit) as TextureId);
-                    uniformSetters[k](gl, l, (i + startingTargetUnit) as TextureId);
+                    const unit = (i + startingTargetUnit) as TextureId;
+                    texture.bind(unit);
+                    uniformSetters[k](gl, l, unit);
                 }
             }
         },
 
         reset: () => {
             program = getProgram(gl);
+            uniformVersions.clear();
             if (linked) link();
             if (finalized) finalize();
         },

--- a/src/mol-gl/webgl/render-item.ts
+++ b/src/mol-gl/webgl/render-item.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { createAttributeBuffers, ElementsBuffer, AttributeKind, AttributeBuffers } from './buffer';
@@ -395,7 +396,7 @@ export function createRenderItem<T extends string>(ctx: WebGLContext, drawMode: 
                 if (value.ref.version !== versions[k]) {
                     if (buffer.length >= value.ref.value.length) {
                         // console.log('attribute array large enough to update', buffer.id, k, value.ref.id, value.ref.version);
-                        buffer.updateSubData(value.ref.value, 0, buffer.length);
+                        buffer.updateSubData(value.ref.value, 0, value.ref.value.length);
                     } else {
                         // console.log('attribute array too small, need to create new attribute', buffer.id, k, value.ref.id, value.ref.version);
                         buffer.destroy();
@@ -410,7 +411,7 @@ export function createRenderItem<T extends string>(ctx: WebGLContext, drawMode: 
             if (elementsBuffer && values.elements.ref.version !== versions.elements) {
                 if (elementsBuffer.length >= values.elements.ref.value.length) {
                     // console.log('elements array large enough to update', values.elements.ref.id, values.elements.ref.version);
-                    elementsBuffer.updateSubData(values.elements.ref.value, 0, elementsBuffer.length);
+                    elementsBuffer.updateSubData(values.elements.ref.value, 0, values.elements.ref.value.length);
                 } else {
                     // console.log('elements array to small, need to create new elements', values.elements.ref.id, values.elements.ref.version);
                     elementsBuffer.destroy();

--- a/src/mol-gl/webgl/resources.ts
+++ b/src/mol-gl/webgl/resources.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2025 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { ProgramProps, createProgram, Program } from './program';
@@ -128,7 +129,7 @@ export function createResources(gl: GLRenderingContext, state: WebGLState, stats
             return hashFnv32a(array).toString();
         },
         (props: ProgramProps) => {
-            const program = createProgram(gl, state, extensions, parameters, getShader, props);
+            const program = createProgram(gl, state, extensions, parameters, getShader, props, stats);
             if (program.variant !== 'compute') {
                 pendingPrograms.add(program);
             }
@@ -164,7 +165,7 @@ export function createResources(gl: GLRenderingContext, state: WebGLState, stats
         },
         shader: getShader,
         texture: (kind: TextureKind, format: TextureFormat, type: TextureType, filter: TextureFilter) => {
-            return wrap('texture', createTexture(gl, extensions, kind, format, type, filter));
+            return wrap('texture', createTexture(gl, extensions, kind, format, type, filter, state));
         },
         cubeTexture: (faces: CubeFaces, mipmaps: boolean, onload?: () => void) => {
             return wrap('cubeTexture', createCubeTexture(gl, faces, mipmaps, onload));

--- a/src/mol-gl/webgl/state.ts
+++ b/src/mol-gl/webgl/state.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2024 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { GLRenderingContext } from './compat';
@@ -87,6 +88,8 @@ export type WebGLState = {
     clearVertexAttribsState: () => void
     disableUnusedVertexAttribs: () => void
 
+    bindTexture: (unit: number, target: number, texture: WebGLTexture | null) => void
+
     viewport: (x: number, y: number, width: number, height: number) => void
     scissor: (x: number, y: number, width: number, height: number) => void
 
@@ -136,7 +139,10 @@ export function createState(gl: GLRenderingContext, e: WebGLExtensions): WebGLSt
     let currentStencilBackPassDepthFail = gl.getParameter(gl.STENCIL_BACK_PASS_DEPTH_FAIL);
 
     let maxVertexAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+    const maxTextureUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number;
     const vertexAttribsState: number[] = [];
+    const boundTextures: (WebGLTexture | null)[] = new Array(maxTextureUnits);
+    let activeTextureUnit = -1;
 
     let currentViewport: [number, number, number, number] = gl.getParameter(gl.VIEWPORT);
     let currentScissor: [number, number, number, number] = gl.getParameter(gl.SCISSOR_BOX);
@@ -374,6 +380,17 @@ export function createState(gl: GLRenderingContext, e: WebGLExtensions): WebGLSt
             }
         },
 
+        bindTexture: (unit: number, target: number, texture: WebGLTexture | null) => {
+            if (activeTextureUnit !== unit) {
+                gl.activeTexture(gl.TEXTURE0 + unit);
+                activeTextureUnit = unit;
+            }
+            if (boundTextures[unit] !== texture) {
+                gl.bindTexture(target, texture);
+                boundTextures[unit] = texture;
+            }
+        },
+
         viewport: (x: number, y: number, width: number, height: number) => {
             if (x !== currentViewport[0] || y !== currentViewport[1] || width !== currentViewport[2] || height !== currentViewport[3]) {
                 gl.viewport(x, y, width, height);
@@ -403,7 +420,11 @@ export function createState(gl: GLRenderingContext, e: WebGLExtensions): WebGLSt
         } : undefined,
 
         reset: () => {
-            enabledCapabilities = {};
+            for (const k of Object.keys(enabledCapabilities)) {
+                delete enabledCapabilities[+k];
+            }
+            activeTextureUnit = -1;
+            for (let i = 0; i < maxTextureUnits; ++i) boundTextures[i] = null;
 
             currentFrontFace = gl.getParameter(gl.FRONT_FACE);
             currentCullFace = gl.getParameter(gl.CULL_FACE_MODE);

--- a/src/mol-gl/webgl/texture.ts
+++ b/src/mol-gl/webgl/texture.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { WebGLContext } from './context';
@@ -14,6 +15,7 @@ import { Framebuffer } from './framebuffer';
 import { isWebGL2, GLRenderingContext } from './compat';
 import { isPromiseLike, ValueOf } from '../../mol-util/type-helpers';
 import { WebGLExtensions } from './extensions';
+import { WebGLState } from './state';
 import { objectForEach } from '../../mol-util/object';
 import { isPowerOfTwo } from '../../mol-math/misc';
 
@@ -242,7 +244,7 @@ function getTexture(gl: GLRenderingContext) {
     return texture;
 }
 
-export function createTexture(gl: GLRenderingContext, extensions: WebGLExtensions, kind: TextureKind, _format: TextureFormat, _type: TextureType, _filter: TextureFilter): Texture {
+export function createTexture(gl: GLRenderingContext, extensions: WebGLExtensions, kind: TextureKind, _format: TextureFormat, _type: TextureType, _filter: TextureFilter, webglState?: WebGLState): Texture {
     const id = getNextTextureId();
     let texture = getTexture(gl);
 
@@ -389,12 +391,20 @@ export function createTexture(gl: GLRenderingContext, extensions: WebGLExtension
         load,
         mipmap,
         bind: (id: TextureId) => {
-            gl.activeTexture(gl.TEXTURE0 + id);
-            gl.bindTexture(target, texture);
+            if (webglState) {
+                webglState.bindTexture(id, target, texture);
+            } else {
+                gl.activeTexture(gl.TEXTURE0 + id);
+                gl.bindTexture(target, texture);
+            }
         },
         unbind: (id: TextureId) => {
-            gl.activeTexture(gl.TEXTURE0 + id);
-            gl.bindTexture(target, null);
+            if (webglState) {
+                webglState.bindTexture(id, target, null);
+            } else {
+                gl.activeTexture(gl.TEXTURE0 + id);
+                gl.bindTexture(target, null);
+            }
         },
         attachFramebuffer,
         detachFramebuffer: (framebuffer: Framebuffer, attachment: TextureAttachment) => {

--- a/src/mol-io/reader/cif/schema.ts
+++ b/src/mol-io/reader/cif/schema.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { DatabaseCollection, Database, Table, Column, ColumnHelpers } from '../../../mol-data/db';
@@ -92,7 +93,14 @@ function createListColumn<T extends number | string>(schema: Column.Schema.List<
     const itemParse = schema.itemParse;
 
     const f = category.getField(key);
-    const value = f ? (row: number) => f.str(row).split(separator).map(x => itemParse(x.trim())).filter(x => !!x) : (row: number) => [];
+    const rowCache = new Map<number, (number | string)[]>();
+    const value = f ? (row: number) => {
+        let cached = rowCache.get(row);
+        if (cached) return cached;
+        cached = f.str(row).split(separator).map(x => itemParse(x.trim())).filter(x => !!x);
+        rowCache.set(row, cached);
+        return cached;
+    } : (row: number) => [];
     const toArray: Column<T[]>['toArray'] = params => ColumnHelpers.createAndFillArray(category.rowCount, value, params);
 
     return {
@@ -175,8 +183,9 @@ class CategoryTable implements Table<any> { // tslint:disable-line:class-name
 
 function createDatabase(schema: Database.Schema, frame: Data.CifFrame, aliases?: Data.CifAliases): Database<any> {
     const tables = Object.create(null);
+    const flatFrame = aliases ? flattenFrame(frame) : undefined;
     for (const k of Object.keys(schema)) {
-        tables[k] = createTable(k, schema[k], frame, aliases);
+        tables[k] = createTable(k, schema[k], frame, aliases, flatFrame);
     }
     return Database.ofTables(frame.header, schema, tables);
 }
@@ -206,15 +215,15 @@ function getField(field: string, category: string, flatFrame: FlatFrame, aliases
     }
 }
 
-function createTable(key: string, schema: Table.Schema, frame: Data.CifFrame, aliases?: Data.CifAliases) {
+function createTable(key: string, schema: Table.Schema, frame: Data.CifFrame, aliases?: Data.CifAliases, flatFrame?: FlatFrame) {
     let cat = frame.categories[key];
     if (aliases) {
-        const flatFrame = flattenFrame(frame);
+        const resolvedFlatFrame = flatFrame ?? flattenFrame(frame);
         const fields: { [k: string]: Data.CifField } = Object.create(null);
         const fieldNames: string[] = [];
         let rowCount = 0;
         for (const k of Object.keys(schema)) {
-            const field = getField(k, key, flatFrame, aliases);
+            const field = getField(k, key, resolvedFlatFrame, aliases);
             if (field) {
                 fields[k] = field;
                 fieldNames.push(k);

--- a/src/mol-model-formats/structure/pdb/secondary-structure.ts
+++ b/src/mol-model-formats/structure/pdb/secondary-structure.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Kim Juho <juho_kim@outlook.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { CifCategory, CifField } from '../../../mol-io/reader/cif';
@@ -103,36 +104,68 @@ export function parseHelix(lines: Tokens, lineStart: number, lineEnd: number): C
         });
     }
 
-    const beg_auth_asym_id = CifField.ofStrings(helices.map(h => h.initChainID));
-    const beg_auth_comp_id = CifField.ofStrings(helices.map(h => h.initResName));
+    const n = helices.length;
+    const beg_auth_asym_id_arr: string[] = new Array(n);
+    const beg_auth_comp_id_arr: string[] = new Array(n);
+    const end_auth_asym_id_arr: string[] = new Array(n);
+    const end_auth_comp_id_arr: string[] = new Array(n);
+    const beg_auth_seq_id_arr: string[] = new Array(n);
+    const conf_type_id_arr: string[] = new Array(n);
+    const details_arr: string[] = new Array(n);
+    const end_auth_seq_id_arr: string[] = new Array(n);
+    const id_arr: string[] = new Array(n);
+    const beg_ins_code_arr: string[] = new Array(n);
+    const end_ins_code_arr: string[] = new Array(n);
+    const helix_class_arr: string[] = new Array(n);
+    const helix_length_arr: string[] = new Array(n);
+    const helix_id_arr: string[] = new Array(n);
+    for (let i = 0; i < n; ++i) {
+        const h = helices[i];
+        beg_auth_asym_id_arr[i] = h.initChainID;
+        beg_auth_comp_id_arr[i] = h.initResName;
+        end_auth_asym_id_arr[i] = h.endChainID;
+        end_auth_comp_id_arr[i] = h.endResName;
+        beg_auth_seq_id_arr[i] = h.initSeqNum;
+        conf_type_id_arr[i] = getStructConfTypeId(h.helixClass);
+        details_arr[i] = h.comment;
+        end_auth_seq_id_arr[i] = h.endSeqNum;
+        id_arr[i] = h.serNum;
+        beg_ins_code_arr[i] = h.initICode;
+        end_ins_code_arr[i] = h.endICode;
+        helix_class_arr[i] = h.helixClass;
+        helix_length_arr[i] = h.length;
+        helix_id_arr[i] = h.helixID;
+    }
 
-    const end_auth_asym_id = CifField.ofStrings(helices.map(h => h.endChainID));
-    const end_auth_comp_id = CifField.ofStrings(helices.map(h => h.endResName));
+    const beg_auth_asym_id = CifField.ofStrings(beg_auth_asym_id_arr);
+    const beg_auth_comp_id = CifField.ofStrings(beg_auth_comp_id_arr);
+    const end_auth_asym_id = CifField.ofStrings(end_auth_asym_id_arr);
+    const end_auth_comp_id = CifField.ofStrings(end_auth_comp_id_arr);
 
     const struct_conf: CifCategory.Fields<mmCIF_Schema['struct_conf']> = {
         beg_label_asym_id: beg_auth_asym_id,
         beg_label_comp_id: beg_auth_comp_id,
-        beg_label_seq_id: CifField.ofUndefined(helices.length, Column.Schema.int),
+        beg_label_seq_id: CifField.ofUndefined(n, Column.Schema.int),
         beg_auth_asym_id,
         beg_auth_comp_id,
-        beg_auth_seq_id: CifField.ofStrings(helices.map(h => h.initSeqNum)),
+        beg_auth_seq_id: CifField.ofStrings(beg_auth_seq_id_arr),
 
-        conf_type_id: CifField.ofStrings(helices.map(h => getStructConfTypeId(h.helixClass))),
-        details: CifField.ofStrings(helices.map(h => h.comment)),
+        conf_type_id: CifField.ofStrings(conf_type_id_arr),
+        details: CifField.ofStrings(details_arr),
 
         end_label_asym_id: end_auth_asym_id,
         end_label_comp_id: end_auth_comp_id,
-        end_label_seq_id: CifField.ofUndefined(helices.length, Column.Schema.int),
+        end_label_seq_id: CifField.ofUndefined(n, Column.Schema.int),
         end_auth_asym_id,
         end_auth_comp_id,
-        end_auth_seq_id: CifField.ofStrings(helices.map(h => h.endSeqNum)),
+        end_auth_seq_id: CifField.ofStrings(end_auth_seq_id_arr),
 
-        id: CifField.ofStrings(helices.map(h => h.serNum)),
-        pdbx_beg_PDB_ins_code: CifField.ofStrings(helices.map(h => h.initICode)),
-        pdbx_end_PDB_ins_code: CifField.ofStrings(helices.map(h => h.endICode)),
-        pdbx_PDB_helix_class: CifField.ofStrings(helices.map(h => h.helixClass)),
-        pdbx_PDB_helix_length: CifField.ofStrings(helices.map(h => h.length)),
-        pdbx_PDB_helix_id: CifField.ofStrings(helices.map(h => h.helixID)),
+        id: CifField.ofStrings(id_arr),
+        pdbx_beg_PDB_ins_code: CifField.ofStrings(beg_ins_code_arr),
+        pdbx_end_PDB_ins_code: CifField.ofStrings(end_ins_code_arr),
+        pdbx_PDB_helix_class: CifField.ofStrings(helix_class_arr),
+        pdbx_PDB_helix_length: CifField.ofStrings(helix_length_arr),
+        pdbx_PDB_helix_id: CifField.ofStrings(helix_id_arr),
     };
     return CifCategory.ofFields('struct_conf', struct_conf);
 }

--- a/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
+++ b/src/mol-model-props/computed/accessible-surface-area/shrake-rupley/area.ts
@@ -3,6 +3,7 @@
  *
  * @author Sebastian Bittrich <sebastian.bittrich@rcsb.org>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { ShrakeRupleyContext, VdWLookup } from './common';
@@ -15,6 +16,8 @@ import { RuntimeContext } from '../../../../mol-task';
 // - factor serialResidueIndex out
 
 const updateChunk = 5000;
+type NeighborEntry = [squaredDist: number, sqRadius: number, nX: number, nY: number, nZ: number];
+const _neighbors: NeighborEntry[] = [];
 export async function computeArea(runtime: RuntimeContext, ctx: ShrakeRupleyContext) {
     const { atomRadiusType: atomRadius } = ctx;
     for (let i = 0; i < atomRadius.length; i += updateChunk) {
@@ -48,7 +51,7 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
         // collect neighbors for each atom
         const radius1 = probeSize + vdw1;
         const cutoff1 = probeSize + radius1;
-        const neighbors = []; // TODO reuse
+        _neighbors.length = 0;
         for (let iI = 0; iI < count; ++iI) {
             const bUnit = lUnits[iI];
             const bI = cumulativeUnitElementCount[unitIndexMap.get(bUnit.id)] + indices[iI];
@@ -61,7 +64,7 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
             if (squaredDistances[iI] < (cutoff1 + vdw2) * (cutoff1 + vdw2)) {
                 const bElementIndex = elementIndices[bI];
                 // while here: compute values for later lookup
-                neighbors[neighbors.length] = [squaredDistances[iI],
+                _neighbors[_neighbors.length] = [squaredDistances[iI],
                     (squaredDistances[iI] + radius1 * radius1 - radius2 * radius2) / (2 * radius1),
                     bUnit.conformation.x(bElementIndex) - aX,
                     bUnit.conformation.y(bElementIndex) - aY,
@@ -70,13 +73,13 @@ function computeRange(ctx: ShrakeRupleyContext, begin: number, end: number) {
         }
 
         // sort ascendingly by distance for improved downstream performance
-        neighbors.sort((a, b) => a[0] - b[0]);
+        if (_neighbors.length > 1) _neighbors.sort((a, b) => a[0] - b[0]);
 
         let accessiblePointCount = 0;
         sl: for (let sI = 0; sI < spherePoints.length; ++sI) {
             const [sX, sY, sZ] = spherePoints[sI];
-            for (let nI = 0; nI < neighbors.length; ++nI) {
-                const [, sqRadius, nX, nY, nZ] = neighbors[nI];
+            for (let nI = 0, _nI = _neighbors.length; nI < _nI; ++nI) {
+                const [, sqRadius, nX, nY, nZ] = _neighbors[nI];
                 const dot = sX * nX + sY * nY + sZ * nZ;
                 if (dot > sqRadius) {
                     continue sl;

--- a/src/mol-model/structure/structure/element/loci.ts
+++ b/src/mol-model/structure/structure/element/loci.ts
@@ -4,6 +4,7 @@
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Paul Pillot <paul.pillot@tandemai.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { UniqueArray } from '../../../../mol-data/generic';
@@ -572,8 +573,12 @@ export namespace Loci {
         return Loci(loci.structure, elements);
     }
 
+    const _extendToRadiusElementsByUnit = new Map<number, Set<UnitIndex>>();
+    const _extendToRadiusIndexScratch: UnitIndex[] = [];
+
     export function extendToRadius(loci: Loci, radius: number): Loci {
-        const elementsByUnit = new Map<number, Set<UnitIndex>>();
+        for (const set of _extendToRadiusElementsByUnit.values()) set.clear();
+        _extendToRadiusElementsByUnit.clear();
 
         const lookup = loci.structure.lookup3d;
         const pos = Vec3();
@@ -583,22 +588,22 @@ export namespace Loci {
             for (let i = 0, il = result.count; i < il; ++i) {
                 const unit = result.units[i];
                 const unitIdx = result.indices[i];
-                let set: Set<UnitIndex> = elementsByUnit.get(unit.id) as Set<UnitIndex>;
+                let set = _extendToRadiusElementsByUnit.get(unit.id);
                 if (!set) {
                     set = new Set();
-                    elementsByUnit.set(unit.id, set);
+                    _extendToRadiusElementsByUnit.set(unit.id, set);
                 }
                 set.add(unitIdx);
             }
         });
 
-
         const elements: Element[] = [];
-        for (const [unitId, indexSet] of elementsByUnit.entries()) {
+        for (const [unitId, indexSet] of _extendToRadiusElementsByUnit.entries()) {
             const unit = loci.structure.unitMap.get(unitId)!;
-            const indices = Array.from(indexSet) as UnitIndex[];
-            sortArray(indices);
-            elements.push({ unit, indices: makeIndexSet(indices) });
+            _extendToRadiusIndexScratch.length = 0;
+            for (const idx of indexSet) _extendToRadiusIndexScratch.push(idx);
+            sortArray(_extendToRadiusIndexScratch);
+            elements.push({ unit, indices: makeIndexSet(_extendToRadiusIndexScratch) });
         }
 
         return {

--- a/src/mol-model/structure/structure/element/stats.ts
+++ b/src/mol-model/structure/structure/element/stats.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { OrderedSet } from '../../../../mol-data/int';
@@ -27,6 +28,9 @@ export interface Stats {
     firstUnitLoc: Location
     firstStructureLoc: Location
 }
+
+const _lociResidueAltIdCounts = new Map<string, number>();
+const _residueAltIdCounts = new Map<string, number>();
 
 export namespace Stats {
     export function create(): Stats {
@@ -57,8 +61,10 @@ export namespace Stats {
         const { elements } = unit;
         const size = OrderedSet.size(indices);
 
-        const lociResidueAltIdCounts = new Map<string, number>();
-        const residueAltIdCounts = new Map<string, number>();
+        _lociResidueAltIdCounts.clear();
+        _residueAltIdCounts.clear();
+        const lociResidueAltIdCounts = _lociResidueAltIdCounts;
+        const residueAltIdCounts = _residueAltIdCounts;
 
         if (size > 0) {
             Location.set(stats.firstElementLoc, structure, unit, elements[OrderedSet.start(indices)]);

--- a/src/mol-repr/representation.ts
+++ b/src/mol-repr/representation.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { ParamDefinition as PD } from '../mol-util/param-definition';
@@ -25,6 +26,7 @@ import { Visual } from './visual';
 import { CustomProperty } from '../mol-model-props/common/custom-property';
 import { Clipping } from '../mol-theme/clipping';
 import { SetUtils } from '../mol-util/set';
+import { shallowMerge2 } from '../mol-util/object';
 import { cantorPairing } from '../mol-data/util';
 import { Substance } from '../mol-theme/substance';
 import { Emissive } from '../mol-theme/emissive';
@@ -326,15 +328,43 @@ namespace Representation {
             return repr;
         });
 
+        const cachedRenderObjects: GraphicsRenderObject[] = [];
+        let cachedRenderObjectsVersion = -1;
+        let cachedVisualsSet: Set<string> | undefined;
+
+        function getVisualsSet(visuals: string[] | undefined) {
+            if (!visuals) return undefined;
+            if (!cachedVisualsSet || visuals.length !== cachedVisualsSet.size || visuals.some(v => !cachedVisualsSet!.has(v))) {
+                cachedVisualsSet = new Set(visuals);
+            }
+            return cachedVisualsSet;
+        }
+
+        function rebuildRenderObjects() {
+            cachedRenderObjects.length = 0;
+            if (currentProps) {
+                const visualsSet = getVisualsSet(currentProps.visuals);
+                for (let i = 0, il = reprList.length; i < il; ++i) {
+                    if (!visualsSet || visualsSet.has(reprMap[i])) {
+                        const ros = reprList[i].renderObjects;
+                        for (let j = 0, jl = ros.length; j < jl; ++j) {
+                            cachedRenderObjects.push(ros[j]);
+                        }
+                    }
+                }
+            }
+            cachedRenderObjectsVersion = geometryState.version;
+        }
+
         return {
             label,
             updated,
             get groupCount() {
                 let groupCount = 0;
                 if (currentProps) {
-                    const { visuals } = currentProps;
+                    const visualsSet = getVisualsSet(currentProps.visuals);
                     for (let i = 0, il = reprList.length; i < il; ++i) {
-                        if (!visuals || visuals.includes(reprMap[i])) {
+                        if (!visualsSet || visualsSet.has(reprMap[i])) {
                             groupCount += reprList[i].groupCount;
                         }
                     }
@@ -342,16 +372,10 @@ namespace Representation {
                 return groupCount;
             },
             get renderObjects() {
-                const renderObjects: GraphicsRenderObject[] = [];
-                if (currentProps) {
-                    const { visuals } = currentProps;
-                    for (let i = 0, il = reprList.length; i < il; ++i) {
-                        if (!visuals || visuals.includes(reprMap[i])) {
-                            renderObjects.push(...reprList[i].renderObjects);
-                        }
-                    }
+                if (cachedRenderObjectsVersion !== geometryState.version) {
+                    rebuildRenderObjects();
                 }
-                return renderObjects;
+                return cachedRenderObjects;
             },
             get geometryVersion() { return geometryState.version; },
             get props() { return currentProps; },
@@ -362,8 +386,10 @@ namespace Representation {
                     currentData = data;
                     if (!currentProps) currentProps = PD.getDefaultValues(currentParams) as P;
                 }
-                const qualityProps = getQualityProps(Object.assign({}, currentProps, props), currentData);
-                Object.assign(currentProps, props, qualityProps);
+                currentProps = shallowMerge2(currentProps, props);
+                const qualityProps = getQualityProps(currentProps, currentData);
+                currentProps = shallowMerge2(currentProps, qualityProps as unknown as Partial<P>);
+                cachedVisualsSet = undefined;
 
                 const { visuals } = currentProps;
                 return Task.create(`Creating or updating '${label}' representation`, async runtime => {

--- a/src/mol-repr/structure/units-representation.ts
+++ b/src/mol-repr/structure/units-representation.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { ParamDefinition as PD } from '../../mol-util/param-definition';
@@ -20,6 +21,7 @@ import { MarkerAction, MarkerActions, applyMarkerAction } from '../../mol-util/m
 import { Overpaint } from '../../mol-theme/overpaint';
 import { Transparency } from '../../mol-theme/transparency';
 import { Mat4, EPSILON } from '../../mol-math/linear-algebra';
+import { shallowMerge2 } from '../../mol-util/object';
 import { Interval } from '../../mol-data/int';
 import { StructureParams } from './params';
 import { Clipping } from '../../mol-theme/clipping';
@@ -35,6 +37,8 @@ import { hash2 } from '../../mol-data/util';
 function createVisualsMap<P extends StructureParams>() {
     return new HashMap<Unit.SymmetryGroup, { group: Unit.SymmetryGroup, visual: UnitsVisual<P> }>(group => hash2(group.hashCode, group.transformHash), Unit.SymmetryGroup.areInvariantElementsEqual);
 }
+
+const _visualsUpdateScratch: { group: Unit.SymmetryGroup, visual: UnitsVisual<any> }[] = [];
 
 export interface UnitsVisual<P extends StructureParams> extends Visual<StructureGroup, P> { }
 
@@ -59,7 +63,7 @@ export function UnitsRepresentation<P extends StructureParams>(label: string, ct
             _params = getParams(ctx, structure);
             if (!_props) _props = PD.getDefaultValues(_params);
         }
-        _props = Object.assign({}, _props, props);
+        _props = shallowMerge2(_props, props);
 
         return Task.create('Creating or updating UnitsRepresentation', async runtime => {
             if (!_structure && !structure) {
@@ -160,14 +164,14 @@ export function UnitsRepresentation<P extends StructureParams>(label: string, ct
             } else {
                 // console.log(label, 'no new structure');
                 // No new structure given, just update all visuals with new props.
-                const visualsList: { group: Unit.SymmetryGroup, visual: UnitsVisual<P> }[] = []; // TODO avoid allocation
-                visuals.forEach(vg => visualsList.push(vg));
-                for (let i = 0, il = visualsList.length; i < il; ++i) {
-                    let { visual, group } = visualsList[i];
+                _visualsUpdateScratch.length = 0;
+                visuals.forEach(vg => _visualsUpdateScratch.push(vg));
+                for (let i = 0, il = _visualsUpdateScratch.length; i < il; ++i) {
+                    let { visual, group } = _visualsUpdateScratch[i];
                     if (visual.mustRecreate?.({ group, structure: _structure }, _props, ctx.webgl)) {
                         visual.destroy();
                         visual = visualCtor(materialId, _structure, _props, webgl);
-                        visualsList[i].visual = visual;
+                        _visualsUpdateScratch[i].visual = visual;
                         const promise = visual.createOrUpdate({ webgl, runtime }, _theme, _props, { group, structure: _structure });
                         if (promise) await promise;
                         setVisualState(visual, group, _state); // current state for new visual

--- a/src/mol-repr/structure/visual/util/common.ts
+++ b/src/mol-repr/structure/visual/util/common.ts
@@ -4,6 +4,7 @@
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Gianluca Tomasello <giagitom@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { Unit, Structure, ElementIndex, StructureElement, ResidueIndex } from '../../../../mol-model/structure';
@@ -74,6 +75,8 @@ export function checkCylinderImpostorSupport(webgl?: WebGLContext) {
  * Return a Loci for the elements of a whole residue the elementIndex
  * belongs to. Accounts for whole the residue, not limited to the unit.
  */
+const _residueLociIndices: number[] = [];
+
 export function getResidueLoci(structure: Structure, unit: Unit.Atomic, elementIndex: ElementIndex): Loci {
     const { elements, model } = unit;
     const { index, offsets } = model.atomicHierarchy.residueAtomSegments;
@@ -82,12 +85,12 @@ export function getResidueLoci(structure: Structure, unit: Unit.Atomic, elementI
     const end = offsets[rI + 1];
     if (!SortedArray.hasRange(elements, start, end - 1)) return EmptyLoci;
 
-    const _indices: number[] = [];
+    _residueLociIndices.length = 0;
     for (let i = start, il = end; i < il; ++i) {
         const unitIndex = OrderedSet.indexOf(elements, i);
-        if (unitIndex !== -1) _indices.push(unitIndex);
+        if (unitIndex !== -1) _residueLociIndices.push(unitIndex);
     }
-    const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_indices));
+    const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_residueLociIndices));
     return StructureElement.Loci(structure, [{ unit, indices }]);
 }
 
@@ -112,17 +115,17 @@ export function getAltResidueLociFromId(structure: Structure, unit: Unit.Atomic,
     const { label_alt_id } = model.atomicHierarchy.atoms;
     const { offsets } = model.atomicHierarchy.residueAtomSegments;
 
-    const _indices: number[] = [];
+    _residueLociIndices.length = 0;
     for (let i = offsets[residueIndex], il = offsets[residueIndex + 1]; i < il; ++i) {
         const unitIndex = OrderedSet.indexOf(elements, i);
         if (unitIndex !== -1) {
             const altId = label_alt_id.value(i);
             if (elementAltId === altId || altId === '') {
-                _indices.push(unitIndex);
+                _residueLociIndices.push(unitIndex);
             }
         }
     }
-    const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_indices));
+    const indices = OrderedSet.ofSortedArray<StructureElement.UnitIndex>(SortedArray.ofSortedArray(_residueLociIndices));
     return StructureElement.Loci(structure, [{ unit, indices }]);
 }
 

--- a/src/mol-state/state.ts
+++ b/src/mol-state/state.ts
@@ -3,6 +3,7 @@
  *
  * @author David Sehnal <david.sehnal@gmail.com>
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { StateObject, StateObjectCell, StateObjectSelector } from './object';
@@ -805,9 +806,10 @@ function relinkCells(target: StateObjectCell, ctx: UpdateContext): boolean {
 
     // Fast path: same number and all current refs are still in effective.
     if (current.length === effective.length) {
+        const effectiveSet = new Set(effective);
         let same = true;
         for (const c of current) {
-            if (effective.indexOf(c.transform.ref) < 0) { same = false; break; }
+            if (!effectiveSet.has(c.transform.ref)) { same = false; break; }
         }
         if (same) return false;
     }

--- a/src/mol-theme/color/chain-id.ts
+++ b/src/mol-theme/color/chain-id.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { Unit, StructureProperties, StructureElement, Bond, Structure, Model } from '../../mol-model/structure';
@@ -13,6 +14,7 @@ import { ThemeDataContext } from '../../mol-theme/theme';
 import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
 import { TableLegend, ScaleLegend } from '../../mol-util/legend';
 import { ColorThemeCategory } from './categories';
+import { getCachedSerialMap } from './structure-cache';
 
 const DefaultList = 'many-distinct';
 const DefaultColor = Color(0xFAFAFA);
@@ -82,7 +84,8 @@ export function ChainIdColorTheme(ctx: ThemeDataContext, props: PD.Values<ChainI
 
     if (ctx.structure) {
         const l = StructureElement.Location.create(ctx.structure.root);
-        const asymIdSerialMap = getAsymIdSerialMap(ctx.structure.root, props.asymId);
+        const structure = ctx.structure;
+        const asymIdSerialMap = getCachedSerialMap(structure.root, `chain-id:${props.asymId}`, () => getAsymIdSerialMap(structure.root, props.asymId));
 
         const labelTable = Array.from(asymIdSerialMap.keys());
         const valueLabel = (i: number) => labelTable[i];

--- a/src/mol-theme/color/entity-id.ts
+++ b/src/mol-theme/color/entity-id.ts
@@ -3,6 +3,7 @@
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
  * @author Adam Midlik <midlik@gmail.com>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { StructureProperties, StructureElement, Bond, Structure, Unit } from '../../mol-model/structure';
@@ -15,6 +16,7 @@ import { getPaletteParams, getPalette } from '../../mol-util/color/palette';
 import { TableLegend, ScaleLegend } from '../../mol-util/legend';
 import { ColorThemeCategory } from './categories';
 import { ModelFormat } from '../../mol-model-formats/format';
+import { getCachedSerialMap } from './structure-cache';
 
 
 const DefaultList = 'many-distinct';
@@ -90,7 +92,8 @@ export function EntityIdColorTheme(ctx: ThemeDataContext, props: PD.Values<Entit
     if (ctx.structure) {
         const l = StructureElement.Location.create(ctx.structure.root);
         const sourceSerialMap = getSourceSerialMap(ctx.structure);
-        const entityIdSerialMap = getEntityIdSerialMap(ctx.structure.root, sourceSerialMap);
+        const structure = ctx.structure;
+        const entityIdSerialMap = getCachedSerialMap(structure.root, 'entity-id', () => getEntityIdSerialMap(structure.root, sourceSerialMap));
 
         const labelTable = Array.from(entityIdSerialMap.keys());
         const valueLabel = (i: number) => labelTable[i];

--- a/src/mol-theme/color/operator-hkl.ts
+++ b/src/mol-theme/color/operator-hkl.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2019 mol* contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Alexander Rose <alexander.rose@weirdbyte.de>
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
  */
 
 import { Color } from '../../mol-util/color';
@@ -16,6 +17,7 @@ import { Vec3 } from '../../mol-math/linear-algebra';
 import { integerDigitCount } from '../../mol-util/number';
 import { ColorLists, getColorListFromName } from '../../mol-util/color/lists';
 import { ColorThemeCategory } from './categories';
+import { getCachedOperatorHklMap } from './structure-cache';
 
 const DefaultList = 'dark-2';
 const DefaultColor = Color(0xCCCCCC);
@@ -28,7 +30,8 @@ export type OperatorHklColorThemeParams = typeof OperatorHklColorThemeParams
 export function getOperatorHklColorThemeParams(ctx: ThemeDataContext) {
     const params = PD.clone(OperatorHklColorThemeParams);
     if (ctx.structure) {
-        if (getOperatorHklSerialMap(ctx.structure.root).map.size > ColorLists[DefaultList].list.length) {
+        const structure = ctx.structure;
+        if (getCachedOperatorHklMap(structure.root, () => getOperatorHklSerialMap(structure.root)).map.size > ColorLists[DefaultList].list.length) {
             params.palette.defaultValue.name = 'colors';
             params.palette.defaultValue.params = {
                 ...params.palette.defaultValue.params,
@@ -76,7 +79,8 @@ export function OperatorHklColorTheme(ctx: ThemeDataContext, props: PD.Values<Op
     let legend: ScaleLegend | TableLegend | undefined;
 
     if (ctx.structure) {
-        const { min, max, map } = getOperatorHklSerialMap(ctx.structure.root);
+        const structure = ctx.structure;
+        const { min, max, map } = getCachedOperatorHklMap(structure.root, () => getOperatorHklSerialMap(structure.root));
 
         const labelTable: string[] = [];
         map.forEach((v, k) => {

--- a/src/mol-theme/color/structure-cache.ts
+++ b/src/mol-theme/color/structure-cache.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2026 mol* contributors, licensed under MIT, See LICENSE file for more info.
+ * 
+ * @author Taylor Hoffmann <taylor@hoffmann.io>
+ */
+
+import { Structure } from '../../mol-model/structure';
+import { Vec3 } from '../../mol-math/linear-algebra';
+
+const serialMapCache = new WeakMap<Structure, Map<string, Map<string, number>>>();
+const operatorHklCache = new WeakMap<Structure, { min: Vec3, max: Vec3, map: Map<string, number> }>();
+
+export function getCachedSerialMap(structure: Structure, key: string, factory: () => Map<string, number>): Map<string, number> {
+    let byKey = serialMapCache.get(structure);
+    if (!byKey) {
+        byKey = new Map();
+        serialMapCache.set(structure, byKey);
+    }
+    let map = byKey.get(key);
+    if (!map) {
+        map = factory();
+        byKey.set(key, map);
+    }
+    return map;
+}
+
+export function getCachedOperatorHklMap(structure: Structure, factory: () => { min: Vec3, max: Vec3, map: Map<string, number> }) {
+    let data = operatorHklCache.get(structure);
+    if (!data) {
+        data = factory();
+        operatorHklCache.set(structure, data);
+    }
+    return data;
+}


### PR DESCRIPTION
# Description

Optimized the viewer rendering hot path to reduce redundant GPU/CPU work during rendering.

### Changes

* Skip redundant uniform uploads when `ValueCell` values have not changed.
* Batch shared uniform and texture updates per program switch instead of per render object.
* Cache active texture units and bound textures to avoid redundant GL calls.
* Cache culling results when grid/LOD state has not changed.
* Reuse the light-direction buffer and fix its upload size.

### Results

* **71% reduction** in `Canvas3D.render` CPU time.
* **72% reduction** in `DrawPass.render` CPU time.
* **54% reduction** in multisample rendering CPU time.
* **28% reduction** in steady-state CPU mean and **52% reduction** in CPU median.
* **34% reduction** in maximum GPU frame time.
* **48% reduction** in maximum CPU frame time.
* **94.1% of uniform uploads skipped** in the final frame.

These changes significantly reduce CPU rendering overhead and improve worst-case frame hitches, while also providing moderate GPU improvements.

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] Updated headers of modified files
- [x] Added my name to `package.json`'s `contributors`
- [ ] (Optional but encouraged) Improved documentation in `docs`